### PR TITLE
chore: add .editorconfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+max_line_length = 120
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

- Add `.editorconfig` to standardize indentation, charset, and line endings across all editors
- Python: 4-space indent, 120 char max line length
- YAML/JS/TS: 2-space indent
- Markdown: preserve trailing whitespace (for line breaks)
- Makefile: tab indent

## Why

Contributors using different editors (VS Code, Vim, JetBrains, etc.) will automatically pick up the correct formatting without manual configuration.