### PR TITLE
ci: add stale issue/PR bot workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Stale Issues
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs. Thank you for your contributions.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs.
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security,enhancement
+          exempt-pr-labels: pinned,security


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow using `actions/stale@v9` to manage inactive issues and PRs
- Issues/PRs marked stale after 60 days of inactivity
- Auto-closed after 14 additional days with no response
- Exempts issues labeled `pinned`, `security`, or `enhancement`
- Runs weekly (Monday 00:00 UTC) and supports manual trigger

## Why

Keeps the issue tracker clean and signals to visitors that the project is actively maintained. Stale issues that are still relevant can simply be commented on to reset the timer.