### PR TITLE
feat: mobile reading optimization for TextReaderPage

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -2,15 +2,35 @@ import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
-import { Typography, Spin, Button, Select, Breadcrumb, Space } from "antd";
-import { HomeOutlined, LeftOutlined, RightOutlined } from "@ant-design/icons";
+import { Typography, Spin, Button, Select, Breadcrumb } from "antd";
+import {
+  HomeOutlined,
+  LeftOutlined,
+  RightOutlined,
+  FontSizeOutlined,
+} from "@ant-design/icons";
 import { getJuanList, getJuanContent } from "../api/client";
+import "../styles/reader.css";
+
+const FONT_SIZE_MIN = 14;
+const FONT_SIZE_MAX = 28;
+const FONT_SIZE_STEP = 2;
+const FONT_SIZE_KEY = "fojin-reader-font-size";
+
+function getInitialFontSize(): number {
+  try {
+    const v = localStorage.getItem(FONT_SIZE_KEY);
+    if (v) return Math.min(Math.max(Number(v), FONT_SIZE_MIN), FONT_SIZE_MAX);
+  } catch { /* noop */ }
+  return 18;
+}
 
 export default function TextReaderPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const textId = Number(id);
   const [juanNum, setJuanNum] = useState(1);
+  const [fontSize, setFontSize] = useState(getInitialFontSize);
 
   const { data: juanList } = useQuery({
     queryKey: ["juanList", textId],
@@ -24,31 +44,60 @@ export default function TextReaderPage() {
     enabled: !!textId,
   });
 
+  const changeFontSize = (delta: number) => {
+    setFontSize((prev) => {
+      const next = Math.min(Math.max(prev + delta, FONT_SIZE_MIN), FONT_SIZE_MAX);
+      try { localStorage.setItem(FONT_SIZE_KEY, String(next)); } catch { /* noop */ }
+      return next;
+    });
+  };
+
   return (
-    <div style={{ maxWidth: 800, margin: "24px auto", padding: "0 16px" }}>
+    <div className="reader-container">
       <Helmet>
-        <title>{content?.title_zh ? `${content.title_zh} 第${juanNum}卷` : "在线阅读"} — 佛津</title>
+        <title>
+          {content?.title_zh
+            ? `${content.title_zh} 第${juanNum}卷`
+            : "在线阅读"}{" "}
+          — 佛津
+        </title>
       </Helmet>
 
       <Breadcrumb
         style={{ marginBottom: 16 }}
         items={[
-          { title: <span style={{ cursor: "pointer" }} onClick={() => navigate("/")}><HomeOutlined /> 首页</span> },
-          { title: <span style={{ cursor: "pointer" }} onClick={() => navigate(`/texts/${textId}`)}>经典详情</span> },
+          {
+            title: (
+              <span style={{ cursor: "pointer" }} onClick={() => navigate("/")}>
+                <HomeOutlined /> 首页
+              </span>
+            ),
+          },
+          {
+            title: (
+              <span
+                style={{ cursor: "pointer" }}
+                onClick={() => navigate(`/texts/${textId}`)}
+              >
+                经典详情
+              </span>
+            ),
+          },
           { title: "在线阅读" },
         ]}
       />
 
       {/* Header */}
-      <div style={{ marginBottom: 24 }}>
-        <Typography.Title level={3} style={{ marginBottom: 8 }}>
+      <div className="reader-header">
+        <Typography.Title level={3}>
           {content?.title_zh || juanList?.title_zh || "加载中..."}
         </Typography.Title>
-        <Space>
+
+        <div className="reader-nav">
           <Select
+            className="juan-select"
             value={juanNum}
             onChange={setJuanNum}
-            style={{ width: 140 }}
             options={
               juanList?.juans.map((j) => ({
                 value: j.juan_num,
@@ -56,20 +105,45 @@ export default function TextReaderPage() {
               })) || [{ value: 1, label: "第 1 卷" }]
             }
           />
-          <Button
-            icon={<LeftOutlined />}
-            disabled={!content?.prev_juan}
-            onClick={() => content?.prev_juan && setJuanNum(content.prev_juan)}
-          >
-            上一卷
-          </Button>
-          <Button
-            disabled={!content?.next_juan}
-            onClick={() => content?.next_juan && setJuanNum(content.next_juan)}
-          >
-            下一卷 <RightOutlined />
-          </Button>
-        </Space>
+          <div className="nav-btn-group">
+            <Button
+              icon={<LeftOutlined />}
+              disabled={!content?.prev_juan}
+              onClick={() =>
+                content?.prev_juan && setJuanNum(content.prev_juan)
+              }
+            >
+              上一卷
+            </Button>
+            <Button
+              disabled={!content?.next_juan}
+              onClick={() =>
+                content?.next_juan && setJuanNum(content.next_juan)
+              }
+            >
+              下一卷 <RightOutlined />
+            </Button>
+          </div>
+          <div className="reader-font-controls">
+            <Button
+              size="small"
+              icon={<FontSizeOutlined />}
+              disabled={fontSize <= FONT_SIZE_MIN}
+              onClick={() => changeFontSize(-FONT_SIZE_STEP)}
+            >
+              A-
+            </Button>
+            <span className="font-size-label">{fontSize}</span>
+            <Button
+              size="small"
+              icon={<FontSizeOutlined />}
+              disabled={fontSize >= FONT_SIZE_MAX}
+              onClick={() => changeFontSize(FONT_SIZE_STEP)}
+            >
+              A+
+            </Button>
+          </div>
+        </div>
       </div>
 
       {/* Content */}
@@ -79,17 +153,8 @@ export default function TextReaderPage() {
         </div>
       ) : content ? (
         <div
-          style={{
-            fontFamily: '"Noto Serif SC", "Source Han Serif SC", serif',
-            fontSize: 18,
-            lineHeight: 2.2,
-            color: "var(--fj-ink)",
-            whiteSpace: "pre-wrap",
-            background: "var(--fj-card-bg)",
-            padding: "32px 24px",
-            borderRadius: 8,
-            border: "1px solid var(--fj-border)",
-          }}
+          className="reader-body"
+          style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
         >
           {content.content}
         </div>
@@ -99,16 +164,20 @@ export default function TextReaderPage() {
 
       {/* Bottom navigation */}
       {content && (
-        <div style={{ display: "flex", justifyContent: "space-between", marginTop: 24, marginBottom: 48 }}>
+        <div className="reader-bottom-nav">
           <Button
             disabled={!content.prev_juan}
-            onClick={() => content.prev_juan && setJuanNum(content.prev_juan)}
+            onClick={() =>
+              content.prev_juan && setJuanNum(content.prev_juan)
+            }
           >
             <LeftOutlined /> 上一卷
           </Button>
           <Button
             disabled={!content.next_juan}
-            onClick={() => content.next_juan && setJuanNum(content.next_juan)}
+            onClick={() =>
+              content.next_juan && setJuanNum(content.next_juan)
+            }
           >
             下一卷 <RightOutlined />
           </Button>

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -1,0 +1,110 @@
+/* ── TextReaderPage: mobile reading optimisation ── */
+
+.reader-container {
+  max-width: 800px;
+  margin: 24px auto;
+  padding: 0 16px;
+}
+
+.reader-header {
+  margin-bottom: 24px;
+}
+
+.reader-header h3 {
+  margin-bottom: 8px;
+}
+
+.reader-nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.reader-nav .juan-select {
+  width: 140px;
+}
+
+.reader-font-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.reader-font-controls .font-size-label {
+  font-size: 12px;
+  color: var(--fj-text-secondary, #999);
+  min-width: 28px;
+  text-align: center;
+}
+
+.reader-body {
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-size: var(--reader-font-size, 18px);
+  line-height: 2.2;
+  color: var(--fj-ink);
+  white-space: pre-wrap;
+  background: var(--fj-card-bg);
+  padding: 32px 24px;
+  border-radius: 8px;
+  border: 1px solid var(--fj-border);
+}
+
+.reader-bottom-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 24px;
+  margin-bottom: 48px;
+}
+
+/* ── Mobile ── */
+@media (max-width: 768px) {
+  .reader-container {
+    margin: 16px auto;
+    padding: 0 12px;
+  }
+
+  .reader-nav {
+    gap: 6px;
+  }
+
+  .reader-nav .juan-select {
+    width: 100%;
+    order: -1;
+  }
+
+  .reader-nav .nav-btn-group {
+    display: flex;
+    gap: 6px;
+    flex: 1;
+  }
+
+  .reader-nav .nav-btn-group .ant-btn {
+    flex: 1;
+  }
+
+  .reader-font-controls {
+    margin-left: 0;
+    order: -1;
+    width: 100%;
+    justify-content: flex-end;
+    margin-bottom: 4px;
+  }
+
+  .reader-body {
+    padding: 20px 16px;
+    border-radius: 6px;
+  }
+
+  .reader-bottom-nav .ant-btn {
+    flex: 1;
+  }
+}
+
+@media (max-width: 480px) {
+  .reader-body {
+    padding: 16px 12px;
+    line-height: 2.0;
+  }
+}


### PR DESCRIPTION
## Summary

Optimize the sutra reading experience on mobile devices.

### Changes

- **Extract inline styles to `reader.css`** with responsive breakpoints at 768px and 480px
- **Add font size controls (A-/A+)** — persisted in localStorage, range 14–28px
- **Mobile (≤768px)**:
  - Juan selector expands to full width
  - Navigation buttons fill available space
  - Content padding reduced (32px → 20px)
  - Font controls move to top row
- **Small screen (≤480px)**:
  - Further reduced padding (16px 12px)
  - Slightly tighter line-height (2.0)

### Before / After

| | Desktop | Mobile |
|---|---|---|
| Before | Fixed 18px, inline styles | Same layout, overflows on narrow screens |
| After | Adjustable font size, clean CSS classes | Responsive layout, full-width controls |

### Files changed

- `frontend/src/pages/TextReaderPage.tsx` — refactored to use CSS classes + font size state
- `frontend/src/styles/reader.css` — new responsive stylesheet