### PR TITLE
docs: enhance CONTRIBUTING.md with translation guide and community section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,18 @@ Thank you for your interest in contributing to FoJin! This project aims to make 
 
 ## Ways to Contribute
 
-- **Add a data source** — Know a Buddhist text database we're missing? Open an issue or submit an import script.
-- **Improve search** — Better tokenization, ranking, or multilingual support.
-- **Fix bugs** — Check the [issues](https://github.com/xr843/fojin/issues) page.
-- **Translate** — Help translate the UI or documentation.
+### No coding required
+- **Translate the UI** — Help make FoJin accessible in your language. See [Translation Guide](#translation).
+- **Add a data source** — Know a Buddhist text database we're missing? [Open an issue](https://github.com/xr843/fojin/issues/new?labels=data-source&title=New+data+source:+) with the URL and details.
 - **Documentation** — Improve guides, add examples, fix typos.
+- **Report bugs** — Found something broken? [File a bug report](https://github.com/xr843/fojin/issues/new?labels=bug).
+- **Spread the word** — Star the repo, share it with researchers, write about it.
+
+### Code contributions
+- **Fix bugs** — Check issues labeled [`good first issue`](https://github.com/xr843/fojin/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to get started.
+- **Improve search** — Better tokenization, ranking, or multilingual support.
+- **Frontend improvements** — UI/UX enhancements, accessibility, responsive design.
+- **Backend features** — API endpoints, data pipelines, performance optimization.
 
 ## Getting Started
 
@@ -42,6 +49,31 @@ To add a new Buddhist text data source:
 - Use the GitHub issue templates
 - Include steps to reproduce for bugs
 - For feature requests, describe the use case
+
+## Translation
+
+We welcome translations of both the UI and documentation. Currently supported languages and their status:
+
+| Language | UI | Docs | Status |
+|----------|-----|------|--------|
+| English | ✅ | ✅ | Complete |
+| 中文 (Chinese) | ✅ | ✅ | Complete |
+| 日本語 (Japanese) | ❌ | ❌ | Help wanted |
+| 한국어 (Korean) | ❌ | ❌ | Help wanted |
+| ไทย (Thai) | ❌ | ❌ | Help wanted |
+| Tiếng Việt (Vietnamese) | ❌ | ❌ | Help wanted |
+| සිංහල (Sinhala) | ❌ | ❌ | Help wanted |
+| Myanmar (Burmese) | ❌ | ❌ | Help wanted |
+
+To contribute a translation:
+1. Copy `frontend/src/locales/en.json` to `frontend/src/locales/<lang-code>.json`
+2. Translate the values (keep the keys in English)
+3. Submit a PR
+
+## Community
+
+- **Discord**: [Join our server](https://discord.gg/fojin) (coming soon)
+- **GitHub Discussions**: [Ask questions & share ideas](https://github.com/xr843/fojin/discussions)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Split contributions into "no coding required" and "code contributions" sections for clarity
- Added translation guide with language status table (Japanese, Korean, Thai, Vietnamese, Sinhala, Burmese)
- Added community section with Discord and GitHub Discussions links
- Added direct links to issue templates for bug reports and data source requests

## Related Issues
Supports #20 #21 #22 #23 #24 #25 (translation issues)

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Check all links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)