### PR TITLE
fix: correct region for foyan and texta-studio to 中国大陆

### DIFF
--- a/backend/alembic/versions/0089_fix_foyan_texta_region.py
+++ b/backend/alembic/versions/0089_fix_foyan_texta_region.py
@@ -1,0 +1,36 @@
+"""Fix region for foyan and texta-studio: 台湾 → 中国大陆.
+
+Revision ID: 0089
+Revises: 0088
+Create Date: 2026-03-16
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text as sa_text
+
+revision: str = "0089"
+down_revision: Union[str, None] = "0088"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa_text("""
+            UPDATE data_sources SET region = '中国大陆'
+            WHERE code IN ('foyan', 'texta-studio')
+        """)
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa_text("""
+            UPDATE data_sources SET region = '台湾'
+            WHERE code IN ('foyan', 'texta-studio')
+        """)
+    )


### PR DESCRIPTION
## Summary
- Fix region classification: 台湾 → 中国大陆 for foyan and texta-studio data sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)