### PR TITLE
fix: unify region naming 台湾 → 中国台湾

### DIFF
--- a/backend/alembic/versions/0090_fix_buddhason_region.py
+++ b/backend/alembic/versions/0090_fix_buddhason_region.py
@@ -1,0 +1,30 @@
+"""Fix buddhason region: 台湾 → 中国台湾.
+
+Unify region naming — '台湾' should be '中国台湾' to match existing convention.
+
+Revision ID: 0090
+Revises: 0089
+Create Date: 2026-03-16
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text as sa_text
+
+revision: str = "0090"
+down_revision: Union[str, None] = "0089"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.get_bind().execute(
+        sa_text("UPDATE data_sources SET region = '中国台湾' WHERE region = '台湾'")
+    )
+
+
+def downgrade() -> None:
+    op.get_bind().execute(
+        sa_text("UPDATE data_sources SET region = '台湾' WHERE code = 'buddhason'")
+    )


### PR DESCRIPTION
## Summary
- Rename region '台湾' to '中国台湾' for buddhason data source, matching existing convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)