### PR TITLE
fix: remove broken Discord badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Aggregating the world's Buddhist digital heritage — from the Chinese Tripitaka
 [![Security Scan](https://github.com/xr843/fojin/actions/workflows/security.yml/badge.svg)](https://github.com/xr843/fojin/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/xr843/fojin?style=social)](https://github.com/xr843/fojin)
-[![Discord](https://img.shields.io/discord/1482908181125529732?label=Discord&logo=discord&logoColor=white)](https://discord.gg/76SZeuJekq)
 
 ![FoJin — Global Buddhist Digital Text Platform](./docs/screenshots/hero.png)
 


### PR DESCRIPTION
## Summary
- Remove Discord badge that shows "invalid" due to disabled server widget
- Discord link remains in the header text, only the broken badge is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)