### PR TITLE
refactor: use custom FoJinError consistently across all API endpoints

### DIFF
--- a/backend/app/api/dictionary.py
+++ b/backend/app/api/dictionary.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from opencc import OpenCC
 from sqlalchemy import case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from app.core.exceptions import DictionaryEntryNotFoundError
 from app.database import get_db
 from app.models.dictionary import DictionaryEntry
 
@@ -90,7 +91,7 @@ async def get_entry(entry_id: int, db: AsyncSession = Depends(get_db)):
     )
     entry = result.scalar_one_or_none()
     if not entry:
-        raise HTTPException(status_code=404, detail="词条未找到")
+        raise DictionaryEntryNotFoundError(entry_id=entry_id)
 
     return {
         "id": entry.id,

--- a/backend/app/api/iiif.py
+++ b/backend/app/api/iiif.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.exceptions import ManifestNotFoundError
 from app.database import get_db
 from app.schemas.iiif import IIIFManifestResponse
 from app.services.iiif import get_manifest_by_id, get_manifest_json, get_text_manifests
@@ -18,7 +19,7 @@ async def list_text_manifests(text_id: int, db: AsyncSession = Depends(get_db)):
 async def get_manifest(manifest_id: int, db: AsyncSession = Depends(get_db)):
     manifest = await get_manifest_by_id(db, manifest_id)
     if not manifest:
-        raise HTTPException(status_code=404, detail="Manifest 未找到")
+        raise ManifestNotFoundError()
     return manifest
 
 
@@ -28,5 +29,5 @@ async def proxy_manifest(manifest_id: int, request: Request, db: AsyncSession = 
     redis_client = getattr(request.app.state, "redis", None)
     data = await get_manifest_json(db, manifest_id, redis_client)
     if not data:
-        raise HTTPException(status_code=404, detail="Manifest 数据获取失败")
+        raise ManifestNotFoundError("Manifest 数据获取失败")
     return data

--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.exceptions import KGEntityNotFoundError
 from app.database import get_db
 from app.schemas.knowledge_graph import (
     KGEntityDetailResponse,
@@ -41,7 +42,7 @@ async def search_kg_entities(
 async def get_kg_entity(entity_id: int, db: AsyncSession = Depends(get_db)):
     entity = await get_entity(db, entity_id)
     if not entity:
-        raise HTTPException(status_code=404, detail="实体未找到")
+        raise KGEntityNotFoundError(entity_id=entity_id)
     relations = await get_entity_relations(db, entity_id)
     return KGEntityDetailResponse(
         **KGEntityResponse.model_validate(entity).model_dump(),
@@ -59,7 +60,7 @@ async def get_kg_entity_graph(
 ):
     entity = await get_entity(db, entity_id)
     if not entity:
-        raise HTTPException(status_code=404, detail="实体未找到")
+        raise KGEntityNotFoundError(entity_id=entity_id)
     pred_list = [p.strip() for p in predicates.split(",") if p.strip()] if predicates else None
     graph = await get_entity_graph(db, entity_id, depth, max_nodes=max_nodes, predicates=pred_list)
     return graph

--- a/backend/app/api/relations.py
+++ b/backend/app/api/relations.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.exceptions import NotFoundError, TextNotFoundError
 from app.database import get_db
 from app.schemas.relation import ParallelReadResponse, RelatedTextInfo, TextRelationsResponse
 from app.services.relation import get_parallel_content, get_text_relations
@@ -17,7 +18,7 @@ async def list_text_relations(
 ):
     text = await get_text_by_id(db, text_id)
     if not text:
-        raise HTTPException(status_code=404, detail="经典未找到")
+        raise TextNotFoundError(text_id=text_id)
 
     relations = await get_text_relations(db, text_id)
     if relation_type:
@@ -38,5 +39,5 @@ async def parallel_read(
 ):
     result = await get_parallel_content(db, text_id, compare, juan)
     if not result:
-        raise HTTPException(status_code=404, detail="对照内容未找到")
+        raise NotFoundError("对照内容未找到")
     return result

--- a/backend/app/api/source_suggestions.py
+++ b/backend/app/api/source_suggestions.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.exceptions import SuggestionNotFoundError
 from app.core.role_guard import require_role
 from app.database import get_db
 from app.models.source import SourceSuggestion
@@ -104,7 +105,7 @@ async def delete_source_suggestion(
     )
     suggestion = result.scalar_one_or_none()
     if not suggestion:
-        raise HTTPException(status_code=404, detail="推荐记录不存在")
+        raise SuggestionNotFoundError()
     await db.delete(suggestion)
     await db.commit()
 
@@ -121,7 +122,7 @@ async def update_suggestion_status(
     )
     suggestion = result.scalar_one_or_none()
     if not suggestion:
-        raise HTTPException(status_code=404, detail="推荐记录不存在")
+        raise SuggestionNotFoundError()
     suggestion.status = payload.status
     await db.commit()
     await db.refresh(suggestion)

--- a/backend/app/api/sources.py
+++ b/backend/app/api/sources.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.exceptions import SourceNotFoundError
 from app.database import get_db
 from app.models.source import DataSource, TextIdentifier
 from app.models.text import BuddhistText, TextContent
@@ -137,7 +138,7 @@ async def list_primary_ingest_distributions(db: AsyncSession = Depends(get_db)):
 async def list_source_distributions(code: str, db: AsyncSession = Depends(get_db)):
     source = await get_source_by_code(db, code)
     if not source:
-        raise HTTPException(status_code=404, detail="数据源未找到")
+        raise SourceNotFoundError(code)
     return await get_source_distributions(db, code)
 
 
@@ -145,5 +146,5 @@ async def list_source_distributions(code: str, db: AsyncSession = Depends(get_db
 async def get_source(code: str, db: AsyncSession = Depends(get_db)):
     source = await get_source_by_code(db, code)
     if not source:
-        raise HTTPException(status_code=404, detail="数据源未找到")
+        raise SourceNotFoundError(code)
     return source

--- a/backend/app/api/texts.py
+++ b/backend/app/api/texts.py
@@ -1,9 +1,10 @@
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_optional_user
+from app.core.exceptions import TextNotFoundError
 from app.database import get_db
 from app.models.user import ReadingHistory, User
 from app.schemas.text import JuanContentResponse, JuanListResponse, TextResponseBase
@@ -18,7 +19,7 @@ async def get_text(text_id: int, db: AsyncSession = Depends(get_db)):
     """获取经典详情。"""
     text = await get_text_by_id(db, text_id)
     if not text:
-        raise HTTPException(status_code=404, detail="经典未找到")
+        raise TextNotFoundError(text_id=text_id)
     return text
 
 
@@ -27,7 +28,7 @@ async def list_juans(text_id: int, db: AsyncSession = Depends(get_db)):
     """获取经典的卷列表。"""
     result = await get_juan_list(db, text_id)
     if result is None:
-        raise HTTPException(status_code=404, detail="经典未找到")
+        raise TextNotFoundError(text_id=text_id)
     return result
 
 
@@ -41,7 +42,7 @@ async def read_juan(
     """获取经典某一卷的内容。登录用户自动记录阅读历史。"""
     result = await get_juan_content(db, text_id, juan_num)
     if result is None:
-        raise HTTPException(status_code=404, detail="卷内容未找到")
+        raise TextNotFoundError(text_id=text_id)
 
     # Record reading history for logged-in users
     if user is not None:

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -47,6 +47,34 @@ class SourceNotFoundError(NotFoundError):
         self.code = code
 
 
+class DictionaryEntryNotFoundError(NotFoundError):
+    """A dictionary entry was not found."""
+
+    def __init__(self, *, entry_id: int):
+        super().__init__(f"词条未找到: {entry_id}")
+        self.entry_id = entry_id
+
+
+class KGEntityNotFoundError(NotFoundError):
+    """A knowledge-graph entity was not found."""
+
+    def __init__(self, *, entity_id: int):
+        super().__init__(f"实体未找到: {entity_id}")
+        self.entity_id = entity_id
+
+
+class ManifestNotFoundError(NotFoundError):
+    """An IIIF manifest was not found."""
+
+    message = "Manifest 未找到"
+
+
+class SuggestionNotFoundError(NotFoundError):
+    """A source suggestion was not found."""
+
+    message = "推荐记录不存在"
+
+
 # ---- Service errors ----
 
 class ServiceError(FoJinError):
@@ -107,6 +135,10 @@ STATUS_MAP: dict[type, int] = {
     NotFoundError: status.HTTP_404_NOT_FOUND,
     TextNotFoundError: status.HTTP_404_NOT_FOUND,
     SourceNotFoundError: status.HTTP_404_NOT_FOUND,
+    DictionaryEntryNotFoundError: status.HTTP_404_NOT_FOUND,
+    KGEntityNotFoundError: status.HTTP_404_NOT_FOUND,
+    ManifestNotFoundError: status.HTTP_404_NOT_FOUND,
+    SuggestionNotFoundError: status.HTTP_404_NOT_FOUND,
     AuthError: status.HTTP_401_UNAUTHORIZED,
     InvalidCredentialsError: status.HTTP_401_UNAUTHORIZED,
     TokenExpiredError: status.HTTP_401_UNAUTHORIZED,

--- a/backend/tests/test_exceptions.py
+++ b/backend/tests/test_exceptions.py
@@ -5,11 +5,15 @@ from fastapi import status
 from app.core.exceptions import (
     AuthError,
     DianjinServiceError,
+    DictionaryEntryNotFoundError,
     FoJinError,
     InvalidCredentialsError,
+    KGEntityNotFoundError,
+    ManifestNotFoundError,
     NotFoundError,
     SearchServiceError,
     SourceNotFoundError,
+    SuggestionNotFoundError,
     TextNotFoundError,
     TokenExpiredError,
     ValidationError,
@@ -41,11 +45,33 @@ class TestExceptionHierarchy:
         err = SourceNotFoundError("cbeta")
         assert "cbeta" in err.message
 
+    def test_dictionary_entry_not_found(self):
+        err = DictionaryEntryNotFoundError(entry_id=99)
+        assert "99" in err.message
+        assert err.entry_id == 99
+
+    def test_kg_entity_not_found(self):
+        err = KGEntityNotFoundError(entity_id=7)
+        assert "7" in err.message
+        assert err.entity_id == 7
+
+    def test_manifest_not_found(self):
+        err = ManifestNotFoundError()
+        assert "Manifest" in err.message
+
+    def test_suggestion_not_found(self):
+        err = SuggestionNotFoundError()
+        assert err.message == "推荐记录不存在"
+
     def test_inheritance(self):
         assert isinstance(TextNotFoundError(text_id=1), NotFoundError)
         assert isinstance(TextNotFoundError(text_id=1), FoJinError)
         assert isinstance(SearchServiceError(), FoJinError)
         assert isinstance(InvalidCredentialsError(), AuthError)
+        assert isinstance(DictionaryEntryNotFoundError(entry_id=1), NotFoundError)
+        assert isinstance(KGEntityNotFoundError(entity_id=1), NotFoundError)
+        assert isinstance(ManifestNotFoundError(), NotFoundError)
+        assert isinstance(SuggestionNotFoundError(), NotFoundError)
 
 
 class TestErrorToHTTP:
@@ -76,6 +102,22 @@ class TestErrorToHTTP:
     def test_base_error_maps_to_500(self):
         http = fojin_error_to_http(FoJinError("unexpected"))
         assert http.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    def test_dictionary_entry_maps_to_404(self):
+        http = fojin_error_to_http(DictionaryEntryNotFoundError(entry_id=1))
+        assert http.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_kg_entity_maps_to_404(self):
+        http = fojin_error_to_http(KGEntityNotFoundError(entity_id=1))
+        assert http.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_manifest_maps_to_404(self):
+        http = fojin_error_to_http(ManifestNotFoundError())
+        assert http.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_suggestion_maps_to_404(self):
+        http = fojin_error_to_http(SuggestionNotFoundError())
+        assert http.status_code == status.HTTP_404_NOT_FOUND
 
     def test_detail_preserved(self):
         http = fojin_error_to_http(TextNotFoundError(cbeta_id="T0001"))


### PR DESCRIPTION
## Summary
- Replace all 14 raw `raise HTTPException(status_code=404)` with typed `FoJinError` subclasses across 7 API modules
- Add 4 new exception types: `DictionaryEntryNotFoundError`, `KGEntityNotFoundError`, `ManifestNotFoundError`, `SuggestionNotFoundError`
- Extend `STATUS_MAP` and test coverage (22 → 30 test cases)

## Why
The project already has a well-designed custom exception hierarchy (`FoJinError` → `NotFoundError` etc.) with a global exception handler in `main.py`, but 7 API modules still used raw `HTTPException`. This inconsistency meant:
- Error responses bypassed the centralized error mapping
- No type-safe error identifiers (e.g., `text_id`, `entity_id`) in exceptions
- Harder to maintain uniform error format across the API

## Test plan
- [x] `pytest tests/test_exceptions.py` — 30/30 passed
- [ ] CI backend smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)