### PR TITLE
ci: split type-check from build, tighten ESLint threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npx eslint src/ --max-warnings 100
+      - name: Lint (ESLint)
+        run: npx eslint src/ --max-warnings 50
 
-      - name: Type check & build
-        run: npm run build
+      - name: Type check
+        run: npx tsc -b --noEmit
+
+      - name: Build (Vite)
+        run: npx vite build


### PR DESCRIPTION
## Summary
- Separate TypeScript type-check (`tsc -b --noEmit`) from Vite build into distinct CI steps
- Reduce ESLint `--max-warnings` from 100 → 50 (current warning count: 49)

## Why
- **Clearer failure diagnostics**: When CI fails, you immediately see whether it's a type error or a build error, without scanning through combined output
- **Prevent warning debt**: The project currently has 49 ESLint warnings. The old threshold of 100 allowed adding 51 more warnings silently. The new threshold of 50 locks in the current level and prevents regression.

## Test plan
- [ ] CI frontend job passes with separated type-check and build steps
- [ ] ESLint step passes with `--max-warnings 50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)