### PR TITLE
docs: add missing env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,9 +33,15 @@ LLM_API_URL=https://api.deepseek.com/v1
 EMBEDDING_API_KEY=sk-your-embedding-api-key
 EMBEDDING_API_URL=https://api.siliconflow.cn/v1
 
+# 典津 API（古籍跨平台检索，可选）
+DIANJIN_API_KEY=
+DIANJIN_API_URL=https://guji.cckb.cn/api
+
 # Apify (爬虫)
 APIFY_TOKEN=apify_api_your-token-here
 
+# CORS（多个用逗号分隔，Docker 默认已含 localhost 端口）
+# CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # Dify AI 助手 (前端)
 VITE_DIFY_APP_TOKEN=your-dify-token


### PR DESCRIPTION
## Summary
- Add `DIANJIN_API_KEY` and `DIANJIN_API_URL` (典津古籍API) to `.env.example`
- Add commented `CORS_ORIGINS` example for local development

## Why
These variables are used in `backend/app/config.py` and `docker-compose.yml` respectively, but were not documented in `.env.example`. New contributors cloning the project wouldn't know these options exist.

## Test plan
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)