### PR TITLE
infra: add HSTS header and backend Docker healthcheck

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,6 +87,8 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
         return response
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,12 @@ services:
     volumes:
       - ./backend:/app
       - ./data:/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
     depends_on:
       postgres:
         condition: service_healthy
@@ -100,6 +106,9 @@ services:
         condition: service_healthy
 
   frontend:
+    depends_on:
+      backend:
+        condition: service_healthy
     build:
       context: ./frontend
       dockerfile: Dockerfile
@@ -110,8 +119,6 @@ services:
     cpus: 0.25
     ports:
       - "${FRONTEND_PORT:-3000}:80"
-    depends_on:
-      - backend
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- Add `Strict-Transport-Security` and `X-Permitted-Cross-Domain-Policies` security headers
- Add Docker healthcheck to backend container via `/api/health` endpoint
- Frontend now waits for backend healthy status before starting

## Why
- **HSTS**: Forces browsers to use HTTPS, preventing downgrade attacks. fojin.app is behind Cloudflare with HTTPS, so this header is safe to add.
- **Backend healthcheck**: postgres, elasticsearch, and redis all had healthchecks, but backend did not. This caused the frontend to start before backend was ready, potentially serving errors on first load.

## Test plan
- [ ] CI passes
- [ ] `docker compose up -d` starts correctly with healthcheck
- [ ] Response headers include `Strict-Transport-Security`

🤖 Generated with [Claude Code](https://claude.com/claude-code)