### PR TITLE
feat: make rate limits configurable via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,11 @@ DIANJIN_API_URL=https://guji.cckb.cn/api
 # Apify (爬虫)
 APIFY_TOKEN=apify_api_your-token-here
 
+# Rate limiting (requests per minute, optional)
+# RATE_LIMIT_DEFAULT=200
+# RATE_LIMIT_LOGIN=10
+# RATE_LIMIT_REGISTER=5
+
 # CORS（多个用逗号分隔，Docker 默认已含 localhost 端口）
 # CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,6 +43,11 @@ class Settings(BaseSettings):
     dianjin_api_key: str = ""
     dianjin_api_url: str = "https://guji.cckb.cn/api"
 
+    # Rate limiting (requests per minute)
+    rate_limit_default: int = 200
+    rate_limit_login: int = 10
+    rate_limit_register: int = 5
+
     @property
     def database_url(self) -> str:
         return (

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -6,12 +6,14 @@ import time
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from app.config import settings
+
 logger = logging.getLogger(__name__)
 
 # Stricter rate limits for sensitive auth endpoints (requests per minute)
 STRICT_PATHS: dict[str, int] = {
-    "/api/auth/login": 10,
-    "/api/auth/register": 5,
+    "/api/auth/login": settings.rate_limit_login,
+    "/api/auth/register": settings.rate_limit_register,
 }
 
 
@@ -37,7 +39,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         # Determine rate limit for this path
         strict_limit = STRICT_PATHS.get(path)
-        rate_limit = strict_limit if strict_limit is not None else 200
+        rate_limit = strict_limit if strict_limit is not None else settings.rate_limit_default
 
         # Use path-specific key for strict paths to avoid sharing budget
         if strict_limit is not None:


### PR DESCRIPTION
## Summary
- Move hardcoded rate limits from `rate_limit.py` to `Settings` (pydantic-settings)
- New env vars: `RATE_LIMIT_DEFAULT` (200), `RATE_LIMIT_LOGIN` (10), `RATE_LIMIT_REGISTER` (5)
- Document in `.env.example`

## Why
Different environments need different rate limits — production may need stricter limits than development. Previously required code changes to adjust.

## Test plan
- [ ] CI passes
- [ ] Default behavior unchanged (same limits when env vars not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)