### PR TITLE
infra: Debian-based Nginx + Docker DNS re-resolution

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,11 +10,11 @@ RUN npm run build
 RUN find dist -type f \( -name '*.js' -o -name '*.css' -o -name '*.html' -o -name '*.svg' -o -name '*.json' \) \
     -exec gzip -9 -k {} \;
 
-FROM nginx:alpine
+FROM nginx:bookworm-slim
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Run as non-root nginx user (nginx:alpine provides this user)
+# Run as non-root nginx user
 RUN chown -R nginx:nginx /usr/share/nginx/html && \
     chown -R nginx:nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx && \

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -41,8 +41,12 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # Use Docker DNS resolver so backend can be re-resolved after restarts
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_backend http://backend:8000;
+
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass $upstream_backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -51,15 +55,15 @@ server {
 
     # OpenAPI docs (Swagger UI + ReDoc)
     location /docs {
-        proxy_pass http://backend:8000/docs;
+        proxy_pass $upstream_backend/docs;
         proxy_set_header Host $host;
     }
     location /redoc {
-        proxy_pass http://backend:8000/redoc;
+        proxy_pass $upstream_backend/redoc;
         proxy_set_header Host $host;
     }
     location /openapi.json {
-        proxy_pass http://backend:8000/openapi.json;
+        proxy_pass $upstream_backend/openapi.json;
         proxy_set_header Host $host;
     }
 


### PR DESCRIPTION
## Summary
- Switch frontend runtime from `nginx:alpine` to `nginx:bookworm-slim`
- Add `resolver 127.0.0.11 valid=30s` for Docker internal DNS
- Use variable upstream (`$upstream_backend`) so backend IP re-resolves after container restarts

Closes #17

## Test plan
- [ ] Build frontend Docker image and verify it starts correctly
- [ ] Restart backend container and confirm frontend still proxies correctly
- [ ] Verify gzip_static and all existing nginx features work

🤖 Generated with [Claude Code](https://claude.com/claude-code)