### PR TITLE
feat: improve mobile responsiveness of reading view

### DIFF
--- a/frontend/src/pages/ParallelReaderPage.tsx
+++ b/frontend/src/pages/ParallelReaderPage.tsx
@@ -4,6 +4,7 @@ import { Typography, Spin, Row, Col, Card, Select, InputNumber, Space, Empty, Bu
 import { SwapOutlined, ArrowLeftOutlined } from "@ant-design/icons";
 import { useNavigate } from "react-router-dom";
 import { getParallelRead, getTextRelations } from "../api/client";
+import "../styles/parallel.css";
 
 const { Title, Paragraph } = Typography;
 
@@ -37,21 +38,20 @@ export default function ParallelReaderPage() {
   };
 
   return (
-    <div style={{ maxWidth: 1400, margin: "24px auto", padding: "0 16px" }}>
-      <Space style={{ marginBottom: 16 }}>
+    <div className="parallel-container">
+      <div className="parallel-header">
         <Button type="text" icon={<ArrowLeftOutlined />} onClick={() => navigate(-1)}>
           返回
         </Button>
         <Title level={3} style={{ margin: 0 }}>
           <SwapOutlined /> 平行对照阅读
         </Title>
-      </Space>
+      </div>
 
-      <Card size="small" style={{ marginBottom: 16 }}>
+      <Card size="small" style={{ marginBottom: 16 }} className="parallel-controls">
         <Space wrap>
           <span>对照版本：</span>
           <Select
-            style={{ width: 400 }}
             placeholder="选择对照文本"
             value={compareId ? Number(compareId) : undefined}
             onChange={handleCompareChange}
@@ -83,7 +83,7 @@ export default function ParallelReaderPage() {
       ) : !parallel ? (
         <Empty description="对照内容未找到" />
       ) : (
-        <Row gutter={16}>
+        <Row gutter={[16, 12]} className="parallel-columns">
           <Col xs={24} md={12}>
             <Card
               title={
@@ -98,16 +98,10 @@ export default function ParallelReaderPage() {
               }
               size="small"
             >
-              <div
-                style={{
-                  maxHeight: "70vh",
-                  overflow: "auto",
-                  lineHeight: 2,
-                  fontSize: 16,
-                  whiteSpace: "pre-wrap",
-                }}
-              >
-                {parallel.text_a.content || <Paragraph type="secondary">暂无内容</Paragraph>}
+              <div className="parallel-reader-col">
+                <div className="reader-content">
+                  {parallel.text_a.content || <Paragraph type="secondary">暂无内容</Paragraph>}
+                </div>
               </div>
             </Card>
           </Col>
@@ -125,16 +119,10 @@ export default function ParallelReaderPage() {
               }
               size="small"
             >
-              <div
-                style={{
-                  maxHeight: "70vh",
-                  overflow: "auto",
-                  lineHeight: 2,
-                  fontSize: 16,
-                  whiteSpace: "pre-wrap",
-                }}
-              >
-                {parallel.text_b.content || <Paragraph type="secondary">暂无内容</Paragraph>}
+              <div className="parallel-reader-col">
+                <div className="reader-content">
+                  {parallel.text_b.content || <Paragraph type="secondary">暂无内容</Paragraph>}
+                </div>
               </div>
             </Card>
           </Col>

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -93,7 +93,7 @@ export default function TextDetailPage() {
   }
 
   return (
-    <div style={{ maxWidth: 800, margin: "24px auto" }}>
+    <div className="text-detail-page">
       <Helmet>
         <title>{text.title_zh} — 佛津</title>
         <meta name="description" content={`${text.title_zh}${text.translator ? ` · ${text.translator}` : ""}${text.category ? ` · ${text.category}` : ""} — 佛津佛教古籍资源`} />

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -138,6 +138,58 @@ em {
   overflow-y: auto;
 }
 
+/* ========== Layout Content Mobile ========== */
+@media (max-width: 768px) {
+  .ant-layout-content {
+    padding: 12px 10px !important;
+  }
+}
+
+/* ========== Text Detail Page Mobile ========== */
+.text-detail-page {
+  max-width: 800px;
+  margin: 24px auto;
+}
+
+@media (max-width: 768px) {
+  .text-detail-page {
+    margin: 8px auto;
+  }
+
+  .text-detail-page .ant-card {
+    border-radius: 6px;
+  }
+
+  .text-detail-page .ant-descriptions {
+    font-size: 13px;
+  }
+
+  .text-detail-page .ant-space {
+    gap: 8px !important;
+  }
+
+  .text-detail-page .ant-btn-lg {
+    height: 36px;
+    font-size: 14px;
+    padding: 4px 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .text-detail-page {
+    margin: 4px auto;
+  }
+
+  .text-detail-page .ant-descriptions-item-label {
+    width: 70px !important;
+    padding: 6px 8px !important;
+  }
+
+  .text-detail-page .ant-descriptions-item-content {
+    padding: 6px 8px !important;
+  }
+}
+
 /* ========== Reduced Motion ========== */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/frontend/src/styles/parallel.css
+++ b/frontend/src/styles/parallel.css
@@ -1,3 +1,26 @@
+/* ── ParallelReaderPage responsive styles ── */
+
+.parallel-container {
+  max-width: 1400px;
+  margin: 24px auto;
+  padding: 0 16px;
+}
+
+.parallel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.parallel-header h3 {
+  margin: 0 !important;
+}
+
+.parallel-controls .ant-select {
+  width: 400px;
+}
+
 .parallel-reader-col {
   height: 70vh;
   overflow-y: auto;
@@ -19,9 +42,92 @@
   border-radius: 3px;
 }
 
+/* ── Tablet (max-width: 1024px) ── */
+@media (max-width: 1024px) {
+  .parallel-container {
+    margin: 16px auto;
+    padding: 0 12px;
+  }
+
+  .parallel-controls .ant-select {
+    width: 300px;
+  }
+
+  .parallel-reader-col {
+    height: 60vh;
+  }
+
+  .parallel-reader-col .reader-content {
+    font-size: 15px;
+    padding: 12px;
+  }
+}
+
+/* ── Mobile (max-width: 768px) ── */
 @media (max-width: 768px) {
+  .parallel-container {
+    margin: 12px auto;
+    padding: 0 8px;
+  }
+
+  .parallel-header {
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 12px;
+  }
+
+  .parallel-header h3 {
+    font-size: 18px !important;
+  }
+
+  .parallel-controls {
+    width: 100%;
+  }
+
+  .parallel-controls .ant-space {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .parallel-controls .ant-select {
+    width: 100% !important;
+    min-width: 0;
+  }
+
   .parallel-reader-col {
     height: auto;
     max-height: 50vh;
+  }
+
+  .parallel-reader-col .reader-content {
+    font-size: 15px;
+    line-height: 1.9;
+    padding: 12px 10px;
+  }
+
+  /* Add vertical spacing between stacked cards on mobile */
+  .parallel-columns .ant-col {
+    margin-bottom: 12px;
+  }
+
+  .parallel-columns .ant-col:last-child {
+    margin-bottom: 0;
+  }
+}
+
+/* ── Small phone (max-width: 480px) ── */
+@media (max-width: 480px) {
+  .parallel-container {
+    padding: 0 6px;
+  }
+
+  .parallel-reader-col {
+    max-height: 40vh;
+  }
+
+  .parallel-reader-col .reader-content {
+    font-size: 14px;
+    line-height: 1.8;
+    padding: 10px 8px;
   }
 }

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -58,11 +58,32 @@
   margin-bottom: 48px;
 }
 
-/* ── Mobile ── */
+/* ── Tablet (max-width: 1024px) ── */
+@media (max-width: 1024px) {
+  .reader-container {
+    margin: 20px auto;
+    padding: 0 14px;
+  }
+
+  .reader-body {
+    padding: 28px 20px;
+  }
+}
+
+/* ── Mobile (max-width: 768px) ── */
 @media (max-width: 768px) {
   .reader-container {
-    margin: 16px auto;
-    padding: 0 12px;
+    margin: 12px auto;
+    padding: 0 10px;
+  }
+
+  .reader-header {
+    margin-bottom: 16px;
+  }
+
+  .reader-header h3 {
+    font-size: 18px !important;
+    margin-bottom: 6px;
   }
 
   .reader-nav {
@@ -93,8 +114,15 @@
   }
 
   .reader-body {
-    padding: 20px 16px;
+    padding: 20px 14px;
     border-radius: 6px;
+    line-height: 2.0;
+  }
+
+  .reader-bottom-nav {
+    margin-top: 16px;
+    margin-bottom: 32px;
+    gap: 8px;
   }
 
   .reader-bottom-nav .ant-btn {
@@ -102,9 +130,20 @@
   }
 }
 
+/* ── Small phone (max-width: 480px) ── */
 @media (max-width: 480px) {
+  .reader-container {
+    padding: 0 8px;
+  }
+
   .reader-body {
-    padding: 16px 12px;
-    line-height: 2.0;
+    padding: 14px 10px;
+    line-height: 1.9;
+    font-size: var(--reader-font-size, 16px);
+    border-radius: 4px;
+  }
+
+  .reader-bottom-nav {
+    margin-bottom: 24px;
   }
 }


### PR DESCRIPTION
## Summary
- Add responsive breakpoints at 1024px (tablet), 768px (mobile), 480px (small phone)
- Stack parallel reading columns vertically on phones with independent scroll
- Reduce padding, font sizes, and margins for small screens
- Replace inline styles with CSS classes for responsive control

Closes #28

## Test plan
- [ ] Test reading view at 375px, 768px, and 1024px widths
- [ ] Verify parallel reader stacks columns on phone, side-by-side on tablet+
- [ ] Confirm desktop layout is unchanged
- [ ] Check text detail page spacing on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)