### PR TITLE
feat: add citation export (BibTeX, RIS, APA)

### DIFF
--- a/frontend/src/components/CitationGenerator.tsx
+++ b/frontend/src/components/CitationGenerator.tsx
@@ -1,70 +1,101 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Select, Typography, Button, Space, message, Modal } from "antd";
-import { CopyOutlined, BookOutlined } from "@ant-design/icons";
-import api from "../api/client";
+import { Typography, Button, Space, message, Modal, Segmented } from "antd";
+import { CopyOutlined, DownloadOutlined, BookOutlined } from "@ant-design/icons";
+import { getTextDetail, type TextDetail } from "../api/client";
+import {
+  generateCitation,
+  downloadCitation,
+  type CitationFormat,
+  type CitationMeta,
+} from "../utils/citationFormats";
 
 const { Paragraph, Text } = Typography;
 
-interface CitationResponse {
-  text_id: number;
-  title: string;
-  style: string;
-  citation: string;
-}
-
 interface CitationGeneratorProps {
+  /** Text ID to generate citations for. */
   textId: number;
+  /** If textData is already available (e.g. from parent), skip the fetch. */
+  textData?: TextDetail | null;
   open: boolean;
   onClose: () => void;
 }
 
-const styleOptions = [
-  { value: "chicago", label: "Chicago" },
+const FORMAT_OPTIONS: { value: CitationFormat; label: string }[] = [
+  { value: "bibtex", label: "BibTeX" },
+  { value: "ris", label: "RIS" },
   { value: "apa", label: "APA" },
-  { value: "mla", label: "MLA" },
-  { value: "harvard", label: "Harvard" },
 ];
 
-export default function CitationGenerator({ textId, open, onClose }: CitationGeneratorProps) {
-  const [style, setStyle] = useState("chicago");
+function buildMeta(t: TextDetail): CitationMeta {
+  return {
+    id: t.id,
+    cbetaId: t.cbeta_id,
+    titleZh: t.title_zh,
+    titleEn: null,
+    translator: t.translator,
+    dynasty: t.dynasty,
+    category: t.category,
+  };
+}
 
-  const { data: citation } = useQuery<CitationResponse>({
-    queryKey: ["citation", textId, style],
-    queryFn: async () =>
-      (await api.get(`/citations/text/${textId}`, { params: { style } })).data,
-    enabled: open && !!textId,
+export default function CitationGenerator({
+  textId,
+  textData,
+  open,
+  onClose,
+}: CitationGeneratorProps) {
+  const [format, setFormat] = useState<CitationFormat>("bibtex");
+
+  // Only fetch if the parent didn't pass textData
+  const { data: fetched } = useQuery({
+    queryKey: ["text", textId],
+    queryFn: () => getTextDetail(textId),
+    enabled: open && !!textId && !textData,
   });
 
-  const handleCopy = () => {
-    if (citation) {
-      navigator.clipboard.writeText(citation.citation);
+  const text = textData ?? fetched;
+  const meta = text ? buildMeta(text) : null;
+  const citation = meta ? generateCitation(format, meta) : "";
+
+  const handleCopy = async () => {
+    if (!citation) return;
+    try {
+      await navigator.clipboard.writeText(citation);
       message.success("引用已复制到剪贴板");
+    } catch {
+      message.error("复制失败，请手动选择文本复制");
     }
+  };
+
+  const handleDownload = () => {
+    if (!meta) return;
+    downloadCitation(format, meta);
+    message.success("文件已下载");
   };
 
   return (
     <Modal
       title={
         <Space>
-          <BookOutlined /> 生成引用格式
+          <BookOutlined /> 导出引用
         </Space>
       }
       open={open}
       onCancel={onClose}
       footer={null}
-      width={500}
+      width={560}
     >
-      <Space direction="vertical" style={{ width: "100%" }}>
-        <Space>
-          <Text>引用风格:</Text>
-          <Select
-            value={style}
-            onChange={setStyle}
-            options={styleOptions}
-            style={{ width: 150 }}
+      <Space direction="vertical" style={{ width: "100%" }} size="middle">
+        <div>
+          <Text style={{ marginRight: 8 }}>引用格式:</Text>
+          <Segmented
+            value={format}
+            onChange={(v) => setFormat(v as CitationFormat)}
+            options={FORMAT_OPTIONS}
           />
-        </Space>
+        </div>
+
         {citation && (
           <div
             style={{
@@ -72,16 +103,42 @@ export default function CitationGenerator({ textId, open, onClose }: CitationGen
               padding: 16,
               borderRadius: 8,
               border: "1px solid #f0f0f0",
+              maxHeight: 240,
+              overflow: "auto",
             }}
           >
-            <Paragraph style={{ margin: 0, whiteSpace: "pre-wrap" }}>
-              {citation.citation}
+            <Paragraph
+              style={{
+                margin: 0,
+                whiteSpace: "pre-wrap",
+                fontFamily:
+                  format === "apa"
+                    ? "inherit"
+                    : "'Fira Code', 'Cascadia Code', monospace",
+                fontSize: format === "apa" ? 14 : 13,
+              }}
+            >
+              {citation}
             </Paragraph>
           </div>
         )}
-        <Button icon={<CopyOutlined />} onClick={handleCopy} disabled={!citation}>
-          复制引用
-        </Button>
+
+        <Space>
+          <Button
+            icon={<CopyOutlined />}
+            onClick={handleCopy}
+            disabled={!citation}
+          >
+            复制
+          </Button>
+          <Button
+            icon={<DownloadOutlined />}
+            onClick={handleDownload}
+            disabled={!meta}
+          >
+            下载文件
+          </Button>
+        </Space>
       </Space>
     </Modal>
   );

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -194,24 +194,17 @@ export default function TextDetailPage() {
               手稿影像 ({manifests.length})
             </Button>
           )}
-          {/* TODO: 引用格式生成器和笔记功能待后端完善后启用
           <Button
             icon={<BookOutlined />}
             onClick={() => setCitationOpen(true)}
           >
-            引用
+            导出引用
           </Button>
-          <Button
-            icon={<FileTextOutlined />}
-            onClick={() => navigate("/notes")}
-          >
-            笔记
-          </Button>
-          */}
         </Space>
 
         <CitationGenerator
           textId={text.id}
+          textData={text}
           open={citationOpen}
           onClose={() => setCitationOpen(false)}
         />

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -8,8 +8,10 @@ import {
   LeftOutlined,
   RightOutlined,
   FontSizeOutlined,
+  BookOutlined,
 } from "@ant-design/icons";
-import { getJuanList, getJuanContent } from "../api/client";
+import { getJuanList, getJuanContent, getTextDetail } from "../api/client";
+import CitationGenerator from "../components/CitationGenerator";
 import "../styles/reader.css";
 
 const FONT_SIZE_MIN = 14;
@@ -31,6 +33,7 @@ export default function TextReaderPage() {
   const textId = Number(id);
   const [juanNum, setJuanNum] = useState(1);
   const [fontSize, setFontSize] = useState(getInitialFontSize);
+  const [citationOpen, setCitationOpen] = useState(false);
 
   const { data: juanList } = useQuery({
     queryKey: ["juanList", textId],
@@ -41,6 +44,12 @@ export default function TextReaderPage() {
   const { data: content, isLoading } = useQuery({
     queryKey: ["juanContent", textId, juanNum],
     queryFn: () => getJuanContent(textId, juanNum),
+    enabled: !!textId,
+  });
+
+  const { data: textDetail } = useQuery({
+    queryKey: ["text", textId],
+    queryFn: () => getTextDetail(textId),
     enabled: !!textId,
   });
 
@@ -124,6 +133,13 @@ export default function TextReaderPage() {
               下一卷 <RightOutlined />
             </Button>
           </div>
+          <Button
+            size="small"
+            icon={<BookOutlined />}
+            onClick={() => setCitationOpen(true)}
+          >
+            引用
+          </Button>
           <div className="reader-font-controls">
             <Button
               size="small"
@@ -183,6 +199,13 @@ export default function TextReaderPage() {
           </Button>
         </div>
       )}
+
+      <CitationGenerator
+        textId={textId}
+        textData={textDetail}
+        open={citationOpen}
+        onClose={() => setCitationOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/utils/citationFormats.ts
+++ b/frontend/src/utils/citationFormats.ts
@@ -1,0 +1,155 @@
+/**
+ * Citation format generators for Buddhist texts.
+ *
+ * Generates BibTeX, RIS, and APA citation strings from text metadata.
+ * Pure frontend — no backend API needed.
+ */
+
+export interface CitationMeta {
+  id: number;
+  cbetaId: string;
+  titleZh: string;
+  titleEn?: string | null;
+  translator?: string | null;
+  dynasty?: string | null;
+  category?: string | null;
+  url?: string;
+}
+
+/** Sanitise a string for use as a BibTeX key (ASCII only, no spaces). */
+function bibKey(meta: CitationMeta): string {
+  return meta.cbetaId.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+/** Build the canonical FoJin URL for a text. */
+function canonicalUrl(meta: CitationMeta): string {
+  return meta.url ?? `https://fojin.app/texts/${meta.id}`;
+}
+
+/** Format author field — uses translator if available, otherwise "CBETA". */
+function authorField(meta: CitationMeta): string {
+  if (meta.translator) {
+    return meta.dynasty ? `${meta.translator} (${meta.dynasty})` : meta.translator;
+  }
+  return "CBETA";
+}
+
+// ---------------------------------------------------------------------------
+// BibTeX
+// ---------------------------------------------------------------------------
+
+export function toBibTeX(meta: CitationMeta): string {
+  const key = bibKey(meta);
+  const author = authorField(meta);
+  const title = meta.titleEn
+    ? `${meta.titleZh} (${meta.titleEn})`
+    : meta.titleZh;
+  const url = canonicalUrl(meta);
+
+  const lines = [
+    `@misc{${key},`,
+    `  title   = {${title}},`,
+    `  author  = {${author}},`,
+    `  note    = {CBETA ${meta.cbetaId}${meta.category ? `, ${meta.category}` : ""}},`,
+    `  url     = {${url}},`,
+    `  urldate = {${new Date().toISOString().slice(0, 10)}}`,
+    `}`,
+  ];
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// RIS
+// ---------------------------------------------------------------------------
+
+export function toRIS(meta: CitationMeta): string {
+  const author = authorField(meta);
+  const url = canonicalUrl(meta);
+
+  const lines = [
+    "TY  - BOOK",
+    `TI  - ${meta.titleZh}`,
+    `AU  - ${author}`,
+    `ID  - ${meta.cbetaId}`,
+  ];
+  if (meta.titleEn) lines.push(`T2  - ${meta.titleEn}`);
+  if (meta.category) lines.push(`KW  - ${meta.category}`);
+  if (meta.dynasty) lines.push(`N1  - ${meta.dynasty}`);
+  lines.push(
+    `UR  - ${url}`,
+    `Y2  - ${new Date().toISOString().slice(0, 10)}`,
+    "ER  - ",
+  );
+  return lines.join("\r\n");
+}
+
+// ---------------------------------------------------------------------------
+// APA (7th edition style)
+// ---------------------------------------------------------------------------
+
+export function toAPA(meta: CitationMeta): string {
+  const author = authorField(meta);
+  const url = canonicalUrl(meta);
+  const accessDate = new Date().toLocaleDateString("zh-CN", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  // Author. (Dynasty/n.d.). Title (CBETA ID). Source. URL
+  const datePart = meta.dynasty ?? "n.d.";
+  const titlePart = meta.titleEn
+    ? `${meta.titleZh} [${meta.titleEn}]`
+    : meta.titleZh;
+
+  return `${author}. (${datePart}). ${titlePart} (CBETA ${meta.cbetaId}). 佛津 FoJin. ${url} (${accessDate} 访问)`;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export type CitationFormat = "bibtex" | "ris" | "apa";
+
+export function generateCitation(
+  format: CitationFormat,
+  meta: CitationMeta,
+): string {
+  switch (format) {
+    case "bibtex":
+      return toBibTeX(meta);
+    case "ris":
+      return toRIS(meta);
+    case "apa":
+      return toAPA(meta);
+  }
+}
+
+const FILE_EXT: Record<CitationFormat, string> = {
+  bibtex: ".bib",
+  ris: ".ris",
+  apa: ".txt",
+};
+
+const MIME_TYPE: Record<CitationFormat, string> = {
+  bibtex: "application/x-bibtex",
+  ris: "application/x-research-info-systems",
+  apa: "text/plain",
+};
+
+/** Trigger a file download in the browser. */
+export function downloadCitation(
+  format: CitationFormat,
+  meta: CitationMeta,
+): void {
+  const text = generateCitation(format, meta);
+  const blob = new Blob([text], { type: MIME_TYPE[format] });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${meta.cbetaId}${FILE_EXT[format]}`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Add `citationFormats.ts` utility for generating BibTeX, RIS, and APA citations
- Rewrite `CitationGenerator` as frontend-only component (no extra API call)
- Add export button on text detail page and reader toolbar
- Support copy to clipboard and download as `.bib` / `.ris` / `.txt` files

Closes #29

## Test plan
- [ ] Open a text detail page and click "Export Citation"
- [ ] Switch between BibTeX, RIS, and APA formats
- [ ] Copy citation to clipboard and verify content
- [ ] Download each format and verify file contents
- [ ] Test from the reader page toolbar as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)