### PR TITLE
fix: use correct nginx:stable-bookworm image tag

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 RUN find dist -type f \( -name '*.js' -o -name '*.css' -o -name '*.html' -o -name '*.svg' -o -name '*.json' \) \
     -exec gzip -9 -k {} \;
 
-FROM nginx:bookworm-slim
+FROM nginx:stable-bookworm
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
## Summary
- Fix `nginx:bookworm-slim` → `nginx:stable-bookworm` (the correct Docker Hub tag)

## Test plan
- [ ] `docker compose build frontend` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)