### PR TITLE
feat(chat): typing animation with thinking placeholder

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -627,81 +627,31 @@ export async function sendChatMessageStream(
   sessionId: number | undefined,
   callbacks: StreamCallbacks,
 ): Promise<void> {
-  let token = "";
   try {
-    const raw = localStorage.getItem("fojin-auth");
-    if (raw) {
-      const { state } = JSON.parse(raw);
-      if (state?.token) token = state.token;
+    const resp = await sendChatMessage(message, sessionId);
+    callbacks.onSessionId(resp.session_id);
+    if (resp.sources.length > 0) {
+      callbacks.onSources(resp.sources);
     }
-  } catch { /* ignore */ }
-
-  // Use stream.fojin.ai to bypass Cloudflare compression for real SSE streaming
-  const streamBase = "https://stream.fojin.ai";
-
-  const resp = await fetch(`${streamBase}/api/chat/stream`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify({ message, session_id: sessionId }),
-  });
-
-  if (!resp.ok) {
-    let detail = "请求失败";
-    try {
-      const err = await resp.json();
-      detail = err.detail || detail;
-    } catch { /* ignore */ }
+    // Typing animation — emit characters progressively for natural feel
+    const text = resp.message;
+    let i = 0;
+    const emit = () => {
+      if (i < text.length) {
+        const chunk = text.slice(i, i + 1 + Math.floor(Math.random() * 2));
+        callbacks.onToken(chunk);
+        i += chunk.length;
+        setTimeout(emit, 30 + Math.random() * 40);
+      } else {
+        callbacks.onDone();
+      }
+    };
+    emit();
+  } catch (err: any) {
+    const detail = err?.response?.data?.detail || "发送失败，请稍后重试";
     callbacks.onError(detail);
     callbacks.onDone();
-    return;
   }
-
-  const reader = resp.body?.getReader();
-  if (!reader) {
-    callbacks.onError("浏览器不支持流式响应");
-    callbacks.onDone();
-    return;
-  }
-
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-
-    const lines = buffer.split("\n");
-    buffer = lines.pop() || "";
-
-    for (const line of lines) {
-      if (!line.startsWith("data: ")) continue;
-      try {
-        const event = JSON.parse(line.slice(6));
-        switch (event.type) {
-          case "token":
-            callbacks.onToken(event.content);
-            break;
-          case "sources":
-            callbacks.onSources(event.sources);
-            break;
-          case "session_id":
-            callbacks.onSessionId(event.session_id);
-            break;
-          case "error":
-            callbacks.onError(event.message);
-            break;
-          case "done":
-            callbacks.onDone();
-            return;
-        }
-      } catch { /* skip malformed lines */ }
-    }
-  }
-  callbacks.onDone();
 }
 
 // --- BYOK (Bring Your Own Key) ---

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -95,7 +95,7 @@ export default function ChatPage() {
     const assistantMsg: ChatMessageItem = {
       id: assistantId,
       role: "assistant",
-      content: "",
+      content: "正在检索经文并生成回答...",
       sources: null,
       created_at: new Date().toISOString(),
     };
@@ -108,9 +108,12 @@ export default function ChatPage() {
     await sendChatMessageStream(msg, sessionId, {
       onToken: (content: string) => {
         setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantId ? { ...m, content: m.content + content } : m,
-          ),
+          prev.map((m) => {
+            if (m.id !== assistantId) return m;
+            // Clear the "thinking" placeholder on first real token
+            const current = m.content === "正在检索经文并生成回答..." ? "" : m.content;
+            return { ...m, content: current + content };
+          }),
         );
         scrollToBottom();
       },
@@ -129,6 +132,14 @@ export default function ChatPage() {
       },
       onError: (errMsg: string) => {
         message.error(errMsg);
+        // Clear thinking placeholder on error
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId && m.content === "正在检索经文并生成回答..."
+              ? { ...m, content: "请求失败，请重试" }
+              : m,
+          ),
+        );
       },
       onDone: () => {
         streamingIdRef.current = 0;


### PR DESCRIPTION
## Summary
- Replace SSE streaming with non-streaming `/chat` endpoint + frontend typing animation
- Cloudflare gzip compression and user network proxies buffer SSE responses, making real streaming unreliable
- Show "正在检索经文并生成回答..." placeholder immediately when user sends a message
- Emit characters progressively (1-2 chars per 30-70ms) for natural typing feel
- Clear placeholder on first token or replace with error message on failure

## Test plan
- [ ] Send a question on /chat — should see "正在检索经文并生成回答..." immediately
- [ ] After backend responds, text appears with typing animation
- [ ] On error, placeholder is replaced with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)