### PR TITLE
fix(kg): remove CONCURRENTLY from trgm index migration

### DIFF
--- a/backend/alembic/versions/0095_add_kg_trgm_index.py
+++ b/backend/alembic/versions/0095_add_kg_trgm_index.py
@@ -18,7 +18,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
     op.execute(
-        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_kg_entities_name_zh_trgm "
+        "CREATE INDEX IF NOT EXISTS ix_kg_entities_name_zh_trgm "
         "ON kg_entities USING gin (name_zh gin_trgm_ops)"
     )
 


### PR DESCRIPTION
## Summary
- `CREATE INDEX CONCURRENTLY` 不能在 alembic 事务块内运行，改为普通 `CREATE INDEX`

## Test plan
- [x] 生产服务器 alembic upgrade head 报错确认
- [ ] 修复后 alembic upgrade head 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)