### PR TITLE
feat(search): show highlight matches in results

### DIFF
--- a/frontend/src/components/search/ResultCard.tsx
+++ b/frontend/src/components/search/ResultCard.tsx
@@ -37,6 +37,11 @@ export default function ResultCard({ hit, rank }: { hit: SearchHit; rank: number
         <div className="s-card-meta">
           <span>编号: {hit.cbeta_id}</span>
         </div>
+        {hit.highlight && Object.entries(hit.highlight).filter(([k]) => k !== "title_zh").map(([field, fragments]) => (
+          <div key={field} className="s-card-preview" dangerouslySetInnerHTML={{
+            __html: sanitizeHighlight(fragments[0]),
+          }} />
+        ))}
         <div className="s-card-actions">
           {cbetaUrl && (
             <Button type="primary" size="small" icon={<LinkOutlined />}

--- a/frontend/src/styles/search.css
+++ b/frontend/src/styles/search.css
@@ -197,6 +197,19 @@
   font-weight: 600;
 }
 
+.s-card-preview {
+  font-size: 12px;
+  color: var(--fj-ink-muted);
+  margin-bottom: 4px;
+  line-height: 1.6;
+}
+
+.s-card-preview em {
+  color: var(--fj-accent);
+  font-style: normal;
+  font-weight: 600;
+}
+
 .s-card-actions {
   margin-top: 12px;
   display: flex;


### PR DESCRIPTION
## Summary
- Display highlighted field matches (translator, title_en, etc.) below search result cards
- Shows users why a result matched their query
- Title highlight was already shown; this adds other matching fields
- Added `.s-card-preview` CSS with muted text and accent-colored `<em>` highlights

Closes #63

## Test plan
- [ ] Search "玄奘" → translator highlight shows below matching results
- [ ] Search by Sanskrit/English title → see highlighted match
- [ ] No extra preview shown when only title matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)