### PR TITLE
feat(search): add rate limiting and filters caching

### DIFF
--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -47,9 +48,13 @@ async def content_search(
     return await search_content(es, q, page, size, sources, lang)
 
 
+_filters_cache: dict = {"data": None, "expires": 0}
+
 @router.get("/filters")
 async def filters(db: AsyncSession = Depends(get_db)):
-    """获取可用的筛选选项（朝代、分类、语言、数据源）。"""
+    """获取可用的筛选选项（朝代、分类、语言、数据源）。缓存 5 分钟。"""
+    if _filters_cache["data"] and time.time() < _filters_cache["expires"]:
+        return _filters_cache["data"]
     es = get_es()
     aggs = await get_aggregations(es)
 
@@ -70,6 +75,8 @@ async def filters(db: AsyncSession = Depends(get_db)):
 
     aggs["languages"] = languages_with_data
     aggs["languages_all"] = sorted(all_langs)
+    _filters_cache["data"] = aggs
+    _filters_cache["expires"] = time.time() + 300  # 5 min TTL
     return aggs
 
 

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -11,10 +11,12 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-# Stricter rate limits for sensitive auth endpoints (requests per minute)
+# Stricter rate limits for sensitive/expensive endpoints (requests per minute)
 STRICT_PATHS: dict[str, int] = {
     "/api/auth/login": settings.rate_limit_login,
     "/api/auth/register": settings.rate_limit_register,
+    "/api/search": 60,
+    "/api/search/content": 30,
 }
 
 


### PR DESCRIPTION
## Summary
- Rate limit `/api/search` to 60 req/min per IP
- Rate limit `/api/search/content` to 30 req/min per IP  
- Cache `/api/filters` response in memory (5 min TTL) to reduce ES aggregation load
- Uses existing Redis sliding window rate limiter

Closes #66

## Test plan
- [ ] Normal search works without hitting limits
- [ ] Rapid-fire requests get 429 after threshold
- [ ] Filters endpoint serves cached response on subsequent calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)