### PR TITLE
feat(reader): add annotation button and panel

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -497,6 +497,43 @@ export interface DictSearchResponse {
   results: DictEntry[];
 }
 
+// --- Annotations ---
+
+export interface AnnotationItem {
+  id: number;
+  text_id: number;
+  juan_num: number;
+  start_pos: number;
+  end_pos: number;
+  annotation_type: string;
+  content: string;
+  user_id: number;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getAnnotations(textId: number, juanNum: number): Promise<AnnotationItem[]> {
+  const { data } = await api.get<AnnotationItem[]>("/annotations", { params: { text_id: textId, juan_num: juanNum } });
+  return data;
+}
+
+export async function createAnnotation(payload: {
+  text_id: number;
+  juan_num: number;
+  start_pos: number;
+  end_pos: number;
+  annotation_type: string;
+  content: string;
+}): Promise<AnnotationItem> {
+  const { data } = await api.post<AnnotationItem>("/annotations", payload);
+  return data;
+}
+
+export async function deleteAnnotation(annotationId: number): Promise<void> {
+  await api.delete(`/annotations/${annotationId}`);
+}
+
 export async function searchDictionary(params: {
   q: string;
   page?: number;

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -9,12 +9,14 @@ import {
   RightOutlined,
   FontSizeOutlined,
   BookOutlined,
+  EditOutlined,
   HeartOutlined,
   HeartFilled,
 } from "@ant-design/icons";
 import { getJuanList, getJuanContent, getTextDetail, checkBookmark, addBookmark, removeBookmark } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
 import CitationGenerator from "../components/CitationGenerator";
+import AnnotationPanel from "../components/AnnotationPanel";
 import "../styles/reader.css";
 
 const FONT_SIZE_MIN = 14;
@@ -37,6 +39,7 @@ export default function TextReaderPage() {
   const [juanNum, setJuanNum] = useState(1);
   const [fontSize, setFontSize] = useState(getInitialFontSize);
   const [citationOpen, setCitationOpen] = useState(false);
+  const [annotationOpen, setAnnotationOpen] = useState(false);
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
   const { user } = useAuthStore();
   const queryClient = useQueryClient();
@@ -177,6 +180,13 @@ export default function TextReaderPage() {
           </Button>
           <Button
             size="small"
+            icon={<EditOutlined />}
+            onClick={() => setAnnotationOpen(true)}
+          >
+            标注
+          </Button>
+          <Button
+            size="small"
             icon={<BookOutlined />}
             onClick={() => setCitationOpen(true)}
           >
@@ -247,6 +257,13 @@ export default function TextReaderPage() {
         textData={textDetail}
         open={citationOpen}
         onClose={() => setCitationOpen(false)}
+      />
+
+      <AnnotationPanel
+        textId={textId}
+        juanNum={juanNum}
+        visible={annotationOpen}
+        onClose={() => setAnnotationOpen(false)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add "标注" button in text reader header (next to 收藏 and 引用)
- Opens existing AnnotationPanel drawer for creating/viewing annotations
- Add annotation API client functions to frontend
- Users can create notes/corrections/tags, submit for review, delete own annotations

Closes #71

## Test plan
- [ ] Open a text → see "标注" button in reader header
- [ ] Click → annotation drawer opens
- [ ] Create a new annotation → appears in list
- [ ] Delete own annotation → removed from list

🤖 Generated with [Claude Code](https://claude.com/claude-code)