### PR TITLE
feat(chat): use real SSE streaming instead of typing animation

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -697,29 +697,88 @@ export async function sendChatMessageStream(
   sessionId: number | undefined,
   callbacks: StreamCallbacks,
 ): Promise<void> {
+  // Get auth token from localStorage (same pattern as axios interceptor)
+  let token = "";
   try {
-    const resp = await sendChatMessage(message, sessionId);
-    callbacks.onSessionId(resp.session_id);
-    if (resp.sources.length > 0) {
-      callbacks.onSources(resp.sources);
+    const raw = localStorage.getItem("fojin-auth");
+    if (raw) {
+      const { state } = JSON.parse(raw);
+      if (state?.token) token = state.token;
     }
-    // Typing animation — emit characters progressively for natural feel
-    const text = resp.message;
-    let i = 0;
-    const emit = () => {
-      if (i < text.length) {
-        const chunk = text.slice(i, i + 1 + Math.floor(Math.random() * 2));
-        callbacks.onToken(chunk);
-        i += chunk.length;
-        setTimeout(emit, 30 + Math.random() * 40);
-      } else {
-        callbacks.onDone();
+  } catch { /* ignore */ }
+
+  try {
+    const resp = await fetch("/api/chat/stream", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ message, session_id: sessionId ?? null }),
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      let detail = "发送失败，请稍后重试";
+      try { detail = JSON.parse(text).detail || detail; } catch { /* ignore */ }
+      if (resp.status === 401) {
+        useAuthStore.getState().logout();
+        window.location.href = "/login";
       }
-    };
-    emit();
+      callbacks.onError(detail);
+      callbacks.onDone();
+      return;
+    }
+
+    const reader = resp.body?.getReader();
+    if (!reader) {
+      callbacks.onError("浏览器不支持流式响应");
+      callbacks.onDone();
+      return;
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      // Keep the last incomplete line in the buffer
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        const payload = line.slice(6).trim();
+        if (!payload) continue;
+        try {
+          const event = JSON.parse(payload);
+          switch (event.type) {
+            case "token":
+              callbacks.onToken(event.content);
+              break;
+            case "sources":
+              callbacks.onSources(event.sources);
+              break;
+            case "session_id":
+              callbacks.onSessionId(event.session_id);
+              break;
+            case "error":
+              callbacks.onError(event.message);
+              break;
+            case "done":
+              callbacks.onDone();
+              return;
+          }
+        } catch { /* skip malformed JSON */ }
+      }
+    }
+    // Stream ended without explicit "done" event
+    callbacks.onDone();
   } catch (err: any) {
-    const detail = err?.response?.data?.detail || "发送失败，请稍后重试";
-    callbacks.onError(detail);
+    callbacks.onError(err?.message || "网络错误，请稍后重试");
     callbacks.onDone();
   }
 }


### PR DESCRIPTION
## Summary
- 将前端 AI 问答从"非流式接口 + 打字动画模拟"改为真正的 SSE 流式输出
- 使用原生 `fetch` + `ReadableStream` 调用后端 `/api/chat/stream` 端点
- 实时解析 SSE 事件（token/sources/session_id/error/done），用户可即时看到 LLM 生成的内容

## 改动
- `frontend/src/api/client.ts`: 重写 `sendChatMessageStream()`，从模拟打字动画改为真实 SSE 流式解析

## 技术细节
- 后端 `send_message_stream()` 已完整实现 SSE 流式（含 2KB padding 刷新 Cloudflare 缓冲）
- Nginx 已配置 `/api/chat/stream` 的 `proxy_buffering off` + `gzip off`
- 前端之前未调用该端点，此 PR 补齐了前端侧的实现

## Test plan
- [ ] 登录 fojin.app → 进入 /chat → 发送问题
- [ ] 验证回答逐字流式输出（非整段突然出现）
- [ ] 验证引用来源正常显示经名 + 可点击
- [ ] 验证新会话自动创建、会话列表刷新
- [ ] 验证错误场景（未登录、配额用完）提示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)