### PR TITLE
fix(i18n): language detection and async loading

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -10,6 +10,7 @@ i18n
   .init({
     fallbackLng: "zh",
     supportedLngs: ["zh", "ja"],
+    load: "languageOnly",
     ns: ["translation"],
     defaultNS: "translation",
     backend: {
@@ -22,6 +23,9 @@ i18n
     },
     interpolation: {
       escapeValue: false,
+    },
+    react: {
+      useSuspense: false,
     },
   });
 


### PR DESCRIPTION
## Summary
- 添加 `load: "languageOnly"` 使 `zh-CN` 正确匹配 `zh` locale
- 设置 `react.useSuspense: false` 支持异步翻译文件加载

## Test plan
- [ ] 访问 `fojin.app/?lang=ja` 验证日语翻译生效
- [ ] 通过语言切换器切换语言

🤖 Generated with [Claude Code](https://claude.com/claude-code)