### PR TITLE
fix(i18n): guard hot_tags array against async loading

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -51,7 +51,8 @@ export default function HomePage() {
   const srcLabel = selectedSources.size > 0
     ? t("home.selected_sources", { count: selectedSources.size })
     : t("home.all_sources");
-  const hotTags = t("home.hot_tags", { returnObjects: true }) as string[];
+  const rawTags = t("home.hot_tags", { returnObjects: true });
+  const hotTags = Array.isArray(rawTags) ? rawTags : [];
 
   return (
     <div className="home-page">


### PR DESCRIPTION
## Summary
修复当 i18n 翻译文件异步加载时，`t("home.hot_tags", { returnObjects: true })` 返回字符串而非数组，导致 `.map()` 崩溃的问题。

## Root cause
`useSuspense: false` 模式下，翻译文件加载完成前 `t()` 返回 key 字符串。对数组类型的翻译值需要 `Array.isArray()` 保护。

🤖 Generated with [Claude Code](https://claude.com/claude-code)