### PR TITLE
chore(i18n): keep Chinese name in English app title + auto-deploy webhook

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1,5 +1,5 @@
 {
-  "app.name": "FoJin",
+  "app.name": "佛津 FoJin",
   "app.tagline": "Global Buddhist Classics Digital Resource Platform",
   "app.title": "FoJin — Global Buddhist Classics Digital Resource Platform",
   "nav.sources": "Sources",


### PR DESCRIPTION
## Summary
- English app name 改为 "佛津 FoJin" 保持品牌统一
- 测试自动部署 webhook 流程

## Auto-deploy 配置（已在服务器完成）
- Webhook 服务（Python + systemd）监听 127.0.0.1:9876
- Nginx 反向代理 /webhook/deploy → webhook 服务
- GitHub webhook 配置完成（push to master 触发）
- 部署脚本自动检测前端/后端/迁移变更并按需重建

🤖 Generated with [Claude Code](https://claude.com/claude-code)