### PR TITLE
feat(ui): replace broken favicon with lotus flower SVG

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#8b2500" />
     <meta name="description" content="佛津 FoJin — 聚合全球 40+ 佛教数字资源，提供平行阅读、知识图谱、AI 问答等功能的古籍研究平台。覆盖汉传、藏传、南传、梵文等传统。" />

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!-- Lotus flower favicon for FoJin -->
+  <!-- Center petal -->
+  <ellipse cx="32" cy="22" rx="7" ry="16" fill="#8b2500" opacity="0.95"/>
+  <!-- Left petals -->
+  <ellipse cx="32" cy="22" rx="7" ry="16" fill="#a03020" opacity="0.85" transform="rotate(-25 32 32)"/>
+  <ellipse cx="32" cy="22" rx="7" ry="16" fill="#b04535" opacity="0.7" transform="rotate(-50 32 32)"/>
+  <!-- Right petals -->
+  <ellipse cx="32" cy="22" rx="7" ry="16" fill="#a03020" opacity="0.85" transform="rotate(25 32 32)"/>
+  <ellipse cx="32" cy="22" rx="7" ry="16" fill="#b04535" opacity="0.7" transform="rotate(50 32 32)"/>
+  <!-- Gold center dot -->
+  <circle cx="32" cy="26" r="3.5" fill="#b08d57"/>
+  <!-- Base leaves -->
+  <ellipse cx="22" cy="44" rx="10" ry="4" fill="#5c7a4a" opacity="0.7" transform="rotate(-10 22 44)"/>
+  <ellipse cx="42" cy="44" rx="10" ry="4" fill="#5c7a4a" opacity="0.7" transform="rotate(10 42 44)"/>
+</svg>


### PR DESCRIPTION
## Summary
- Old favicon referenced `/vite.svg` (Vite default) which no longer exists — showed a broken yellow square
- Created custom lotus flower SVG favicon in project accent colors (朱砂红 petals + 金色 center)
- Updated `index.html` to reference `/favicon.svg`

## Test plan
- [ ] Browser tab shows lotus flower icon instead of yellow square
- [ ] Icon renders clearly at small sizes (16x16, 32x32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)