### PR TITLE
fix(style): reduce letter-spacing for English/Japanese subtitle

### DIFF
--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -84,6 +84,10 @@
   letter-spacing: 8px;
   margin-bottom: 28px;
 }
+:lang(en) .home-subtitle,
+:lang(ja) .home-subtitle {
+  letter-spacing: 2px;
+}
 
 /* ---------- 合并搜索栏 ---------- */
 .search-combo {
@@ -553,6 +557,8 @@
   .home-hero { padding: 80px 20px 48px; }
   .home-title { font-size: 48px; letter-spacing: 12px; }
   .home-subtitle { font-size: 12px; letter-spacing: 4px; }
+  :lang(en) .home-subtitle,
+  :lang(ja) .home-subtitle { letter-spacing: 1px; }
   .home-search-wrap { margin-bottom: 48px; }
 
   .home-stats { flex-direction: column; max-width: 200px; }


### PR DESCRIPTION
## Summary
中文 `letter-spacing: 8px` 在英文/日文下字母间距过大不可读。使用 `:lang()` 选择器为非中文语言设置 `2px` 间距。

🤖 Generated with [Claude Code](https://claude.com/claude-code)