### PR TITLE
fix(i18n): localize homepage title — show FoJin in English mode

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1,5 +1,7 @@
 {
   "app.name": "佛津 FoJin",
+  "home.title_accent": "Fo",
+  "home.title_rest": "Jin",
   "app.tagline": "Global Buddhist Classics Digital Resource Platform",
   "app.title": "FoJin — Global Buddhist Classics Digital Resource Platform",
   "nav.sources": "Sources",

--- a/frontend/public/locales/ja/translation.json
+++ b/frontend/public/locales/ja/translation.json
@@ -1,5 +1,7 @@
 {
   "app.name": "佛津",
+  "home.title_accent": "佛",
+  "home.title_rest": "津",
   "app.tagline": "世界の仏教古典デジタルリソースプラットフォーム",
   "app.title": "佛津 — 世界の仏教古典デジタルリソースプラットフォーム",
   "nav.sources": "データソース",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1,5 +1,7 @@
 {
   "app.name": "佛津",
+  "home.title_accent": "佛",
+  "home.title_rest": "津",
   "app.tagline": "全球佛教古籍数字资源聚合平台",
   "app.title": "佛津 — 全球佛教古籍数字资源聚合平台",
   "nav.sources": "数据源",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -64,7 +64,7 @@ export default function HomePage() {
           <img src="/landscape-bg.png" alt="" />
         </div>
         <h1 className="home-title">
-          <span className="home-title-accent">佛</span>津
+          <span className="home-title-accent">{t("home.title_accent")}</span>{t("home.title_rest")}
         </h1>
         <div className="home-subtitle">{t("app.tagline")}</div>
 

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -84,6 +84,11 @@
   letter-spacing: 8px;
   margin-bottom: 28px;
 }
+:lang(en) .home-title,
+:lang(ja) .home-title {
+  letter-spacing: 8px;
+  font-size: 72px;
+}
 :lang(en) .home-subtitle,
 :lang(ja) .home-subtitle {
   letter-spacing: 2px;
@@ -556,6 +561,8 @@
 @media (max-width: 768px) {
   .home-hero { padding: 80px 20px 48px; }
   .home-title { font-size: 48px; letter-spacing: 12px; }
+  :lang(en) .home-title,
+  :lang(ja) .home-title { font-size: 40px; letter-spacing: 4px; }
   .home-subtitle { font-size: 12px; letter-spacing: 4px; }
   :lang(en) .home-subtitle,
   :lang(ja) .home-subtitle { letter-spacing: 1px; }


### PR DESCRIPTION
## Summary
- 英文模式首页标题显示 "**Fo**Jin"（红色 Fo + 黑色 Jin），与中文 "**佛**津" 保持一致
- 调整英文/日文标题 letter-spacing 和 font-size 适配

🤖 Generated with [Claude Code](https://claude.com/claude-code)