### PR TITLE
fix(style): keep Japanese title spacing same as Chinese

### DIFF
--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -84,8 +84,7 @@
   letter-spacing: 8px;
   margin-bottom: 28px;
 }
-:lang(en) .home-title,
-:lang(ja) .home-title {
+:lang(en) .home-title {
   letter-spacing: 8px;
   font-size: 72px;
 }
@@ -561,8 +560,7 @@
 @media (max-width: 768px) {
   .home-hero { padding: 80px 20px 48px; }
   .home-title { font-size: 48px; letter-spacing: 12px; }
-  :lang(en) .home-title,
-  :lang(ja) .home-title { font-size: 40px; letter-spacing: 4px; }
+  :lang(en) .home-title { font-size: 40px; letter-spacing: 4px; }
   .home-subtitle { font-size: 12px; letter-spacing: 4px; }
   :lang(en) .home-subtitle,
   :lang(ja) .home-subtitle { letter-spacing: 1px; }


### PR DESCRIPTION
## Summary
日文标题是汉字"佛津"，应保持与中文相同的宽间距。只有英文 "FoJin" 需要缩小间距。

🤖 Generated with [Claude Code](https://claude.com/claude-code)