### PR TITLE
fix(i18n): use resolvedLanguage for language switcher display

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -179,11 +179,11 @@ export default function Layout() {
                 { key: "vi", label: "Tiếng Việt" },
               ],
               onClick: ({ key }) => i18n.changeLanguage(key),
-              selectedKeys: [i18n.language],
+              selectedKeys: [i18n.resolvedLanguage ?? i18n.language],
             }}
           >
             <Button type="text" icon={<GlobalOutlined />} style={{ color: inkMuted, fontSize: 13 }}>
-              {t(`language.${i18n.language}`)}
+              {t(`language.${i18n.resolvedLanguage ?? i18n.language}`)}
             </Button>
           </Dropdown>
           {user ? (


### PR DESCRIPTION
## Summary
- Fix language switcher showing raw key "language.en-US" instead of "English" when browser locale is "en-US"
- Replace `i18n.language` with `i18n.resolvedLanguage` in both the display label and `selectedKeys`, so the resolved short code (e.g. "en") is always used for translation lookup and menu selection

## Test plan
- [ ] Set browser language to "en-US" and verify the language switcher displays "English" (not "language.en-US")
- [ ] Switch languages via the dropdown and confirm the label updates correctly
- [ ] Verify `selectedKeys` highlights the correct language in the dropdown menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)