### PR TITLE
feat(i18n): add missing Sinhala key in Burmese locale

### DIFF
--- a/frontend/public/locales/my/translation.json
+++ b/frontend/public/locales/my/translation.json
@@ -71,5 +71,6 @@
   "language.ko": "한국어",
   "language.th": "ไทย",
   "language.vi": "Tiếng Việt",
+  "language.si": "සිංහල",
   "language.my": "မြန်မာ"
 }


### PR DESCRIPTION
## Summary
- Add missing `language.si` key to Burmese (`my`) locale file
- The Sinhala translation was previously added but the Burmese locale file was missed during that change

## Test plan
- [ ] Verify language switcher shows "සිංහල" correctly when Burmese is the active language
- [ ] Verify all 8 locale files now have complete `language.*` keys for all supported languages

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)