### PR TITLE
fix(security): add Permissions-Policy header and HSTS preload

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,8 +87,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
         response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
+        response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), payment=()"
         return response
 
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,6 +10,8 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:;" always;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Serve pre-compressed .gz files when available
     gzip_static on;


### PR DESCRIPTION
## Summary
- Add `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()` to restrict unused browser APIs
- Upgrade HSTS to `max-age=63072000; includeSubDomains; preload` (2 years, preload-eligible)
- Applied consistently in both backend middleware and nginx config

## Security impact
- Restricts browser API access surface for defense-in-depth
- Enables submission to [hstspreload.org](https://hstspreload.org) for HSTS preload list inclusion
- Targets A+ rating on [securityheaders.com](https://securityheaders.com)

## Test plan
- [ ] Verify headers present: `curl -sI https://fojin.app | grep -i permissions-policy`
- [ ] Verify HSTS: `curl -sI https://fojin.app | grep -i strict-transport`
- [ ] Site functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)