### PR TITLE
fix(security): require admin role for annotation review endpoint

### DIFF
--- a/backend/app/api/annotations.py
+++ b/backend/app/api/annotations.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
+from app.core.role_guard import require_role
 from app.database import get_db
 from app.models.user import User
 from app.schemas.annotation import AnnotationCreate, AnnotationResponse, AnnotationReviewCreate
@@ -75,7 +76,7 @@ async def submit(
 async def review(
     annotation_id: int,
     data: AnnotationReviewCreate,
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_role("admin", "reviewer")),
     db: AsyncSession = Depends(get_db),
 ):
     """审核标注（pending → approved/rejected/draft）。"""


### PR DESCRIPTION
## Summary
- Fix IDOR (Insecure Direct Object Reference) vulnerability in `/api/annotations/{id}/review`
- Previously any authenticated user could approve/reject annotations (privilege escalation)
- Now requires `admin` or `reviewer` role via `require_role` guard

## Security impact
- **Before**: Any registered user → `POST /api/annotations/123/review` → success (privilege escalation)
- **After**: Non-admin/non-reviewer → 403 Forbidden

## Changes
- `backend/app/api/annotations.py`: Replace `get_current_user` with `require_role("admin", "reviewer")` on review endpoint

## Test plan
- [ ] Admin user can review annotations → 200
- [ ] Regular user gets 403 on review endpoint
- [ ] Unauthenticated request gets 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)