### PR TITLE
feat(ci): add bandit SAST and dependency audit to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,3 +46,99 @@ jobs:
             exit 1
           fi
           echo "No secrets found."
+
+  bandit:
+    name: Python SAST (bandit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install bandit
+        run: pip install bandit
+
+      - name: Run bandit on backend
+        run: bandit -r backend/app/ --severity-level medium -f json -o bandit-report.json || true
+
+      - name: Display bandit results
+        if: always()
+        run: bandit -r backend/app/ --severity-level medium
+
+      - name: Upload bandit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-report
+          path: bandit-report.json
+
+  pip-audit:
+    name: Python dependency audit
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Run pip-audit
+        run: pip-audit --desc --output pip-audit-report.json --format json || true
+
+      - name: Display pip-audit results
+        if: always()
+        run: pip-audit --desc
+
+      - name: Upload pip-audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report
+          path: backend/pip-audit-report.json
+
+  npm-audit:
+    name: Frontend dependency audit
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: npm audit --omit=dev || true
+
+      - name: Run npm audit (JSON report)
+        if: always()
+        run: npm audit --omit=dev --json > npm-audit-report.json || true
+
+      - name: Upload npm audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: frontend/npm-audit-report.json


### PR DESCRIPTION
## Summary
Add three security scanning jobs to CI pipeline:
- **bandit**: Python SAST scanning `backend/app/` (medium+ severity)
- **pip-audit**: Python dependency vulnerability scanning
- **npm audit**: Frontend dependency vulnerability scanning

## Details
- All three jobs run in parallel with existing `secrets-scan`
- Each uploads JSON report as GitHub Actions artifact
- `pip-audit` and `npm audit` use `continue-on-error: true` to avoid blocking CI while existing issues are addressed
- `bandit` enforces clean results (no continue-on-error)

## Test plan
- [ ] CI workflow runs successfully
- [ ] Artifacts are uploaded for each scanner
- [ ] bandit scan passes on `backend/app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)