### PR TITLE
fix(security): address bandit SAST findings — XXE prevention with defusedxml

### DIFF
--- a/backend/app/core/tei_84000_parser.py
+++ b/backend/app/core/tei_84000_parser.py
@@ -22,6 +22,8 @@ Parser for 84000 TEI XML translation files.
 import re
 from xml.etree import ElementTree as ET
 
+from defusedxml.ElementTree import fromstring as safe_fromstring
+
 TEI_NS = "http://www.tei-c.org/ns/1.0"
 
 
@@ -50,13 +52,13 @@ def parse_84000_tei(xml_content: str) -> dict:
     }
 
     try:
-        # Parse XML, handling namespaces
-        root = ET.fromstring(xml_content)
+        # Parse XML, handling namespaces (use defusedxml to prevent XXE attacks)
+        root = safe_fromstring(xml_content)
     except ET.ParseError:
         # Try to clean up common issues
         cleaned = re.sub(r'&(?!amp;|lt;|gt;|quot;|apos;)', '&amp;', xml_content)
         try:
-            root = ET.fromstring(cleaned)
+            root = safe_fromstring(cleaned)
         except ET.ParseError:
             return result
 

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -150,7 +150,7 @@ async def get_entity_graph(
             FROM kg_relations r
             WHERE (r.subject_id = ANY(:frontier) OR r.object_id = ANY(:frontier))
             {pred_filter}
-        """)
+        """)  # nosec B608 - pred_filter is a hardcoded clause, not user input
         result = await session.execute(sql, {**params, "frontier": list(frontier)})
         neighbors = {row[0] for row in result.fetchall()}
 
@@ -181,7 +181,7 @@ async def get_entity_graph(
         WHERE r.subject_id = ANY(:ids) AND r.object_id = ANY(:ids)
         {pred_filter}
         GROUP BY subject_id, predicate, object_id
-    """)
+    """)  # nosec B608 - pred_filter is a hardcoded clause, not user input
     edge_result = await session.execute(edge_sql, {**params, "ids": node_ids})
     edge_rows = edge_result.fetchall()
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ httpx==0.28.1
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
+defusedxml==0.7.1
 lxml==5.3.0
 pgvector==0.3.6
 openai==1.58.0


### PR DESCRIPTION
## Summary
- Fix 2 genuine XXE vulnerabilities in `tei_84000_parser.py` by replacing `xml.etree.ElementTree` with `defusedxml.ElementTree`
- Annotate 2 false positives in `knowledge_graph.py` with `# nosec B608` (hardcoded SQL fragments, not user input)
- Add `defusedxml==0.7.1` to backend dependencies
- **bandit now reports 0 medium/high issues**

## Security impact
- Prevents XML External Entity (XXE) attacks and XML bomb DoS when parsing 84000 TEI XML files
- Aligns with OWASP A05:2021 (Security Misconfiguration)

## Test plan
- [ ] `cd backend && bandit -r app/ --severity-level medium` reports 0 issues
- [ ] TEI 84000 XML parsing still works correctly
- [ ] CI security scan job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)