### PR TITLE
fix(security): include security headers in index.html location block

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -106,6 +106,13 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
+        # Repeat security headers (nginx add_header in location overrides server-level)
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:;" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary
Nginx `add_header` in a location block overrides server-level headers. The `location = /index.html` block only had cache-control headers, missing all security headers (CSP, HSTS, Permissions-Policy, etc.).

This is the entry page for all users — the most critical page to protect.

## Test plan
- [ ] `curl -sI https://fojin.app/ | grep -i permissions-policy` returns header
- [ ] `curl -sI https://fojin.app/ | grep -i content-security-policy` returns header

🤖 Generated with [Claude Code](https://claude.com/claude-code)