### PR TITLE
refactor(layout): CSS class for content padding + cache bust

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -243,7 +243,7 @@ export default function Layout() {
           )}
         </Space>
       </Header>
-      <Content id="main-content" style={{ padding: isHome ? 0 : "24px 32px", flex: 1 }}>
+      <Content id="main-content" style={{ padding: isHome ? 0 : undefined, flex: 1 }} className={isHome ? undefined : "layout-content-inner"}>
         <Outlet />
       </Content>
       <Footer

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -160,10 +160,14 @@ em {
   overflow-y: auto;
 }
 
-/* ========== Layout Content Mobile ========== */
+/* ========== Layout Content ========== */
+.layout-content-inner {
+  padding: 24px 32px;
+}
+
 @media (max-width: 768px) {
-  .ant-layout-content {
-    padding: 12px 10px !important;
+  .layout-content-inner {
+    padding: 12px 10px;
   }
 }
 


### PR DESCRIPTION
## Summary
- 将内容区 padding 从内联样式改为 CSS class，支持响应式 media query
- 触发新的 Vite asset hash（旧 hash `nf_UIoen` 被浏览器 immutable 缓存锁定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)