### PR TITLE
fix: AI panel flush right, no wasted space

### DIFF
--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -4,9 +4,7 @@
 .reader-with-sidebar {
   display: flex;
   gap: 0;
-  max-width: 1800px;
-  margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 0 0 24px;
 }
 
 .reader-container {
@@ -14,6 +12,8 @@
   padding: 0;
   flex: 1;
   min-width: 0;
+  max-width: 900px;
+  padding-right: 24px;
 }
 
 /* ── Desktop sidebar ── */
@@ -278,15 +278,13 @@
   flex-shrink: 0;
   align-self: flex-start;
   position: sticky;
-  top: 16px;
-  height: calc(100vh - 32px);
+  top: 0;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   background: #fff;
-  border: 1px solid var(--fj-border, #e8e0d4);
-  border-radius: 8px;
+  border-left: 1px solid var(--fj-border, #e8e0d4);
   overflow: hidden;
-  margin-top: 24px;
 }
 
 /* Drag handle / divider */
@@ -295,7 +293,6 @@
   flex-shrink: 0;
   cursor: col-resize;
   align-self: stretch;
-  margin-top: 24px;
   position: relative;
   z-index: 10;
 }


### PR DESCRIPTION
AI 面板贴到视口右边缘，去掉右侧多余空白，类似 drawer 从右边滑出的感觉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)