### PR TITLE
refactor: remove versions panel from reader page

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -21,7 +21,7 @@ import CitationGenerator from "../components/CitationGenerator";
 import AnnotationPanel from "../components/AnnotationPanel";
 import AskXiaojinButton from "../components/AskXiaojinButton";
 import ReaderAIPanel from "../components/ReaderAIPanel";
-import TextVersionsPanel from "../components/TextVersionsPanel";
+
 import "../styles/versions-panel.css";
 import "../styles/reader.css";
 
@@ -344,7 +344,7 @@ export default function TextReaderPage() {
   const [fontSize, setFontSize] = useState(getInitialFontSize);
   const [citationOpen, setCitationOpen] = useState(false);
   const [annotationOpen, setAnnotationOpen] = useState(false);
-  const [versionsOpen, setVersionsOpen] = useState(true);
+
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
   const [compareLang, setCompareLang] = useState<string | null>(null);
   const { user } = useAuthStore();
@@ -757,7 +757,6 @@ export default function TextReaderPage() {
         onClose={() => setAnnotationOpen(false)}
       />
     </div>
-    {versionsOpen && <TextVersionsPanel textId={textId} onClose={() => setVersionsOpen(false)} />}
 
     {/* AI 解读：右侧内联面板 + 拖拽分割条 */}
     {aiPanelOpen ? (


### PR DESCRIPTION
## Summary
- 从阅读页移除"不同异本"面板，阅读页专注正文内容和AI解读
- 用户可在经典详情页选择不同译本后再进入阅读

## Test plan
- [x] 已部署到生产环境验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)