### PR TITLE
feat: ui polish for reader and search cards

### DIFF
--- a/frontend/src/components/search/CrossLangCard.tsx
+++ b/frontend/src/components/search/CrossLangCard.tsx
@@ -109,7 +109,7 @@ export default function CrossLangCard({ hit, rank }: { hit: CrossLanguageSearchH
               CBETA 阅读
             </Button>
           )}
-          <Button size="small" icon={<EyeOutlined />}
+          <Button type="primary" size="small" icon={<EyeOutlined />}
             onClick={() => navigate(`/texts/${hit.id}`)}>
             查看详情
           </Button>

--- a/frontend/src/components/search/ResultCard.tsx
+++ b/frontend/src/components/search/ResultCard.tsx
@@ -86,7 +86,7 @@ export default function ResultCard({ hit, rank }: { hit: SearchHit; rank: number
               CBETA 阅读
             </Button>
           )}
-          <Button size="small" icon={<EyeOutlined />}
+          <Button type="primary" size="small" icon={<EyeOutlined />}
             onClick={() => navigate(`/texts/${hit.id}`)}>
             查看详情
           </Button>

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -12,7 +12,7 @@
 /* When AI panel is open: lock height, each side scrolls independently */
 .reader-with-sidebar.reader-ai-active {
   max-width: none;
-  height: 100vh;
+  height: calc(100vh - 64px);
   overflow: hidden;
   padding-right: 0;
 }


### PR DESCRIPTION
## Summary
- AI解读面板默认高度修正：减去顶部导航栏高度64px，确保输入框可见
- 搜索结果卡片的"查看详情"按钮改为primary样式，与"在线阅读"保持一致

## Test plan
- [x] 已部署到生产环境验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)