### PR TITLE
fix: tighten chat markdown spacing

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -98,12 +98,16 @@ em {
 }
 
 /* ========== Chat Markdown ========== */
+/* Override bubble's pre-wrap so markdown controls its own whitespace */
+.chat-markdown { white-space: normal; line-height: 1.65; }
+.chat-markdown > * + * { margin-top: 0.35em; }
 .chat-markdown p { margin: 0; }
 .chat-markdown ul, .chat-markdown ol { margin: 0; padding-left: 1.5em; }
 .chat-markdown li { margin: 0; padding: 0; }
-.chat-markdown li + li { margin-top: 0.2em; }
+.chat-markdown li + li { margin-top: 0.15em; }
 .chat-markdown li p { margin: 0; }
 .chat-markdown li > ul, .chat-markdown li > ol { margin: 0; }
+.chat-markdown hr { margin: 0.4em 0; border: none; border-top: 1px solid rgba(217,208,193,0.6); }
 .chat-markdown pre {
   background: rgba(0,0,0,0.06);
   border-radius: 6px;
@@ -128,7 +132,7 @@ em {
 .chat-markdown h1, .chat-markdown h2, .chat-markdown h3 {
   font-size: 1em;
   font-weight: 600;
-  margin: 0.2em 0 0;
+  margin: 0.3em 0 0.1em;
 }
 
 /* ========== Chat Sidebar Mobile ========== */


### PR DESCRIPTION
## Summary
- AI问答回答内容段落间距过大修复：.chat-markdown 覆盖 pre-wrap 为 normal
- 设置紧凑的兄弟节点间距、收紧标题间距、优化hr分隔线

## Test plan
- [x] 已部署到生产环境验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)