### PR TITLE
ui(search): 列表页去除重复的 CBETA 阅读按钮

### DIFF
--- a/frontend/src/components/search/CrossLangCard.tsx
+++ b/frontend/src/components/search/CrossLangCard.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from "react-router-dom";
 import { Tag, Button } from "antd";
-import { EyeOutlined, LinkOutlined, TranslationOutlined } from "@ant-design/icons";
+import { EyeOutlined, TranslationOutlined } from "@ant-design/icons";
 import BookmarkButton from "../BookmarkButton";
 import { sanitizeHighlight } from "../../utils/sanitize";
-import { getSourceLabel, buildCbetaReadUrl } from "../../utils/sourceUrls";
+import { getSourceLabel } from "../../utils/sourceUrls";
 import type { CrossLanguageSearchHit } from "../../api/client";
 
 const LANG_LABELS: Record<string, string> = {
@@ -34,7 +34,6 @@ export default function CrossLangCard({ hit, rank }: { hit: CrossLanguageSearchH
   const navigate = useNavigate();
   const titleHtml = hit.highlight?.title_zh?.[0] ?? hit.title_zh;
   const sourceName = hit.source_code ? getSourceLabel(hit.source_code) : null;
-  const cbetaUrl = buildCbetaReadUrl(hit.cbeta_id);
   const relatedTranslations = hit.related_translations || [];
 
   // Collect all available titles for this text
@@ -102,13 +101,6 @@ export default function CrossLangCard({ hit, rank }: { hit: CrossLanguageSearchH
           </div>
         )}
         <div className="s-card-actions">
-          {cbetaUrl && (
-            <Button type="primary" size="small" icon={<LinkOutlined />}
-              style={{ background: "#8b2500", borderColor: "#8b2500" }}
-              href={cbetaUrl} target="_blank" rel="noopener noreferrer">
-              CBETA 阅读
-            </Button>
-          )}
           <Button type="primary" size="small" icon={<EyeOutlined />}
             onClick={() => navigate(`/texts/${hit.id}`)}>
             查看详情

--- a/frontend/src/components/search/ResultCard.tsx
+++ b/frontend/src/components/search/ResultCard.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from "react-router-dom";
 import { Tag, Button } from "antd";
-import { EyeOutlined, LinkOutlined, TranslationOutlined } from "@ant-design/icons";
+import { EyeOutlined, TranslationOutlined } from "@ant-design/icons";
 import BookmarkButton from "../BookmarkButton";
 import { sanitizeHighlight } from "../../utils/sanitize";
-import { getSourceLabel, buildCbetaReadUrl } from "../../utils/sourceUrls";
+import { getSourceLabel } from "../../utils/sourceUrls";
 import type { SearchHit } from "../../api/client";
 
 const LANG_LABELS: Record<string, string> = {
@@ -28,7 +28,6 @@ export default function ResultCard({ hit, rank }: { hit: SearchHit; rank: number
   const navigate = useNavigate();
   const titleHtml = hit.highlight?.title_zh?.[0] ?? hit.title_zh;
   const sourceName = hit.source_code ? getSourceLabel(hit.source_code) : null;
-  const cbetaUrl = buildCbetaReadUrl(hit.cbeta_id);
   const relatedTranslations = hit.related_translations || [];
 
   return (
@@ -79,13 +78,6 @@ export default function ResultCard({ hit, rank }: { hit: SearchHit; rank: number
           </div>
         )}
         <div className="s-card-actions">
-          {cbetaUrl && (
-            <Button type="primary" size="small" icon={<LinkOutlined />}
-              style={{ background: "#8b2500", borderColor: "#8b2500" }}
-              href={cbetaUrl} target="_blank" rel="noopener noreferrer">
-              CBETA 阅读
-            </Button>
-          )}
           <Button type="primary" size="small" icon={<EyeOutlined />}
             onClick={() => navigate(`/texts/${hit.id}`)}>
             查看详情


### PR DESCRIPTION
## Summary

- 搜索结果列表每条原有 "CBETA 阅读 + 查看详情 + 收藏" 三个按钮，详情页又给出一次 CBETA 阅读，形成跨层重复。
- 列表页精简到 "查看详情 + 收藏"，把 CBETA 阅读统一收敛到详情页。减少列表页视觉噪声（一屏 60 条 × 3 按钮 → × 2 按钮），同时保持用户仍能一键跳 CBETA（从详情页入口）。
- `ContentCard`（搜经文段落级结果）保持不变——它没有"查看详情"入口，CBETA 阅读是段落的唯一跳转动作，语义与经典列表完全不同。

## 改动文件

- `frontend/src/components/search/ResultCard.tsx` — 删除 CBETA 阅读按钮及相关 import
- `frontend/src/components/search/CrossLangCard.tsx` — 同上

## Test plan

- [x] `npx tsc --noEmit` 通过
- [x] 生产环境（VPS）已部署：`docker compose build frontend` + `docker compose up -d frontend`
- [x] 部署后 bundle 中 `CBETA 阅读` 字面量仅保留在 `TextDetailPage` 和 `ContentCard`（SearchPage 中因 ContentCard 仍需）
- [ ] 在 https://fojin.xyz 搜 "华严经"，确认列表卡片只剩 "查看详情" + 收藏
- [ ] 点击 "查看详情" 进入详情页，确认 CBETA 阅读按钮仍在
- [ ] "搜经文" tab 下的段落卡片 CBETA 阅读按钮仍在

🤖 Generated with [Claude Code](https://claude.com/claude-code)