### PR TITLE
ui(detail): 交换收藏/导出引用位置，收藏改紫色 solid 样式

### DIFF
--- a/frontend/src/components/BookmarkButton.tsx
+++ b/frontend/src/components/BookmarkButton.tsx
@@ -7,9 +7,10 @@ import { addBookmark, removeBookmark, checkBookmark } from "../api/client";
 interface BookmarkButtonProps {
   textId: number;
   size?: "small" | "middle" | "large";
+  solid?: boolean;
 }
 
-export default function BookmarkButton({ textId, size }: BookmarkButtonProps) {
+export default function BookmarkButton({ textId, size, solid }: BookmarkButtonProps) {
   const user = useAuthStore((s) => s.user);
   const queryClient = useQueryClient();
 
@@ -32,6 +33,21 @@ export default function BookmarkButton({ textId, size }: BookmarkButtonProps) {
   });
 
   if (!user) return null;
+
+  if (solid) {
+    return (
+      <Button
+        type="primary"
+        size={size}
+        icon={bookmarked ? <HeartFilled /> : <HeartOutlined />}
+        loading={mutation.isPending}
+        onClick={() => mutation.mutate()}
+        style={{ background: "#7c3aed", borderColor: "#7c3aed", color: "#fff" }}
+      >
+        {bookmarked ? "已收藏" : "收藏"}
+      </Button>
+    );
+  }
 
   return (
     <Button

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -198,7 +198,13 @@ export default function TextDetailPage() {
               CBETA 阅读
             </Button>
           )}
-          <BookmarkButton textId={text.id} />
+          <Button
+            icon={<BookOutlined />}
+            onClick={() => setCitationOpen(true)}
+            style={{ background: "#5b8c6b", borderColor: "#5b8c6b", color: "#fff" }}
+          >
+            导出引用
+          </Button>
           {manifests && manifests.length > 0 && (
             <Button
               icon={<FileImageOutlined />}
@@ -207,13 +213,7 @@ export default function TextDetailPage() {
               手稿影像 ({manifests.length})
             </Button>
           )}
-          <Button
-            icon={<BookOutlined />}
-            onClick={() => setCitationOpen(true)}
-            style={{ background: "#5b8c6b", borderColor: "#5b8c6b", color: "#fff" }}
-          >
-            导出引用
-          </Button>
+          <BookmarkButton textId={text.id} solid />
         </Space>
 
         <CitationGenerator


### PR DESCRIPTION
## Summary

- 详情页按钮顺序调整：从 \`在线阅读 / CBETA / 收藏 / 手稿影像 / 导出引用\` 改为 \`在线阅读 / CBETA / 导出引用 / 手稿影像 / 收藏\`。
- 详情页的收藏按钮切换到紫色 (\`#7c3aed\`) 填充样式，与蓝色"在线阅读"、酒红 CBETA、橄榄绿"导出引用"形成四色区分。
- \`BookmarkButton\` 新增可选 \`solid\` prop。只有详情页传入 \`solid\`，列表页继续用默认 text 轻量样式，避免搜索结果一屏堆满紫色方块。

## Test plan

- [x] \`npx tsc --noEmit\` 通过
- [x] VPS \`docker compose build frontend\` + 重启容器
- [x] 新构建产物 \`BookmarkButton-*.js\` 包含 \`#7c3aed\` 字面量
- [ ] 手动刷新 fojin 详情页，确认按钮顺序为 在线阅读 → CBETA → 导出引用 → 手稿影像 → 收藏，收藏为紫色
- [ ] 搜索结果列表的小号收藏按钮仍为 text 样式，没有被误改

🤖 Generated with [Claude Code](https://claude.com/claude-code)