### PR TITLE
ui(detail): 撤回收藏按钮紫色背景，恢复 text 样式

### DIFF
--- a/frontend/src/components/BookmarkButton.tsx
+++ b/frontend/src/components/BookmarkButton.tsx
@@ -7,10 +7,9 @@ import { addBookmark, removeBookmark, checkBookmark } from "../api/client";
 interface BookmarkButtonProps {
   textId: number;
   size?: "small" | "middle" | "large";
-  solid?: boolean;
 }
 
-export default function BookmarkButton({ textId, size, solid }: BookmarkButtonProps) {
+export default function BookmarkButton({ textId, size }: BookmarkButtonProps) {
   const user = useAuthStore((s) => s.user);
   const queryClient = useQueryClient();
 
@@ -33,21 +32,6 @@ export default function BookmarkButton({ textId, size, solid }: BookmarkButtonPr
   });
 
   if (!user) return null;
-
-  if (solid) {
-    return (
-      <Button
-        type="primary"
-        size={size}
-        icon={bookmarked ? <HeartFilled /> : <HeartOutlined />}
-        loading={mutation.isPending}
-        onClick={() => mutation.mutate()}
-        style={{ background: "#7c3aed", borderColor: "#7c3aed", color: "#fff" }}
-      >
-        {bookmarked ? "已收藏" : "收藏"}
-      </Button>
-    );
-  }
 
   return (
     <Button

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -213,7 +213,7 @@ export default function TextDetailPage() {
               手稿影像 ({manifests.length})
             </Button>
           )}
-          <BookmarkButton textId={text.id} solid />
+          <BookmarkButton textId={text.id} />
         </Space>
 
         <CitationGenerator


### PR DESCRIPTION
## Summary

- 撤回 PR #408 引入的详情页紫色收藏按钮，恢复为原先的透明 text 样式。
- 按钮位置交换（导出引用 ↔ 收藏）**保留**，只是收藏的视觉回到原样。
- \`BookmarkButton\` 的 \`solid\` prop 一并删除，该 prop 已无任何调用点。

## Test plan

- [x] \`npx tsc --noEmit\` 通过
- [x] VPS 重 build + 重启，新 bundle 不再包含紫色 \`#7c3aed\` 字面量
- [ ] 刷新详情页，确认收藏按钮为透明 text 样式，顺序仍为 在线阅读 → CBETA → 导出引用 →（手稿影像）→ 收藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)