### PR TITLE
ui(nav): 恢复「佛教地理」菜单入口

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -76,8 +76,7 @@ export default function Layout() {
     { icon: <RobotOutlined />, label: t("nav.chat"), path: "/chat" },
     { icon: <FileTextOutlined />, label: t("nav.dictionary"), path: "/dictionary" },
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
-    // TODO: 佛教地理暂时隐藏，待数据完善后重新上线
-    // { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
+    { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
     // TODO: 佛学动态暂时隐藏，待加入cron定时抓取后重新上线
     // { icon: <NotificationOutlined />, label: t("nav.activity"), path: "/activity" },


### PR DESCRIPTION
## Summary

恢复被注释的佛教地理 (KGMap) 菜单入口。

当时暂时隐藏的原因是"待数据完善后重新上线"。现在后端实测：

- \`/api/kg/geo\`: **78,632** 个带坐标的 KG 实体
- \`/api/kg/lineage-arcs\`: **745** 条师承弧线

数据量已经可以支撑 \`KGMapPage\` 的时空探索交互。

## 技术细节

只取消 \`frontend/src/components/Layout.tsx\` 第 80 行菜单条目的注释。其它所有部件一直在位：

- 路由 \`/map\` 在 App.tsx 已配好（lazy 加载 KGMapPage）
- \`GlobalOutlined\` icon 已在 Layout.tsx 的 import 中
- i18n key \`nav.geo\` 在 9 种语言的 translation.json 中都已存在
- \`KGMapPage\`、\`DeckGLMap\`、\`MapEntityPopup\` 组件文件都健全

## Test plan

- [x] \`npx tsc --noEmit\` 通过
- [x] VPS 重 build + 重启 frontend 容器
- [x] 容器自身 \`/\` 和 \`/map\` 返回 200
- [x] 新 bundle 含 \`nav.geo\` 字面量
- [ ] 浏览器刷新 fojin.app 确认菜单栏出现"佛教地理"
- [ ] 点击进入 \`/map\`，确认地图加载、人物/地点 marker 显示、师承弧线渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)