### PR TITLE
fix(geo): amap v3 urlencode + regeo 排除 bdrc

### DIFF
--- a/backend/scripts/backfill_address_regeo.py
+++ b/backend/scripts/backfill_address_regeo.py
@@ -112,6 +112,7 @@ async def main():
               AND (properties->>'country' = 'CN' OR properties->>'country' = '中国'
                    OR properties->>'geo_source' LIKE 'osm:CN%' OR properties->>'geo_source' LIKE 'osm:中国%'
                    OR properties->>'geo_source' LIKE 'osm_ext%')
+              AND COALESCE(properties->>'geo_source', '') <> 'bdrc'
               AND (properties->>'province' IS NULL OR properties->>'province' = '')
               AND properties->>'latitude' IS NOT NULL
             LIMIT :limit

--- a/backend/scripts/fetch_amap_temples_v3.py
+++ b/backend/scripts/fetch_amap_temples_v3.py
@@ -46,7 +46,13 @@ def api_call(url):
 
 def get_all_cities():
     """Get all prefecture-level cities from Amap district API."""
-    url = f"https://restapi.amap.com/v3/config/district?key={AMAP_KEY}&keywords=中国&subdistrict=2&extensions=base"
+    params = urllib.parse.urlencode({
+        'key': AMAP_KEY,
+        'keywords': '中国',
+        'subdistrict': 2,
+        'extensions': 'base',
+    })
+    url = f"https://restapi.amap.com/v3/config/district?{params}"
     data = api_call(url)
     cities = []
     if data.get('status') == '1':


### PR DESCRIPTION
## 问题背景

在核查佛教地理数据时发现两个静默运行的定时任务都在空跑：

1. **\`fetch_amap_temples_v3.py\`** 自 2026-04-08 起每天 0:30 在 \`get_all_cities()\` 第一步 crash：
   \`\`\`
   UnicodeEncodeError: 'ascii' codec can't encode characters in position 70-71
   \`\`\`
   V3 的 progress 和 output 文件从未生成。
2. **\`backfill_address_regeo.py\`** 每天 12:30 找到 222 条 "待补行政区划" 的中国寺院，全是 BDRC 藏传佛教数据，高德反查要么 SSL 超时要么返回空，updated=0 持续卡死。

## 修复

### 1. V3 脚本：urlencode 包装 keywords 参数

\`get_all_cities()\` 把汉字 "中国" 直接塞进了 f-string URL，\`urllib.request\` 在发请求时会对 URL 做 ASCII 编码而崩溃。改用 \`urllib.parse.urlencode\` 正确处理：

\`\`\`python
params = urllib.parse.urlencode({
    'key': AMAP_KEY,
    'keywords': '中国',
    'subdistrict': 2,
    'extensions': 'base',
})
url = f"https://restapi.amap.com/v3/config/district?{params}"
\`\`\`

### 2. regeo 脚本：排除 bdrc 来源

BDRC 有自己的坐标和行政区划数据来源，高德反查无法为其提供额外价值，反而会在偏远或境外坐标上浪费 API 配额。WHERE 子句增加 \`COALESCE(properties->>'geo_source','') <> 'bdrc'\`。

## 验证

- [x] V3 脚本 \`python -m py_compile\` 通过
- [x] regeo 脚本 \`python -m py_compile\` 通过
- [x] VPS 上手动调 \`get_all_cities()\` 返回 **396 个地级市**（和 memory project_fojin_amap_v3 记录的预期完全对上）
- [x] VPS 上 SQL 验证新 WHERE 子句：regeo 候选数从 **222 降到 0**
- [ ] 明天 0:30 和 12:30 cron 自然运行，观察日志回归干净、V3 开始真正抓寺院

## 预期增量

V3 会按 396 城市 × 3 关键词 ("寺"/"庵"/"禅寺") × 最多 25 页分页抓取，绕开 V2 按省份 500 条封顶的问题。具体能多挖出多少条寺院要跑完才知道，有 progress 文件支持断点续传，预计 1-2 天完成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)