### PR TITLE
feat(kg): 地图和师承接口过滤非佛教人物

### DIFF
--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -283,6 +283,7 @@ async def get_geo_entities(
         "(e.properties->>'latitude') IS NOT NULL",
         "(e.properties->>'longitude') IS NOT NULL",
         "e.entity_type != 'sub_entity'",
+        "COALESCE(e.properties->>'is_buddhist', 'true') != 'false'",
     ]
     params: dict = {"limit": limit}
 
@@ -382,6 +383,8 @@ async def get_lineage_arcs(
         "(s.properties->>'latitude') != ''",
         "COALESCE(t.properties->>'geo_source', '') NOT LIKE 'teacher_hop%%'",
         "COALESCE(s.properties->>'geo_source', '') NOT LIKE 'teacher_hop%%'",
+        "COALESCE(t.properties->>'is_buddhist', 'true') != 'false'",
+        "COALESCE(s.properties->>'is_buddhist', 'true') != 'false'",
     ]
     params: dict = {"limit": limit}
 


### PR DESCRIPTION
## Summary

fojin 精准定位佛教人物数据库。数据库里 ~1% 的人物是 DILA 因佛教史籍提及而收录的"相关人物"（儒家/道家/历代皇帝/文人居士/近现代政治人物），用户要求从地图和师承接口排除。

## 方案：软删除 + API 层过滤

### 数据库层（已在生产库直接操作）

对 582 条记录打 `properties.is_buddhist = false` 标记，按来源类别附加 `excluded_reason`：

| 批次 | 规则（带佛教保护词） | 标记数 |
|---|---|---|
| L1 道教 | \`道士 / 天師 / 羽士 / 道觀\` | 167 |
| L1 儒家 | \`孔子弟子 / 儒學 / 太學博士\` + 儒道墨韩诸子 + 孔门弟子白名单 | 90 |
| L1 皇帝 | \`位皇帝 / 代皇帝 / 開國皇帝 / 即帝位\` | 123 |
| L1 世俗文人 | 苏轼、白居易、李白、章太炎等姓名白名单 | 20 |
| L1 神话 | \`神話人物 / 傳說 / 神仙 / 道教神\` | 56 |
| L2 政治 | \`政治人物 / 革命家 / 軍閥 / 國民黨 / 行政院 / 總統\` | 131 |
| 手动恢复 FP | 定池、道教顯意、鎌田茂雄、岡野正道、宗炳 | **-5** |
| **合计净清理** | | **582** |

所有规则都附带至少 15 个佛教强信号保护词（\`釋/僧/禪/菩薩/法師/和尚/住持/法嗣/淨土/華嚴/薙染/剃度/得法/示寂/駐錫\` 等），抽样验证精度后再执行 UPDATE。

### API 层（本 PR）

\`backend/app/services/knowledge_graph.py\` 的两个查询加一条 WHERE 子句：

\`\`\`python
"COALESCE(e.properties->>'is_buddhist', 'true') != 'false'"
\`\`\`

COALESCE 默认 'true' 意味着：未打标记的记录（99% 以上）照常返回；只有明确 \`is_buddhist=false\` 的从结果中消失。对 \`get_lineage_arcs\` 的 teacher 和 student 两端都加了过滤，防止跨界弧线。

## 实测生效

\`\`\`
person total:         18459 → 18230 (-229, 有坐标的被清理掉的)
all entities total:   78632 → 78403 (-229)
lineage arcs total:     745 → 743  (-2)
\`\`\`

## 可逆性

- 所有标记是 \`UPDATE properties\` 不是 \`DELETE\`
- 每条都保留 \`excluded_reason\` 字段标明被移除的理由
- 单条回滚：\`UPDATE kg_entities SET properties = (properties::jsonb - 'is_buddhist' - 'excluded_reason')::json WHERE id = X;\`
- 批量回滚：按 \`excluded_reason\` 撤销某个类别
- 后续可以基于现场反馈继续收紧规则或加保护词

## Test plan

- [x] VPS 上直接 SQL 抽样验证每批规则 10-12 条
- [x] 发现 5 个 false positive 单独恢复
- [x] \`docker compose restart backend\` 后 API 返回数字减少 229
- [x] 师承弧线减少 2 条（非佛教人物本来就不常有 teacher_of）
- [ ] 浏览器刷新 fojin.app 佛教地理页面，人物 marker 明显减少

🤖 Generated with [Claude Code](https://claude.com/claude-code)