### PR TITLE
ui(nav): 暂时隐藏「佛教地理」菜单入口

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -76,7 +76,9 @@ export default function Layout() {
     { icon: <RobotOutlined />, label: t("nav.chat"), path: "/chat" },
     { icon: <FileTextOutlined />, label: t("nav.dictionary"), path: "/dictionary" },
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
-    { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
+    // TODO: 佛教地理暂时隐藏，待人物 geocoding 数据质量问题解决后重新上线
+    // （~1000 条中国僧人因 desc_match 贪心匹配被错投到韩国同名寺院，见 session 2026-04-12）
+    // { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
     // TODO: 佛学动态暂时隐藏，待加入cron定时抓取后重新上线
     // { icon: <NotificationOutlined />, label: t("nav.activity"), path: "/activity" },


### PR DESCRIPTION
## Summary

在 geocoding pipeline 的数据质量问题修复前，从顶部导航栏暂时移除「佛教地理」菜单项。

## 背景

今日会话中发现：目前 \`monastery\` 表对中国著名古刹（杭州靈隱寺、上海龍華寺等）覆盖极少，而对韩国 OSM 数据覆盖非常全（龍華寺 24 条韩国 / 0 条中国，觀音寺 44 条韩国 / 3 条中国）。\`desc_match\` geocoding 算法贪心取首个同名 monastery，导致 \`1148\` 条"南朝鲜人物"里约 1000 条实际是中国云南、福建、江浙的僧人被错投到韩国境内。

尝试过一次 L1 "CN 优先" remap 修复，但方法论不严谨（单信号决策 + 弱负证据依赖），**已全部回滚**。正确的修复路径需要：
- 重写 geocoding pipeline 为多信号加权（朝代 + 地名 + 引用文献 + 寺名），或
- 手工补全 monastery 表中国主要古刹坐标（~50-100 条）后重跑 desc_match

这两条路径都需要独立的 session 专注做。

## 为什么现在要隐藏而不是修

在 fojin.app 地图上，用户打开看到的是"南朝鲜遍地高僧、中国南方稀疏"，给人**数据不可信的第一印象**。这比没有这个功能更糟——没有功能只是"缺失"，错误的数据展示会让用户怀疑整个平台的数据质量。PR #410 之前也是因为数据未完善主动隐藏过，这次是同样的考量。

## 改动

仅注释 \`Layout.tsx\` 第 80 行菜单条目，加了一个清晰的 TODO 注释说明恢复条件。其它一切保留：

- 路由 \`/map\` 仍在 App.tsx 里，直接访问 URL 仍可打开页面
- \`KGMapPage\`、\`DeckGLMap\`、\`MapEntityPopup\` 组件不动
- \`GlobalOutlined\` icon 仍被语言切换按钮（Layout.tsx 第 245 行）使用
- 9 种语言的 \`nav.geo\` i18n key 保留

## 恢复方式

数据质量问题解决后，取消第 80 行的注释即可（这是 PR #410 / #414 之前的工作的反向操作）。

## Test plan

- [x] \`npx tsc --noEmit\` 通过
- [x] \`eslint Layout.tsx --max-warnings 0\` 通过
- [x] VPS 已 rebuild + force-recreate frontend 容器
- [x] VPS 源文件第 81 行确认为注释状态
- [ ] 刷新 fojin.app 确认顶部导航不再显示🌐「佛教地理」
- [ ] 直接访问 fojin.app/map 确认页面本身仍可加载（fallback 入口）

🤖 Generated with [Claude Code](https://claude.com/claude-code)