### PR TITLE
ui(auth): 隐藏手机登录 Tab 和相关文案（SMS 未配置）

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Card, Form, Input, Button, Typography, Tabs, Divider, message, Space } from "antd";
-import { UserOutlined, LockOutlined, MailOutlined, MobileOutlined, GithubOutlined, GoogleOutlined } from "@ant-design/icons";
+import { UserOutlined, LockOutlined, MailOutlined, GithubOutlined, GoogleOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../stores/authStore";
 import api from "../api/client";
@@ -161,11 +161,6 @@ export default function LoginPage() {
                 </Form>
               ),
             },
-            {
-              key: "phone",
-              label: "手机登录",
-              children: <PhoneLoginForm />,
-            },
           ]}
         />
       </Card>
@@ -204,99 +199,3 @@ function SocialLoginButtons() {
 }
 
 
-function PhoneLoginForm() {
-  const navigate = useNavigate();
-  const setAuth = useAuthStore((s) => s.setAuth);
-  const [loading, setLoading] = useState(false);
-  const [codeSent, setCodeSent] = useState(false);
-  const [countdown, setCountdown] = useState(0);
-  const [form] = Form.useForm();
-
-  useEffect(() => {
-    if (countdown <= 0) return;
-    const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
-    return () => clearTimeout(timer);
-  }, [countdown]);
-
-  const handleSendCode = async () => {
-    const phone = form.getFieldValue("phone");
-    if (!phone || phone.length < 10) {
-      message.warning("请输入有效的手机号码");
-      return;
-    }
-    setLoading(true);
-    try {
-      const { data } = await api.post("/auth/sms/send-code", { phone });
-      if (data.ok) {
-        setCodeSent(true);
-        setCountdown(60);
-        message.success("验证码已发送");
-      } else {
-        message.error(data.message || "发送失败");
-      }
-    } catch {
-      message.error("发送失败，请稍后重试");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleLogin = async (values: { phone: string; code: string }) => {
-    setLoading(true);
-    try {
-      const { data: tokenData } = await api.post("/auth/sms/login", values);
-      const { data: user } = await api.get("/auth/me", {
-        headers: { Authorization: `Bearer ${tokenData.access_token}` },
-      });
-      setAuth(tokenData.access_token, user);
-      message.success("登录成功");
-      navigate("/");
-    } catch (err: any) {
-      message.error(err.response?.data?.detail || "验证码错误或已过期");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <Form form={form} onFinish={handleLogin} layout="vertical">
-      <Form.Item name="phone" rules={[{ required: true, message: "请输入手机号" }]}>
-        <Input
-          prefix={<MobileOutlined />}
-          placeholder="手机号码"
-          size="large"
-          maxLength={15}
-        />
-      </Form.Item>
-      <Form.Item>
-        <Space.Compact style={{ width: "100%" }}>
-          <Form.Item name="code" noStyle rules={[{ required: true, message: "请输入验证码" }]}>
-            <Input
-              prefix={<LockOutlined />}
-              placeholder="验证码"
-              size="large"
-              maxLength={6}
-              style={{ flex: 1 }}
-            />
-          </Form.Item>
-          <Button
-            size="large"
-            onClick={handleSendCode}
-            disabled={countdown > 0}
-            loading={loading && !codeSent}
-          >
-            {countdown > 0 ? `${countdown}s` : codeSent ? "重新发送" : "获取验证码"}
-          </Button>
-        </Space.Compact>
-      </Form.Item>
-      <Form.Item>
-        <Button type="primary" htmlType="submit" loading={loading} block size="large">
-          登录 / 注册
-        </Button>
-      </Form.Item>
-      <Text type="secondary" style={{ fontSize: 12, display: "block", textAlign: "center" }}>
-        首次使用手机号登录将自动创建账号
-      </Text>
-    </Form>
-  );
-}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -356,8 +356,8 @@ export default function ProfilePage() {
                           </div>
                           <div style={{ color: "#8c6e3e" }}>
                             只有使用 <strong>用户名 + 密码</strong> 注册的账号可以在这里修改密码。如果你当初是通过
-                            <strong> GitHub 登录</strong>、<strong>Google 登录</strong> 或 <strong>手机验证码</strong> 进入 fojin
-                            的，你的账号没有独立密码——下次登录时，请继续在登录页点击对应的 GitHub / Google 按钮，或使用手机验证码即可。
+                            <strong> GitHub 登录</strong> 或 <strong>Google 登录</strong> 进入 fojin 的，你的账号没有独立密码——
+                            下次登录时，请继续在登录页点击对应的 GitHub / Google 按钮即可。
                           </div>
                         </div>
                       }


### PR DESCRIPTION
## Summary

fojin.app 生产 \`.env\` 里没有配置任何 \`ALIYUN_SMS_*\` 凭证，但 \`send_sms_code\` 服务在 key 缺失时有 dev-mode fallback：把验证码写到 backend 日志然后 \`return True\`，前端显示"验证码已发送"但手机收不到任何短信。这是比报错更糟的"默默失败"——用户会以为系统坏了或怀疑整个平台不可靠。

在 SMS 凭证没有正式配置前，应该**把手机登录入口完全隐藏**，而不是让它默默坏掉。

## 改动

### LoginPage.tsx

- Tabs items 去掉 \`{ key: "phone", label: "手机登录" }\` 条目
- 删除 \`PhoneLoginForm\` 函数（约 95 行）
- 删除只被它用到的 \`MobileOutlined\` icon import

### ProfilePage.tsx

账户安全 Tab 的 Alert 文案去掉 "或手机验证码" 的提及。PR #415 里我写的时候假设了 SMS 开通，这是这次核对后的修正。

## 保留的东西

- 后端端点 \`/api/auth/sms/send-code\` 和 \`/api/auth/sms/login\` 照旧
- \`services/oauth.py\` 里的 \`send_sms_code\` / \`verify_sms_code\` / \`sms_login\` 服务照旧
- 9 种语言 i18n 的手机登录翻译 key 保留
- \`aliyun_sms\` service 模块和 settings 字段保留

## 恢复条件

未来要真正开通 SMS 登录：

1. VPS \`/home/admin/fojin/.env\` 补 \`ALIYUN_SMS_ACCESS_KEY_ID\` / \`SECRET\` / \`TEMPLATE_CODE\` 三字段
2. 重启 backend
3. 在阿里云后台实测短信下发成功
4. \`git blame\` 本次 commit 还原 \`PhoneLoginForm\` 代码 + \`MobileOutlined\` import + Tabs entry
5. \`ProfilePage\` Alert 文案恢复手机验证码提及

## Test plan

- [x] \`npx tsc --noEmit\` 通过
- [x] \`eslint src/ --max-warnings 50\` 通过（46 warnings，净减 1 条）
- [x] VPS rebuild + force-recreate frontend 容器
- [ ] 刷新 fojin.app 登录页：Tabs 只剩 "登录 / 注册"，无 "手机登录"
- [ ] 账户安全 Tab Alert 文案只提 GitHub / Google，不提手机验证码

🤖 Generated with [Claude Code](https://claude.com/claude-code)