### PR TITLE
ui(reader): 给 AI 解读浮动按钮加 Tooltip

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Typography, Spin, Button, Select, Breadcrumb, Row, Col, message } from "antd";
+import { Typography, Spin, Button, Select, Breadcrumb, Row, Col, message, Tooltip } from "antd";
 import {
   HomeOutlined,
   LeftOutlined,
@@ -778,14 +778,17 @@ export default function TextReaderPage() {
         </div>
       </>
     ) : (
-      <Button
-        className="reader-ai-fab"
-        type="primary"
-        shape="circle"
-        size="large"
-        icon={<RobotOutlined />}
-        onClick={() => setAiPanelOpen(true)}
-      />
+      <Tooltip title="AI 解读" placement="left">
+        <Button
+          className="reader-ai-fab"
+          type="primary"
+          shape="circle"
+          size="large"
+          icon={<RobotOutlined />}
+          onClick={() => setAiPanelOpen(true)}
+          aria-label="AI 解读"
+        />
+      </Tooltip>
     )}
     </div>
   );


### PR DESCRIPTION
## Summary

阅读页（\`TextReaderPage\`）右下角的红色圆形浮动按钮（\`reader-ai-fab\`）是 AI 解读功能的入口，但没有任何说明文字。用户第一次看到只会当成设计装饰，不知道能点。截图证据：用户直接反馈"要么用户不知道这是干嘛用"。

## 改动

- 从 \`antd\` 多导入 \`Tooltip\`
- 用 \`<Tooltip title="AI 解读" placement="left">\` 包住按钮
- 同时加 \`aria-label="AI 解读"\` 改善屏幕阅读器支持
- \`placement="left"\` 是因为按钮在屏幕右下角，tooltip 往左冒出来不会被右边屏幕边缘遮挡

点击后打开 AI 解读侧边栏的交互完全不变。

## Test plan

- [x] \`npx tsc --noEmit\` 通过
- [x] \`eslint TextReaderPage.tsx\` 无新增 warning
- [x] VPS rebuild + force-recreate frontend
- [ ] 刷新经文阅读页，鼠标悬停右下角红色按钮应显示 "AI 解读" tooltip
- [ ] 点击仍能正常打开 AI 侧边栏

🤖 Generated with [Claude Code](https://claude.com/claude-code)