### PR TITLE
fix(auth): restore last_active_at tracking broken by password-version change

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -291,9 +291,10 @@ class LastActiveMiddleware(BaseHTTPMiddleware):
         try:
             from app.core.auth import verify_token
             token = auth_header[7:]
-            user_id = verify_token(token)
-            if user_id is None:
+            result = verify_token(token)
+            if result is None:
                 return response
+            user_id, _pwd_v = result
 
             redis_client = getattr(request.app.state, "redis", None)
             if redis_client is None:

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -28,11 +28,13 @@ async def register_user(db: AsyncSession, data: UserRegister) -> User:
     if result.scalar_one_or_none():
         raise DuplicateEmailError()
 
+    now = datetime.now(UTC)
     user = User(
         username=data.username,
         email=data.email,
         hashed_password=hash_password(data.password),
         display_name=data.display_name or data.username,
+        last_active_at=now,
     )
     db.add(user)
     await db.commit()
@@ -53,6 +55,9 @@ async def login_user(db: AsyncSession, username: str, password: str) -> TokenRes
 
     if not user.is_active:
         raise AccountDisabledError()
+
+    user.last_active_at = datetime.now(UTC)
+    await db.commit()
 
     token = create_access_token(user.id, user.password_version)
     return TokenResponse(access_token=token)

--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -7,6 +7,7 @@ import json
 import logging
 import secrets
 import string
+from datetime import UTC, datetime
 
 import httpx
 from sqlalchemy import select
@@ -39,9 +40,11 @@ async def _find_or_create_user(
     social = result.scalar_one_or_none()
 
     if social:
-        # Existing link — fetch the user
+        # Existing link — fetch the user and update last_active_at
         user_result = await db.execute(select(User).where(User.id == social.user_id))
         user = user_result.scalar_one()
+        user.last_active_at = datetime.now(UTC)
+        await db.commit()
         return user
 
     # If we have an email, check if a user with that email already exists
@@ -68,6 +71,7 @@ async def _find_or_create_user(
             email=email or f"{provider}_{provider_user_id}@noreply.fojin.app",
             hashed_password=hash_password(random_pw),
             display_name=display_name or username,
+            last_active_at=datetime.now(UTC),
         )
         db.add(user)
         await db.flush()  # Get user.id


### PR DESCRIPTION
## Summary
- PR #414 changed `verify_token()` return from `int` to `tuple[int, int]`, but `LastActiveMiddleware` was not updated — `last_active_at` silently stopped updating for all users
- Set `last_active_at` at registration and login time (password, OAuth, SMS) so new users have the field populated immediately instead of waiting for the first middleware update
- Backfilled 374 users with NULL `last_active_at` to `created_at` on production

## Test plan
- [x] Deployed to production, verified user management page shows correct times
- [x] New registrations will have `last_active_at` set from the start

🤖 Generated with [Claude Code](https://claude.com/claude-code)