### PR TITLE
ui(home): update anonymous tip to mention AI Q&A is available

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -129,9 +129,9 @@ export default function HomePage() {
           <div className="home-tip">
             <InfoCircleOutlined style={{ marginRight: 6, flexShrink: 0 }} />
             <span>
-              无需注册即可搜索与浏览。
+              无需注册即可搜索、浏览并体验 AI 佛典问答。
               <a onClick={() => navigate("/login")} style={{ cursor: "pointer", textDecoration: "underline" }}>注册登录</a>
-              后可使用收藏夹、AI 问答、阅读历史、标注笔记、自定义 API Key 等功能。
+              后可畅享 AI 问答，并解锁收藏夹、阅读历史、标注笔记、自定义 API Key 等功能。
             </span>
             <CloseOutlined
               onClick={() => setTipDismissed(true)}


### PR DESCRIPTION
## Summary

Previous tip on the anonymous homepage implied that **AI 问答** was a signup-gated feature, but anonymous users actually get 10/day. Rewrite the tip to accurately invite visitors to try AI 问答 and position signup as the path to unlimited usage (200/day, paired with PR #424).

## Before

> 无需注册即可搜索与浏览。注册登录后可使用收藏夹、AI 问答、阅读历史、标注笔记、自定义 API Key 等功能。

## After

> 无需注册即可搜索、浏览并体验 AI 佛典问答。注册登录后可畅享 AI 问答，并解锁收藏夹、阅读历史、标注笔记、自定义 API Key 等功能。

## Test plan

- [x] Rebuild frontend on VPS
- [ ] Confirm anonymous user on homepage sees new tip text

🤖 Generated with [Claude Code](https://claude.com/claude-code)