### PR TITLE
feat(share): public Q&A deep links

### DIFF
--- a/backend/alembic/versions/0118_add_shared_qa_table.py
+++ b/backend/alembic/versions/0118_add_shared_qa_table.py
@@ -1,0 +1,51 @@
+"""Add shared_qa table for public Q&A sharing.
+
+Revision ID: 0118
+Revises: 0117
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0118"
+down_revision = "0117"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "shared_qa",
+        sa.Column("id", sa.String(16), primary_key=True),
+        sa.Column("question", sa.Text(), nullable=False),
+        sa.Column("answer", sa.Text(), nullable=False),
+        sa.Column("sources", sa.JSON(), nullable=True),
+        sa.Column(
+            "creator_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("view_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_shared_qa_creator_user_id",
+        "shared_qa",
+        ["creator_user_id"],
+    )
+    op.create_index(
+        "ix_shared_qa_created_at",
+        "shared_qa",
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_shared_qa_created_at", table_name="shared_qa")
+    op.drop_index("ix_shared_qa_creator_user_id", table_name="shared_qa")
+    op.drop_table("shared_qa")

--- a/backend/app/api/share.py
+++ b/backend/app/api/share.py
@@ -1,0 +1,93 @@
+import secrets
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.core.deps import get_optional_user
+from app.database import get_db
+from app.models.chat import SharedQA
+from app.models.user import User
+from app.schemas.chat import (
+    ShareQACreateResponse,
+    ShareQARequest,
+    ShareQAResponse,
+)
+
+router = APIRouter(prefix="/share", tags=["share"])
+
+
+_ID_ALPHABET = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+
+def _generate_short_id(length: int = 12) -> str:
+    return "".join(secrets.choice(_ID_ALPHABET) for _ in range(length))
+
+
+def _public_share_url(short_id: str) -> str:
+    base = settings.oauth_redirect_base.rstrip("/")
+    return f"{base}/share/qa/{short_id}"
+
+
+@router.post("/qa", response_model=ShareQACreateResponse)
+async def create_shared_qa(
+    payload: ShareQARequest,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a publicly shareable Q&A snapshot. Anyone with the short ID can read it.
+
+    创建公开可访问的问答快照,用于社交分享。"""
+    sources_payload = (
+        [s.model_dump() for s in payload.sources] if payload.sources else None
+    )
+
+    for _ in range(5):
+        short_id = _generate_short_id()
+        existing = await db.scalar(select(SharedQA.id).where(SharedQA.id == short_id))
+        if not existing:
+            break
+    else:
+        raise HTTPException(status_code=500, detail="Failed to allocate share id")
+
+    record = SharedQA(
+        id=short_id,
+        question=payload.question,
+        answer=payload.answer,
+        sources=sources_payload,
+        creator_user_id=user.id if user else None,
+    )
+    db.add(record)
+    await db.commit()
+
+    return ShareQACreateResponse(id=short_id, url=_public_share_url(short_id))
+
+
+@router.get("/qa/{share_id}", response_model=ShareQAResponse)
+async def get_shared_qa(
+    share_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Fetch a publicly shared Q&A. Increments view count.
+
+    获取一条公开分享的问答,会递增浏览次数。"""
+    record = await db.scalar(select(SharedQA).where(SharedQA.id == share_id))
+    if not record:
+        raise HTTPException(status_code=404, detail="Shared Q&A not found")
+
+    await db.execute(
+        update(SharedQA)
+        .where(SharedQA.id == share_id)
+        .values(view_count=SharedQA.view_count + 1)
+    )
+    await db.commit()
+
+    return ShareQAResponse(
+        id=record.id,
+        question=record.question,
+        answer=record.answer,
+        sources=record.sources,
+        view_count=record.view_count + 1,
+        created_at=record.created_at,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from app.api import (
     relations,
     rss,
     search,
+    share,
     sitemap,
     source_suggestions,
     sources,
@@ -352,6 +353,7 @@ app.include_router(iiif.router, prefix="/api")
 
 # Phase 3 routers
 app.include_router(chat.router, prefix="/api")
+app.include_router(share.router, prefix="/api")
 app.include_router(annotations.router, prefix="/api")
 
 # Dictionary

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -43,3 +43,19 @@ class ChatMessage(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
+
+
+class SharedQA(Base):
+    __tablename__ = "shared_qa"
+
+    id: Mapped[str] = mapped_column(String(16), primary_key=True)
+    question: Mapped[str] = mapped_column(Text)
+    answer: Mapped[str] = mapped_column(Text)
+    sources: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    creator_user_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id"), nullable=True
+    )
+    view_count: Mapped[int] = mapped_column(Integer, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -59,3 +59,25 @@ class SessionListItem(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class ShareQARequest(BaseModel):
+    question: str = Field(..., min_length=1, max_length=2000)
+    answer: str = Field(..., min_length=1, max_length=20000)
+    sources: list[ChatSource] | None = None
+
+
+class ShareQACreateResponse(BaseModel):
+    id: str
+    url: str
+
+
+class ShareQAResponse(BaseModel):
+    id: str
+    question: str
+    answer: str
+    sources: list[ChatSource] | None
+    view_count: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ const TimelinePage = lazy(() => import("./pages/TimelinePage"));
 const DashboardPage = lazy(() => import("./pages/DashboardPage"));
 const KGMapPage = lazy(() => import("./pages/KGMapPage"));
 const ActivityFeedPage = lazy(() => import("./pages/ActivityFeedPage"));
+const SharedQAPage = lazy(() => import("./pages/SharedQAPage"));
 
 function Loading() {
   return (
@@ -72,6 +73,7 @@ function App() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/dictionary" element={<DictionaryPage />} />
             <Route path="/chat" element={<RouteErrorBoundary><ChatPage /></RouteErrorBoundary>} />
+            <Route path="/share/qa/:id" element={<RouteErrorBoundary><SharedQAPage /></RouteErrorBoundary>} />
             <Route element={<ProtectedRoute />}>
               <Route path="/profile" element={<ProfilePage />} />
             </Route>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1063,6 +1063,34 @@ export interface ChatMessageItem {
   created_at: string;
 }
 
+export interface SharedQA {
+  id: string;
+  question: string;
+  answer: string;
+  sources: ChatSource[] | null;
+  view_count: number;
+  created_at: string;
+}
+
+export interface SharedQACreated {
+  id: string;
+  url: string;
+}
+
+export async function createSharedQA(payload: {
+  question: string;
+  answer: string;
+  sources: ChatSource[] | null;
+}): Promise<SharedQACreated> {
+  const { data } = await api.post<SharedQACreated>("/share/qa", payload);
+  return data;
+}
+
+export async function getSharedQA(id: string): Promise<SharedQA> {
+  const { data } = await api.get<SharedQA>(`/share/qa/${id}`);
+  return data;
+}
+
 export async function sendChatMessage(
   message: string,
   sessionId?: number,

--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -3,7 +3,7 @@ import { Modal, Button, message, Spin } from "antd";
 import { DownloadOutlined, CopyOutlined } from "@ant-design/icons";
 import html2canvas from "html2canvas-pro";
 import QRCode from "qrcode";
-import type { ChatSource } from "../api/client";
+import { createSharedQA, type ChatSource } from "../api/client";
 
 interface ShareCardProps {
   open: boolean;
@@ -14,7 +14,22 @@ interface ShareCardProps {
 }
 
 const CARD_WIDTH = 720;
-const SHARE_URL = "https://fojin.app/chat";
+const FALLBACK_SHARE_URL = "https://fojin.app/chat";
+
+function sanitizeFilenameSegment(text: string): string {
+  return text
+    .replace(/["《》【】「」『』〈〉()（）<>:"/\\|?*\u0000-\u001F]/g, "")
+    .replace(/\s+/g, "")
+    .slice(0, 18);
+}
+
+function buildFilename(question: string): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const datePart = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const titlePart = sanitizeFilenameSegment(question || "佛典问答") || "佛典问答";
+  return `fojin-${datePart}-${titlePart}.png`;
+}
 
 function stripMarkdown(md: string): string {
   return md
@@ -52,17 +67,39 @@ export default function ShareCard({ open, onClose, question, answer, sources }: 
   const cardRef = useRef<HTMLDivElement>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string>("");
   const [generating, setGenerating] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string>(FALLBACK_SHARE_URL);
+  const [creatingShare, setCreatingShare] = useState(false);
 
   useEffect(() => {
     if (!open) return;
-    QRCode.toDataURL(SHARE_URL, {
+    let cancelled = false;
+    setCreatingShare(true);
+    setShareUrl(FALLBACK_SHARE_URL);
+    createSharedQA({ question, answer, sources })
+      .then((res) => {
+        if (!cancelled) setShareUrl(res.url);
+      })
+      .catch((e) => {
+        console.error("create shared QA failed", e);
+      })
+      .finally(() => {
+        if (!cancelled) setCreatingShare(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, question, answer, sources]);
+
+  useEffect(() => {
+    if (!open) return;
+    QRCode.toDataURL(shareUrl, {
       width: 140,
       margin: 1,
       color: { dark: "#2b2318", light: "#f8f5ef" },
     })
       .then(setQrDataUrl)
       .catch(() => setQrDataUrl(""));
-  }, [open]);
+  }, [open, shareUrl]);
 
   const cleanAnswer = stripMarkdown(answer);
   const { text: answerText, truncated } = truncate(cleanAnswer, 420);
@@ -83,7 +120,7 @@ export default function ShareCard({ open, onClose, question, answer, sources }: 
       });
       const dataUrl = canvas.toDataURL("image/png");
       const link = document.createElement("a");
-      link.download = `fojin-qa-${Date.now()}.png`;
+      link.download = buildFilename(question);
       link.href = dataUrl;
       link.click();
       message.success("图片已保存");
@@ -96,7 +133,7 @@ export default function ShareCard({ open, onClose, question, answer, sources }: 
   };
 
   const handleCopyLink = () => {
-    navigator.clipboard.writeText(SHARE_URL).then(() => {
+    navigator.clipboard.writeText(shareUrl).then(() => {
       message.success("链接已复制");
     });
   };
@@ -288,8 +325,14 @@ export default function ShareCard({ open, onClose, question, answer, sources }: 
         >
           下载图片
         </Button>
-        <Button icon={<CopyOutlined />} onClick={handleCopyLink} size="large">
-          复制链接
+        <Button
+          icon={<CopyOutlined />}
+          onClick={handleCopyLink}
+          size="large"
+          loading={creatingShare}
+          disabled={creatingShare}
+        >
+          {creatingShare ? "生成链接中…" : "复制链接"}
         </Button>
       </div>
       {generating && (

--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -17,10 +17,15 @@ const CARD_WIDTH = 720;
 const FALLBACK_SHARE_URL = "https://fojin.app/chat";
 
 function sanitizeFilenameSegment(text: string): string {
-  return text
-    .replace(/["《》【】「」『』〈〉()（）<>:"/\\|?*\u0000-\u001F]/g, "")
-    .replace(/\s+/g, "")
-    .slice(0, 18);
+  const blocked = new Set('"《》【】「」『』〈〉()（）<>:"/\\|?*');
+  let out = "";
+  for (const ch of text) {
+    const code = ch.charCodeAt(0);
+    if (code < 0x20) continue;
+    if (blocked.has(ch)) continue;
+    out += ch;
+  }
+  return out.replace(/\s+/g, "").slice(0, 18);
 }
 
 function buildFilename(question: string): string {

--- a/frontend/src/pages/SharedQAPage.tsx
+++ b/frontend/src/pages/SharedQAPage.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
+import { Spin, Button, Result } from "antd";
+import { RobotOutlined, MessageOutlined, ShareAltOutlined } from "@ant-design/icons";
+import Markdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
+import { getSharedQA, type SharedQA } from "../api/client";
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+}
+
+export default function SharedQAPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [data, setData] = useState<SharedQA | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    getSharedQA(id)
+      .then((d) => {
+        setData(d);
+        setError(null);
+      })
+      .catch(() => setError("not_found"))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Result
+        status="404"
+        title="未找到此分享"
+        subTitle="链接可能已失效或被删除"
+        extra={
+          <Button type="primary" onClick={() => navigate("/chat")}>
+            去 AI 问答
+          </Button>
+        }
+      />
+    );
+  }
+
+  const previewText = data.answer.slice(0, 140).replace(/\n/g, " ");
+  const ogTitle = `${data.question.slice(0, 60)} — 佛津 AI 佛典问答`;
+
+  return (
+    <div style={{ maxWidth: 780, margin: "0 auto", padding: "32px 20px 80px" }}>
+      <Helmet>
+        <title>{ogTitle}</title>
+        <meta name="description" content={previewText} />
+        <meta property="og:title" content={ogTitle} />
+        <meta property="og:description" content={previewText} />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={`https://fojin.app/share/qa/${data.id}`} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={ogTitle} />
+        <meta name="twitter:description" content={previewText} />
+      </Helmet>
+
+      <div style={{ marginBottom: 28 }}>
+        <Link
+          to="/"
+          style={{
+            fontSize: 24,
+            fontWeight: 700,
+            color: "var(--fj-accent, #8b2500)",
+            letterSpacing: 3,
+            textDecoration: "none",
+            fontFamily: '"Noto Serif SC", serif',
+          }}
+        >
+          佛津 · FoJin
+        </Link>
+        <div style={{ fontSize: 12, color: "var(--fj-ink-muted, #9a8e7a)", marginTop: 4 }}>
+          AI 佛典问答 · 引据原典 · {formatDate(data.created_at)}
+        </div>
+      </div>
+
+      <div style={{ marginBottom: 32 }}>
+        <div
+          style={{
+            display: "inline-block",
+            fontSize: 12,
+            color: "#fff",
+            background: "var(--fj-accent, #8b2500)",
+            padding: "3px 12px",
+            marginBottom: 12,
+            letterSpacing: 2,
+          }}
+        >
+          问
+        </div>
+        <h1
+          style={{
+            fontSize: 22,
+            lineHeight: 1.6,
+            margin: 0,
+            color: "var(--fj-ink, #2b2318)",
+            borderLeft: "3px solid var(--fj-accent, #8b2500)",
+            paddingLeft: 16,
+            fontFamily: '"Noto Serif SC", serif',
+          }}
+        >
+          {data.question}
+        </h1>
+      </div>
+
+      <div style={{ marginBottom: 32 }}>
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 12,
+            color: "#fff",
+            background: "var(--fj-gold, #b08d57)",
+            padding: "3px 12px",
+            marginBottom: 12,
+            letterSpacing: 2,
+          }}
+        >
+          <RobotOutlined /> 答
+        </div>
+        <div
+          className="chat-markdown"
+          style={{
+            fontSize: 16,
+            lineHeight: 1.9,
+            color: "var(--fj-ink-light, #5c4f3d)",
+            fontFamily: '"Noto Serif SC", serif',
+          }}
+        >
+          <Markdown rehypePlugins={[rehypeSanitize]}>{data.answer}</Markdown>
+        </div>
+      </div>
+
+      {data.sources && data.sources.length > 0 && (
+        <div
+          style={{
+            background: "var(--fj-bg-alt, #f0ebe2)",
+            border: "1px solid var(--fj-border, #d9d0c1)",
+            padding: "16px 20px",
+            marginBottom: 32,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--fj-ink-muted, #9a8e7a)",
+              marginBottom: 10,
+              letterSpacing: 2,
+            }}
+          >
+            引据原典
+          </div>
+          {data.sources
+            .filter((s) => s.title_zh)
+            .slice(0, 5)
+            .map((s, i) => (
+              <div
+                key={i}
+                style={{
+                  fontSize: 14,
+                  color: "var(--fj-ink-light, #5c4f3d)",
+                  lineHeight: 1.8,
+                  marginBottom: 4,
+                }}
+              >
+                <span style={{ color: "var(--fj-gold, #b08d57)", marginRight: 6 }}>▸</span>
+                {s.text_id > 0 ? (
+                  <Link
+                    to={`/texts/${s.text_id}/read?juan=${s.juan_num}`}
+                    style={{ color: "var(--fj-ink-light, #5c4f3d)" }}
+                  >
+                    《{s.title_zh}》{s.juan_num > 0 ? `第${s.juan_num}卷` : ""}
+                  </Link>
+                ) : (
+                  <span>
+                    《{s.title_zh}》{s.juan_num > 0 ? `第${s.juan_num}卷` : ""}
+                  </span>
+                )}
+              </div>
+            ))}
+        </div>
+      )}
+
+      <div
+        style={{
+          background: "var(--fj-card-bg, rgba(255,255,255,0.6))",
+          border: "1px solid var(--fj-border, #d9d0c1)",
+          padding: "24px 28px",
+          textAlign: "center",
+          marginTop: 40,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 16,
+            color: "var(--fj-ink, #2b2318)",
+            marginBottom: 14,
+            fontWeight: 600,
+          }}
+        >
+          想问自己的佛学问题？
+        </div>
+        <div style={{ fontSize: 13, color: "var(--fj-ink-muted, #9a8e7a)", marginBottom: 18 }}>
+          佛津 AI 佛典问答 — 每一个回答都引据原典,汇聚 CBETA · SuttaCentral 等 600+ 数据源
+        </div>
+        <Button
+          type="primary"
+          size="large"
+          icon={<MessageOutlined />}
+          onClick={() => navigate("/chat")}
+          style={{
+            background: "var(--fj-accent, #8b2500)",
+            borderColor: "var(--fj-accent, #8b2500)",
+          }}
+        >
+          打开 AI 问答
+        </Button>
+      </div>
+
+      <div
+        style={{
+          marginTop: 24,
+          textAlign: "center",
+          fontSize: 12,
+          color: "var(--fj-ink-muted, #9a8e7a)",
+        }}
+      >
+        <ShareAltOutlined /> 已被浏览 {data.view_count} 次
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds real public share links so each card download is backed by a permanent URL like `https://fojin.app/share/qa/grhxdNKSNFhY` (12-char short id)
- New `/share/qa/:id` route renders a clean, read-only Q&A page with full markdown, citation links, OG meta tags, and a CTA back to /chat
- ShareCard's "复制链接" now copies the actual deep link instead of the chat homepage; QR code points to the same URL
- Download filename: `fojin-2026-04-13-色不异空的含义.png` instead of `fojin-qa-1776073916307.png`

## Why
The previous implementation broke the viral loop — recipients who got a share link saw the chat homepage, not the original Q&A. With real deep links, the flow becomes: user shares → friend opens link → reads the Q&A → "ask your own question" CTA → conversion. This is the actual virality mechanism.

## Backend
- Migration `0118_add_shared_qa_table.py` (verified on prod DB)
- `POST /api/share/qa` creates a record (12-char short id, retries on collision)
- `GET /api/share/qa/{id}` returns snapshot, increments view_count
- Optional `creator_user_id` for future "my shares" feature
- Public — no auth required, by design

## Frontend
- `SharedQAPage.tsx` — read-only page with FoJin branding, citation links to the original sutra reader, view counter, OG/Twitter meta
- `ShareCard.tsx` — POSTs on modal open, bakes returned URL into QR code, "复制链接" button shows loading state during creation
- Lazy-loaded route, no impact on initial bundle

## Test plan
- [x] POST /api/share/qa returns short id + url (verified on prod: `grhxdNKSNFhY`)
- [x] GET /api/share/qa/{id} returns snapshot + increments view_count
- [x] Frontend route /share/qa/:id returns 200
- [ ] Open share modal in browser, verify "生成链接中…" → "复制链接" transition
- [ ] Click copy link, verify clipboard contains real `/share/qa/{id}` URL
- [ ] Click downloaded file is `fojin-YYYY-MM-DD-{question}.png`
- [ ] Open shared link in incognito, verify read-only Q&A renders correctly with citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)