### PR TITLE
ui(share): shorten 复制图片 toast

### DIFF
--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -159,7 +159,7 @@ export default function ShareCard({ open, onClose, question, answer, sources }: 
         return;
       }
       await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
-      message.success("图片已复制，可粘贴到微信/微博/聊天窗口");
+      message.success("图片已复制");
     } catch (e) {
       console.error("copy image failed", e);
       message.error("复制图片失败，请改用「下载图片」");


### PR DESCRIPTION
## Summary
Per user feedback, shortens the 复制图片 success toast from "图片已复制，可粘贴到微信/微博/聊天窗口" to just "图片已复制" — matches the terse style of the 复制链接 toast next to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)