### PR TITLE
ui(share): tint copy buttons with distinct light colors

### DIFF
--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -366,6 +366,11 @@ export default function ShareCard({ open, onClose, question, answer, sources }: 
           onClick={handleCopyImage}
           size="large"
           loading={generating}
+          style={{
+            background: "#f6ead0",
+            borderColor: "#c9a85e",
+            color: "#6e5217",
+          }}
         >
           复制图片
         </Button>
@@ -375,6 +380,11 @@ export default function ShareCard({ open, onClose, question, answer, sources }: 
           size="large"
           loading={creatingShare}
           disabled={creatingShare}
+          style={{
+            background: "#ece4d3",
+            borderColor: "#a89878",
+            color: "#5c4f3d",
+          }}
         >
           {creatingShare ? "生成链接中…" : "复制链接"}
         </Button>


### PR DESCRIPTION
## Summary
Per user feedback, gives 复制图片 and 复制链接 distinct light tints so they're visually separable from each other and from the dark red primary 下载图片. All three colors stay in FoJin's warm earth-tone palette.

| Button | Background | Border | Text |
|---|---|---|---|
| 下载图片 | #8b2500 (primary) | #8b2500 | #fff |
| 复制图片 | #f6ead0 (light gold) | #c9a85e | #6e5217 |
| 复制链接 | #ece4d3 (light taupe) | #a89878 | #5c4f3d |

🤖 Generated with [Claude Code](https://claude.com/claude-code)