### PR TITLE
fix(chat): citation drawer doesn't open — whitelist fojin-citation URL scheme

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -3,8 +3,8 @@ import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { Input, Button, Space, message, Alert, Tooltip, Modal, Select } from "antd";
-import Markdown from "react-markdown";
-import rehypeSanitize from "rehype-sanitize";
+import Markdown, { defaultUrlTransform } from "react-markdown";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import {
   SendOutlined,
   RobotOutlined,
@@ -80,6 +80,28 @@ function parseFollowUps(content: string): { cleanContent: string; suggestions: s
 }
 
 const CITATION_URL_SCHEME = "fojin-citation";
+
+// rehype-sanitize's defaultSchema strips any <a href> whose protocol is not
+// in its allowlist (http, https, mailto, tel, …). We add our custom citation
+// scheme so the citation-drawer machinery below can intercept it instead of
+// seeing href=undefined on every click.
+const CHAT_SANITIZE_SCHEMA = {
+  ...defaultSchema,
+  protocols: {
+    ...(defaultSchema.protocols ?? {}),
+    href: [...(defaultSchema.protocols?.href ?? []), CITATION_URL_SCHEME],
+  },
+};
+
+// react-markdown runs its own urlTransform before rehype plugins run; the
+// built-in one rewrites any non-(http|https|mailto|…) URL to an empty string,
+// which would nuke our fojin-citation:// scheme even before rehype-sanitize
+// gets a chance to allow it. Pass through our scheme explicitly and delegate
+// to the default for everything else.
+const chatUrlTransform = (url: string): string => {
+  if (url.startsWith(`${CITATION_URL_SCHEME}:`)) return url;
+  return defaultUrlTransform(url);
+};
 
 /**
  * Replace citation patterns like 【《心经》第1卷】 with markdown links whose
@@ -822,7 +844,7 @@ export default function ChatPage() {
                       return (
                         <>
                           <div className="chat-markdown">
-                            <Markdown rehypePlugins={[rehypeSanitize]} components={markdownComponents}>{tightenLists(injectCitationLinks(cleanContent, m.sources)) + (isStreaming ? " ▌" : "")}</Markdown>
+                            <Markdown rehypePlugins={[[rehypeSanitize, CHAT_SANITIZE_SCHEMA]]} urlTransform={chatUrlTransform} components={markdownComponents}>{tightenLists(injectCitationLinks(cleanContent, m.sources)) + (isStreaming ? " ▌" : "")}</Markdown>
                           </div>
                           {suggestions.length > 0 && !sending && (
                             <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>


### PR DESCRIPTION
## Symptom
After #435 shipped the in-chat citation drawer, clicking a 【《…》第N卷】 link in an AI answer did nothing — no drawer, no navigation, no console error.

## Root cause
The \`fojin-citation://\` URL scheme I use to carry citation metadata into the DOM was being stripped by **two** independent sanitizers before the React event handler ever got a chance to fire:

1. **react-markdown's \`defaultUrlTransform\`** (\`safeProtocol = /^(https?|ircs?|mailto|xmpp)$/i\`) rewrote every non-http href to \`""\` — so by the time rehype ran, the \`<a>\` had no href.
2. **rehype-sanitize's \`defaultSchema\`** has \`protocols.href\` locked to an http-family allowlist and strips anything else as an extra safety net.

Either one alone would have been enough to break the feature. With both in play, \`components.a\` received \`href=undefined\`, fell through to the plain external-link branch, and the \`<a>\` rendered without a clickable target.

## Fix
Whitelist \`fojin-citation\` in **both** layers:

\`\`\`ts
import Markdown, { defaultUrlTransform } from "react-markdown";
import rehypeSanitize, { defaultSchema } from "rehype-sanitize";

const CHAT_SANITIZE_SCHEMA = {
  ...defaultSchema,
  protocols: {
    ...(defaultSchema.protocols ?? {}),
    href: [...(defaultSchema.protocols?.href ?? []), CITATION_URL_SCHEME],
  },
};

const chatUrlTransform = (url: string) =>
  url.startsWith(\`\${CITATION_URL_SCHEME}:\`) ? url : defaultUrlTransform(url);

<Markdown
  rehypePlugins={[[rehypeSanitize, CHAT_SANITIZE_SCHEMA]]}
  urlTransform={chatUrlTransform}
  components={markdownComponents}
/>
\`\`\`

## Why it slipped past local validation
The offline TestClient test exercised the backend endpoint end-to-end, and the vitest suite doesn't cover the chat Markdown render path. There's no test that mounts react-markdown with a fojin-citation URL and asserts the DOM keeps the href. I'll add one in a followup — for now, shipping the fix unblocks users.

## Test plan
- [x] \`tsc -b --noEmit\`
- [x] \`eslint src/pages/ChatPage.tsx\`
- [ ] Deploy to VPS, click a citation in the chat, verify the drawer opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)