### PR TITLE
fix(chat): wrap bare 《sutra》 references into citation drawer buttons

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -104,12 +104,21 @@ const chatUrlTransform = (url: string): string => {
 };
 
 /**
- * Replace citation patterns like 【《心经》第1卷】 with markdown links whose
- * href is a custom `fojin-citation://{text_id}/{juan_num}/{chunk_index}`
- * URL. The markdown renderer intercepts this scheme to pop the citation
- * drawer instead of navigating away. When no chunk_index is available
- * (history from before chunk_index was wired through), we fall back to
- * -1 and the drawer component handles the missing-data case.
+ * Turn sutra references inside an AI answer into citation-drawer buttons.
+ *
+ * The LLM is wildly inconsistent about citation style — sometimes it emits the
+ * explicit 【《心经》第1卷】 marker, sometimes it just drops 《佛说无量寿经》
+ * inline as prose. We handle both:
+ *
+ *  1. First pass rewrites 【《title》第N卷】 into a markdown link pointing at
+ *     our custom `fojin-citation://{text_id}/{juan_num}/{chunk_index}` URL.
+ *  2. Second pass scans the remaining plaintext for bare 《title》 occurrences
+ *     and wraps them when `title` is in the RAG source map. Existing markdown
+ *     links from pass 1 are skipped so we never double-wrap.
+ *
+ * When a matched source lacks chunk_index (legacy chat history from before
+ * the chunk_index field was wired through) we emit chunk_index=-1; the click
+ * handler in the renderer falls back to reader-page navigation in that case.
  */
 function injectCitationLinks(content: string, sources: ChatSource[] | null): string {
   if (!sources || sources.length === 0) return content;
@@ -124,15 +133,43 @@ function injectCitationLinks(content: string, sources: ChatSource[] | null): str
   }
   if (titleMap.size === 0) return content;
 
-  return content.replace(/【《([^》]+)》(?:第(\d+)卷)?】/g, (_match, title: string, juanStr: string | undefined) => {
-    const source = titleMap.get(title);
-    if (!source) return _match;
-    const juan = juanStr ? parseInt(juanStr, 10) : source.juan_num;
+  const buildUrl = (source: ChatSource, title: string, juan: number): string => {
     const chunkIdx = source.chunk_index ?? -1;
-    const url = `${CITATION_URL_SCHEME}://${source.text_id}/${juan}/${chunkIdx}/${encodeURIComponent(title)}`;
-    const label = juanStr ? `【《${title}》第${juanStr}卷】` : `【《${title}》】`;
-    return `[${label}](${url})`;
-  });
+    return `${CITATION_URL_SCHEME}://${source.text_id}/${juan}/${chunkIdx}/${encodeURIComponent(title)}`;
+  };
+
+  // Pass 1 — explicit 【《title》第N卷】 markers.
+  let withExplicit = content.replace(
+    /【《([^》]+)》(?:第(\d+)卷)?】/g,
+    (_match, title: string, juanStr: string | undefined) => {
+      const source = titleMap.get(title);
+      if (!source) return _match;
+      const juan = juanStr ? parseInt(juanStr, 10) : source.juan_num;
+      const url = buildUrl(source, title, juan);
+      const label = juanStr ? `【《${title}》第${juanStr}卷】` : `【《${title}》】`;
+      return `[${label}](${url})`;
+    },
+  );
+
+  // Pass 2 — bare 《title》 in prose. Split on any markdown links already in
+  // the content (the ones pass 1 just produced, plus any pre-existing links)
+  // so we only process plaintext segments. Split with a capture group: JS
+  // interleaves the matches into the output array, so odd indices are the
+  // preserved link strings and even indices are plaintext we can rewrite.
+  const parts = withExplicit.split(/(\[[^\]]*\]\([^)]*\))/g);
+  withExplicit = parts
+    .map((part, i) => {
+      if (i % 2 === 1) return part; // preserved markdown link
+      return part.replace(/《([^》]+)》/g, (bareMatch, title: string) => {
+        const source = titleMap.get(title);
+        if (!source) return bareMatch;
+        const url = buildUrl(source, title, source.juan_num);
+        return `[《${title}》](${url})`;
+      });
+    })
+    .join("");
+
+  return withExplicit;
 }
 
 interface ParsedCitation {


### PR DESCRIPTION
## Symptom
After the sanitize fix in #436, explicit 【《心经》第1卷】 style citations opened the drawer correctly. But a follow-up test turned up another dark path: for many answers the LLM doesn't use the explicit marker form at all — it just drops bare 《佛说无量寿经》 as prose. Those references were plain text, no dashed underline, and clicking did nothing.

## Root cause
\`injectCitationLinks\` only matched \`/【《([^》]+)》(?:第(\d+)卷)?】/g\`. If a sutra name appeared without the \`【 】\` wrapper, it fell through untouched.

## Fix
Two-pass rewrite in \`injectCitationLinks\`:

1. **Pass 1** — same as before: explicit \`【《title》第N卷】\` → \`[label](fojin-citation://…)\`.
2. **Pass 2** — split the content on any markdown links already present (including the ones pass 1 just produced plus any pre-existing external links) and scan the plaintext segments for bare \`《title》\`. Wrap them only when \`title\` is in the RAG \`titleMap\`.

Splitting with a capture group (\`split(/(\\[[^\\]]*\\]\\([^)]*\\))/g)\`) is the cheap trick — JS interleaves the matches into the output array, so odd indices are preserved link strings and even indices are plaintext we can safely rewrite. No double-wrap, no regex lookbehind gymnastics.

## Trade-offs considered
- **False positives**: bare \`《》\` in prose could legitimately reference a sutra we're not citing. We filter strictly by \`titleMap\` membership, so only titles that appeared in the current RAG retrieval become buttons. Low false-positive rate in practice since the source set is small (≤5 sources per answer).
- **Multiple mentions**: the same sutra referenced N times in one answer becomes N buttons. All open the same drawer. Fine — every mention is a legitimate verification entrypoint.

## Test plan
- [x] \`tsc -b --noEmit\`
- [x] \`eslint src/pages/ChatPage.tsx\`
- [ ] Deploy to VPS, open the 无量寿经 answer from the screenshot, click any of the bare \`《…》\` references, verify drawer opens
- [ ] Click an explicit \`【《…》第N卷】\` reference, verify drawer still opens (regression guard for the previous fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)