### PR TITLE
fix(chat): traditional↔simplified citation matching + loose qualifier regex

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Input, Button, Space, message, Alert, Tooltip, Modal, Select } from "antd";
 import Markdown, { defaultUrlTransform } from "react-markdown";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import * as OpenCC from "opencc-js";
 import {
   SendOutlined,
   RobotOutlined,
@@ -81,6 +82,15 @@ function parseFollowUps(content: string): { cleanContent: string; suggestions: s
 
 const CITATION_URL_SCHEME = "fojin-citation";
 
+// CBETA stores sutra titles in traditional Chinese; LLM answers come back in
+// simplified Chinese whenever the user's question was simplified. Normalizing
+// both sides to simplified via opencc-js lets injectCitationLinks actually
+// find matches in the RAG source map.
+const _t2s = OpenCC.Converter({ from: "tw", to: "cn" });
+const toSimplified = (s: string): string => {
+  try { return _t2s(s); } catch { return s; }
+};
+
 // rehype-sanitize's defaultSchema strips any <a href> whose protocol is not
 // in its allowlist (http, https, mailto, tel, …). We add our custom citation
 // scheme so the citation-drawer machinery below can intercept it instead of
@@ -123,12 +133,17 @@ const chatUrlTransform = (url: string): string => {
 function injectCitationLinks(content: string, sources: ChatSource[] | null): string {
   if (!sources || sources.length === 0) return content;
 
+  // Key on the simplified form so titles coming back from CBETA in
+  // traditional characters can be matched against simplified-Chinese
+  // answer text. Multiple traditional sources that collapse to the same
+  // simplified key keep the highest-scoring one.
   const titleMap = new Map<string, ChatSource>();
   for (const s of sources) {
     if (!s.title_zh || s.text_id <= 0) continue;
-    const existing = titleMap.get(s.title_zh);
+    const key = toSimplified(s.title_zh);
+    const existing = titleMap.get(key);
     if (!existing || s.score > existing.score) {
-      titleMap.set(s.title_zh, s);
+      titleMap.set(key, s);
     }
   }
   if (titleMap.size === 0) return content;
@@ -138,16 +153,22 @@ function injectCitationLinks(content: string, sources: ChatSource[] | null): str
     return `${CITATION_URL_SCHEME}://${source.text_id}/${juan}/${chunkIdx}/${encodeURIComponent(title)}`;
   };
 
-  // Pass 1 — explicit 【《title》第N卷】 markers.
+  // Pass 1 — explicit 【《title》…】 markers. Previously the tail was locked to
+  // "第(\d+)卷", which dropped perfectly-valid variants like "卷上" or
+  // "第十八愿" on the floor. Now we accept any qualifier up to the close
+  // bracket and only parse a juan number out of it when we can.
   let withExplicit = content.replace(
-    /【《([^》]+)》(?:第(\d+)卷)?】/g,
-    (_match, title: string, juanStr: string | undefined) => {
-      const source = titleMap.get(title);
+    /【《([^》]+)》([^】]*)】/g,
+    (_match, rawTitle: string, tail: string) => {
+      const title = rawTitle.trim();
+      const simplifiedTitle = toSimplified(title);
+      const source = titleMap.get(simplifiedTitle);
       if (!source) return _match;
-      const juan = juanStr ? parseInt(juanStr, 10) : source.juan_num;
-      const url = buildUrl(source, title, juan);
-      const label = juanStr ? `【《${title}》第${juanStr}卷】` : `【《${title}》】`;
-      return `[${label}](${url})`;
+      const juanMatch = tail.match(/第(\d+)卷/);
+      const juan = juanMatch ? parseInt(juanMatch[1], 10) : source.juan_num;
+      const url = buildUrl(source, simplifiedTitle, juan);
+      const labelTail = tail ? tail : "";
+      return `[【《${title}》${labelTail}】](${url})`;
     },
   );
 
@@ -160,10 +181,12 @@ function injectCitationLinks(content: string, sources: ChatSource[] | null): str
   withExplicit = parts
     .map((part, i) => {
       if (i % 2 === 1) return part; // preserved markdown link
-      return part.replace(/《([^》]+)》/g, (bareMatch, title: string) => {
-        const source = titleMap.get(title);
+      return part.replace(/《([^》]+)》/g, (bareMatch, rawTitle: string) => {
+        const title = rawTitle.trim();
+        const simplifiedTitle = toSimplified(title);
+        const source = titleMap.get(simplifiedTitle);
         if (!source) return bareMatch;
-        const url = buildUrl(source, title, source.juan_num);
+        const url = buildUrl(source, simplifiedTitle, source.juan_num);
         return `[《${title}》](${url})`;
       });
     })


### PR DESCRIPTION
## Symptom
Browser test of the inline citation panel on a fresh question turned up zero clickable citations in the answer body, even though the answer text contained plenty of explicit 【《…》…】 markers and the RAG sources list came back populated.

## Root cause (two bugs in one injection pipeline)

### 1. Traditional vs simplified mismatch
CBETA stores all sutra titles in **traditional** Chinese. The backend round-trip for this query returned:

\`\`\`json
[
  { "title_zh": "紫柏尊者全集",        "text_id": 13217, "score": 0.497 },
  { "title_zh": "銷釋金剛經科儀會要註解", "text_id": 12409, "score": 0.476 },
  { "title_zh": "無量壽經記",           "text_id": 12363, "score": 0.476 },
  ...
]
\`\`\`

But when the user asks in simplified Chinese, the LLM writes the answer in simplified too: \`《无量寿经》\`, \`《无量寿经记》\`, etc. \`injectCitationLinks\` keyed its \`titleMap\` on the raw traditional title, so \`titleMap.get("无量寿经记")\` always returned \`undefined\`.

Fix: run both sides through \`opencc-js\` (\`tw → cn\`) before indexing and lookup. When two traditional sources collapse to the same simplified key, keep the highest-scoring one. \`opencc-js\` was already a direct dependency (KGMapPage uses it), so no new package.

### 2. Over-strict explicit-marker regex
The old pattern:

\`\`\`
/【《([^》]+)》(?:第(\\d+)卷)?】/g
\`\`\`

locks the tail to \`第N卷\` with Arabic digits. Plenty of perfectly valid variants that the LLM actually emits — \`【《无量寿经》卷上】\`, \`【《无量寿经》第十八愿】\`, \`【《观经四帖疏》】\` (bare) — dropped on the floor.

Fix: loosened to \`/【《([^》]+)》([^】]*)】/g\`. Parse a juan number out of the tail only when \`/第(\\d+)卷/\` actually matches; otherwise fall back to \`source.juan_num\`. The matched label text is preserved verbatim in the rendered button so users still see whatever qualifier the LLM wrote.

## Test plan
- [x] \`tsc -b --noEmit\`
- [x] \`eslint src/pages/ChatPage.tsx\` (0 errors)
- [ ] Deploy to VPS, ask 《无量寿经》四十八愿 question again, verify \`【《无量寿经》卷上】\` and bare \`《无量寿经》\` both become inline-panel buttons
- [ ] Click one, verify the side panel opens without blocking the chat on the left

🤖 Generated with [Claude Code](https://claude.com/claude-code)