### PR TITLE
ui(citation): drop redundant 关闭 button from drawer footer

### DIFF
--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -138,9 +138,6 @@ export default function CitationDrawer({ target, onClose }: Props) {
       </div>
 
       <div className="chat-citation-panel-footer">
-        <Button onClick={onClose} size="middle">
-          关闭
-        </Button>
         <Link to={readerUrl} onClick={onClose}>
           <Button
             type="primary"


### PR DESCRIPTION
## Why
User feedback: the citation drawer footer has a 关闭 button that's redundant with the close X already in the top-right header. Two buttons doing the same thing crowds the primary action.

## Change
Footer now contains only the right-aligned 在阅读器中打开 primary action. The top-right header X (standard drawer escape hatch, universally understood) is the single way to close.

Single-file, 3-line delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)