### PR TITLE
ui(chat): welcome screen scrolls the page, not an inner container

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -689,7 +689,18 @@ export default function ChatPage() {
       <Helmet><title>{t("chat.page_title")}</title></Helmet>
       <div style={{
         display: "flex",
-        height: "calc(100vh - 120px)",
+        // When the chat has no messages yet, the welcome splash can exceed
+        // the messages container at high browser zoom (125% / 150%) because
+        // 100vh shrinks but the welcome's static content does not. Switching
+        // `height` → `minHeight` lets the outer container grow to fit the
+        // welcome and hand scrolling off to the browser's page scrollbar
+        // (where it belongs). When an actual chat is in progress we lock
+        // back to a fixed height so the messages div can internal-scroll
+        // as new bubbles stream in — that's the only place scroll makes
+        // sense to live inside the page.
+        ...(messages.length === 0
+          ? { minHeight: "calc(100vh - 120px)" }
+          : { height: "calc(100vh - 120px)" }),
         maxWidth: citationTarget ? undefined : 1100,
         margin: citationTarget ? "0 16px" : "0 auto",
         gap: 16,
@@ -818,7 +829,20 @@ export default function ChatPage() {
             )}
           </div>
           {/* Messages */}
-          <div style={{ flex: 1, overflow: "auto", padding: "16px 0" }}>
+          <div style={{
+            // Welcome state: natural height (`flex: 0 0 auto`) so the
+            // container sizes to the welcome content instead of being
+            // locked to the flex-remainder of the 100vh-120 box. Combined
+            // with the outer `minHeight` switch, this lets the browser's
+            // page scrollbar take over at extreme zoom — no more ugly
+            // inner scrollbar on the splash.
+            // Chat state: restore `flex: 1` + `overflow: auto` so the
+            // message list scrolls internally and the input bar stays
+            // pinned during an actual conversation.
+            flex: messages.length === 0 ? "0 0 auto" : 1,
+            overflow: messages.length === 0 ? "visible" : "auto",
+            padding: "16px 0",
+          }}>
             <div ref={messagesTopRef} />
             {hasOlderMessages && (
               <div style={{ textAlign: "center", marginBottom: 12 }}>


### PR DESCRIPTION
## Why
#442 compressed the welcome block by ~86 px, which fixed the inner scrollbar at 125% browser zoom but not at 150%. Screenshot evidence showed the inner scrollbar still appearing at 150%. Compression hit diminishing returns — the welcome is ~380 px static and the messages flex-child shrinks to ~310 px at 150% zoom (\`100vh\` → 600 CSS px, minus outer padding + chat header + input area ≈ 310 px).

The real fix is architectural: stop trying to keep the welcome inside a fixed-height inner box and just let the page scroll naturally when a splash screen doesn't fit.

## Change
Two conditional style switches, both keyed on \`messages.length === 0\`:

- **Outer chat wrapper**: \`height: calc(100vh - 120px)\` → \`minHeight: calc(100vh - 120px)\`. The container can now grow beyond the viewport instead of enforcing a fixed height.
- **Inner messages container**: \`flex: 1 / overflow: auto\` → \`flex: 0 0 auto / overflow: visible\`. The container sizes to its welcome content instead of taking the flex-remainder of a fixed-height parent.

Together these let the welcome expand naturally; if it exceeds the viewport, the browser's own page scrollbar takes over — which is where scroll belongs on a splash screen.

## What about the input bar?
At extreme zoom (150%+) with a short viewport, the input bar ends up below the fold. That's acceptable because:

1. Users scroll the page the same way they'd scroll any other web page — it's not a special affordance
2. At 100%-125% zoom (the common case), the min-height: calc(100vh - 120px) still provides enough room for welcome + input bar without page scroll at all
3. Once a real chat is in progress (messages.length > 0), the old fixed-height layout comes back and the input bar is pinned again — zero regression on the chat UX where input pinning actually matters

## Test plan
- [x] \`tsc -b --noEmit\`
- [ ] 100% zoom: welcome fits without scroll (both inner and page)
- [ ] 125% zoom: welcome fits without scroll
- [ ] 150% zoom: no inner scrollbar, may have a minor page scroll — acceptable
- [ ] 150% + start a chat: fixed-height layout returns, messages scroll internally, input pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)