### PR TITLE
revert(chat): undo #443 — broke sidebar + input bar

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -689,18 +689,7 @@ export default function ChatPage() {
       <Helmet><title>{t("chat.page_title")}</title></Helmet>
       <div style={{
         display: "flex",
-        // When the chat has no messages yet, the welcome splash can exceed
-        // the messages container at high browser zoom (125% / 150%) because
-        // 100vh shrinks but the welcome's static content does not. Switching
-        // `height` → `minHeight` lets the outer container grow to fit the
-        // welcome and hand scrolling off to the browser's page scrollbar
-        // (where it belongs). When an actual chat is in progress we lock
-        // back to a fixed height so the messages div can internal-scroll
-        // as new bubbles stream in — that's the only place scroll makes
-        // sense to live inside the page.
-        ...(messages.length === 0
-          ? { minHeight: "calc(100vh - 120px)" }
-          : { height: "calc(100vh - 120px)" }),
+        height: "calc(100vh - 120px)",
         maxWidth: citationTarget ? undefined : 1100,
         margin: citationTarget ? "0 16px" : "0 auto",
         gap: 16,
@@ -829,20 +818,7 @@ export default function ChatPage() {
             )}
           </div>
           {/* Messages */}
-          <div style={{
-            // Welcome state: natural height (`flex: 0 0 auto`) so the
-            // container sizes to the welcome content instead of being
-            // locked to the flex-remainder of the 100vh-120 box. Combined
-            // with the outer `minHeight` switch, this lets the browser's
-            // page scrollbar take over at extreme zoom — no more ugly
-            // inner scrollbar on the splash.
-            // Chat state: restore `flex: 1` + `overflow: auto` so the
-            // message list scrolls internally and the input bar stays
-            // pinned during an actual conversation.
-            flex: messages.length === 0 ? "0 0 auto" : 1,
-            overflow: messages.length === 0 ? "visible" : "auto",
-            padding: "16px 0",
-          }}>
+          <div style={{ flex: 1, overflow: "auto", padding: "16px 0" }}>
             <div ref={messagesTopRef} />
             {hasOlderMessages && (
               <div style={{ textAlign: "center", marginBottom: 12 }}>


### PR DESCRIPTION
## Symptom
After #443 merged, the chat page layout completely broke:

1. **Left session sidebar no longer scrolled internally** — the entire 今天/昨天 session list flowed straight down the page, below the viewport fold
2. **Input bar unpinned** from the bottom of the chat area, floating in the middle of the page directly under the welcome cards
3. **Empty whitespace** + stray Umami tracker dot below the floating input bar

Screenshot: `/home/lqsxi/$截图/PixPin_2026-04-14_22-09-03.png`

## Root cause
#443 switched the outermost chat wrapper from \`height: calc(100vh - 120px)\` to \`minHeight: …\` (conditional on \`messages.length === 0\`) to let the welcome splash overflow onto the browser's page scrollbar. But that wrapper isn't just the chat column — it's the **flex row** that contains **both** the left session sidebar **and** the chat column.

The left sidebar's session list uses \`flex: 1, overflow: auto\` inside that fixed-height row to scroll in place. Once the row became grow-able, the list had no bound → flowed naturally → the whole page stretched. The chat column's input bar had been pinned at the bottom via flex layout — once its parent could grow, the remainder-space went to bottom padding instead of the input bar position, so input floated under the welcome content.

I scoped the minHeight switch too aggressively. The architectural fix needed to touch only the chat column's **internal** layout, not the outer row that the sidebar also depends on.

## Change
Revert the two problematic edits:
- Outer: \`minHeight\` conditional → back to unconditional \`height: calc(100vh - 120px)\`
- Inner messages: \`flex: 0 0 auto / overflow: visible\` conditional → back to unconditional \`flex: 1, overflow: auto\`

#442's compression (\`clamp(16px, 4vh, 60px)\` padding + tighter margins) stays. This puts us back at "welcome fits 125% on typical desktops but may show an inner scrollbar at 150% on a small laptop" — which was #442's state and what the user originally asked me to fix.

150% + small laptop is a less common edge case; I'll revisit it with a more surgical fix (probably restructuring only the chat column's direct children, not the outer flex row) if it becomes a real complaint.

## Test plan
- [x] \`tsc -b --noEmit\`
- [x] Deployed to VPS, frontend rebuilt + healthy
- [ ] Reload the chat page at 100% zoom — sidebar session list scrolls internally, input bar pinned at the bottom, welcome fits without scroll
- [ ] Scroll the session list in the left sidebar — verify it scrolls independently of the chat area
- [ ] Start a chat, verify messages scroll internally and input stays pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)