### PR TITLE
feat(seo): inject per-text title + meta for /texts/{id} routes

### DIFF
--- a/backend/app/api/seo.py
+++ b/backend/app/api/seo.py
@@ -1,0 +1,178 @@
+"""Server-side meta tag injection for SPA routes that need real SEO.
+
+Google's standard crawler does not execute JavaScript, so the React-side
+``react-helmet-async`` titles set by ``TextReaderPage`` and friends never
+reach the search index. Every text URL ends up advertising the homepage
+``<title>`` and ``<meta description>``, which is why GSC reports near-zero
+impressions for content queries (sutra names, translator names, CBETA IDs).
+
+This module intercepts a small allowlist of high-value routes — currently
+just ``/texts/{id}`` and ``/texts/{id}/read`` — fetches the actual built
+``index.html`` from the frontend nginx container, replaces the head meta
+tags with text-specific values, and returns the patched HTML. The React
+bundle still mounts in the user's browser exactly as before; this only
+changes what crawlers (and link-preview bots) see.
+
+The frontend ``index.html`` is cached for 60 seconds so a frontend redeploy
+is picked up within a minute without restarting the backend.
+"""
+
+import logging
+import re
+import time
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.services.text import get_text_by_id
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["seo"])
+
+# Inside the docker compose network, the nginx-served frontend is reachable
+# at this hostname. The backend container has no filesystem access to the
+# built dist/, so it has to fetch the entry HTML over HTTP.
+_FRONTEND_INDEX_URL = "http://frontend/index.html"
+_INDEX_HTML_CACHE_TTL = 60.0  # seconds
+_index_html_cache: dict[str, object] = {}
+
+_TITLE_RE = re.compile(r"<title>[^<]*</title>", re.IGNORECASE)
+_DESCRIPTION_RE = re.compile(
+    r'<meta\s+name="description"\s+content="[^"]*"\s*/?>',
+    re.IGNORECASE,
+)
+_CANONICAL_RE = re.compile(
+    r'<link\s+rel="canonical"\s+href="[^"]*"\s*/?>',
+    re.IGNORECASE,
+)
+_HEAD_CLOSE_RE = re.compile(r"</head>", re.IGNORECASE)
+
+
+def _escape_meta_value(value: str) -> str:
+    """Escape characters that would break out of an HTML attribute value."""
+    return (
+        value.replace("&", "&amp;")
+        .replace('"', "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+async def _fetch_index_html() -> str:
+    """Fetch the built index.html from the frontend container with TTL caching."""
+    now = time.monotonic()
+    cached_at = _index_html_cache.get("ts")
+    cached_html = _index_html_cache.get("html")
+    if (
+        isinstance(cached_at, float)
+        and isinstance(cached_html, str)
+        and now - cached_at < _INDEX_HTML_CACHE_TTL
+    ):
+        return cached_html
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(_FRONTEND_INDEX_URL)
+        resp.raise_for_status()
+        html = resp.text
+
+    _index_html_cache["html"] = html
+    _index_html_cache["ts"] = now
+    return html
+
+
+def _inject_meta(html: str, title: str, description: str, canonical_url: str) -> str:
+    """Replace <title>, <meta name="description">, and <link rel="canonical">.
+
+    If a canonical link is missing entirely (the default for the React SPA
+    template), we add it just before the closing </head> tag.
+    """
+    safe_title = _escape_meta_value(title)
+    safe_desc = _escape_meta_value(description)
+    safe_canonical = _escape_meta_value(canonical_url)
+
+    new_html = _TITLE_RE.sub(f"<title>{safe_title}</title>", html, count=1)
+    new_html = _DESCRIPTION_RE.sub(
+        f'<meta name="description" content="{safe_desc}" />',
+        new_html,
+        count=1,
+    )
+    canonical_tag = f'<link rel="canonical" href="{safe_canonical}" />'
+    if _CANONICAL_RE.search(new_html):
+        new_html = _CANONICAL_RE.sub(canonical_tag, new_html, count=1)
+    else:
+        new_html = _HEAD_CLOSE_RE.sub(f"  {canonical_tag}\n  </head>", new_html, count=1)
+    return new_html
+
+
+def _build_text_meta(text, request: Request) -> tuple[str, str, str]:
+    """Compose the per-text title, description, and canonical URL."""
+    title_zh = text.title_zh or "佛典"
+    translator = (text.translator or "").strip()
+    dynasty = (text.dynasty or "").strip()
+    cbeta_id = (text.cbeta_id or "").strip()
+
+    title_parts = [f"《{title_zh}》"]
+    if translator:
+        title_parts.append(f" {translator}译")
+    title_parts.append(" — 在线全文阅读 | 佛津 FoJin")
+    title = "".join(title_parts)
+
+    desc_parts = [f"《{title_zh}》"]
+    meta_bits = []
+    if dynasty:
+        meta_bits.append(dynasty)
+    if translator:
+        meta_bits.append(f"{translator}译")
+    if cbeta_id:
+        meta_bits.append(f"CBETA {cbeta_id}")
+    if meta_bits:
+        desc_parts.append("，" + "，".join(meta_bits))
+    desc_parts.append("。佛津 FoJin 数字佛典平台提供全文阅读、平行对照、AI 智能问答与原典引用。汉传、藏传、南传、梵文、巴利文多语种佛教文献聚合检索。")
+    description = "".join(desc_parts)
+
+    base = str(request.base_url).rstrip("/")
+    # base_url comes from the inbound request — under cloudflare/nginx the
+    # forwarded scheme/host should already be set on the request.
+    canonical = f"{base}/texts/{text.id}/read"
+    return title, description, canonical
+
+
+async def _serve_text_seo_html(text_id: int, request: Request, db: AsyncSession) -> HTMLResponse:
+    text = await get_text_by_id(db, text_id)
+    if text is None:
+        raise HTTPException(status_code=404, detail="text not found")
+    try:
+        html = await _fetch_index_html()
+    except httpx.HTTPError as e:
+        logger.warning("Failed to fetch frontend index.html: %s", e)
+        # Fall back to a minimal HTML so the bot still gets correct meta;
+        # the user's browser would fail anyway since the bundle refs are
+        # missing — but bots don't care about JS.
+        title, description, canonical = _build_text_meta(text, request)
+        fallback = (
+            "<!doctype html><html><head>"
+            f"<title>{_escape_meta_value(title)}</title>"
+            f'<meta name="description" content="{_escape_meta_value(description)}" />'
+            f'<link rel="canonical" href="{_escape_meta_value(canonical)}" />'
+            "</head><body></body></html>"
+        )
+        return HTMLResponse(content=fallback, status_code=200)
+
+    title, description, canonical = _build_text_meta(text, request)
+    return HTMLResponse(content=_inject_meta(html, title, description, canonical))
+
+
+@router.get("/texts/{text_id}", response_class=HTMLResponse, include_in_schema=False)
+async def text_detail_seo_html(text_id: int, request: Request, db: AsyncSession = Depends(get_db)):
+    """SEO-friendly HTML for the text detail landing page."""
+    return await _serve_text_seo_html(text_id, request, db)
+
+
+@router.get("/texts/{text_id}/read", response_class=HTMLResponse, include_in_schema=False)
+async def text_reader_seo_html(text_id: int, request: Request, db: AsyncSession = Depends(get_db)):
+    """SEO-friendly HTML for the full-text reader page."""
+    return await _serve_text_seo_html(text_id, request, db)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from app.api import (
     relations,
     rss,
     search,
+    seo,
     share,
     sitemap,
     source_suggestions,
@@ -392,6 +393,11 @@ app.include_router(sitemap.router)
 
 # SEO: RSS feed at root (no /api prefix)
 app.include_router(rss.router)
+
+# SEO: per-text HTML with injected meta tags (intercepts /texts/{id}
+# and /texts/{id}/read so Google's no-JS crawler sees real titles
+# instead of the homepage default).
+app.include_router(seo.router)
 
 
 @app.get("/api/health")

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -75,6 +75,22 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # SEO HTML for individual sutra pages — backend injects per-text
+    # <title> + <meta description> + canonical so Googlebot (which doesn't
+    # execute the React bundle) sees real metadata. The user's browser
+    # still loads the same hashed JS bundle and React mounts on top.
+    # Only matches /texts/{numeric_id} and /texts/{numeric_id}/read so
+    # other /texts/* sub-routes (if any) keep falling through to the SPA.
+    location ~ ^/texts/[0-9]+(/read)?$ {
+        proxy_pass $upstream_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Don't cache so a frontend redeploy is visible immediately
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
     # Pre-built SEO pages — serve their own index.html with correct meta tags
     location = /search {
         try_files /search/index.html /index.html;


### PR DESCRIPTION
## Why
Google Search Console diagnosis on 2026-04-15 turned up a stark gap:

- All 10,531 indexed text pages return the **homepage** \`<title>\` (\`佛津 FoJin — 全球佛教古籍数字资源聚合平台\`) and the same homepage \`<meta description>\`
- 85% of all search clicks (33/39) come from the brand queries \`佛津\` + \`fojin\`
- Content queries like \`佛說摩利支天經\`, \`cbeta\`, \`行事鈔\`, \`tiantai\`, \`bdrc\` get 0-1 clicks each despite the corresponding texts being in the corpus

Root cause: the React SPA uses \`react-helmet-async\` to set per-page titles **at runtime**, but Google's standard crawler doesn't execute the JS bundle. It just fetches \`index.html\`, sees the homepage meta, and walks away.

## Fix
Backend intercepts \`/texts/{id}\` and \`/texts/{id}/read\`, fetches the built \`index.html\` from the frontend nginx container, replaces \`<title>\` + \`<meta description>\` with text-specific values, adds a \`<link rel="canonical">\`, and returns the patched HTML. **The React bundle still mounts in the user's browser exactly as before** — the only thing that changes is what crawlers (and link-preview bots) see.

### \`backend/app/api/seo.py\` — new module
- \`_fetch_index_html()\`: \`http://frontend/index.html\` via httpx with **60-second TTL cache**, so a frontend redeploy is picked up within a minute without restarting backend
- \`_build_text_meta()\`: composes title \`《{title}》{translator}译 — 在线全文阅读 | 佛津 FoJin\` and a multi-field description containing dynasty + translator + CBETA id + the platform pitch
- \`_inject_meta()\`: regex-replaces the existing tags, inserts canonical before \`</head>\` if missing. Every value is HTML-escaped to prevent attribute breakouts
- Two routes: \`GET /texts/{id}\` and \`GET /texts/{id}/read\`, both \`HTMLResponse\`, both \`include_in_schema=False\`

### \`backend/app/main.py\`
- Imports + registers the new \`seo\` router at root (no \`/api\` prefix)

### \`frontend/nginx.conf\`
- New \`location ~ ^/texts/[0-9]+(/read)?\$\` block proxying to backend
- Placed before the SPA fallback so it wins
- \`Cache-Control: no-cache\` so changes ship instantly
- Regex is intentionally narrow (numeric id only, optional \`/read\` suffix) so other \`/texts/*\` sub-routes (none exist today) keep falling through to the SPA shell

## Expected impact
Per the GSC numbers:
- **Impressions for content queries** should start ramping up within 1-2 weeks as Google re-crawls the sitemap entries and discovers the new metadata
- **CTR on non-brand queries** should rise from near-zero toward the average 5-8%
- The 21062 URLs (10531 texts × 2 routes) will start competing on long-tail Buddhist queries

This doesn't fix everything — dictionary entries, knowledge graph entities, and other deep routes still serve the homepage meta. They can be added to the same module in follow-up PRs once we see the impact on \`/texts/*\`.

## Test plan
- [x] \`ruff check app/api/seo.py app/main.py\`
- [x] AST parse on both files
- [ ] Deploy to VPS, \`curl https://fojin.app/texts/1/read\`, verify the returned HTML has a per-text \`<title>\` and \`<meta description>\`
- [ ] \`curl https://fojin.app/texts/1\` returns the same metadata (detail page route)
- [ ] User browser navigation to /texts/1/read still mounts the React app correctly (same hashed bundle URLs in the patched HTML)
- [ ] \`curl https://fojin.app/texts/9999999/read\` returns 404 (unknown text)
- [ ] Sitemap entries (\`https://fojin.app/sitemap-texts-0.xml\`) still serve the same URLs as before — Google will re-crawl them on its own schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)