### PR TITLE
chore: hide IIIF frontend entry until coverage is meaningful

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,6 @@ const LoginPage = lazy(() => import("./pages/LoginPage"));
 const ProfilePage = lazy(() => import("./pages/ProfilePage"));
 const ParallelReaderPage = lazy(() => import("./pages/ParallelReaderPage"));
 const KnowledgeGraphPage = lazy(() => import("./pages/KnowledgeGraphPage"));
-const ManuscriptViewerPage = lazy(() => import("./pages/ManuscriptViewerPage"));
 const ChatPage = lazy(() => import("./pages/ChatPage"));
 const DictionaryPage = lazy(() => import("./pages/DictionaryPage"));
 const SutraLandingPage = lazy(() => import("./pages/SutraLandingPage"));
@@ -86,7 +85,6 @@ function App() {
             </Route>
             <Route path="/parallel/:textId" element={<ParallelReaderPage />} />
             <Route path="/kg" element={<RouteErrorBoundary><KnowledgeGraphPage /></RouteErrorBoundary>} />
-            <Route path="/manuscripts/:textId" element={<RouteErrorBoundary><ManuscriptViewerPage /></RouteErrorBoundary>} />
             <Route path="/exports" element={<ExportsPage />} />
             <Route path="/timeline" element={<TimelinePage />} />
             <Route path="/dashboard" element={<DashboardPage />} />

--- a/frontend/src/components/TextVersionsPanel.tsx
+++ b/frontend/src/components/TextVersionsPanel.tsx
@@ -43,7 +43,7 @@ export default function TextVersionsPanel({ textId, onClose }: Props) {
   if (!data) return null;
 
   const { translations, iiif_manifests } = data;
-  const hasContent = translations.length > 0 || iiif_manifests.length > 0;
+  const hasContent = translations.length > 0 || iiif_manifests.length >= 3;
 
   if (!hasContent) return null;
 
@@ -90,8 +90,8 @@ export default function TextVersionsPanel({ textId, onClose }: Props) {
         </div>
       )}
 
-      {/* IIIF Manuscripts */}
-      {iiif_manifests.length > 0 && (
+      {/* IIIF Manuscripts — 仅在覆盖足够多时显示，避免 0.3% 佛典个别露出导致负面体验 */}
+      {iiif_manifests.length >= 3 && (
         <div className="versions-section">
           <div className="versions-section-title">
             <PictureOutlined /> 写本 / 刻本图像 ({iiif_manifests.length})

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -14,11 +14,10 @@ import {
 } from "antd";
 import {
   ReadOutlined,
-  FileImageOutlined,
   HomeOutlined,
   BookOutlined,
 } from "@ant-design/icons";
-import { getTextDetail, getTextManifests } from "../api/client";
+import { getTextDetail } from "../api/client";
 import { buildCbetaReadUrl } from "../utils/sourceUrls";
 import BookmarkButton from "../components/BookmarkButton";
 import { RelatedTextsStandalone as RelatedTexts } from "../components/RelatedTexts";
@@ -35,12 +34,6 @@ export default function TextDetailPage() {
   const { data: text, isLoading } = useQuery({
     queryKey: ["text", id],
     queryFn: () => getTextDetail(Number(id)),
-    enabled: !!id,
-  });
-
-  const { data: manifests } = useQuery({
-    queryKey: ["manifests", id],
-    queryFn: () => getTextManifests(Number(id)),
     enabled: !!id,
   });
 
@@ -205,14 +198,6 @@ export default function TextDetailPage() {
           >
             导出引用
           </Button>
-          {manifests && manifests.length > 0 && (
-            <Button
-              icon={<FileImageOutlined />}
-              onClick={() => navigate(`/manuscripts/${text.id}`)}
-            >
-              手稿影像 ({manifests.length})
-            </Button>
-          )}
           <BookmarkButton textId={text.id} />
         </Space>
 


### PR DESCRIPTION
## 背景

IIIF 前端入口长期处于"能点但用不了"状态：

1. **数据覆盖率极低**：689 条 manifest 里只有 85 条 (12%) 关联到 text_id，关联后仅覆盖 **30 部佛典 = 0.28%**
2. **内容目标群错配**：CUDL 580 + BnF 109 全部是梵文写本，FoJin 95%+ 中文用户无法消费
3. **IIIFViewer 组件存在严重 bug**：`IIIFViewer.tsx:30` 把 IIIF Presentation Manifest URL 直接传给 OpenSeadragon 的 `tileSources`，实际需要先解析 manifest JSON 提取 Image API URL。线上这条路径从来没真正渲染成功过

## 改动

- 移除 `/manuscripts/:textId` 路由（文件保留，供未来复活）
- `TextDetailPage` 去掉"手稿影像"按钮 + 相关 useQuery
- `TextVersionsPanel` 阈值从 `>0` 提到 `>=3`，避免单个佛典露出 1-2 条零星图像

## 保留

- `backend/app/api/iiif.py` 后端 API
- `iiif_manifests` 表（689 条数据完整）
- `data_sources.supports_iiif` 字段
- `SourcesPage` 的 "689 影像" 统计（基于 supports_iiif 聚合，不受影响）
- `ManuscriptViewerPage.tsx` / `IIIFViewer.tsx` 源文件（方便未来修复 viewer + 复活）

## 复活触发条件（任一满足）

1. 接入 IDP 敦煌或 BDRC 藏传 IIIF，汉传/藏传写本覆盖 ≥ 500 部
2. 出现付费学术合作要求 IIIF 展示
3. FoJin MAU 增长到 5000+，长尾学术用户撑得起 niche 功能

## Test plan

- [x] \`npm run build\` 本地通过
- [ ] 部署后 \`/manuscripts/xxx\` 返回 404（或 NotFoundPage）
- [ ] 佛典详情页不再显示"手稿影像"按钮
- [ ] 佛典版本面板在 iiif_manifests < 3 时不显示 IIIF 区块
- [ ] /sources 的 "影像" 统计仍然正常显示