### PR TITLE
feat(rag): per-language retrieval + alignment-aware parallel chunks

### DIFF
--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -1,0 +1,180 @@
+"""Cross-canon alignment API.
+
+Exposes the alignment_pairs table to the frontend Reader "他藏对读" tab.
+Given a chunk (text_id, juan_num, chunk_index), returns the aligned parallel
+passages in other canons (lzh ↔ pi ↔ bo), each with full chunk_text and
+source metadata for rendering.
+"""
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import text as sql_text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+
+router = APIRouter(prefix="/alignment", tags=["alignment"])
+
+
+class ParallelPair(BaseModel):
+    """One aligned parallel passage."""
+    text_id: int
+    juan_num: int
+    chunk_index: int
+    chunk_text: str
+    lang: str
+    title: str = ""
+    confidence: float = 1.0
+
+
+class ChunkAlignmentResponse(BaseModel):
+    """All parallels for one source chunk."""
+    source_text_id: int
+    source_juan_num: int
+    source_chunk_index: int
+    parallels: list[ParallelPair]
+
+
+class JuanAlignmentEntry(BaseModel):
+    """One chunk inside a juan + its parallels (for Reader sidebar rendering)."""
+    chunk_index: int
+    chunk_text: str
+    parallels: list[ParallelPair]
+
+
+class JuanAlignmentResponse(BaseModel):
+    text_id: int
+    juan_num: int
+    total_chunks: int
+    chunks_with_parallels: int
+    entries: list[JuanAlignmentEntry]
+
+
+@router.get("/chunks/{text_id}/{juan_num}/{chunk_index}", response_model=ChunkAlignmentResponse)
+async def get_chunk_alignment(
+    text_id: int,
+    juan_num: int,
+    chunk_index: int,
+    limit: int = Query(5, ge=1, le=20),
+    db: AsyncSession = Depends(get_db),
+) -> ChunkAlignmentResponse:
+    """Get all aligned parallels for a single chunk.
+
+    Checks both sides of alignment_pairs (text_a_* and text_b_*) so the
+    alignment is direction-agnostic.
+    """
+    rows = (await db.execute(
+        sql_text("""
+            SELECT
+                CASE WHEN ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx
+                     THEN ap.text_b_id ELSE ap.text_a_id END,
+                CASE WHEN ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx
+                     THEN ap.text_b_juan_num ELSE ap.text_a_juan_num END,
+                CASE WHEN ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx
+                     THEN ap.text_b_chunk_index ELSE ap.text_a_chunk_index END,
+                CASE WHEN ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx
+                     THEN ap.text_b_lang ELSE ap.text_a_lang END,
+                ap.confidence
+            FROM alignment_pairs ap
+            WHERE (
+                (ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx)
+                OR
+                (ap.text_b_id = :tid AND ap.text_b_juan_num = :juan AND ap.text_b_chunk_index = :cidx)
+            )
+            AND ap.text_a_chunk_index IS NOT NULL
+            ORDER BY ap.confidence DESC
+            LIMIT :limit
+        """),
+        {"tid": text_id, "juan": juan_num, "cidx": chunk_index, "limit": limit},
+    )).fetchall()
+
+    parallels: list[ParallelPair] = []
+    for row in rows:
+        other_tid, other_juan, other_cidx, other_lang, conf = row
+        text_row = (await db.execute(
+            sql_text(
+                "SELECT te.chunk_text, "
+                "COALESCE(bt.title_zh, bt.title_sa, bt.title_pi, bt.title_en, '') "
+                "FROM text_embeddings te "
+                "LEFT JOIN buddhist_texts bt ON bt.id = te.text_id "
+                "WHERE te.text_id = :tid AND te.juan_num = :juan AND te.chunk_index = :cidx"
+            ),
+            {"tid": other_tid, "juan": other_juan, "cidx": other_cidx},
+        )).fetchone()
+        if text_row:
+            parallels.append(ParallelPair(
+                text_id=other_tid,
+                juan_num=other_juan,
+                chunk_index=other_cidx,
+                chunk_text=text_row[0],
+                lang=other_lang or "lzh",
+                title=text_row[1] or "",
+                confidence=float(conf),
+            ))
+
+    return ChunkAlignmentResponse(
+        source_text_id=text_id,
+        source_juan_num=juan_num,
+        source_chunk_index=chunk_index,
+        parallels=parallels,
+    )
+
+
+@router.get("/texts/{text_id}/juans/{juan_num}", response_model=JuanAlignmentResponse)
+async def get_juan_alignment(
+    text_id: int,
+    juan_num: int,
+    db: AsyncSession = Depends(get_db),
+) -> JuanAlignmentResponse:
+    """Get all chunks of a juan that have any alignment parallels.
+
+    Used by Reader's "他藏对读" panel to show a segment-by-segment index of
+    which paragraphs in this juan have parallel passages in other canons.
+    Chunks without any alignment are omitted from entries but counted in
+    total_chunks for UX progress display.
+    """
+    # Count total chunks in this juan
+    total_row = (await db.execute(
+        sql_text(
+            "SELECT COUNT(*) FROM text_embeddings "
+            "WHERE text_id = :tid AND juan_num = :juan"
+        ),
+        {"tid": text_id, "juan": juan_num},
+    )).fetchone()
+    total_chunks = int(total_row[0]) if total_row else 0
+
+    # Get chunks that have alignments (either direction)
+    rows = (await db.execute(
+        sql_text("""
+            SELECT DISTINCT te.chunk_index, te.chunk_text
+            FROM text_embeddings te
+            WHERE te.text_id = :tid AND te.juan_num = :juan
+            AND EXISTS (
+                SELECT 1 FROM alignment_pairs ap
+                WHERE ap.text_a_chunk_index IS NOT NULL
+                AND (
+                    (ap.text_a_id = te.text_id AND ap.text_a_juan_num = te.juan_num AND ap.text_a_chunk_index = te.chunk_index)
+                    OR
+                    (ap.text_b_id = te.text_id AND ap.text_b_juan_num = te.juan_num AND ap.text_b_chunk_index = te.chunk_index)
+                )
+            )
+            ORDER BY te.chunk_index
+        """),
+        {"tid": text_id, "juan": juan_num},
+    )).fetchall()
+
+    entries: list[JuanAlignmentEntry] = []
+    for chunk_idx, chunk_text in rows:
+        alignment_resp = await get_chunk_alignment(text_id, juan_num, chunk_idx, 5, db)
+        entries.append(JuanAlignmentEntry(
+            chunk_index=chunk_idx,
+            chunk_text=chunk_text,
+            parallels=alignment_resp.parallels,
+        ))
+
+    return JuanAlignmentResponse(
+        text_id=text_id,
+        juan_num=juan_num,
+        total_chunks=total_chunks,
+        chunks_with_parallels=len(entries),
+        entries=entries,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from datetime import UTC
 
 from app.api import (
     admin,
+    alignment,
     annotations,
     auth,
     bookmarks,
@@ -351,6 +352,7 @@ app.include_router(sources.router, prefix="/api")
 app.include_router(relations.router, prefix="/api")
 app.include_router(knowledge_graph.router, prefix="/api")
 app.include_router(iiif.router, prefix="/api")
+app.include_router(alignment.router, prefix="/api")
 
 # Phase 3 routers
 app.include_router(chat.router, prefix="/api")

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -33,6 +33,23 @@ class FeedbackRequest(BaseModel):
     feedback: Literal["up", "down"] | None = None
 
 
+class ParallelChunk(BaseModel):
+    """A cross-canon parallel passage linked via alignment_pairs.
+
+    Used in trilingual RAG: when the primary RAG hit is a 汉文 chunk that has
+    aligned Pali/Tibetan parallels in alignment_pairs, those parallels ride
+    along on the ChatSource so the LLM can reference them and the frontend
+    citation drawer can show side-by-side tabs.
+    """
+    text_id: int
+    juan_num: int
+    chunk_index: int
+    chunk_text: str
+    lang: str
+    title: str = ""
+    confidence: float = 1.0
+
+
 class ChatSource(BaseModel):
     text_id: int
     juan_num: int
@@ -40,6 +57,11 @@ class ChatSource(BaseModel):
     chunk_text: str
     score: float
     title_zh: str = ""
+    # Trilingual RAG additions (all optional for backward compat with stored
+    # chat history predating this migration).
+    lang: str = "lzh"
+    source_id: int | None = None
+    parallel_chunks: list[ParallelChunk] = []
 
 
 class ChatResponse(BaseModel):

--- a/backend/app/services/embedding.py
+++ b/backend/app/services/embedding.py
@@ -119,39 +119,46 @@ async def similarity_search(
     query_embedding: list[float],
     limit: int = 5,
     scope_text_ids: list[int] | None = None,
+    lang_list: list[str] | None = None,
 ) -> list[dict]:
     """Find most similar text chunks using pgvector cosine distance.
 
-    When scope_text_ids is provided, only search within those texts
-    (used for master persona mode to restrict RAG to the master's core scriptures).
+    Args:
+        scope_text_ids: restrict search to these text_ids (master persona mode)
+        lang_list: restrict search to these language codes ('lzh' | 'pi' | 'bo' | ...).
+                   Used by trilingual RAG to retrieve per-canon top-K separately.
+
+    Returns dicts including `lang` and `source_id` for downstream alignment-aware
+    merging in rag_retrieval._merge_with_alignment.
     """
     embedding_str = "[" + ",".join(str(x) for x in query_embedding) + "]"
     raw_conn = await session.connection()
+
+    base_select = (
+        "SELECT te.text_id, te.juan_num, te.chunk_index, te.chunk_text, "
+        "1 - (te.embedding <=> $1::vector) AS score, "
+        "COALESCE(bt.title_zh, '') AS title_zh, "
+        "bt.lang, bt.source_id "
+        "FROM text_embeddings te "
+        "LEFT JOIN buddhist_texts bt ON bt.id = te.text_id "
+        "WHERE te.embedding IS NOT NULL"
+    )
+    filters: list[str] = []
     if scope_text_ids:
         placeholders = ",".join(str(tid) for tid in scope_text_ids)
-        result = await raw_conn.exec_driver_sql(
-            "SELECT te.text_id, te.juan_num, te.chunk_index, te.chunk_text, "
-            "1 - (te.embedding <=> $1::vector) AS score, "
-            "COALESCE(bt.title_zh, '') AS title_zh "
-            "FROM text_embeddings te "
-            "LEFT JOIN buddhist_texts bt ON bt.id = te.text_id "
-            f"WHERE te.embedding IS NOT NULL AND te.text_id IN ({placeholders}) "  # nosec B608 — IDs from hardcoded MasterProfile, not user input
-            "ORDER BY te.embedding <=> $1::vector "
-            "LIMIT $2",
-            (embedding_str, limit),
-        )
-    else:
-        result = await raw_conn.exec_driver_sql(
-            "SELECT te.text_id, te.juan_num, te.chunk_index, te.chunk_text, "
-            "1 - (te.embedding <=> $1::vector) AS score, "
-            "COALESCE(bt.title_zh, '') AS title_zh "
-            "FROM text_embeddings te "
-            "LEFT JOIN buddhist_texts bt ON bt.id = te.text_id "
-            "WHERE te.embedding IS NOT NULL "
-            "ORDER BY te.embedding <=> $1::vector "
-            "LIMIT $2",
-            (embedding_str, limit),
-        )
+        filters.append(f"te.text_id IN ({placeholders})")  # nosec B608 — hardcoded MasterProfile IDs
+    if lang_list:
+        # Language codes are whitelist values from buddhist_texts.lang; inlining
+        # is safe because callers pass hardcoded lists like ['lzh','pi','bo'].
+        lang_placeholders = ",".join(f"'{_escape_lang(l)}'" for l in lang_list)
+        filters.append(f"bt.lang IN ({lang_placeholders})")  # nosec B608
+    where_clause = (" AND " + " AND ".join(filters)) if filters else ""
+
+    sql = (
+        base_select + where_clause
+        + " ORDER BY te.embedding <=> $1::vector LIMIT $2"
+    )
+    result = await raw_conn.exec_driver_sql(sql, (embedding_str, limit))
     rows = result.fetchall()
     return [
         {
@@ -161,9 +168,16 @@ async def similarity_search(
             "chunk_text": row[3],
             "score": float(row[4]),
             "title_zh": row[5],
+            "lang": row[6] or "lzh",
+            "source_id": row[7],
         }
         for row in rows
     ]
+
+
+def _escape_lang(lang: str) -> str:
+    """Defense-in-depth for lang_list inlining. Only alphanumeric + underscore allowed."""
+    return "".join(c for c in lang if c.isalnum() or c == "_")[:10]
 
 
 async def source_similarity_search(

--- a/backend/app/services/embedding.py
+++ b/backend/app/services/embedding.py
@@ -150,7 +150,7 @@ async def similarity_search(
     if lang_list:
         # Language codes are whitelist values from buddhist_texts.lang; inlining
         # is safe because callers pass hardcoded lists like ['lzh','pi','bo'].
-        lang_placeholders = ",".join(f"'{_escape_lang(l)}'" for l in lang_list)
+        lang_placeholders = ",".join(f"'{_escape_lang(lang)}'" for lang in lang_list)
         filters.append(f"bt.lang IN ({lang_placeholders})")  # nosec B608
     where_clause = (" AND " + " AND ".join(filters)) if filters else ""
 

--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -7,14 +7,13 @@ import time
 import httpx
 from opencc import OpenCC
 from sqlalchemy import or_, select
+from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from sqlalchemy import text as sql_text
-
 from app.config import settings
 from app.models.dictionary import DictionaryEntry
-from app.schemas.chat import ChatSource, ParallelChunk
+from app.schemas.chat import ChatSource
 from app.services.embedding import generate_embedding, similarity_search, source_similarity_search
 
 logger = logging.getLogger(__name__)

--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -10,9 +10,11 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from sqlalchemy import text as sql_text
+
 from app.config import settings
 from app.models.dictionary import DictionaryEntry
-from app.schemas.chat import ChatSource
+from app.schemas.chat import ChatSource, ParallelChunk
 from app.services.embedding import generate_embedding, similarity_search, source_similarity_search
 
 logger = logging.getLogger(__name__)
@@ -24,11 +26,142 @@ MIN_RELEVANCE_SCORE = 0.35
 # Maximum chunks to send to LLM after reranking (fewer but more relevant = better answers)
 MAX_CONTEXT_CHUNKS = 5
 
+# Trilingual RAG: enable per-language retrieval + alignment-aware merging.
+# When True, retrieve_rag_context fetches separately from lzh/pi/bo and then
+# attaches parallel_chunks to primary hits via alignment_pairs lookup.
+# Controlled by env var so it can be disabled in one place if needed.
+ENABLE_PARALLEL_RAG = settings.enable_parallel_rag if hasattr(settings, "enable_parallel_rag") else True
+
+# Per-lang top-k budgets for parallel mode. Total retrieved = LZH_K + PI_K + BO_K.
+# Keep larger for lzh since 95%+ users read Chinese and primary narrative stays in lzh.
+PARALLEL_LZH_K = 8
+PARALLEL_PI_K = 4
+PARALLEL_BO_K = 4
+
 
 def _format_source_label(result: dict) -> str:
     if result.get("title_zh"):
         return f"《{result['title_zh']}》第{result['juan_num']}卷"
     return f"文本#{result['text_id']} 第{result['juan_num']}卷"
+
+
+def _merge_with_alignment_sync(lzh_hits: list[dict], pi_hits: list[dict], bo_hits: list[dict]) -> list[dict]:
+    """Merge per-language RAG hits into a single score-ranked list.
+
+    Called in place of a single similarity_search when ENABLE_PARALLEL_RAG is on.
+    Primary source (highest-ranked lzh) is preserved; pi/bo hits are interleaved
+    by score so the LLM gets a cross-canon sampling. Alignment parallels are
+    attached later in _attach_parallel_chunks, not here — keeps responsibilities
+    separated.
+    """
+    merged: list[dict] = []
+    merged.extend(lzh_hits)
+    merged.extend(pi_hits)
+    merged.extend(bo_hits)
+    merged.sort(key=lambda r: r["score"], reverse=True)
+    return merged
+
+
+async def _attach_parallel_chunks(db: AsyncSession, results: list[dict]) -> None:
+    """For each result in-place, populate its parallel_chunks via alignment_pairs.
+
+    Looks up alignment_pairs for the (text_id, juan_num, chunk_index) tuple in
+    both directions (text_a and text_b sides). For each match, fetches the
+    aligned chunk's text from text_embeddings + title_zh from buddhist_texts.
+
+    Modifies `results` in place by setting result["parallel_chunks"] to a list
+    of ParallelChunk-compatible dicts.
+    """
+    if not results:
+        return
+    # Build a bulk query: "for any of these (text_id, juan, chunk) tuples, find
+    # alignment_pairs where text_a_* OR text_b_* matches, and return the other side"
+    for r in results:
+        r.setdefault("parallel_chunks", [])
+    try:
+        for r in results:
+            tid = r["text_id"]
+            juan = r["juan_num"]
+            cidx = r["chunk_index"]
+            sql = sql_text("""
+                SELECT
+                    CASE WHEN ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx
+                         THEN ap.text_b_id ELSE ap.text_a_id END AS other_text_id,
+                    CASE WHEN ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx
+                         THEN ap.text_b_juan_num ELSE ap.text_a_juan_num END AS other_juan,
+                    CASE WHEN ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx
+                         THEN ap.text_b_chunk_index ELSE ap.text_a_chunk_index END AS other_chunk_idx,
+                    CASE WHEN ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx
+                         THEN ap.text_b_lang ELSE ap.text_a_lang END AS other_lang,
+                    ap.confidence
+                FROM alignment_pairs ap
+                WHERE (
+                    (ap.text_a_id = :tid AND ap.text_a_juan_num = :juan AND ap.text_a_chunk_index = :cidx)
+                    OR
+                    (ap.text_b_id = :tid AND ap.text_b_juan_num = :juan AND ap.text_b_chunk_index = :cidx)
+                )
+                AND ap.text_a_chunk_index IS NOT NULL
+                ORDER BY ap.confidence DESC
+                LIMIT 5
+            """)
+            rows = (await db.execute(sql, {"tid": tid, "juan": juan, "cidx": cidx})).fetchall()
+            if not rows:
+                continue
+            # Fetch chunk_text + title for each parallel. Loop-per-row is fine
+            # for the expected small N (≤ 5 parallels × 5 primary results).
+            parallel_keys = [(row[0], row[1], row[2], row[3], float(row[4])) for row in rows]
+            text_map: dict[tuple[int, int, int], tuple[str, str]] = {}
+            for other_tid, other_juan, other_cidx, _lang, _conf in parallel_keys:
+                text_row = (await db.execute(
+                    sql_text(
+                        "SELECT te.chunk_text, "
+                        "COALESCE(bt.title_zh, bt.title_sa, bt.title_pi, bt.title_en, '') "
+                        "FROM text_embeddings te "
+                        "LEFT JOIN buddhist_texts bt ON bt.id = te.text_id "
+                        "WHERE te.text_id = :tid AND te.juan_num = :juan AND te.chunk_index = :cidx"
+                    ),
+                    {"tid": other_tid, "juan": other_juan, "cidx": other_cidx},
+                )).fetchone()
+                if text_row:
+                    text_map[(other_tid, other_juan, other_cidx)] = (text_row[0], text_row[1])
+            for other_tid, other_juan, other_cidx, other_lang, conf in parallel_keys:
+                key = (other_tid, other_juan, other_cidx)
+                if key not in text_map:
+                    continue
+                chunk_text, title = text_map[key]
+                r["parallel_chunks"].append({
+                    "text_id": other_tid,
+                    "juan_num": other_juan,
+                    "chunk_index": other_cidx,
+                    "chunk_text": chunk_text,
+                    "lang": other_lang or "lzh",
+                    "title": title,
+                    "confidence": conf,
+                })
+    except Exception:
+        logger.exception("Failed to attach parallel chunks")
+
+
+def _format_context_block(result: dict) -> str:
+    """Format a single RAG result into the LLM context string.
+
+    Adds [跨藏对读] annotations when parallel_chunks are present, so the LLM
+    knows it has cross-canon evidence available for the citation.
+    """
+    header = f"[出处: {_format_source_label(result)}]"
+    body = result["chunk_text"]
+    parallels = result.get("parallel_chunks") or []
+    if parallels:
+        parallel_lines = []
+        for p in parallels[:3]:  # cap at 3 parallels per primary source
+            lang_label = {"pi": "巴利", "bo": "藏", "sa": "梵", "en": "英", "lzh": "汉"}.get(p["lang"], p["lang"])
+            title = p.get("title", "") or "其他藏经"
+            parallel_lines.append(
+                f"  · [{lang_label}] 《{title}》 第{p['juan_num']}卷: {p['chunk_text'][:300]}"
+            )
+        parallel_block = "\n[跨藏对读 parallel_chunks]\n" + "\n".join(parallel_lines)
+        return f"{header}\n{body}{parallel_block}"
+    return f"{header}\n{body}"
 
 
 def _keyword_rerank(query: str, results: list[dict]) -> list[dict]:
@@ -267,8 +400,18 @@ async def retrieve_rag_context(
         t1 = time.monotonic()
         logger.debug("TIMING: Embedding took %.2fs", t1 - t0)
 
-        # Search text chunks, then data sources (sequential to avoid session conflicts)
-        text_results = await similarity_search(db, query_embedding, limit=pgvector_limit, scope_text_ids=scope_text_ids)
+        # Text chunk retrieval: two modes depending on ENABLE_PARALLEL_RAG
+        if ENABLE_PARALLEL_RAG and not scope_text_ids:
+            # Per-language top-k retrieval, then alignment-aware merging.
+            # scope_text_ids (master persona mode) bypasses parallel mode
+            # since master's scriptures are already filtered to a specific set.
+            lzh_hits = await similarity_search(db, query_embedding, limit=PARALLEL_LZH_K, lang_list=["lzh"])
+            pi_hits = await similarity_search(db, query_embedding, limit=PARALLEL_PI_K, lang_list=["pi"])
+            bo_hits = await similarity_search(db, query_embedding, limit=PARALLEL_BO_K, lang_list=["bo"])
+            text_results = _merge_with_alignment_sync(lzh_hits, pi_hits, bo_hits)
+        else:
+            text_results = await similarity_search(db, query_embedding, limit=pgvector_limit, scope_text_ids=scope_text_ids)
+
         source_results = await source_similarity_search(db, query_embedding, limit=3, min_score=0.5)
         logger.debug("TIMING: pgvector search took %.2fs", time.monotonic() - t1)
 
@@ -290,8 +433,14 @@ async def retrieve_rag_context(
         # Cap at MAX_CONTEXT_CHUNKS (fewer but more relevant after reranking)
         search_results = reranked[:MAX_CONTEXT_CHUNKS]
 
-        sources = [ChatSource(**r) for r in search_results]
-        context_parts = [f"[出处: {_format_source_label(r)}]\n{r['chunk_text']}" for r in search_results]
+        # Attach alignment parallels to sources (only if parallel mode on).
+        # Query alignment_pairs for each primary hit; if found, inject the
+        # aligned chunks' text into parallel_chunks for downstream use.
+        if ENABLE_PARALLEL_RAG and search_results:
+            await _attach_parallel_chunks(db, search_results)
+
+        sources = [ChatSource(**{k: v for k, v in r.items() if k not in ("source_id",)} | {"source_id": r.get("source_id")}) for r in search_results]
+        context_parts = [_format_context_block(r) for r in search_results]
         context_text = "\n\n".join(context_parts)
 
         # Append source recommendations if any matched


### PR DESCRIPTION
## Summary

Day 6 + Day 7 of trilingual RAG MVP. Wires the alignment_pairs data (built in PR #449 + running now in background on VPS) into the RAG pipeline and exposes it via REST API for the upcoming Reader \"他藏对读\" panel.

**Does not touch frontend** — that's Day 8 + 9 in a separate PR.

## Behavior change

When \`ENABLE_PARALLEL_RAG=True\` (default on), \`retrieve_rag_context()\` changes:

Before:
\`\`\`
similarity_search(pgvector top-10) → dedupe → rerank → top-5 to LLM
\`\`\`

After:
\`\`\`
lzh_hits (top-8) + pi_hits (top-4) + bo_hits (top-4)
→ merge by score
→ dedupe → rerank → top-5
→ attach alignment_pairs parallels for each top-5 result
→ format context block with [跨藏对读 parallel_chunks] annotation
\`\`\`

Master persona mode (\`scope_text_ids\`) bypasses parallel mode.

## New API endpoints

- \`GET /api/alignment/chunks/{text_id}/{juan_num}/{chunk_index}\` — parallels for one chunk
- \`GET /api/alignment/texts/{text_id}/juans/{juan_num}\` — all chunks in a juan with parallels

Both return \`ParallelPair[]\` with lang/title/confidence for frontend rendering. Direction-agnostic (checks both text_a and text_b sides of alignment_pairs).

## Schema additions

- \`ParallelChunk\` model
- \`ChatSource\` gains optional \`lang\`, \`source_id\`, \`parallel_chunks\` (all with defaults for backward compat with stored chat history)

## Alignment data status (as of this PR)

Currently running on production VPS, populated so far:
- 心经 T0252 ↔ Toh 21: **6 pairs** (完成)
- 转法轮经 SN 56.11 ↔ T0099: **14 pairs** (完成)
- 法句经 T0210 ↔ SC Dhammapada: **29 pairs** (完成)
- 念处经 MN 10 ↔ T0026: running
- 维摩诘经 T0475 ↔ Toh 176: queued

## Test plan

- [x] Python syntax check on all 5 touched files
- [ ] VPS deploy + backend container rebuild
- [ ] curl \`/api/alignment/chunks/10/1/0\` returns 心经 parallels
- [ ] curl \`/api/alignment/texts/10/juans/1\` returns juan summary
- [ ] curl \`/api/chat/send\` with \"心经里色即是空\" returns \`sources[0].parallel_chunks\` non-empty
- [ ] Non-MVP question (e.g. \"四大名山\") still returns normal single-source RAG (no regression)
- [ ] \`ENABLE_PARALLEL_RAG=false\` env var can disable new path (fallback works)