### PR TITLE
fix(admin): align 30-day trends series to full date grid

### DIFF
--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -50,12 +50,14 @@ async def _count_with_today(db: AsyncSession, model, created_field, today_start:
 
 
 async def get_trends(db: AsyncSession, days: int = 30) -> dict:
-    since = date.today() - timedelta(days=days - 1)
+    today = date.today()
+    since = today - timedelta(days=days - 1)
     since_dt = datetime(since.year, since.month, since.day, tzinfo=UTC)
+    date_grid = [since + timedelta(days=i) for i in range(days)]
 
-    registrations = await _daily_counts(db, User, User.created_at, since_dt)
-    messages = await _daily_counts(db, ChatMessage, ChatMessage.created_at, since_dt)
-    active_users = await _daily_active_users(db, since_dt)
+    registrations = await _daily_counts(db, User, User.created_at, since_dt, date_grid)
+    messages = await _daily_counts(db, ChatMessage, ChatMessage.created_at, since_dt, date_grid)
+    active_users = await _daily_active_users(db, since_dt, date_grid)
 
     return {
         "registrations": registrations,
@@ -64,7 +66,13 @@ async def get_trends(db: AsyncSession, days: int = 30) -> dict:
     }
 
 
-async def _daily_counts(db: AsyncSession, model, created_field, since: datetime) -> list[DailyCount]:
+def _fill_missing_days(rows: dict[date, int], date_grid: list[date]) -> list[DailyCount]:
+    return [DailyCount(date=d.isoformat(), count=rows.get(d, 0)) for d in date_grid]
+
+
+async def _daily_counts(
+    db: AsyncSession, model, created_field, since: datetime, date_grid: list[date]
+) -> list[DailyCount]:
     day_col = cast(created_field, Date)
     result = await db.execute(
         select(day_col, func.count())
@@ -73,10 +81,13 @@ async def _daily_counts(db: AsyncSession, model, created_field, since: datetime)
         .group_by(day_col)
         .order_by(day_col)
     )
-    return [DailyCount(date=str(row[0]), count=row[1]) for row in result.all()]
+    rows = {row[0]: row[1] for row in result.all()}
+    return _fill_missing_days(rows, date_grid)
 
 
-async def _daily_active_users(db: AsyncSession, since: datetime) -> list[DailyCount]:
+async def _daily_active_users(
+    db: AsyncSession, since: datetime, date_grid: list[date]
+) -> list[DailyCount]:
     """Active users = distinct users who sent chat messages OR read texts each day."""
     chat_day = cast(ChatSession.created_at, Date)
     read_day = cast(ReadingHistory.last_read_at, Date)
@@ -96,7 +107,8 @@ async def _daily_active_users(db: AsyncSession, since: datetime) -> list[DailyCo
         .group_by(union_q.c.day)
         .order_by(union_q.c.day)
     )
-    return [DailyCount(date=str(row[0]), count=row[1]) for row in result.all()]
+    rows = {row[0]: row[1] for row in result.all()}
+    return _fill_missing_days(rows, date_grid)
 
 
 async def list_users(


### PR DESCRIPTION
## 问题

管理后台 "最近 30 天趋势" 图表 X 轴最后一个 tick 渲染成 `2026-04-02`（应为今天 `2026-04-16`）。tooltip 日期正确（`2026-04-15 = 132 消息数`），纯属轴标签错位。

## 根因

`admin_service.get_trends()` 三个 series（`registrations` / `messages` / `active_users`）都用 SQL `GROUP BY Date` 直接返回，**只包含有数据的天**。三者日期集合不一致——`active_users` 最后一条恰好落在 `2026-04-02`。

前端 `chartData = [...reg, ...msg, ...active]` 拼接后交给 `@ant-design/charts`，图表按 **首次出现顺序** 构建分类 X 轴尺度，`active_users` 尾部的 `2026-04-02` 被错误地当成全局最后一个 tick。

## 修复

`backend/app/services/admin_service.py`：
- `get_trends` 生成 `[since, today]` 完整 30 天 `date_grid`。
- 新增 `_fill_missing_days()` 按 grid 把缺失日期补 0。
- 三个 series 返回长度/日期完全对齐 → X 轴分类集合就是有序的 30 天，末端必然是今天。

## Test plan

- [ ] 生产环境打开 `/admin`，最近 30 天趋势 X 轴末端为 `2026-04-16`
- [ ] 三条曲线在同一日期网格上绘制，无错位跳点

🤖 Generated with [Claude Code](https://claude.com/claude-code)