### PR TITLE
fix(admin): anchor stats day-boundary to Asia/Shanghai

### DIFF
--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -1,4 +1,5 @@
 from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import Date, case, cast, distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,10 +10,23 @@ from app.models.source import SourceSuggestion
 from app.models.user import ReadingHistory, User
 from app.schemas.admin import AdminAnnotationItem, AdminOverview, DailyCount
 
+# Server, ops team, and end users all live in CST. created_at columns are stored
+# in UTC, so we explicitly anchor "today" / day-bucket boundaries to CST and
+# convert when crossing the SQL ↔ Python boundary, instead of letting Postgres'
+# session timezone or Python's naive date.today() pick the boundary implicitly.
+LOCAL_TZ = ZoneInfo("Asia/Shanghai")
+
+
+def _local_today() -> date:
+    return datetime.now(LOCAL_TZ).date()
+
+
+def _local_midnight_utc(d: date) -> datetime:
+    return datetime.combine(d, datetime.min.time(), tzinfo=LOCAL_TZ).astimezone(UTC)
+
 
 async def get_overview(db: AsyncSession) -> AdminOverview:
-    today = date.today()
-    today_start = datetime(today.year, today.month, today.day, tzinfo=UTC)
+    today_start = _local_midnight_utc(_local_today())
 
     total_users, new_users_today = await _count_with_today(db, User, User.created_at, today_start)
     total_sessions, new_sessions_today = await _count_with_today(db, ChatSession, ChatSession.created_at, today_start)
@@ -50,9 +64,9 @@ async def _count_with_today(db: AsyncSession, model, created_field, today_start:
 
 
 async def get_trends(db: AsyncSession, days: int = 30) -> dict:
-    today = date.today()
+    today = _local_today()
     since = today - timedelta(days=days - 1)
-    since_dt = datetime(since.year, since.month, since.day, tzinfo=UTC)
+    since_dt = _local_midnight_utc(since)
     date_grid = [since + timedelta(days=i) for i in range(days)]
 
     registrations = await _daily_counts(db, User, User.created_at, since_dt, date_grid)
@@ -70,10 +84,21 @@ def _fill_missing_days(rows: dict[date, int], date_grid: list[date]) -> list[Dai
     return [DailyCount(date=d.isoformat(), count=rows.get(d, 0)) for d in date_grid]
 
 
+def _local_day(created_field):
+    """Cast a UTC timestamptz column to its CST calendar date.
+
+    `timezone('Asia/Shanghai', ts)` shifts a timestamptz into CST as a naive
+    timestamp; casting that to Date gives the CST calendar day. Without this,
+    Postgres falls back to the session timezone, which is environment-dependent
+    and can disagree with the Python-side day boundary.
+    """
+    return cast(func.timezone("Asia/Shanghai", created_field), Date)
+
+
 async def _daily_counts(
     db: AsyncSession, model, created_field, since: datetime, date_grid: list[date]
 ) -> list[DailyCount]:
-    day_col = cast(created_field, Date)
+    day_col = _local_day(created_field)
     result = await db.execute(
         select(day_col, func.count())
         .select_from(model)
@@ -89,8 +114,8 @@ async def _daily_active_users(
     db: AsyncSession, since: datetime, date_grid: list[date]
 ) -> list[DailyCount]:
     """Active users = distinct users who sent chat messages OR read texts each day."""
-    chat_day = cast(ChatSession.created_at, Date)
-    read_day = cast(ReadingHistory.last_read_at, Date)
+    chat_day = _local_day(ChatSession.created_at)
+    read_day = _local_day(ReadingHistory.last_read_at)
 
     chat_q = (
         select(chat_day.label("day"), ChatSession.user_id.label("uid"))


### PR DESCRIPTION
## 问题

`admin_service` 计算 \"今天\" / 日桶时把 `date.today()` 直接打上 `tzinfo=UTC` 标签：

\`\`\`python
today = date.today()  # 拿到 CST 的本地日期
today_start = datetime(today.year, today.month, today.day, tzinfo=UTC)  # 但标成 UTC
\`\`\`

服务器和用户都在 CST（UTC+8），`created_at` 列是 UTC timestamptz。这把 \"CST 今天 00:00\" 错当成了 \"UTC 今天 00:00\"，结果**CST 00:00–08:00 注册的用户被错误归到前一天**。

\`get_trends\` 还有一个相关问题：`cast(created_at, Date)` 走 Postgres session timezone，环境依赖，可能与 Python 侧的 `date_grid` 切日不一致。

## 修复

- 新增 `LOCAL_TZ = ZoneInfo(\"Asia/Shanghai\")` 和两个小工具：`_local_today()`、`_local_midnight_utc(date)`。
- `get_overview` 的 `today_start` 改用 `_local_midnight_utc(_local_today())`。
- `get_trends` 同样用本地日期生成 `since` / `date_grid`，并把 SQL 端的 day 列改为 `_local_day(col)` = `cast(timezone('Asia/Shanghai', col), Date)`，确保 SQL 桶和 Python 网格用同一套日界。

## Boundary case 验证

| 场景 | 注册时刻 | 旧 today_start | 旧结果 | 新 today_start | 新结果 |
|---|---|---|---|---|---|
| CST 04-16 02:00 注册 | UTC 04-15 18:00 | UTC 04-16 00:00 | 算成昨天 ❌ | UTC 04-15 16:00 | 算成今天 ✅ |

## Test plan

- [ ] 部署后，凌晨时段（CST 0-8 点）有新注册时，\`new_users_today\` 包括之
- [ ] 30 天趋势图各日期桶 = CST 自然日，不会出现 UTC 跨夜分裂

🤖 Generated with [Claude Code](https://claude.com/claude-code)