### PR TITLE
ui(text-detail): downweight 导出引用 button to secondary style

### DIFF
--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   ReadOutlined,
   HomeOutlined,
   BookOutlined,
+  ExportOutlined,
 } from "@ant-design/icons";
 import { getTextDetail } from "../api/client";
 import { buildCbetaReadUrl } from "../utils/sourceUrls";
@@ -191,14 +192,14 @@ export default function TextDetailPage() {
               CBETA 阅读
             </Button>
           )}
+          <BookmarkButton textId={text.id} />
           <Button
-            icon={<BookOutlined />}
+            type="text"
+            icon={<ExportOutlined />}
             onClick={() => setCitationOpen(true)}
-            style={{ background: "#5b8c6b", borderColor: "#5b8c6b", color: "#fff" }}
           >
             导出引用
           </Button>
-          <BookmarkButton textId={text.id} />
         </Space>
 
         <CitationGenerator


### PR DESCRIPTION
## Summary

- 将 \`导出引用\` 按钮从绿色实心主按钮降级为 \`type=\"text\"\` 轻量样式，与 \`BookmarkButton\` 同级
- 换用 \`ExportOutlined\` 图标，区别于\"在线阅读\"的 \`BookOutlined\`
- 调整顺序：\`[在线阅读] [CBETA 阅读]\` 主按钮组 → \`♡ 收藏  ⤴ 导出引用\` 次级操作

## Why

引用导出是低频学术操作（预估点击率 <5%），不应和\"在线阅读\"\"CBETA 阅读\"共享视觉权重。保留功能一键可达，但让 UI 焦点回到主要阅读入口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)