### PR TITLE
ui(reader): rename 他藏对读 to 汉巴藏对读

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -703,7 +703,7 @@ export default function TextReaderPage() {
               icon={<GlobalOutlined />}
               onClick={() => setParallelPanelOpen((v) => !v)}
             >
-              他藏对读
+              汉巴藏对读
             </Button>
           </Tooltip>
           <div className="reader-font-controls">
@@ -844,7 +844,7 @@ export default function TextReaderPage() {
         <div className="reader-ai-divider" onMouseDown={handleParallelDragStart} />
         <div className="reader-ai-sidebar" style={{ width: parallelPanelWidth }}>
           <div className="reader-ai-sidebar-header">
-            <span className="reader-ai-sidebar-title"><GlobalOutlined /> 他藏对读</span>
+            <span className="reader-ai-sidebar-title"><GlobalOutlined /> 汉巴藏对读</span>
             <Button type="text" size="small" onClick={() => setParallelPanelOpen(false)}>✕</Button>
           </div>
           <ReaderParallelPanel textId={textId} juanNum={juanNum} />


### PR DESCRIPTION
## Summary

- Reader 工具栏按钮 + 面板标题从「他藏对读」改为「汉巴藏对读」

## Why

「他藏」有歧义——在汉传语境里，大正藏、高丽藏、嘉兴藏都是「他藏」。此功能实际对照的是**汉文/巴利/藏文三语藏经**，用「汉巴藏」直接、无歧义。

🤖 Generated with [Claude Code](https://claude.com/claude-code)