### PR TITLE
feat(geo): restore 佛教地理 menu with China-only high-confidence subset

### DIFF
--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -284,6 +284,20 @@ async def get_geo_entities(
         "(e.properties->>'longitude') IS NOT NULL",
         "e.entity_type != 'sub_entity'",
         "COALESCE(e.properties->>'is_buddhist', 'true') != 'false'",
+        # person 只放高置信度 + 中国境内；teacher_hop / desc_match 有误匹配（中国僧人投海外同名寺）
+        # monastery / place 等不受影响
+        """(
+            e.entity_type != 'person'
+            OR (
+                (e.properties->>'latitude')::float BETWEEN 18 AND 54
+                AND (e.properties->>'longitude')::float BETWEEN 73 AND 135
+                AND (
+                    e.properties->>'geo_source' LIKE 'wikidata%'
+                    OR e.properties->>'geo_source' LIKE 'city_match%'
+                    OR e.properties->>'geo_source' LIKE 'province_match%'
+                )
+            )
+        )""",
     ]
     params: dict = {"limit": limit}
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -76,9 +76,7 @@ export default function Layout() {
     { icon: <RobotOutlined />, label: t("nav.chat"), path: "/chat" },
     { icon: <FileTextOutlined />, label: t("nav.dictionary"), path: "/dictionary" },
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
-    // TODO: 佛教地理暂时隐藏，待人物 geocoding 数据质量问题解决后重新上线
-    // （~1000 条中国僧人因 desc_match 贪心匹配被错投到韩国同名寺院，见 session 2026-04-12）
-    // { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
+    { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
     // TODO: 佛学动态暂时隐藏，待加入cron定时抓取后重新上线
     // { icon: <NotificationOutlined />, label: t("nav.activity"), path: "/activity" },

--- a/frontend/src/pages/KGMapPage.tsx
+++ b/frontend/src/pages/KGMapPage.tsx
@@ -150,6 +150,13 @@ export default function KGMapPage() {
             </span>
           </Tooltip>
         )}
+        <Tooltip
+          title="人物数据仅展示中国境内、来源为 Wikidata/城市匹配/省份匹配的高置信度坐标；师承推断与描述贪心匹配的结果已剔除。寺院数据来自高德 V3 全量抓取。"
+        >
+          <span className="kg-map-stats" style={{ cursor: "help", opacity: 0.7 }}>
+            数据说明
+          </span>
+        </Tooltip>
       </div>
 
       {/* Toolbar */}


### PR DESCRIPTION
## Summary
- 恢复 PR #416 中隐藏的佛教地理菜单。
- 后端 `get_geo_entities` 对 `person` 实体增加质量门槛：中国 bbox + geo_source 白名单 (wikidata / city_match / province_match)；剔除 teacher_hop（师承推断）和 desc_match（描述贪心匹配，即此前把中国僧人投到同名韩国/日本寺院的元凶）。
- monastery / place 不受影响（monastery 59836 条已 100% 地理化）。
- 前端头部加"数据说明" tooltip，说明人物层仅中国高置信度。

### Data impact
| entity_type | before | after |
|---|---|---|
| monastery | 59836 | 59836 |
| person | ~18459 (含 ~11k 可疑) | 5983 (high-confidence, China) |
| place | 337 | 337 |

## Test plan
- [x] VPS 后端 API `/api/kg/geo?entity_type=person` → total 5983
- [x] VPS 后端 API `/api/kg/geo?entity_type=monastery` → total 59836
- [x] `/map` 页面 HTTP 200
- [ ] UI 抽查人物标注（全部中国境内，无韩/日误投）

🤖 Generated with [Claude Code](https://claude.com/claude-code)