### PR TITLE
feat(kg): add is_hidden filter + hide 1395 non-Buddhist entities

### DIFF
--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -42,6 +42,14 @@ async def search_entities(
     if entity_type:
         stmt = stmt.where(KGEntity.entity_type == entity_type)
 
+    # Exclude manually hidden entities (properties.is_hidden=true)
+    stmt = stmt.where(
+        func.coalesce(
+            KGEntity.properties.op("->>")("is_hidden"), "false"
+        )
+        != "true"
+    )
+
     # Exclude entities without any KG relations — they add no value to the graph
     stmt = stmt.where(
         exists(
@@ -91,7 +99,13 @@ async def search_entities(
 
 
 async def get_entity(session: AsyncSession, entity_id: int) -> KGEntity | None:
-    return await session.get(KGEntity, entity_id)
+    ent = await session.get(KGEntity, entity_id)
+    if ent is None:
+        return None
+    props = ent.properties or {}
+    if str(props.get("is_hidden", "false")).lower() == "true":
+        return None
+    return ent
 
 
 async def get_entity_relations(
@@ -225,7 +239,13 @@ async def get_entity_graph(
     nodes = []
     if node_ids:
         entities_result = await session.execute(
-            select(KGEntity).where(KGEntity.id.in_(node_ids))
+            select(KGEntity).where(
+                KGEntity.id.in_(node_ids),
+                func.coalesce(
+                    KGEntity.properties["is_hidden"].astext, "false"
+                )
+                != "true",
+            )
         )
         for e in entities_result.scalars().all():
             nodes.append({
@@ -234,6 +254,11 @@ async def get_entity_graph(
                 "entity_type": e.entity_type,
                 "description": e.description,
             })
+        visible_ids = {n["id"] for n in nodes}
+        links = [
+            l for l in links
+            if l["source"] in visible_ids and l["target"] in visible_ids
+        ]
 
     return {"nodes": nodes, "links": links, "truncated": truncated}
 
@@ -284,6 +309,7 @@ async def get_geo_entities(
         "(e.properties->>'longitude') IS NOT NULL",
         "e.entity_type != 'sub_entity'",
         "COALESCE(e.properties->>'is_buddhist', 'true') != 'false'",
+        "COALESCE(e.properties->>'is_hidden', 'false') != 'true'",
         # person 只放高置信度 + 中国境内；teacher_hop / desc_match 有误匹配（中国僧人投海外同名寺）
         # monastery / place 等不受影响
         """(
@@ -399,6 +425,8 @@ async def get_lineage_arcs(
         "COALESCE(s.properties->>'geo_source', '') NOT LIKE 'teacher_hop%%'",
         "COALESCE(t.properties->>'is_buddhist', 'true') != 'false'",
         "COALESCE(s.properties->>'is_buddhist', 'true') != 'false'",
+        "COALESCE(t.properties->>'is_hidden', 'false') != 'true'",
+        "COALESCE(s.properties->>'is_hidden', 'false') != 'true'",
     ]
     params: dict = {"limit": limit}
 


### PR DESCRIPTION
## Summary
- 支持通过 `properties.is_hidden=true` 隐藏特定实体，过滤在 geo / search / detail / graph / lineage-arcs 全部 KG endpoints 生效。
- DB 已标记 **1395 条**：
  - 2 条特定人物（手动隐藏）
  - 1393 条科举官员（`進士|舉人|狀元|殿試|登第|登科|會試|鄉試`），这些是从 DILA 非佛教传记子库（如《明人傳記資料索引》）误导入的儒家科举人物，不应出现在佛教图谱/地图中。
- 前端无改动，依赖后端过滤。

## Effect
| Endpoint | Before | After |
|---|---|---|
| `/api/kg/geo?entity_type=person` | 5983 | 5196 |
| `/api/kg/entities?q=<hidden>` | 命中 | 空结果 |
| `/api/kg/entities/<hidden_id>` | 200 | 404 |

## Test plan
- [x] geo API 人物总数下降 787
- [x] 两条特定人物搜索/详情/图谱全部不可见
- [ ] UI 抽查 /map + /kg 无明清进士出现

🤖 Generated with [Claude Code](https://claude.com/claude-code)