### PR TITLE
feat(reader): sutta-level parallel reading via SuttaCentral

### DIFF
--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -56,6 +56,26 @@ class JuanAlignmentResponse(BaseModel):
     entries: list[JuanAlignmentEntry]
 
 
+class CanonicalParallel(BaseModel):
+    """Sutta-level academic parallel from SuttaCentral (stored in text_relations)."""
+    related_text_id: int
+    related_cbeta_id: str
+    related_title: str
+    related_lang: str
+    relation_type: str
+    note: str | None = None
+    pali_preview: str | None = None
+    english_preview: str | None = None
+
+
+class CanonicalParallelsResponse(BaseModel):
+    text_id: int
+    source_cbeta_id: str
+    source_title: str
+    total: int
+    parallels: list[CanonicalParallel]
+
+
 @router.get("/chunks/{text_id}/{juan_num}/{chunk_index}", response_model=ChunkAlignmentResponse)
 async def get_chunk_alignment(
     text_id: int,
@@ -201,4 +221,97 @@ async def get_juan_alignment(
         total_chunks=total_chunks,
         chunks_with_parallels=len(entries),
         entries=entries,
+    )
+
+
+@router.get("/canonical/{text_id}", response_model=CanonicalParallelsResponse)
+async def get_canonical_parallels(
+    text_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> CanonicalParallelsResponse:
+    """Sutta-level SC parallels for a whole text.
+
+    Reads text_relations (source='suttacentral') — authoritative Akanuma-style
+    correspondences, no inference noise. For each parallel, also pulls the
+    first ~240 chars of the related text's content (Pāli from text_contents,
+    English from text_embeddings chunk 0) to preview in the panel.
+    """
+    src_row = (await db.execute(
+        sql_text(
+            "SELECT cbeta_id, title_zh FROM buddhist_texts WHERE id = :tid"
+        ),
+        {"tid": text_id},
+    )).fetchone()
+    if not src_row:
+        return CanonicalParallelsResponse(
+            text_id=text_id, source_cbeta_id="", source_title="", total=0, parallels=[]
+        )
+
+    rows = (await db.execute(
+        sql_text("""
+            SELECT
+                CASE WHEN tr.text_a_id = :tid THEN tr.text_b_id ELSE tr.text_a_id END AS rel_id,
+                tr.relation_type, tr.note
+            FROM text_relations tr
+            WHERE tr.source = 'suttacentral'
+              AND (tr.text_a_id = :tid OR tr.text_b_id = :tid)
+        """),
+        {"tid": text_id},
+    )).fetchall()
+
+    parallels: list[CanonicalParallel] = []
+    for rel_id, rel_type, note in rows:
+        meta = (await db.execute(
+            sql_text(
+                "SELECT cbeta_id, "
+                "COALESCE(title_pi, title_sa, title_en, title_zh, '') AS title, "
+                "lang "
+                "FROM buddhist_texts WHERE id = :rid"
+            ),
+            {"rid": rel_id},
+        )).fetchone()
+        if not meta:
+            continue
+
+        pali_preview: str | None = None
+        english_preview: str | None = None
+        if meta[2] == "pi":
+            pi_row = (await db.execute(
+                sql_text(
+                    "SELECT LEFT(content, 240) FROM text_contents "
+                    "WHERE text_id = :rid AND lang = 'pi' ORDER BY juan_num LIMIT 1"
+                ),
+                {"rid": rel_id},
+            )).fetchone()
+            if pi_row and pi_row[0]:
+                pali_preview = pi_row[0]
+            en_row = (await db.execute(
+                sql_text(
+                    "SELECT LEFT(chunk_text, 240) FROM text_embeddings "
+                    "WHERE text_id = :rid ORDER BY juan_num, chunk_index LIMIT 1"
+                ),
+                {"rid": rel_id},
+            )).fetchone()
+            if en_row and en_row[0]:
+                english_preview = en_row[0]
+
+        parallels.append(CanonicalParallel(
+            related_text_id=rel_id,
+            related_cbeta_id=meta[0],
+            related_title=meta[1] or "",
+            related_lang=meta[2] or "",
+            relation_type=rel_type,
+            note=note,
+            pali_preview=pali_preview,
+            english_preview=english_preview,
+        ))
+
+    parallels.sort(key=lambda p: (0 if p.relation_type == "parallel" else 1, p.related_cbeta_id))
+
+    return CanonicalParallelsResponse(
+        text_id=text_id,
+        source_cbeta_id=src_row[0],
+        source_title=src_row[1] or "",
+        total=len(parallels),
+        parallels=parallels,
     )

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -256,8 +256,8 @@ async def get_entity_graph(
             })
         visible_ids = {n["id"] for n in nodes}
         links = [
-            l for l in links
-            if l["source"] in visible_ids and l["target"] in visible_ids
+            link for link in links
+            if link["source"] in visible_ids and link["target"] in visible_ids
         ]
 
     return {"nodes": nodes, "links": links, "truncated": truncated}

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -42,6 +42,14 @@ async def search_entities(
     if entity_type:
         stmt = stmt.where(KGEntity.entity_type == entity_type)
 
+    # Exclude manually hidden entities (properties.is_hidden=true)
+    stmt = stmt.where(
+        func.coalesce(
+            KGEntity.properties.op("->>")("is_hidden"), "false"
+        )
+        != "true"
+    )
+
     # Exclude entities without any KG relations — they add no value to the graph
     stmt = stmt.where(
         exists(
@@ -91,7 +99,13 @@ async def search_entities(
 
 
 async def get_entity(session: AsyncSession, entity_id: int) -> KGEntity | None:
-    return await session.get(KGEntity, entity_id)
+    ent = await session.get(KGEntity, entity_id)
+    if ent is None:
+        return None
+    props = ent.properties or {}
+    if str(props.get("is_hidden", "false")).lower() == "true":
+        return None
+    return ent
 
 
 async def get_entity_relations(
@@ -225,7 +239,13 @@ async def get_entity_graph(
     nodes = []
     if node_ids:
         entities_result = await session.execute(
-            select(KGEntity).where(KGEntity.id.in_(node_ids))
+            select(KGEntity).where(
+                KGEntity.id.in_(node_ids),
+                func.coalesce(
+                    KGEntity.properties["is_hidden"].astext, "false"
+                )
+                != "true",
+            )
         )
         for e in entities_result.scalars().all():
             nodes.append({
@@ -234,6 +254,11 @@ async def get_entity_graph(
                 "entity_type": e.entity_type,
                 "description": e.description,
             })
+        visible_ids = {n["id"] for n in nodes}
+        links = [
+            l for l in links
+            if l["source"] in visible_ids and l["target"] in visible_ids
+        ]
 
     return {"nodes": nodes, "links": links, "truncated": truncated}
 
@@ -284,6 +309,7 @@ async def get_geo_entities(
         "(e.properties->>'longitude') IS NOT NULL",
         "e.entity_type != 'sub_entity'",
         "COALESCE(e.properties->>'is_buddhist', 'true') != 'false'",
+        "COALESCE(e.properties->>'is_hidden', 'false') != 'true'",
         # person 只放高置信度 + 中国境内；teacher_hop / desc_match 有误匹配（中国僧人投海外同名寺）
         # monastery / place 等不受影响
         """(
@@ -399,6 +425,8 @@ async def get_lineage_arcs(
         "COALESCE(s.properties->>'geo_source', '') NOT LIKE 'teacher_hop%%'",
         "COALESCE(t.properties->>'is_buddhist', 'true') != 'false'",
         "COALESCE(s.properties->>'is_buddhist', 'true') != 'false'",
+        "COALESCE(t.properties->>'is_hidden', 'false') != 'true'",
+        "COALESCE(s.properties->>'is_hidden', 'false') != 'true'",
     ]
     params: dict = {"limit": limit}
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1121,6 +1121,32 @@ export async function getJuanAlignment(
   return data;
 }
 
+export interface CanonicalParallel {
+  related_text_id: number;
+  related_cbeta_id: string;
+  related_title: string;
+  related_lang: string;
+  relation_type: string;
+  note?: string | null;
+  pali_preview?: string | null;
+  english_preview?: string | null;
+}
+
+export interface CanonicalParallelsResponse {
+  text_id: number;
+  source_cbeta_id: string;
+  source_title: string;
+  total: number;
+  parallels: CanonicalParallel[];
+}
+
+export async function getCanonicalParallels(textId: number): Promise<CanonicalParallelsResponse> {
+  const { data } = await api.get<CanonicalParallelsResponse>(
+    `/alignment/canonical/${textId}`,
+  );
+  return data;
+}
+
 export interface ChunkContextResponse {
   text_id: TextId;
   juan_num: number;

--- a/frontend/src/components/ReaderParallelPanel.tsx
+++ b/frontend/src/components/ReaderParallelPanel.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import { Empty, Spin, Alert, Collapse, Tag, Progress } from "antd";
+import { Empty, Spin, Alert, Collapse, Tag, Progress, Tabs } from "antd";
 import { LinkOutlined, BookOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { getJuanAlignment } from "../api/client";
+import { getJuanAlignment, getCanonicalParallels } from "../api/client";
 
 interface Props {
   textId: number;
@@ -26,17 +26,128 @@ const LANG_COLOR: Record<string, string> = {
   en: "geekblue",
 };
 
-/**
- * Reader 右侧"他藏对读"内联面板（非 modal）。
- *
- * 本组件只渲染内容，不负责容器或关闭按钮 —— 外层 TextReaderPage 的
- * reader-parallel-sidebar wrapper 负责尺寸、header、关闭按钮。这和
- * ReaderAIPanel 是同一个模式，确保两个面板共享容器样式 + 可同时开启 +
- * 可各自拖拽宽度 + 不会 modal 覆盖经文。
- */
-export default function ReaderParallelPanel({ textId, juanNum }: Props) {
-  const [activeKeys, setActiveKeys] = useState<string[]>([]);
+const RELATION_LABEL: Record<string, string> = {
+  parallel: "平行",
+  mention: "提及",
+  retell: "复述",
+};
 
+const RELATION_COLOR: Record<string, string> = {
+  parallel: "green",
+  mention: "orange",
+  retell: "purple",
+};
+
+function CanonicalView({ textId }: { textId: number }) {
+  const [activeKeys, setActiveKeys] = useState<string[]>([]);
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["canonical-parallels", textId],
+    queryFn: () => getCanonicalParallels(textId),
+    enabled: textId > 0,
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin />
+        <div style={{ marginTop: 12, color: "#888" }}>加载 SuttaCentral 对应中…</div>
+      </div>
+    );
+  }
+  if (error) {
+    return <Alert type="error" showIcon message="加载失败" style={{ margin: 12 }} />;
+  }
+  if (!data || data.total === 0) {
+    return (
+      <Empty
+        description="本经暂无 SuttaCentral 学术对应"
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        style={{ marginTop: 40 }}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div style={{ padding: "12px 16px", borderBottom: "1px solid #eee", fontSize: 13, color: "#555" }}>
+        本经《{data.source_title}》共 <b>{data.total}</b> 条 SuttaCentral 学术对应
+      </div>
+      <div style={{ flex: 1, overflow: "auto", padding: "8px 12px" }}>
+        <Collapse
+          activeKey={activeKeys}
+          onChange={(keys) => setActiveKeys(Array.isArray(keys) ? keys : [keys])}
+          ghost
+          items={data.parallels.map((p, idx) => ({
+            key: `${p.related_text_id}-${idx}`,
+            label: (
+              <div style={{ paddingRight: 8 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap", marginBottom: 4 }}>
+                  <Tag color={RELATION_COLOR[p.relation_type] || "default"} style={{ margin: 0 }}>
+                    {RELATION_LABEL[p.relation_type] || p.relation_type}
+                  </Tag>
+                  <Tag color={LANG_COLOR[p.related_lang] || "default"} style={{ margin: 0 }}>
+                    {LANG_LABEL[p.related_lang] || p.related_lang}
+                  </Tag>
+                  <span style={{ fontSize: 12, color: "#666", fontWeight: 500 }}>
+                    《{p.related_title}》
+                  </span>
+                </div>
+                {p.note && (
+                  <div style={{ fontSize: 11, color: "#999" }}>{p.note}</div>
+                )}
+              </div>
+            ),
+            children: (
+              <div style={{ paddingLeft: 8, borderLeft: "2px solid #e8e8e8" }}>
+                {p.pali_preview && (
+                  <div style={{ marginBottom: 10, padding: "8px 10px", background: "#f6fafd", borderLeft: "3px solid #5b8c6b", borderRadius: 4 }}>
+                    <div style={{ fontSize: 11, color: "#5b8c6b", marginBottom: 4, fontWeight: 500 }}>
+                      Pāli 原文
+                    </div>
+                    <div lang="pi" style={{ fontSize: 12, lineHeight: 1.8, color: "#333" }}>
+                      {p.pali_preview}…
+                    </div>
+                  </div>
+                )}
+                {p.english_preview && (
+                  <div style={{ marginBottom: 10, padding: "8px 10px", background: "#fafafa", borderRadius: 4 }}>
+                    <div style={{ fontSize: 11, color: "#666", marginBottom: 4, fontWeight: 500 }}>
+                      English (Sujato)
+                    </div>
+                    <div lang="en" style={{ fontSize: 12, lineHeight: 1.8, color: "#333" }}>
+                      {p.english_preview}…
+                    </div>
+                  </div>
+                )}
+                <div style={{ marginTop: 8, fontSize: 12 }}>
+                  <Link
+                    to={`/texts/${p.related_text_id}/read?juan=1`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: "#5b8c6b" }}
+                  >
+                    <BookOutlined style={{ marginRight: 4 }} />
+                    阅读全文 →
+                  </Link>
+                </div>
+              </div>
+            ),
+          }))}
+        />
+        <div style={{ marginTop: 20, padding: 12, background: "#fafafa", borderRadius: 4, fontSize: 12, color: "#666" }}>
+          <LinkOutlined style={{ marginRight: 6 }} />
+          经级对应来自 SuttaCentral 学术平行表（Akanuma + 现代学者修订）。
+          权威可引用，覆盖四阿含 ↔ 尼柯耶全量对应关系。
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ChunkView({ textId, juanNum }: Props) {
+  const [activeKeys, setActiveKeys] = useState<string[]>([]);
   const { data, isLoading, error } = useQuery({
     queryKey: ["juan-alignment", textId, juanNum],
     queryFn: () => getJuanAlignment(textId, juanNum),
@@ -49,177 +160,158 @@ export default function ReaderParallelPanel({ textId, juanNum }: Props) {
     ? Math.round((data.chunks_with_parallels / data.total_chunks) * 100)
     : 0;
 
+  if (isLoading) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin />
+        <div style={{ marginTop: 12, color: "#888" }}>加载段落对应中…</div>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <Alert
+        type="info" showIcon
+        message="本卷暂无段落级对照数据"
+        description="段级数据由 embedding+LLM 管线生成，覆盖不全且存在噪音。建议以经级对读为主。"
+        style={{ margin: 12 }}
+      />
+    );
+  }
+  if (!data) return null;
+
+  return (
+    <>
+      <div style={{ padding: "12px 16px", borderBottom: "1px solid #eee" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6 }}>
+          <span style={{ fontSize: 13, color: "#555" }}>本卷段落覆盖</span>
+          <span style={{ fontSize: 13, fontWeight: 500 }}>
+            {data.chunks_with_parallels} / {data.total_chunks} 段 ({coveragePct}%)
+          </span>
+        </div>
+        <Progress percent={coveragePct} size="small" showInfo={false}
+          strokeColor={coveragePct > 50 ? "#5b8c6b" : coveragePct > 20 ? "#d48806" : "#999"} />
+      </div>
+      <div style={{ flex: 1, overflow: "auto", padding: "8px 12px" }}>
+        {data.entries.length === 0 && (
+          <Empty description="本卷没有已对齐的段落" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        )}
+        {data.entries.length > 0 && (
+          <Collapse
+            activeKey={activeKeys}
+            onChange={(keys) => setActiveKeys(Array.isArray(keys) ? keys : [keys])}
+            ghost
+            items={data.entries.map((entry) => ({
+              key: `chunk-${entry.chunk_index}`,
+              label: (
+                <div style={{ paddingRight: 8 }}>
+                  <div style={{ fontSize: 12, color: "#888", marginBottom: 4 }}>
+                    段 #{entry.chunk_index} · {entry.parallels.length} 条对应
+                  </div>
+                  <div lang="zh-Hans" style={{
+                    fontFamily: '"Noto Serif SC", "Source Han Serif", serif',
+                    fontSize: 14, lineHeight: 1.7, color: "#222",
+                    display: "-webkit-box", WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical", overflow: "hidden",
+                  }}>
+                    {entry.chunk_text}
+                  </div>
+                </div>
+              ),
+              children: (
+                <div style={{ paddingLeft: 8, borderLeft: "2px solid #e8e8e8" }}>
+                  <div lang="zh-Hans" style={{
+                    fontFamily: '"Noto Serif SC", serif',
+                    fontSize: 14, lineHeight: 1.9, color: "#333",
+                    padding: "8px 12px", background: "#fafafa",
+                    borderRadius: 4, marginBottom: 12,
+                  }}>
+                    {entry.chunk_text}
+                  </div>
+                  {entry.parallels.map((p, idx) => (
+                    <div key={`${p.text_id}-${p.juan_num}-${p.chunk_index}-${idx}`}
+                      style={{ padding: "10px 12px", marginBottom: 10, borderRadius: 4,
+                        background: "#fff", border: "1px solid #e8e8e8" }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6, flexWrap: "wrap" }}>
+                        <Tag color={LANG_COLOR[p.lang] || "default"} style={{ margin: 0 }}>
+                          {LANG_LABEL[p.lang] || p.lang}
+                        </Tag>
+                        <span style={{ fontSize: 12, color: "#666" }}>
+                          《{p.title || "其他藏经"}》第 {p.juan_num} 卷
+                        </span>
+                        <span style={{ fontSize: 11, color: "#999", marginLeft: "auto" }}>
+                          置信度 {(p.confidence * 100).toFixed(0)}%
+                        </span>
+                      </div>
+                      <div lang={p.lang} style={{
+                        fontSize: 13,
+                        lineHeight: p.lang === "bo" ? 2.1 : 1.85,
+                        color: "#333",
+                      }}>
+                        …{p.chunk_text}…
+                      </div>
+                      {p.original_preview && p.original_lang && (
+                        <div lang={p.original_lang} style={{
+                          marginTop: 8, padding: "8px 10px",
+                          background: "#f6fafd", borderLeft: "3px solid #5b8c6b",
+                          fontSize: 12, lineHeight: 1.8, color: "#444",
+                        }}>
+                          <div style={{ fontSize: 11, color: "#5b8c6b", marginBottom: 4, fontWeight: 500 }}>
+                            {p.original_lang === "pi" ? "Pāli 原文（本卷前 500 字）" : "原文（本卷前 500 字）"}
+                          </div>
+                          {p.original_preview}
+                          {p.original_preview.length >= 500 && "…"}
+                        </div>
+                      )}
+                      <div style={{ marginTop: 8, fontSize: 12 }}>
+                        <Link
+                          to={`/texts/${p.text_id}/read?juan=${p.juan_num}`}
+                          target="_blank" rel="noopener noreferrer"
+                          style={{ color: "#5b8c6b" }}
+                        >
+                          <BookOutlined style={{ marginRight: 4 }} />
+                          阅读全文 →
+                        </Link>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ),
+            }))}
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+/**
+ * Reader 右侧"多语对读"内联面板（非 modal）。
+ *
+ * 两个视图：
+ *  - 按经对读（默认）：SuttaCentral 权威经级对应，来源 text_relations
+ *  - 按段对读（实验）：embedding+LLM 段级对齐，来源 alignment_pairs
+ */
+export default function ReaderParallelPanel({ textId, juanNum }: Props) {
   return (
     <div className="reader-parallel-panel">
-      {isLoading && (
-        <div style={{ textAlign: "center", padding: 80 }}>
-          <Spin />
-          <div style={{ marginTop: 12, color: "#888" }}>加载跨藏经对应中…</div>
-        </div>
-      )}
-
-      {error && (
-        <Alert
-          type="info"
-          showIcon
-          message="本卷暂无多语对照数据"
-          description="当前仅 MVP 首批经典 + 长阿含/中阿含部分卷打通了跨语对照。覆盖会持续扩展。"
-          style={{ margin: 12 }}
-        />
-      )}
-
-      {data && !isLoading && !error && (
-        <>
-          <div style={{ padding: "12px 16px", borderBottom: "1px solid #eee" }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6 }}>
-              <span style={{ fontSize: 13, color: "#555" }}>本卷对照覆盖率</span>
-              <span style={{ fontSize: 13, fontWeight: 500 }}>
-                {data.chunks_with_parallels} / {data.total_chunks} 段 ({coveragePct}%)
-              </span>
-            </div>
-            <Progress
-              percent={coveragePct}
-              size="small"
-              showInfo={false}
-              strokeColor={coveragePct > 50 ? "#5b8c6b" : coveragePct > 20 ? "#d48806" : "#999"}
-            />
-          </div>
-
-          <div style={{ flex: 1, overflow: "auto", padding: "8px 12px" }}>
-            {data.entries.length === 0 && (
-              <Empty description="本卷没有已对齐的段落" image={Empty.PRESENTED_IMAGE_SIMPLE} />
-            )}
-
-            {data.entries.length > 0 && (
-              <Collapse
-                activeKey={activeKeys}
-                onChange={(keys) => setActiveKeys(Array.isArray(keys) ? keys : [keys])}
-                ghost
-                items={data.entries.map((entry) => ({
-                  key: `chunk-${entry.chunk_index}`,
-                  label: (
-                    <div style={{ paddingRight: 8 }}>
-                      <div style={{ fontSize: 12, color: "#888", marginBottom: 4 }}>
-                        段 #{entry.chunk_index}
-                        {" · "}
-                        {entry.parallels.length} 条跨藏经对应
-                      </div>
-                      <div
-                        lang="zh-Hans"
-                        style={{
-                          fontFamily: '"Noto Serif SC", "Source Han Serif", serif',
-                          fontSize: 14,
-                          lineHeight: 1.7,
-                          color: "#222",
-                          display: "-webkit-box",
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: "vertical",
-                          overflow: "hidden",
-                        }}
-                      >
-                        {entry.chunk_text}
-                      </div>
-                    </div>
-                  ),
-                  children: (
-                    <div style={{ paddingLeft: 8, borderLeft: "2px solid #e8e8e8" }}>
-                      <div
-                        lang="zh-Hans"
-                        style={{
-                          fontFamily: '"Noto Serif SC", serif',
-                          fontSize: 14,
-                          lineHeight: 1.9,
-                          color: "#333",
-                          padding: "8px 12px",
-                          background: "#fafafa",
-                          borderRadius: 4,
-                          marginBottom: 12,
-                        }}
-                      >
-                        {entry.chunk_text}
-                      </div>
-                      {entry.parallels.map((p, idx) => (
-                        <div
-                          key={`${p.text_id}-${p.juan_num}-${p.chunk_index}-${idx}`}
-                          style={{
-                            padding: "10px 12px",
-                            marginBottom: 10,
-                            borderRadius: 4,
-                            background: "#fff",
-                            border: "1px solid #e8e8e8",
-                          }}
-                        >
-                          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6, flexWrap: "wrap" }}>
-                            <Tag color={LANG_COLOR[p.lang] || "default"} style={{ margin: 0 }}>
-                              {LANG_LABEL[p.lang] || p.lang}
-                            </Tag>
-                            <span style={{ fontSize: 12, color: "#666" }}>
-                              《{p.title || "其他藏经"}》 第 {p.juan_num} 卷
-                            </span>
-                            <span style={{ fontSize: 11, color: "#999", marginLeft: "auto" }}>
-                              置信度 {(p.confidence * 100).toFixed(0)}%
-                            </span>
-                          </div>
-                          <div
-                            lang={p.lang}
-                            style={{
-                              fontSize: 13,
-                              lineHeight: p.lang === "bo" ? 2.1 : 1.85,
-                              color: "#333",
-                            }}
-                          >
-                            {p.chunk_text}
-                          </div>
-                          {p.original_preview && p.original_lang && (
-                            <div
-                              lang={p.original_lang}
-                              style={{
-                                marginTop: 8,
-                                padding: "8px 10px",
-                                background: "#f6fafd",
-                                borderLeft: "3px solid #5b8c6b",
-                                fontSize: 12,
-                                lineHeight: 1.8,
-                                color: "#444",
-                              }}
-                            >
-                              <div style={{ fontSize: 11, color: "#5b8c6b", marginBottom: 4, fontWeight: 500 }}>
-                                {p.original_lang === "pi" ? "Pāli 原文（本卷前 500 字）" : "原文（本卷前 500 字）"}
-                              </div>
-                              {p.original_preview}
-                              {p.original_preview.length >= 500 && "…"}
-                            </div>
-                          )}
-                          <div style={{ marginTop: 8, fontSize: 12 }}>
-                            <Link
-                              to={`/texts/${p.text_id}/read?juan=${p.juan_num}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              style={{ color: "#5b8c6b" }}
-                            >
-                              <BookOutlined style={{ marginRight: 4 }} />
-                              阅读全文 →
-                            </Link>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  ),
-                }))}
-              />
-            )}
-
-            {data.entries.length > 0 && (
-              <div style={{ marginTop: 20, padding: 12, background: "#fafafa", borderRadius: 4, fontSize: 12, color: "#666" }}>
-                <LinkOutlined style={{ marginRight: 6 }} />
-                对齐数据由 FoJin 多语 RAG 管道生成，采用 embedding 粗召回 + LLM 精验证。
-                巴利/藏文条目展示的匹配文本为 Sujato / 84000 英译本；Pāli 原文预览取自 text_contents。
-                低置信度对应可能需人工审核。
-              </div>
-            )}
-          </div>
-        </>
-      )}
+      <Tabs
+        defaultActiveKey="canonical"
+        size="small"
+        style={{ padding: "0 12px" }}
+        items={[
+          {
+            key: "canonical",
+            label: "按经对读",
+            children: <CanonicalView textId={textId} />,
+          },
+          {
+            key: "chunk",
+            label: "按段对读",
+            children: <ChunkView textId={textId} juanNum={juanNum} />,
+          },
+        ]}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

按经级对读替代按段级作为默认视图。数据源从 alignment_pairs（chunk 噪音）切到 text_relations（SuttaCentral 权威）。

### 背景

核查发现 alignment_pairs 聚合到经级后假阳性严重：
- 长阿含卷 18（世记经，学术上无 DN 对应）竟"匹配"到 4 部 DN，avg_conf 0.89
- 卷 13（学术 = DN 3）数据里 DN 2 反而占最高 139 chunks

**根因**：chunk 级 embedding+LLM 把阿含通用套语（如是我闻、诸比丘、四禅等）判成平行。

### 修复

直接用已入库的 SuttaCentral 权威对应（**3293 条**）：
- T0001 长阿含 → 56 SC parallels
- T0026 中阿含 → 261
- T0099 杂阿含 → 1098
- T0125 增壹阿含 → 291

### 新功能

**GET /alignment/canonical/{text_id}**
- 查 text_relations（source='suttacentral'）
- 每条附：SC 经名、relation_type、note（如 \`SC: dn1 ↔ da21\`）、Pāli 前 240 字、Sujato 英译前 240 字

**面板双 Tab**
- **按经对读（默认）**：SC 权威经级对应，按 relation_type 分组
- **按段对读（实验）**：原 chunk 视图保留但弱化，chunk_text 加 … 省略号

## Test plan

- [ ] 打开长阿含任意卷，点「多语对读」默认看到 56 条 SC 对应
- [ ] 展开一条，能看到 Pāli + 英译预览 + 阅读全文链接
- [ ] 切换「按段对读」tab，旧 chunk 视图仍可用
- [ ] T0099 杂阿含打开后 1098 条，滚动流畅

🤖 Generated with [Claude Code](https://claude.com/claude-code)