### PR TITLE
feat(parallel): lazy-load full Pali+English + visible scrollbars

### DIFF
--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -76,6 +76,17 @@ class CanonicalParallelsResponse(BaseModel):
     parallels: list[CanonicalParallel]
 
 
+class FullParallelContentResponse(BaseModel):
+    text_id: int
+    cbeta_id: str
+    title: str
+    lang: str
+    pali_full: str | None = None
+    english_full: str | None = None
+    pali_chars: int = 0
+    english_chars: int = 0
+
+
 @router.get("/chunks/{text_id}/{juan_num}/{chunk_index}", response_model=ChunkAlignmentResponse)
 async def get_chunk_alignment(
     text_id: int,
@@ -314,4 +325,61 @@ async def get_canonical_parallels(
         source_title=src_row[1] or "",
         total=len(parallels),
         parallels=parallels,
+    )
+
+
+@router.get("/canonical/full/{text_id}", response_model=FullParallelContentResponse)
+async def get_full_parallel_content(
+    text_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> FullParallelContentResponse:
+    """Lazy-load full Pāli + English for one parallel sutta.
+
+    Called when user expands a card in 按经对读 panel and wants to see the
+    complete alignment (not just 240-char preview).
+
+    Pāli: concatenates all text_contents.content rows (in juan order) for lang='pi'.
+    English: concatenates all text_embeddings.chunk_text rows in order.
+    """
+    meta = (await db.execute(
+        sql_text(
+            "SELECT cbeta_id, "
+            "COALESCE(title_pi, title_sa, title_en, title_zh, '') AS title, "
+            "lang "
+            "FROM buddhist_texts WHERE id = :tid"
+        ),
+        {"tid": text_id},
+    )).fetchone()
+    if not meta:
+        return FullParallelContentResponse(
+            text_id=text_id, cbeta_id="", title="", lang="",
+        )
+
+    pali_rows = (await db.execute(
+        sql_text(
+            "SELECT content FROM text_contents "
+            "WHERE text_id = :tid AND lang = 'pi' ORDER BY juan_num"
+        ),
+        {"tid": text_id},
+    )).fetchall()
+    pali_full = "\n\n".join(r[0] for r in pali_rows if r[0]) if pali_rows else None
+
+    en_rows = (await db.execute(
+        sql_text(
+            "SELECT chunk_text FROM text_embeddings "
+            "WHERE text_id = :tid ORDER BY juan_num, chunk_index"
+        ),
+        {"tid": text_id},
+    )).fetchall()
+    english_full = "\n\n".join(r[0] for r in en_rows if r[0]) if en_rows else None
+
+    return FullParallelContentResponse(
+        text_id=text_id,
+        cbeta_id=meta[0],
+        title=meta[1] or "",
+        lang=meta[2] or "",
+        pali_full=pali_full,
+        english_full=english_full,
+        pali_chars=len(pali_full) if pali_full else 0,
+        english_chars=len(english_full) if english_full else 0,
     )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1147,6 +1147,24 @@ export async function getCanonicalParallels(textId: number): Promise<CanonicalPa
   return data;
 }
 
+export interface FullParallelContentResponse {
+  text_id: number;
+  cbeta_id: string;
+  title: string;
+  lang: string;
+  pali_full?: string | null;
+  english_full?: string | null;
+  pali_chars: number;
+  english_chars: number;
+}
+
+export async function getFullParallelContent(textId: number): Promise<FullParallelContentResponse> {
+  const { data } = await api.get<FullParallelContentResponse>(
+    `/alignment/canonical/full/${textId}`,
+  );
+  return data;
+}
+
 export interface ChunkContextResponse {
   text_id: TextId;
   juan_num: number;

--- a/frontend/src/components/ReaderParallelPanel.tsx
+++ b/frontend/src/components/ReaderParallelPanel.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import { Empty, Spin, Alert, Collapse, Tag, Progress, Tabs } from "antd";
-import { LinkOutlined, BookOutlined } from "@ant-design/icons";
+import { Empty, Spin, Alert, Collapse, Tag, Progress, Tabs, Button } from "antd";
+import { LinkOutlined, BookOutlined, ExpandAltOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { getJuanAlignment, getCanonicalParallels } from "../api/client";
+import { getJuanAlignment, getCanonicalParallels, getFullParallelContent } from "../api/client";
 
 interface Props {
   textId: number;
@@ -37,6 +37,87 @@ const RELATION_COLOR: Record<string, string> = {
   mention: "orange",
   retell: "purple",
 };
+
+function ParallelCardBody({ p }: { p: import("../api/client").CanonicalParallel }) {
+  const [showFull, setShowFull] = useState(false);
+  const { data: full, isLoading: loadingFull } = useQuery({
+    queryKey: ["canonical-parallel-full", p.related_text_id],
+    queryFn: () => getFullParallelContent(p.related_text_id),
+    enabled: showFull,
+    staleTime: 30 * 60 * 1000,
+  });
+
+  const paliDisplay = full?.pali_full ?? (p.pali_preview ? `${p.pali_preview}…` : null);
+  const englishDisplay = full?.english_full ?? (p.english_preview ? `${p.english_preview}…` : null);
+
+  return (
+    <div style={{ paddingLeft: 8, borderLeft: "2px solid #e8e8e8" }}>
+      {paliDisplay && (
+        <div style={{ marginBottom: 10, padding: "8px 10px", background: "#f6fafd", borderLeft: "3px solid #5b8c6b", borderRadius: 4 }}>
+          <div style={{ fontSize: 11, color: "#5b8c6b", marginBottom: 4, fontWeight: 500, display: "flex", justifyContent: "space-between" }}>
+            <span>Pāli 原文</span>
+            {full?.pali_chars ? <span style={{ color: "#999", fontWeight: 400 }}>{full.pali_chars.toLocaleString()} 字</span> : null}
+          </div>
+          <div
+            lang="pi"
+            className="parallel-full-scroll"
+            style={{
+              fontSize: 12, lineHeight: 1.8, color: "#333",
+              maxHeight: showFull ? 360 : undefined,
+              overflowY: showFull ? "auto" : undefined,
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {paliDisplay}
+          </div>
+        </div>
+      )}
+      {englishDisplay && (
+        <div style={{ marginBottom: 10, padding: "8px 10px", background: "#fafafa", borderRadius: 4 }}>
+          <div style={{ fontSize: 11, color: "#666", marginBottom: 4, fontWeight: 500, display: "flex", justifyContent: "space-between" }}>
+            <span>English (Sujato)</span>
+            {full?.english_chars ? <span style={{ color: "#999", fontWeight: 400 }}>{full.english_chars.toLocaleString()} chars</span> : null}
+          </div>
+          <div
+            lang="en"
+            className="parallel-full-scroll"
+            style={{
+              fontSize: 12, lineHeight: 1.8, color: "#333",
+              maxHeight: showFull ? 360 : undefined,
+              overflowY: showFull ? "auto" : undefined,
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {englishDisplay}
+          </div>
+        </div>
+      )}
+      <div style={{ marginTop: 8, fontSize: 12, display: "flex", gap: 12, flexWrap: "wrap" }}>
+        {!showFull && (
+          <Button
+            type="link"
+            size="small"
+            icon={<ExpandAltOutlined />}
+            onClick={() => setShowFull(true)}
+            loading={loadingFull}
+            style={{ padding: 0, height: "auto", color: "#5b8c6b" }}
+          >
+            展开完整对读
+          </Button>
+        )}
+        <Link
+          to={`/texts/${p.related_text_id}/read?juan=1`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: "#5b8c6b" }}
+        >
+          <BookOutlined style={{ marginRight: 4 }} />
+          在阅读器打开 →
+        </Link>
+      </div>
+    </div>
+  );
+}
 
 function CanonicalView({ textId }: { textId: number }) {
   const [activeKeys, setActiveKeys] = useState<string[]>([]);
@@ -99,41 +180,7 @@ function CanonicalView({ textId }: { textId: number }) {
                 )}
               </div>
             ),
-            children: (
-              <div style={{ paddingLeft: 8, borderLeft: "2px solid #e8e8e8" }}>
-                {p.pali_preview && (
-                  <div style={{ marginBottom: 10, padding: "8px 10px", background: "#f6fafd", borderLeft: "3px solid #5b8c6b", borderRadius: 4 }}>
-                    <div style={{ fontSize: 11, color: "#5b8c6b", marginBottom: 4, fontWeight: 500 }}>
-                      Pāli 原文
-                    </div>
-                    <div lang="pi" style={{ fontSize: 12, lineHeight: 1.8, color: "#333" }}>
-                      {p.pali_preview}…
-                    </div>
-                  </div>
-                )}
-                {p.english_preview && (
-                  <div style={{ marginBottom: 10, padding: "8px 10px", background: "#fafafa", borderRadius: 4 }}>
-                    <div style={{ fontSize: 11, color: "#666", marginBottom: 4, fontWeight: 500 }}>
-                      English (Sujato)
-                    </div>
-                    <div lang="en" style={{ fontSize: 12, lineHeight: 1.8, color: "#333" }}>
-                      {p.english_preview}…
-                    </div>
-                  </div>
-                )}
-                <div style={{ marginTop: 8, fontSize: 12 }}>
-                  <Link
-                    to={`/texts/${p.related_text_id}/read?juan=1`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{ color: "#5b8c6b" }}
-                  >
-                    <BookOutlined style={{ marginRight: 4 }} />
-                    阅读全文 →
-                  </Link>
-                </div>
-              </div>
-            ),
+            children: <ParallelCardBody p={p} />,
           }))}
         />
         <div style={{ marginTop: 20, padding: 12, background: "#fafafa", borderRadius: 4, fontSize: 12, color: "#666" }}>

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -656,3 +656,28 @@
     margin-bottom: 24px;
   }
 }
+/* ── 多语对读 panel: visible scrollbars for inner content blocks ── */
+.reader-parallel-panel .parallel-full-scroll::-webkit-scrollbar,
+.reader-parallel-panel::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.reader-parallel-panel .parallel-full-scroll::-webkit-scrollbar-track,
+.reader-parallel-panel::-webkit-scrollbar-track {
+  background: #f5f5f5;
+  border-radius: 5px;
+}
+.reader-parallel-panel .parallel-full-scroll::-webkit-scrollbar-thumb,
+.reader-parallel-panel::-webkit-scrollbar-thumb {
+  background: #c0c0c0;
+  border-radius: 5px;
+  border: 2px solid #f5f5f5;
+}
+.reader-parallel-panel .parallel-full-scroll::-webkit-scrollbar-thumb:hover,
+.reader-parallel-panel::-webkit-scrollbar-thumb:hover {
+  background: #a0a0a0;
+}
+.reader-parallel-panel .parallel-full-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #c0c0c0 #f5f5f5;
+}


### PR DESCRIPTION
## Summary

- **展开完整对读** 按钮：懒加载整部 Pāli 全文 + Sujato 英译全文
- 滚动容器 max-height 360px，避免长经撑破面板
- 自定义 scrollbar CSS（10px 灰色），原默认细滚条几乎不可见

## Why

之前只显示 240 字片段，用户问"是不是只是一段文本对齐，没有完整的对齐"。

## Test plan

- [ ] 打开长阿含任意卷，展开一条 SC 对应
- [ ] 点「展开完整对读」→ 加载完整 Pali + English
- [ ] 确认滚动条可见

🤖 Generated with [Claude Code](https://claude.com/claude-code)