### PR TITLE
fix(parallel): scroll the 多语对读 list (56 items were stuck)

### DIFF
--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -361,6 +361,22 @@
   overflow: hidden;
 }
 
+/* Propagate flex height through antd Tabs so inner list can scroll */
+.reader-parallel-panel > .ant-tabs {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.reader-parallel-panel > .ant-tabs > .ant-tabs-content-holder,
+.reader-parallel-panel > .ant-tabs > .ant-tabs-content-holder > .ant-tabs-content,
+.reader-parallel-panel > .ant-tabs > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 /* Ensure Collapse inside parallel panel doesn't overflow horizontally */
 .reader-parallel-panel .ant-collapse-header {
   align-items: flex-start !important;


### PR DESCRIPTION
## Summary

Force flex-height propagation through antd Tabs so the inner list's \`flex:1 + overflow:auto\` actually has a bounded parent to scroll within.

## Why

PR #469 added Tabs; the default antd layout broke the flex chain, so 56 SC parallels listed but only first ~10 visible, no scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)