### PR TITLE
fix(parallel): only active tabpane visible (both were showing)

### DIFF
--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -370,7 +370,7 @@
 }
 .reader-parallel-panel > .ant-tabs > .ant-tabs-content-holder,
 .reader-parallel-panel > .ant-tabs > .ant-tabs-content-holder > .ant-tabs-content,
-.reader-parallel-panel > .ant-tabs > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane {
+.reader-parallel-panel > .ant-tabs > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane-active {
   display: flex;
   flex-direction: column;
   flex: 1;


### PR DESCRIPTION
PR #472 selector was too broad; overrode antd's display:none on inactive panes. Target .ant-tabs-tabpane-active instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)