### PR TITLE
fix(backend): repair /api/texts/lookup-cbeta + /kg/graph 500s, cache /kg/geo

### DIFF
--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 
 from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import KGEntityNotFoundError
@@ -131,7 +132,7 @@ async def get_kg_geo_entities(
         cache_key = f"kg:geo:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
         cached = await redis_client.get(cache_key)
         if cached:
-            return KGGeoResponse.model_validate_json(cached)
+            return Response(content=cached, media_type="application/json")
 
     entities, total = await get_geo_entities(
         db, entity_types, year_start, year_end, bounds, limit
@@ -140,9 +141,10 @@ async def get_kg_geo_entities(
         entities=[KGGeoEntity(**e) for e in entities],
         total=total,
     )
+    payload = response.model_dump_json()
     if redis_client and cache_key:
-        await redis_client.setex(cache_key, KG_GEO_CACHE_TTL, response.model_dump_json())
-    return response
+        await redis_client.setex(cache_key, KG_GEO_CACHE_TTL, payload)
+    return Response(content=payload, media_type="application/json")
 
 
 @router.get("/lineage-arcs", response_model=KGLineageArcsResponse)
@@ -168,13 +170,14 @@ async def get_kg_lineage_arcs(
         cache_key = f"kg:lineage:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
         cached = await redis_client.get(cache_key)
         if cached:
-            return KGLineageArcsResponse.model_validate_json(cached)
+            return Response(content=cached, media_type="application/json")
 
     arcs, total = await get_lineage_arcs(db, school, year_start, year_end, limit)
     response = KGLineageArcsResponse(arcs=arcs, total=total)
+    payload = response.model_dump_json()
     if redis_client and cache_key:
-        await redis_client.setex(cache_key, KG_LINEAGE_CACHE_TTL, response.model_dump_json())
-    return response
+        await redis_client.setex(cache_key, KG_LINEAGE_CACHE_TTL, payload)
+    return Response(content=payload, media_type="application/json")
 
 
 @router.get("/texts/{text_id}/entities", response_model=list[KGEntityResponse])

--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -1,8 +1,14 @@
-from fastapi import APIRouter, Depends, Query
+import hashlib
+import json
+
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import KGEntityNotFoundError
 from app.database import get_db
+
+KG_GEO_CACHE_TTL = 1800  # 30 min
+KG_LINEAGE_CACHE_TTL = 1800
 from app.schemas.knowledge_graph import (
     KGEntityDetailResponse,
     KGEntityResponse,
@@ -91,6 +97,7 @@ async def kg_stats(db: AsyncSession = Depends(get_db)):
 
 @router.get("/geo", response_model=KGGeoResponse)
 async def get_kg_geo_entities(
+    request: Request,
     entity_type: str | None = Query(None, description="Comma-separated entity types"),
     year_start: int | None = None,
     year_end: int | None = None,
@@ -112,17 +119,35 @@ async def get_kg_geo_entities(
     bounds = None
     if all(v is not None for v in (south, west, north, east)):
         bounds = (south, west, north, east)  # type: ignore[arg-type]
+
+    redis_client = getattr(request.app.state, "redis", None)
+    cache_key = None
+    if redis_client:
+        key_payload = json.dumps(
+            {"t": entity_types, "ys": year_start, "ye": year_end, "b": bounds, "l": limit},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        cache_key = f"kg:geo:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
+        cached = await redis_client.get(cache_key)
+        if cached:
+            return KGGeoResponse.model_validate_json(cached)
+
     entities, total = await get_geo_entities(
         db, entity_types, year_start, year_end, bounds, limit
     )
-    return KGGeoResponse(
+    response = KGGeoResponse(
         entities=[KGGeoEntity(**e) for e in entities],
         total=total,
     )
+    if redis_client and cache_key:
+        await redis_client.setex(cache_key, KG_GEO_CACHE_TTL, response.model_dump_json())
+    return response
 
 
 @router.get("/lineage-arcs", response_model=KGLineageArcsResponse)
 async def get_kg_lineage_arcs(
+    request: Request,
     school: str | None = None,
     year_start: int | None = None,
     year_end: int | None = None,
@@ -132,8 +157,24 @@ async def get_kg_lineage_arcs(
     """Get teacher-student lineage arcs with coordinates for map visualization.
 
     获取师承传法弧线及坐标，用于地图可视化。"""
+    redis_client = getattr(request.app.state, "redis", None)
+    cache_key = None
+    if redis_client:
+        key_payload = json.dumps(
+            {"s": school, "ys": year_start, "ye": year_end, "l": limit},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        cache_key = f"kg:lineage:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
+        cached = await redis_client.get(cache_key)
+        if cached:
+            return KGLineageArcsResponse.model_validate_json(cached)
+
     arcs, total = await get_lineage_arcs(db, school, year_start, year_end, limit)
-    return KGLineageArcsResponse(arcs=arcs, total=total)
+    response = KGLineageArcsResponse(arcs=arcs, total=total)
+    if redis_client and cache_key:
+        await redis_client.setex(cache_key, KG_LINEAGE_CACHE_TTL, response.model_dump_json())
+    return response
 
 
 @router.get("/texts/{text_id}/entities", response_model=list[KGEntityResponse])

--- a/backend/app/api/texts.py
+++ b/backend/app/api/texts.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.deps import get_optional_user
 from app.core.exceptions import TextNotFoundError
 from app.database import get_db
-from app.models.text import Text
+from app.models.text import BuddhistText
 from app.models.user import ReadingHistory, User
 from app.schemas.text import JuanContentResponse, JuanLanguagesResponse, JuanListResponse, TextResponseBase
 from app.services.content import get_juan_content, get_juan_languages, get_juan_list
@@ -29,7 +29,7 @@ async def lookup_cbeta_ids(
     if not cbeta_ids:
         return {}
     result = await db.execute(
-        select(Text.cbeta_id, Text.id).where(Text.cbeta_id.in_(cbeta_ids))
+        select(BuddhistText.cbeta_id, BuddhistText.id).where(BuddhistText.cbeta_id.in_(cbeta_ids))
     )
     return dict(result.all())
 

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -242,7 +242,7 @@ async def get_entity_graph(
             select(KGEntity).where(
                 KGEntity.id.in_(node_ids),
                 func.coalesce(
-                    KGEntity.properties["is_hidden"].astext, "false"
+                    KGEntity.properties.op("->>")("is_hidden"), "false"
                 )
                 != "true",
             )


### PR DESCRIPTION
## Summary

Three production bugs surfaced through Cloudflare analytics on 2026-04-18:

- **`/api/texts/lookup-cbeta`** (19 × 500 / 24h): `from app.models.text import Text` accidentally imported `sqlalchemy.Text` (a column type re-exported by the module) instead of the `BuddhistText` model, so `Text.cbeta_id` raised `AttributeError`. Fixed the import + query to use `BuddhistText` explicitly.
- **`/api/kg/entities/*/graph`** (81 × 500 / 24h across 3 entities): `KGEntity.properties["is_hidden"].astext` failed with `Comparator has no attribute 'astext'` because the column is `JSON` (not `JSONB`). Switched to the `.op("->>")` pattern already used elsewhere in the same file.
- **`/api/kg/geo` slow** (3.7s avg at CF edge, up to ~100s on the VPS under load): added Redis caching with 30-min TTL to both `/kg/geo` and `/kg/lineage-arcs`. First pass re-validated the cached payload through Pydantic, which made warm reads slower than cold (26MB × 60k models); second commit returns the raw JSON bytes via `Response(...)` so warm hits skip Pydantic entirely.

## Verification

- `GET /api/texts/lookup-cbeta?ids=T0251,T0001,T0099` → `200 {"T0001":1,"T0099":3,"T0251":9}`
- `GET /api/kg/entities/54714/graph?depth=2&max_nodes=150` → `200`
- `GET /api/kg/geo?limit=80000` from loopback: cold 0.36s, warm 0.28–0.31s (vs 3.7s baseline at CF edge)

## Test plan

- [ ] Hit /map in browser, confirm first load subsecond after a cache warm-up
- [ ] Open a KG entity detail page (e.g. 54714), confirm graph tab loads
- [ ] Search a sutra chain on the reading page, confirm lookup-cbeta returns IDs

## Out of scope

- Chat 504 timeouts in the same Cloudflare report are caused by DeepSeek returning `402 Payment Required` — a billing issue, not a code bug. Top up DeepSeek balance to resolve.