### PR TITLE
fix(kg-map): raise /kg/geo timeout (was silently timing out → 暂无地理数据)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -644,7 +644,12 @@ export async function getKGGeoEntities(params?: {
   east?: number;
   limit?: number;
 }): Promise<KGGeoResponse> {
-  const { data } = await api.get<KGGeoResponse>("/kg/geo", { params });
+  // Payload can exceed 16MB (65K+ entities); default 15s timeout trips on
+  // typical networks and leaves the map stuck on "暂无地理数据".
+  const { data } = await api.get<KGGeoResponse>("/kg/geo", {
+    params,
+    timeout: 120000,
+  });
   return data;
 }
 


### PR DESCRIPTION
**Root cause**: /kg/geo?limit=80000 returns ~16MB JSON (65K+ entities). Default axios timeout 15s trips on typical networks → silent failure → 「暂无地理数据」shown instead of map.

Raise to 120s. Proper fix (bbox query + pagination) is separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)