### PR TITLE
refactor(sources): Wave 1 — split component, track clicks, cache list

### DIFF
--- a/backend/app/api/sources.py
+++ b/backend/app/api/sources.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import Response
+from pydantic import TypeAdapter
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,14 +24,28 @@ from app.services.source import (
 
 router = APIRouter(prefix="/sources", tags=["sources"])
 
+SOURCES_LIST_CACHE_KEY = "sources:list:v1"
+SOURCES_LIST_CACHE_TTL = 1800  # 30 min; data only changes on manual admin edits
+
+_sources_list_adapter = TypeAdapter(list[DataSourceResponse])
+
 
 @router.get("", response_model=list[DataSourceResponse])
-async def list_sources(db: AsyncSession = Depends(get_db)):
+async def list_sources(request: Request, db: AsyncSession = Depends(get_db)):
     """List all data sources with metadata, license info, and language coverage.
 
     列出所有数据源及其元数据、许可协议和语言覆盖范围。"""
+    redis_client = getattr(request.app.state, "redis", None)
+    if redis_client:
+        cached = await redis_client.get(SOURCES_LIST_CACHE_KEY)
+        if cached:
+            return Response(content=cached, media_type="application/json")
+
     sources = await get_all_sources(db)
-    return sources
+    payload = _sources_list_adapter.dump_json(sources)
+    if redis_client:
+        await redis_client.setex(SOURCES_LIST_CACHE_KEY, SOURCES_LIST_CACHE_TTL, payload)
+    return Response(content=payload, media_type="application/json")
 
 
 @router.get("/stats")

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -1,26 +1,21 @@
-import { useState, useMemo, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
-import { Input, Select, Tag, Empty, Spin, Form, Button, message } from "antd";
+import { Empty, Input, Select, Spin } from "antd";
+import { SearchOutlined, VerticalAlignTopOutlined } from "@ant-design/icons";
+import { getSources, type DataSource } from "../api/client";
+import { getLangName, normalizeLangCode } from "../utils/sourceUrls";
+import SourceCard from "./sources/SourceCard";
+import SuggestSourceForm from "./sources/SuggestSourceForm";
 import {
-  SearchOutlined, LinkOutlined, GlobalOutlined,
-  ApiOutlined, FileImageOutlined, ReadOutlined,
-  SendOutlined, VerticalAlignTopOutlined,
-} from "@ant-design/icons";
-import { getSources, submitSourceSuggestion, type DataSource } from "../api/client";
-import {
-  buildSearchUrlWithFallback,
-  getLangName,
-  normalizeLangCode,
-} from "../utils/sourceUrls";
+  FIELD_NAMES,
+  FIELD_ORDER,
+  LANG_ORDER,
+  REGION_ORDER,
+} from "./sources/constants";
 import "../styles/sources.css";
 
-function getChannelLabel(channelType: string): string {
-  if (channelType === "git") return "Git";
-  if (channelType === "bulk_dump") return "批量";
-  if (channelType === "api") return "API";
-  return channelType;
-}
+type GroupBy = "region" | "field" | "lang";
 
 export default function SourcesPage() {
   const [search, setSearch] = useState("");
@@ -28,7 +23,7 @@ export default function SourcesPage() {
   const [langFilter, setLangFilter] = useState("all");
   const [fieldFilter, setFieldFilter] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
-  const [groupBy, setGroupBy] = useState<"region" | "field" | "lang">("region");
+  const [groupBy, setGroupBy] = useState<GroupBy>("region");
   const [showTop, setShowTop] = useState(false);
 
   useEffect(() => {
@@ -40,69 +35,60 @@ export default function SourcesPage() {
   const { data: sources, isLoading } = useQuery({
     queryKey: ["sources"],
     queryFn: getSources,
+    staleTime: 30 * 60_000,
+    gcTime: 60 * 60_000,
   });
 
-  // 提取可用筛选项
-  const regionOrder = ["中国大陆", "中国台湾", "中国香港", "中国澳门", "日本", "韩国", "越南", "泰国", "缅甸", "斯里兰卡", "印度", "尼泊尔", "不丹", "蒙古", "老挝", "柬埔寨", "美国", "加拿大", "英国", "德国", "法国", "荷兰", "比利时", "奥地利", "挪威", "丹麦", "意大利", "西班牙", "捷克", "俄罗斯", "澳大利亚", "国际"];
-  const regions = useMemo(() => {
-    if (!sources) return [];
-    const set = new Set<string>();
-    sources.forEach((s) => set.add(s.region || "其他"));
-    return Array.from(set).sort((a, b) => {
+  const { regions, languages, researchFields } = useMemo(() => {
+    const regionSet = new Set<string>();
+    const nameToLangCode = new Map<string, string>();
+    const fieldSet = new Set<string>();
+
+    for (const s of sources ?? []) {
+      regionSet.add(s.region || "其他");
+
+      if (s.languages) {
+        for (const raw of s.languages.split(",")) {
+          const code = normalizeLangCode(raw.trim());
+          const name = getLangName(code);
+          if (!nameToLangCode.has(name)) nameToLangCode.set(name, code);
+        }
+      }
+
+      if (s.research_fields) {
+        for (const raw of s.research_fields.split(",")) {
+          const key = raw.trim();
+          if (key in FIELD_NAMES) fieldSet.add(key);
+        }
+      }
+    }
+
+    const regionArr = Array.from(regionSet).sort((a, b) => {
       if (a === "其他") return 1;
       if (b === "其他") return -1;
-      const ia = regionOrder.indexOf(a);
-      const ib = regionOrder.indexOf(b);
+      const ia = REGION_ORDER.indexOf(a);
+      const ib = REGION_ORDER.indexOf(b);
       return (ia === -1 ? 98 : ia) - (ib === -1 ? 98 : ib);
     });
-  }, [sources]);
 
-  const langOrder = ["zh", "lzh", "sa", "pi", "bo", "en", "ja", "ko"];
-  const languages = useMemo(() => {
-    if (!sources) return [];
-    // 按中文名去重（如 xto/txb 都映射为"吐火罗语"，只保留一个代表代码）
-    const nameToCode = new Map<string, string>();
-    const allCodes = new Set<string>();
-    sources.forEach((s) => {
-      if (s.languages) s.languages.split(",").forEach((l) => {
-        const code = normalizeLangCode(l.trim());
-        allCodes.add(code);
-        const name = getLangName(code);
-        if (!nameToCode.has(name)) nameToCode.set(name, code);
-      });
-    });
-    return Array.from(nameToCode.values()).sort((a, b) => {
-      const order = (c: string) => c === "mul" ? 999 : langOrder.indexOf(c) === -1 ? 99 : langOrder.indexOf(c);
+    const langArr = Array.from(nameToLangCode.values()).sort((a, b) => {
+      const order = (c: string) =>
+        c === "mul" ? 999 : LANG_ORDER.indexOf(c) === -1 ? 99 : LANG_ORDER.indexOf(c);
       return order(a) - order(b);
     });
-  }, [sources]);
 
-  const FIELD_NAMES: Record<string, string> = {
-    han: "汉传佛教", theravada: "南传佛教", tibetan: "藏传佛教",
-    dunhuang: "敦煌学", art: "佛教艺术",
-    dictionary: "辞典工具", dh: "数字人文",
-  };
-  const fieldOrder = ["han", "theravada", "tibetan", "dictionary", "dh", "dunhuang", "art"];
-  const researchFields = useMemo(() => {
-    if (!sources) return [];
-    const set = new Set<string>();
-    sources.forEach((s) => {
-      if (s.research_fields) s.research_fields.split(",").forEach((f) => {
-        const key = f.trim();
-        if (key in FIELD_NAMES) set.add(key);
-      });
-    });
-    return Array.from(set).sort((a, b) => {
-      const ia = fieldOrder.indexOf(a);
-      const ib = fieldOrder.indexOf(b);
+    const fieldArr = Array.from(fieldSet).sort((a, b) => {
+      const ia = FIELD_ORDER.indexOf(a);
+      const ib = FIELD_ORDER.indexOf(b);
       return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
     });
+
+    return { regions: regionArr, languages: langArr, researchFields: fieldArr };
   }, [sources]);
 
-  // 筛选
   const filtered = useMemo(() => {
     if (!sources) return [];
-    const result = sources.filter((s) => {
+    return sources.filter((s) => {
       if (search) {
         const q = search.toLowerCase();
         if (
@@ -110,8 +96,9 @@ export default function SourcesPage() {
           !(s.name_en || "").toLowerCase().includes(q) &&
           !(s.description || "").toLowerCase().includes(q) &&
           !s.code.toLowerCase().includes(q)
-        )
+        ) {
           return false;
+        }
       }
       if (regionFilter !== "all" && (s.region || "其他") !== regionFilter) return false;
       if (langFilter !== "all") {
@@ -125,10 +112,8 @@ export default function SourcesPage() {
       }
       return true;
     });
-    return result;
   }, [sources, search, regionFilter, langFilter, fieldFilter]);
 
-  // 动态分组
   const grouped = useMemo(() => {
     const map: Record<string, DataSource[]> = {};
     const addTo = (key: string, s: DataSource) => {
@@ -139,34 +124,47 @@ export default function SourcesPage() {
       if (groupBy === "region") {
         addTo(s.region || "其他", s);
       } else if (groupBy === "field") {
-        const fields = (s.research_fields || "").split(",").map((f) => f.trim()).filter(Boolean);
+        const fields = (s.research_fields || "")
+          .split(",")
+          .map((f) => f.trim())
+          .filter(Boolean);
         if (fields.length === 0) {
           addTo("其他", s);
         } else {
           fields.forEach((f) => addTo(FIELD_NAMES[f] || f, s));
         }
       } else {
-        const langs = (s.languages || "").split(",").map((l) => l.trim()).filter(Boolean);
+        const langs = (s.languages || "")
+          .split(",")
+          .map((l) => l.trim())
+          .filter(Boolean);
         if (langs.length === 0) {
           addTo("其他", s);
         } else {
-          // 按中文名去重后分组
           const seen = new Set<string>();
           langs.forEach((l) => {
             const name = getLangName(l);
-            if (!seen.has(name)) { seen.add(name); addTo(name, s); }
+            if (!seen.has(name)) {
+              seen.add(name);
+              addTo(name, s);
+            }
           });
         }
       }
     }
-    // 组内按 sort_order 排序（值越小越靠前），相同则按名称
     for (const items of Object.values(map)) {
-      items.sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.name_zh.localeCompare(b.name_zh, "zh"));
+      items.sort(
+        (a, b) =>
+          (a.sort_order ?? 0) - (b.sort_order ?? 0) ||
+          a.name_zh.localeCompare(b.name_zh, "zh"),
+      );
     }
-    // 组间排序
-    const orderList = groupBy === "region" ? regionOrder
-      : groupBy === "field" ? fieldOrder.map((f) => FIELD_NAMES[f] || f)
-      : langOrder.map((l) => getLangName(l));
+    const orderList =
+      groupBy === "region"
+        ? REGION_ORDER
+        : groupBy === "field"
+          ? FIELD_ORDER.map((f) => FIELD_NAMES[f] || f)
+          : LANG_ORDER.map((l) => getLangName(l));
     return Object.entries(map).sort(([a], [b]) => {
       if (a === "其他") return 1;
       if (b === "其他") return -1;
@@ -176,14 +174,16 @@ export default function SourcesPage() {
     });
   }, [filtered, groupBy]);
 
-  const localCount = useMemo(() => (sources || []).filter((s) => s.has_local_fulltext).length, [sources]);
-  const remoteCount = useMemo(() => (sources || []).filter((s) => s.has_remote_fulltext).length, [sources]);
-  const directSearchCount = useMemo(
-    () => (sources || []).filter((s) => s.supports_search).length,
-    [sources],
-  );
-  const iiifCount = useMemo(() => (sources || []).filter((s) => s.supports_iiif).length, [sources]);
-  const apiCount = useMemo(() => (sources || []).filter((s) => s.supports_api).length, [sources]);
+  const counters = useMemo(() => {
+    const all = sources ?? [];
+    return {
+      local: all.filter((s) => s.has_local_fulltext).length,
+      remote: all.filter((s) => s.has_remote_fulltext).length,
+      directSearch: all.filter((s) => s.supports_search).length,
+      iiif: all.filter((s) => s.supports_iiif).length,
+      api: all.filter((s) => s.supports_api).length,
+    };
+  }, [sources]);
 
   if (isLoading) {
     return (
@@ -197,7 +197,10 @@ export default function SourcesPage() {
     <div className="sources-page">
       <Helmet>
         <title>数据源导航 | 佛津</title>
-        <meta name="description" content={`聚合全球 ${sources?.length || 40}+ 佛教数字资源，覆盖图书馆、大学、研究机构、数字项目等。`} />
+        <meta
+          name="description"
+          content={`聚合全球 ${sources?.length || 40}+ 佛教数字资源，覆盖图书馆、大学、研究机构、数字项目等。`}
+        />
         <link rel="canonical" href="https://fojin.app/sources" />
         <link rel="alternate" hrefLang="x-default" href="https://fojin.app/sources" />
         <link rel="alternate" hrefLang="zh" href="https://fojin.app/sources" />
@@ -206,7 +209,7 @@ export default function SourcesPage() {
         <h1 className="sources-title">数据源导航</h1>
         <p className="sources-desc">
           聚合全球 {sources?.length || 0} 个佛教数字资源：
-          {directSearchCount} 可搜索 · {localCount} 已入库全文 · {remoteCount} 外站全文 · {iiifCount} 影像 · {apiCount} API
+          {counters.directSearch} 可搜索 · {counters.local} 已入库全文 · {counters.remote} 外站全文 · {counters.iiif} 影像 · {counters.api} API
         </p>
       </div>
 
@@ -214,24 +217,31 @@ export default function SourcesPage() {
         <div className="sources-trust-items">
           <div className="sources-trust-item">
             <div className="sources-trust-title">来源可溯</div>
-            <div className="sources-trust-desc">所有数据均来自 CBETA、BDRC、SAT、SuttaCentral 等学术机构公开发布的数字资源，每条记录保留原始来源标识与链接。</div>
+            <div className="sources-trust-desc">
+              所有数据均来自 CBETA、BDRC、SAT、SuttaCentral 等学术机构公开发布的数字资源，每条记录保留原始来源标识与链接。
+            </div>
           </div>
           <div className="sources-trust-item">
             <div className="sources-trust-title">定期同步</div>
-            <div className="sources-trust-desc">通过 Git、API、批量导入等渠道与上游数据源保持同步，确保收录内容反映最新发布状态。</div>
+            <div className="sources-trust-desc">
+              通过 Git、API、批量导入等渠道与上游数据源保持同步，确保收录内容反映最新发布状态。
+            </div>
           </div>
           <div className="sources-trust-item">
             <div className="sources-trust-title">自动去重</div>
-            <div className="sources-trust-desc">跨数据源自动识别同一典籍的不同收录，合并为统一记录，保留各源的独立编号与访问链接。</div>
+            <div className="sources-trust-desc">
+              跨数据源自动识别同一典籍的不同收录，合并为统一记录，保留各源的独立编号与访问链接。
+            </div>
           </div>
           <div className="sources-trust-item">
             <div className="sources-trust-title">覆盖广泛</div>
-            <div className="sources-trust-desc">涵盖 {regions.length} 个国家和地区、{languages.length} 种语言，覆盖汉传、藏传、南传、梵文等多种佛教传统。</div>
+            <div className="sources-trust-desc">
+              涵盖 {regions.length} 个国家和地区、{languages.length} 种语言，覆盖汉传、藏传、南传、梵文等多种佛教传统。
+            </div>
           </div>
         </div>
       </div>
 
-      {/* 搜索与过滤栏 */}
       <div className="sources-toolbar">
         <Input
           prefix={<SearchOutlined style={{ color: "#9a8e7a" }} />}
@@ -279,7 +289,6 @@ export default function SourcesPage() {
           ]}
         />
 
-        {/* 试搜功能 */}
         <div className="sources-try-search">
           <Input.Search
             placeholder="输入关键词试搜"
@@ -307,131 +316,16 @@ export default function SourcesPage() {
                 <span className="sources-group-count">{items.length}</span>
               </div>
               <div className="sources-grid">
-                {items.map((s) => {
-                  const langs = [...new Map(
-                    (s.languages || "").split(",").map((l) => l.trim()).filter(Boolean)
-                      .map((l) => [getLangName(l), l] as const)
-                  ).values()]
-                    .sort((a, b) => {
-                      const ia = langOrder.indexOf(a);
-                      const ib = langOrder.indexOf(b);
-                      return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
-                    });
-                  const distributions = (s.distributions || [])
-                    .filter((d) => d.is_active)
-                    .slice(0, 5);
-                  const searchUrl = searchQuery
-                    ? buildSearchUrlWithFallback(s.code, s.base_url, searchQuery)
-                    : null;
-
-                  return (
-                    <div key={s.code} className="source-card">
-                      <div className="source-card-top">
-                        <span className="source-card-icon">
-                          <GlobalOutlined />
-                        </span>
-                        <div className="source-card-titles">
-                          <span className="source-card-name">{s.name_zh}</span>
-                          {s.name_en && (
-                            <span className="source-card-name-en">{s.name_en}</span>
-                          )}
-                        </div>
-                        <div className="source-card-badges">
-                          {s.has_local_fulltext && (
-                            <Tag color="green" style={{ fontSize: 10, margin: 0, lineHeight: "16px", padding: "0 4px" }}>
-                              <ReadOutlined /> 已入库
-                            </Tag>
-                          )}
-                          {s.has_remote_fulltext && !s.has_local_fulltext && (
-                            <Tag color="cyan" style={{ fontSize: 10, margin: 0, lineHeight: "16px", padding: "0 4px" }}>
-                              <ReadOutlined /> 外站全文
-                            </Tag>
-                          )}
-                          {s.supports_search && (
-                            <Tag color="blue" style={{ fontSize: 10, margin: 0, lineHeight: "16px", padding: "0 4px" }}>
-                              <SearchOutlined /> 可搜索
-                            </Tag>
-                          )}
-                          {s.supports_iiif && (
-                            <Tag color="purple" style={{ fontSize: 10, margin: 0, lineHeight: "16px", padding: "0 4px" }}>
-                              <FileImageOutlined /> 影像
-                            </Tag>
-                          )}
-                          {s.supports_api && (
-                            <Tag color="orange" style={{ fontSize: 10, margin: 0, lineHeight: "16px", padding: "0 4px" }}>
-                              <ApiOutlined /> API
-                            </Tag>
-                          )}
-                        </div>
-                      </div>
-
-                      {s.description && (
-                        <p className="source-card-desc">{s.description}</p>
-                      )}
-
-                      {distributions.length > 0 && (
-                        <div className="source-card-dists">
-                          <div className="source-card-dists-title">官方分发端</div>
-                          <div className="source-card-dists-list">
-                            {distributions.map((d) => (
-                              <a
-                                key={d.code}
-                                href={d.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className={`source-dist-link${d.is_primary_ingest ? " is-primary" : ""}`}
-                                title={d.license_note || d.name}
-                              >
-                                <span className="source-dist-name">{d.name}</span>
-                                <span className="source-dist-meta">
-                                  {getChannelLabel(d.channel_type)}
-                                  {d.format ? ` · ${d.format}` : ""}
-                                </span>
-                              </a>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      <div className="source-card-langs">
-                        {langs.map((l) => (
-                          <span key={l} className="source-lang-tag">{getLangName(l)}</span>
-                        ))}
-                      </div>
-
-                      <div className="source-card-actions">
-                        {s.base_url && (
-                          <a
-                            href={s.base_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="source-btn"
-                          >
-                            <GlobalOutlined /> 访问网站
-                          </a>
-                        )}
-                        {searchUrl && (
-                          <a
-                            href={searchUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="source-btn source-btn-search"
-                          >
-                            <LinkOutlined /> 搜索「{searchQuery}」
-                          </a>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
+                {items.map((s) => (
+                  <SourceCard key={s.code} source={s} searchQuery={searchQuery} />
+                ))}
               </div>
             </div>
           ))}
         </div>
       )}
 
-      {/* 推荐数据源 */}
-      <SuggestSourceSection />
+      <SuggestSourceForm />
 
       {showTop && (
         <button
@@ -442,89 +336,6 @@ export default function SourcesPage() {
           <VerticalAlignTopOutlined />
           <span>Top</span>
         </button>
-      )}
-    </div>
-  );
-}
-
-function SuggestSourceSection() {
-  const [form] = Form.useForm();
-  const [submitting, setSubmitting] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
-
-  const handleSubmit = async (values: { name: string; url: string; description?: string }) => {
-    setSubmitting(true);
-    try {
-      await submitSourceSuggestion(values);
-      setSubmitted(true);
-      form.resetFields();
-    } catch {
-      message.error("提交失败，请稍后再试");
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <div className="sources-suggest">
-      <div className="sources-suggest-header">
-        <h2 className="sources-suggest-title">推荐数据源</h2>
-        <p className="sources-suggest-desc">
-          如果您知道尚未收录的佛教数字资源网站，欢迎推荐给我们
-        </p>
-      </div>
-      {submitted ? (
-        <div className="sources-suggest-success">
-          感谢您的推荐！我们会尽快查阅。
-        </div>
-      ) : (
-        <Form
-          form={form}
-          layout="vertical"
-          onFinish={handleSubmit}
-          className="sources-suggest-form"
-        >
-          <div className="sources-suggest-row">
-            <Form.Item
-              name="name"
-              label="网站名称"
-              rules={[{ required: true, message: "请输入网站名称" }]}
-              style={{ flex: 1 }}
-            >
-              <Input placeholder="例：CBETA 在线阅读" />
-            </Form.Item>
-            <Form.Item
-              name="url"
-              label="网站 URL"
-              rules={[
-                { required: true, message: "请输入网站地址" },
-                { type: "url", message: "请输入有效的网址" },
-              ]}
-              style={{ flex: 1 }}
-            >
-              <Input placeholder="https://..." />
-            </Form.Item>
-          </div>
-          <Form.Item name="description" label="简要说明">
-            <Input.TextArea
-              rows={3}
-              placeholder="简要描述该网站收录的内容、语种、特色等（选填）"
-              maxLength={2000}
-              showCount
-            />
-          </Form.Item>
-          <Form.Item style={{ marginBottom: 0 }}>
-            <Button
-              type="primary"
-              htmlType="submit"
-              loading={submitting}
-              icon={<SendOutlined />}
-              className="sources-suggest-btn"
-            >
-              提交推荐
-            </Button>
-          </Form.Item>
-        </Form>
       )}
     </div>
   );

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -1,0 +1,143 @@
+import { Tag } from "antd";
+import {
+  ApiOutlined,
+  FileImageOutlined,
+  GlobalOutlined,
+  LinkOutlined,
+  ReadOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
+import type { DataSource } from "../../api/client";
+import { buildSearchUrlWithFallback, getLangName } from "../../utils/sourceUrls";
+import { LANG_ORDER, getChannelLabel, trackSourceClick } from "./constants";
+
+interface SourceCardProps {
+  source: DataSource;
+  searchQuery: string;
+}
+
+export default function SourceCard({ source: s, searchQuery }: SourceCardProps) {
+  const langs = [
+    ...new Map(
+      (s.languages || "")
+        .split(",")
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((l) => [getLangName(l), l] as const),
+    ).values(),
+  ].sort((a, b) => {
+    const ia = LANG_ORDER.indexOf(a);
+    const ib = LANG_ORDER.indexOf(b);
+    return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+  });
+
+  const distributions = (s.distributions || []).filter((d) => d.is_active).slice(0, 5);
+  const searchUrl = searchQuery
+    ? buildSearchUrlWithFallback(s.code, s.base_url, searchQuery)
+    : null;
+
+  return (
+    <div className="source-card">
+      <div className="source-card-top">
+        <span className="source-card-icon">
+          <GlobalOutlined />
+        </span>
+        <div className="source-card-titles">
+          <span className="source-card-name">{s.name_zh}</span>
+          {s.name_en && <span className="source-card-name-en">{s.name_en}</span>}
+        </div>
+        <div className="source-card-badges">
+          {s.has_local_fulltext && (
+            <Tag color="green" className="source-card-badge">
+              <ReadOutlined /> 已入库
+            </Tag>
+          )}
+          {s.has_remote_fulltext && !s.has_local_fulltext && (
+            <Tag color="cyan" className="source-card-badge">
+              <ReadOutlined /> 外站全文
+            </Tag>
+          )}
+          {s.supports_search && (
+            <Tag color="blue" className="source-card-badge">
+              <SearchOutlined /> 可搜索
+            </Tag>
+          )}
+          {s.supports_iiif && (
+            <Tag color="purple" className="source-card-badge">
+              <FileImageOutlined /> 影像
+            </Tag>
+          )}
+          {s.supports_api && (
+            <Tag color="orange" className="source-card-badge">
+              <ApiOutlined /> API
+            </Tag>
+          )}
+        </div>
+      </div>
+
+      {s.description && <p className="source-card-desc">{s.description}</p>}
+
+      {distributions.length > 0 && (
+        <div className="source-card-dists">
+          <div className="source-card-dists-title">官方分发端</div>
+          <div className="source-card-dists-list">
+            {distributions.map((d) => (
+              <a
+                key={d.code}
+                href={d.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`source-dist-link${d.is_primary_ingest ? " is-primary" : ""}`}
+                title={d.license_note || d.name}
+                onClick={() =>
+                  trackSourceClick(s.code, "distribution", { dist: d.code })
+                }
+              >
+                <span className="source-dist-name">{d.name}</span>
+                <span className="source-dist-meta">
+                  {getChannelLabel(d.channel_type)}
+                  {d.format ? ` · ${d.format}` : ""}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="source-card-langs">
+        {langs.map((l) => (
+          <span key={l} className="source-lang-tag">
+            {getLangName(l)}
+          </span>
+        ))}
+      </div>
+
+      <div className="source-card-actions">
+        {s.base_url && (
+          <a
+            href={s.base_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="source-btn"
+            onClick={() => trackSourceClick(s.code, "visit")}
+          >
+            <GlobalOutlined /> 访问网站
+          </a>
+        )}
+        {searchUrl && (
+          <a
+            href={searchUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="source-btn source-btn-search"
+            onClick={() =>
+              trackSourceClick(s.code, "search", { query: searchQuery.slice(0, 30) })
+            }
+          >
+            <LinkOutlined /> 搜索「{searchQuery}」
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -92,6 +92,11 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
                 onClick={() =>
                   trackSourceClick(s.code, "distribution", { dist: d.code })
                 }
+                onAuxClick={(e) => {
+                  if (e.button === 1) {
+                    trackSourceClick(s.code, "distribution", { dist: d.code });
+                  }
+                }}
               >
                 <span className="source-dist-name">{d.name}</span>
                 <span className="source-dist-meta">
@@ -120,6 +125,9 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
             rel="noopener noreferrer"
             className="source-btn"
             onClick={() => trackSourceClick(s.code, "visit")}
+            onAuxClick={(e) => {
+              if (e.button === 1) trackSourceClick(s.code, "visit");
+            }}
           >
             <GlobalOutlined /> 访问网站
           </a>
@@ -133,6 +141,11 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
             onClick={() =>
               trackSourceClick(s.code, "search", { query: searchQuery.slice(0, 30) })
             }
+            onAuxClick={(e) => {
+              if (e.button === 1) {
+                trackSourceClick(s.code, "search", { query: searchQuery.slice(0, 30) });
+              }
+            }}
           >
             <LinkOutlined /> 搜索「{searchQuery}」
           </a>

--- a/frontend/src/pages/sources/SuggestSourceForm.tsx
+++ b/frontend/src/pages/sources/SuggestSourceForm.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Button, Form, Input, message } from "antd";
+import { SendOutlined } from "@ant-design/icons";
+import { submitSourceSuggestion } from "../../api/client";
+
+export default function SuggestSourceForm() {
+  const [form] = Form.useForm();
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = async (values: { name: string; url: string; description?: string }) => {
+    setSubmitting(true);
+    try {
+      await submitSourceSuggestion(values);
+      setSubmitted(true);
+      form.resetFields();
+    } catch {
+      message.error("提交失败，请稍后再试");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="sources-suggest">
+      <div className="sources-suggest-header">
+        <h2 className="sources-suggest-title">推荐数据源</h2>
+        <p className="sources-suggest-desc">
+          如果您知道尚未收录的佛教数字资源网站，欢迎推荐给我们
+        </p>
+      </div>
+      {submitted ? (
+        <div className="sources-suggest-success">感谢您的推荐！我们会尽快查阅。</div>
+      ) : (
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={handleSubmit}
+          className="sources-suggest-form"
+        >
+          <div className="sources-suggest-row">
+            <Form.Item
+              name="name"
+              label="网站名称"
+              rules={[{ required: true, message: "请输入网站名称" }]}
+              style={{ flex: 1 }}
+            >
+              <Input placeholder="例：CBETA 在线阅读" />
+            </Form.Item>
+            <Form.Item
+              name="url"
+              label="网站 URL"
+              rules={[
+                { required: true, message: "请输入网站地址" },
+                { type: "url", message: "请输入有效的网址" },
+              ]}
+              style={{ flex: 1 }}
+            >
+              <Input placeholder="https://..." />
+            </Form.Item>
+          </div>
+          <Form.Item name="description" label="简要说明">
+            <Input.TextArea
+              rows={3}
+              placeholder="简要描述该网站收录的内容、语种、特色等（选填）"
+              maxLength={2000}
+              showCount
+            />
+          </Form.Item>
+          <Form.Item style={{ marginBottom: 0 }}>
+            <Button
+              type="primary"
+              htmlType="submit"
+              loading={submitting}
+              icon={<SendOutlined />}
+              className="sources-suggest-btn"
+            >
+              提交推荐
+            </Button>
+          </Form.Item>
+        </Form>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/sources/constants.ts
+++ b/frontend/src/pages/sources/constants.ts
@@ -1,0 +1,64 @@
+export const REGION_ORDER = [
+  "中国大陆",
+  "中国台湾",
+  "中国香港",
+  "中国澳门",
+  "日本",
+  "韩国",
+  "越南",
+  "泰国",
+  "缅甸",
+  "斯里兰卡",
+  "印度",
+  "尼泊尔",
+  "不丹",
+  "蒙古",
+  "老挝",
+  "柬埔寨",
+  "美国",
+  "加拿大",
+  "英国",
+  "德国",
+  "法国",
+  "荷兰",
+  "比利时",
+  "奥地利",
+  "挪威",
+  "丹麦",
+  "意大利",
+  "西班牙",
+  "捷克",
+  "俄罗斯",
+  "澳大利亚",
+  "国际",
+];
+
+export const LANG_ORDER = ["zh", "lzh", "sa", "pi", "bo", "en", "ja", "ko"];
+
+export const FIELD_NAMES: Record<string, string> = {
+  han: "汉传佛教",
+  theravada: "南传佛教",
+  tibetan: "藏传佛教",
+  dunhuang: "敦煌学",
+  art: "佛教艺术",
+  dictionary: "辞典工具",
+  dh: "数字人文",
+};
+
+export const FIELD_ORDER = ["han", "theravada", "tibetan", "dictionary", "dh", "dunhuang", "art"];
+
+export function getChannelLabel(channelType: string): string {
+  if (channelType === "git") return "Git";
+  if (channelType === "bulk_dump") return "批量";
+  if (channelType === "api") return "API";
+  return channelType;
+}
+
+export function trackSourceClick(
+  code: string,
+  kind: "visit" | "search" | "distribution",
+  extra?: Record<string, string | number>,
+): void {
+  if (typeof window === "undefined" || !window.umami) return;
+  window.umami.track("source_click", { code, kind, ...extra });
+}

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -152,6 +152,13 @@
   flex-shrink: 0;
 }
 
+.source-card-badge.ant-tag {
+  font-size: 10px;
+  margin: 0;
+  line-height: 16px;
+  padding: 0 4px;
+}
+
 .source-card-desc {
   font-size: 12px;
   color: var(--fj-ink-light);


### PR DESCRIPTION
## Summary

Three small but compounding wins for `/sources`, prepared before Wave 2 (URL state sync) touches the same file.

1. **Refactor** — 532-line `SourcesPage.tsx` split into:
   - `pages/sources/constants.ts` — region/lang/field ordering tables, channel label helper, and the new `trackSourceClick` util
   - `pages/sources/SourceCard.tsx` — one source card, now self-contained with its own click handlers
   - `pages/sources/SuggestSourceForm.tsx` — the recommendation form (previously a trailing inline function)
   - `SourcesPage.tsx` itself shrinks to ~300 lines; the three region/lang/field extraction useMemos fold into a single pass
   - Inline `<Tag style={…}>` moves to a `.source-card-badge` CSS class
2. **Click tracking** — `/sources` had zero outbound-click signal in Umami. Without it we cannot curate the 532-entry catalogue. Three `onClick` hooks on 访问网站, each distribution link, and the try-search launcher, all emitting `source_click` events with `code`, `kind`, and optional `dist`/`query` context. Consistent with existing `chat` / `search` / `read` tracking.
3. **List cache** — `useQuery({ queryKey: ["sources"] })` had no `staleTime`, so every route entry re-fetched **349 KB**. CF data: 416 `/api/sources` hits/24h × 349 KB = ~150 MB/day egress for a near-static payload. Frontend now holds for 30 min; backend mirrors that with a Redis cache (`sources:list:v1`) returning raw JSON bytes on warm hits, which also avoids the pydantic re-validation trap from the `/kg/geo` fix yesterday.

## Verification

- `POST /api/sources` cold 3.3s / warm 1.5s (bulk of each is network; Redis has the key at 349680 bytes)
- Frontend build clean (`tsc --noEmit` + `vite build` both pass)
- Refactored card/form render identically in browser spot check
- `trackSourceClick` no-ops if `window.umami` is absent

## Test plan

- [ ] Open `/sources`, confirm cards and suggest form render
- [ ] Click 访问网站 on any card → Umami "source_click" event with `kind=visit`
- [ ] Click a distribution link → `kind=distribution` + `dist=<code>`
- [ ] Use 试搜 field, click one result → `kind=search` + `query=…`
- [ ] Hit `/sources` twice in quick succession; second visit should not re-fetch the 349 KB list

## Out of scope (Wave 2 follow-up)

- URL param sync for filters / group-by (`?region=…&field=…`)
- SSG / prerendering for SEO — tracked as Wave 3