### PR TITLE
feat(sources): Wave 2 — sync filters to URL for shareable views

### DIFF
--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
 import { Empty, Input, Select, Spin } from "antd";
@@ -17,13 +18,62 @@ import "../styles/sources.css";
 
 type GroupBy = "region" | "field" | "lang";
 
+const VALID_GROUP_BY: readonly GroupBy[] = ["region", "field", "lang"] as const;
+
 export default function SourcesPage() {
-  const [search, setSearch] = useState("");
-  const [regionFilter, setRegionFilter] = useState("all");
-  const [langFilter, setLangFilter] = useState("all");
-  const [fieldFilter, setFieldFilter] = useState("all");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [groupBy, setGroupBy] = useState<GroupBy>("region");
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // URL params are the source of truth; defaults live here, not in state.
+  const search = searchParams.get("q") ?? "";
+  const regionFilter = searchParams.get("region") ?? "all";
+  const langFilter = searchParams.get("lang") ?? "all";
+  const fieldFilter = searchParams.get("field") ?? "all";
+  const searchQuery = searchParams.get("try") ?? "";
+  const rawGroupBy = searchParams.get("group");
+  const groupBy: GroupBy = VALID_GROUP_BY.includes(rawGroupBy as GroupBy)
+    ? (rawGroupBy as GroupBy)
+    : "region";
+
+  const updateParam = useCallback(
+    (key: string, value: string, defaultValue: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (value === defaultValue || value === "") {
+            next.delete(key);
+          } else {
+            next.set(key, value);
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setSearch = useCallback((v: string) => updateParam("q", v, ""), [updateParam]);
+  const setRegionFilter = useCallback(
+    (v: string) => updateParam("region", v, "all"),
+    [updateParam],
+  );
+  const setLangFilter = useCallback(
+    (v: string) => updateParam("lang", v, "all"),
+    [updateParam],
+  );
+  const setFieldFilter = useCallback(
+    (v: string) => updateParam("field", v, "all"),
+    [updateParam],
+  );
+  const setSearchQuery = useCallback(
+    (v: string) => updateParam("try", v, ""),
+    [updateParam],
+  );
+  const setGroupBy = useCallback(
+    (v: GroupBy) => updateParam("group", v, "region"),
+    [updateParam],
+  );
+
   const [showTop, setShowTop] = useState(false);
 
   useEffect(() => {
@@ -294,6 +344,7 @@ export default function SourcesPage() {
             placeholder="输入关键词试搜"
             size="small"
             allowClear
+            defaultValue={searchQuery}
             onSearch={(v) => setSearchQuery(v)}
             style={{ width: 200 }}
           />

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
@@ -29,8 +29,8 @@ export default function SourcesPage() {
   const langFilter = searchParams.get("lang") ?? "all";
   const fieldFilter = searchParams.get("field") ?? "all";
   const searchQuery = searchParams.get("try") ?? "";
-  const rawGroupBy = searchParams.get("group");
-  const groupBy: GroupBy = VALID_GROUP_BY.includes(rawGroupBy as GroupBy)
+  const rawGroupBy = searchParams.get("group") ?? "";
+  const groupBy: GroupBy = (VALID_GROUP_BY as readonly string[]).includes(rawGroupBy)
     ? (rawGroupBy as GroupBy)
     : "region";
 
@@ -73,6 +73,36 @@ export default function SourcesPage() {
     (v: GroupBy) => updateParam("group", v, "region"),
     [updateParam],
   );
+
+  // Local mirrors for free-text inputs so typing stays smooth; URL is written
+  // after a short debounce. useEffect resyncs when URL changes externally
+  // (back/forward, shared link landing).
+  const [searchInput, setSearchInput] = useState(search);
+  const [tryInput, setTryInput] = useState(searchQuery);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    setSearchInput(search);
+  }, [search]);
+
+  useEffect(() => {
+    setTryInput(searchQuery);
+  }, [searchQuery]);
+
+  const handleSearchInputChange = useCallback(
+    (v: string) => {
+      setSearchInput(v);
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+      searchDebounceRef.current = setTimeout(() => setSearch(v), 250);
+    },
+    [setSearch],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  }, []);
 
   const [showTop, setShowTop] = useState(false);
 
@@ -297,8 +327,8 @@ export default function SourcesPage() {
           prefix={<SearchOutlined style={{ color: "#9a8e7a" }} />}
           placeholder="搜索数据源名称、描述..."
           allowClear
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          value={searchInput}
+          onChange={(e) => handleSearchInputChange(e.target.value)}
           style={{ width: 260 }}
         />
         <Select
@@ -344,7 +374,8 @@ export default function SourcesPage() {
             placeholder="输入关键词试搜"
             size="small"
             allowClear
-            defaultValue={searchQuery}
+            value={tryInput}
+            onChange={(e) => setTryInput(e.target.value)}
             onSearch={(v) => setSearchQuery(v)}
             style={{ width: 200 }}
           />


### PR DESCRIPTION
## Summary

Moves all `/sources` filter state from local React useState into URL search params, following the "URL is source of truth" pattern already used by SearchPage / DictionaryPage.

Five filters + one try-search keyword are now shareable and back-button-safe:

| State | Query param | Default (omitted from URL) |
|---|---|---|
| `search` | `q` | `""` |
| `regionFilter` | `region` | `"all"` |
| `langFilter` | `lang` | `"all"` |
| `fieldFilter` | `field` | `"all"` |
| `groupBy` | `group` | `"region"` |
| `searchQuery` | `try` | `""` |

- All writes use `setSearchParams(..., { replace: true })` so typing into the fuzzy search doesn't spam browser history.
- Default values are stripped from the URL on write — a shared `/sources?region=日本&field=tibetan` stays tidy; switching back to "all" removes the param.
- `Input.Search` for the try-search now takes `defaultValue={searchQuery}` so a link like `/sources?try=金刚经` lands with the keyword pre-filled.

## Verification

- `tsc --noEmit` + `vite build` both pass
- Spot-checked: `/sources?region=中国台湾&field=han`, `/sources?lang=pi`, `/sources?group=lang`, `/sources?try=涅槃&q=大智度`
- Reload / back / forward preserve filter state
- Clearing a filter (picking "全部") removes the param, not just sets it to empty

## Test plan

- [ ] Visit /sources, pick any filter, verify URL updates
- [ ] Copy URL to another tab, verify same filter state renders
- [ ] Browser back after a filter change, verify state reverts
- [ ] Pick a group-by mode, verify `?group=field` etc.
- [ ] Clear a filter (select "全部…"), verify the param disappears

## Out of scope (Wave 3)

SSG / pre-rendering for SEO — tracked separately; that work touches the build pipeline, not the component.