### PR TITLE
fix(citation): snap outer context to sentence boundaries

### DIFF
--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -50,6 +50,50 @@ function dedupeOverlap(chunks: ChunkContextItem[]): ChunkContextItem[] {
 }
 
 /**
+ * Snap the outer context edges to the nearest sentence boundary so the
+ * panel does not start or end mid-sentence. Only trims chunks[0] head
+ * and chunks[last] tail, and only when there is actually more text
+ * outside the window (has_more_before/after) — otherwise we are at the
+ * juan boundary and should show everything. Never touches the center
+ * (highlighted) chunk.
+ */
+const SENTENCE_END = /[。！？；][”’》」』）\)]*/g;
+
+function snapSentenceBoundaries(
+  chunks: ChunkContextItem[],
+  hasMoreBefore: boolean,
+  hasMoreAfter: boolean,
+): ChunkContextItem[] {
+  if (chunks.length === 0) return chunks;
+  const out = chunks.map((c) => ({ ...c }));
+
+  if (hasMoreBefore && !out[0].is_center) {
+    const text = out[0].chunk_text;
+    SENTENCE_END.lastIndex = 0;
+    const m = SENTENCE_END.exec(text);
+    if (m && m.index + m[0].length < text.length - 20) {
+      out[0].chunk_text = text.slice(m.index + m[0].length).replace(/^\s+/, '');
+    }
+  }
+
+  const lastIdx = out.length - 1;
+  if (hasMoreAfter && !out[lastIdx].is_center) {
+    const text = out[lastIdx].chunk_text;
+    let lastEnd = -1;
+    SENTENCE_END.lastIndex = 0;
+    let m;
+    while ((m = SENTENCE_END.exec(text)) !== null) {
+      lastEnd = m.index + m[0].length;
+    }
+    if (lastEnd > 20) {
+      out[lastIdx].chunk_text = text.slice(0, lastEnd).replace(/\s+$/, '');
+    }
+  }
+
+  return out;
+}
+
+/**
  * Inline citation panel: a sibling of the main chat column inside a flex
  * row, sized by the parent via an explicit width passed through the CSS
  * class (see .chat-citation-panel in global.css). Not an antd Drawer —
@@ -80,7 +124,14 @@ export default function CitationDrawer({ target, onClose }: Props) {
   });
 
   const dedupedChunks = useMemo(
-    () => (data ? dedupeOverlap(data.chunks) : []),
+    () =>
+      data
+        ? snapSentenceBoundaries(
+            dedupeOverlap(data.chunks),
+            data.has_more_before,
+            data.has_more_after,
+          )
+        : [],
     [data],
   );
 

--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -57,7 +57,7 @@ function dedupeOverlap(chunks: ChunkContextItem[]): ChunkContextItem[] {
  * juan boundary and should show everything. Never touches the center
  * (highlighted) chunk.
  */
-const SENTENCE_END = /[。！？；][”’》」』）\)]*/g;
+const SENTENCE_END = /[。！？；][”’》」』）)]*/g;
 
 function snapSentenceBoundaries(
   chunks: ChunkContextItem[],


### PR DESCRIPTION
## Summary
- Citation drawer shows ±2 chunks of context; chunks are 500-char fixed-length with 50-char overlap, so the outer edges often start/end mid-sentence — visually "every sentence is cut off."
- Add `snapSentenceBoundaries()` applied after `dedupeOverlap`: trims the leading partial sentence off `chunks[0]` and the trailing partial off `chunks[last]`, only when `has_more_before/after` indicates real truncation.
- Never touches `is_center` so the highlighted chunk stays intact.

Frontend-only; no alignment data / chunker changes. Plan B (sentence-aware chunker in ingestion) remains on the roadmap.

## Test plan
- [x] Docker build passes (TS typecheck clean)
- [x] Deployed to prod, frontend container healthy
- [ ] Manual check in browser: open any 汉文 citation, confirm 前文/后文 edges no longer show half sentences
- [ ] Sanity: citation at juan boundary (`has_more_before=false`) still shows full leading text

🤖 Generated with [Claude Code](https://claude.com/claude-code)