### PR TITLE
fix(chat): style markdown tables in chat bubbles

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -156,6 +156,30 @@ em {
   font-weight: 600;
   margin: 0.3em 0 0.1em;
 }
+.chat-markdown table {
+  border-collapse: collapse;
+  margin: 0.5em 0;
+  width: 100%;
+  font-size: 0.95em;
+  display: block;
+  overflow-x: auto;
+}
+.chat-markdown thead {
+  background: rgba(217, 208, 193, 0.35);
+}
+.chat-markdown th, .chat-markdown td {
+  border: 1px solid rgba(217, 208, 193, 0.7);
+  padding: 6px 10px;
+  text-align: left;
+  vertical-align: top;
+  line-height: 1.55;
+}
+.chat-markdown th {
+  font-weight: 600;
+}
+.chat-markdown tbody tr:nth-child(even) {
+  background: rgba(0, 0, 0, 0.02);
+}
 
 /* ========== Chat Sidebar Mobile ========== */
 @media (max-width: 768px) {


### PR DESCRIPTION
## Background

After PR #482 + #483 made the LLM emit proper GFM pipe-tables for 比较分析型 answers, output still looked like space-aligned prose on the live site. Inspecting the raw DB row confirmed the model output was correct markdown:

\`\`\`
| 维度 | 法相宗 | 法性宗 |
| --- | --- | --- |
| **立论基点** | ... | ... |
\`\`\`

Root cause was frontend CSS: \`.chat-markdown\` had rules for ul/ol/li/pre/blockquote/h1-h3 but nothing for \`table/th/td\`, so the browser default (no borders, no padding) made tables collapse into what looked like columnar text. react-markdown + remark-gfm correctly emitted \`<table>\` elements, they just had no style.

## Change

Add table styling to \`.chat-markdown\`: collapsed borders matching the existing \`--fj-gold\` palette, header tint, zebra rows, \`overflow-x: auto\` so wide comparison tables stay scrollable on mobile instead of overflowing the chat bubble.

\`SharedQAPage\` uses the same \`.chat-markdown\` class, so shared answers benefit too.

## Test plan

- [x] tsc clean
- [ ] Re-run "法相宗与法性宗根本立场有何不同？" — verify 关键差异 renders as actual table grid
- [ ] Open a /qa/:id share page with a table-containing answer — verify it renders the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)