### PR TITLE
feat(sources): P0 audit fixes — hero CTA, group collapse, skeleton, metadata backfill

### DIFF
--- a/backend/alembic/versions/0122_normalize_sources_metadata.py
+++ b/backend/alembic/versions/0122_normalize_sources_metadata.py
@@ -1,0 +1,114 @@
+"""Normalize sources metadata: region labels, has_local_fulltext backfill, fill known-null regions.
+
+Three idempotent data fixes surfaced by the sources-page audit:
+
+1. Region label duplicates: four Mongolia entries split across `蒙古` (3) and
+   `蒙古国` (1). Normalize all to `蒙古国` (precise country name, matches other
+   entries like `韩国`, `泰国`).
+
+2. `has_local_fulltext` was almost never flipped to true even as ingestion
+   progressed — only 2 of 532 sources had it set. Recompute from the current
+   state of `buddhist_texts`: a source is "locally fulltext" when at least one
+   linked text has `has_content=true`.
+
+3. Fill region for sources where the publishing institution is unambiguous
+   from the `code` prefix (DILA → 中国台湾, BuddhaSpace → 中国台湾, Cologne
+   Digital Sanskrit Lexicon → 德国, Pali Text Society → 英国, Rangjung Yeshe →
+   国际). Ambiguous single-work dictionaries (weishi, tiantai, sanzang-fashu,
+   ...) are left for a later UI-side "工具书" bucket decision and not touched here.
+
+Revision ID: 0122
+Revises: 0121
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0122"
+down_revision = "0121"
+branch_labels = None
+depends_on = None
+
+
+# (code, new_region) — conservative, only codes whose origin is unambiguous.
+REGION_FILLS: list[tuple[str, str]] = [
+    # DILA (Dharma Drum / 法鼓佛教学院, 中国台湾)
+    ("dila-dfb", "中国台湾"),
+    ("dila-nanshanlu", "中国台湾"),
+    ("dila-plc", "中国台湾"),
+    ("dila-hopkins", "中国台湾"),
+    ("dila-mvp", "中国台湾"),
+    ("dila-ptg", "中国台湾"),
+    ("dila-soothill", "中国台湾"),
+    # BuddhaSpace (buddhaspace.org, 庄春江居士团队, 中国台湾)
+    ("bs-faxiang", "中国台湾"),
+    ("bs-yiqiejing-yinyi", "中国台湾"),
+    ("bs-xu-yinyi", "中国台湾"),
+    ("bs-suihan-lu", "中国台湾"),
+    ("bs-fanfanyu", "中国台湾"),
+    ("bs-agama", "中国台湾"),
+    ("bs-changjianci", "中国台湾"),
+    # Cologne Digital Sanskrit Lexicon (University of Cologne)
+    ("cdsl-mw", "德国"),
+    ("cdsl-bhs", "德国"),
+    ("cdsl-apte", "德国"),
+    # Pali Text Society
+    ("pts-ped", "英国"),
+    ("ncped", "英国"),
+    ("dppn", "英国"),
+    # Rangjung Yeshe Wiki — run by an international Tibetan Buddhist community
+    ("rangjung-yeshe", "国际"),
+]
+
+
+def upgrade() -> None:
+    # 1. Region label normalization: 蒙古 → 蒙古国
+    op.execute(
+        text("UPDATE data_sources SET region = '蒙古国' WHERE region = '蒙古'")
+    )
+
+    # 2. Backfill has_local_fulltext based on current buddhist_texts state.
+    #    Sync both directions so the flag reflects reality even if content was removed.
+    op.execute(
+        text(
+            """
+            UPDATE data_sources ds
+            SET has_local_fulltext = EXISTS (
+                SELECT 1 FROM buddhist_texts bt
+                WHERE bt.source_id = ds.id AND bt.has_content = true
+            )
+            """
+        )
+    )
+
+    # 3. Fill unambiguous null regions.
+    for code, region in REGION_FILLS:
+        op.execute(
+            text("UPDATE data_sources SET region = :r WHERE code = :c AND region IS NULL").bindparams(
+                r=region, c=code
+            )
+        )
+
+
+def downgrade() -> None:
+    # 3. Revert region fills (only where we set the value we'd expect).
+    for code, region in REGION_FILLS:
+        op.execute(
+            text("UPDATE data_sources SET region = NULL WHERE code = :c AND region = :r").bindparams(
+                c=code, r=region
+            )
+        )
+
+    # 2. has_local_fulltext: no principled reverse — resetting all to false is
+    #    destructive, and the upgrade is idempotent so downgrade/re-upgrade is a
+    #    no-op data-wise. Leave the computed values in place.
+
+    # 1. Region normalization: restore the three pre-upgrade `蒙古` rows
+    #    (bdrc-nlm, mongolia-academy, eap-dambadarjaa). The fourth Mongolia
+    #    source (mongolian-kanjur-nlm) was already `蒙古国` and is left alone.
+    op.execute(
+        text(
+            "UPDATE data_sources SET region = '蒙古' "
+            "WHERE code IN ('bdrc-nlm', 'mongolia-academy', 'eap-dambadarjaa')"
+        )
+    )

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
-import { Empty, Input, Select, Spin } from "antd";
-import { SearchOutlined, VerticalAlignTopOutlined } from "@ant-design/icons";
+import { Empty, Input, Select, Skeleton } from "antd";
+import { SearchOutlined, ThunderboltOutlined, VerticalAlignTopOutlined } from "@ant-design/icons";
 import { getSources, type DataSource } from "../api/client";
 import { getLangName, normalizeLangCode } from "../utils/sourceUrls";
 import SourceCard from "./sources/SourceCard";
@@ -70,7 +70,13 @@ export default function SourcesPage() {
     [updateParam],
   );
   const setGroupBy = useCallback(
-    (v: GroupBy) => updateParam("group", v, "region"),
+    (v: GroupBy) => {
+      updateParam("group", v, "region");
+      // Reset expansion state: group names can collide across groupBy modes
+      // (e.g. "其他" exists in all three, "国际" is both a region and could be
+      // a bucket label), so a key like "其他" would carry over incorrectly.
+      setExpandedGroups({});
+    },
     [updateParam],
   );
 
@@ -79,7 +85,12 @@ export default function SourcesPage() {
   // (back/forward, shared link landing).
   const [searchInput, setSearchInput] = useState(search);
   const [tryInput, setTryInput] = useState(searchQuery);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const GROUP_COLLAPSE_LIMIT = 12;
+  const toggleGroup = useCallback((name: string) => {
+    setExpandedGroups((prev) => ({ ...prev, [name]: !prev[name] }));
+  }, []);
 
   useEffect(() => {
     setSearchInput(search);
@@ -267,11 +278,24 @@ export default function SourcesPage() {
 
   if (isLoading) {
     return (
-      <div style={{ textAlign: "center", padding: 80 }}>
-        <Spin size="large" />
+      <div className="sources-page">
+        <div className="sources-header">
+          <Skeleton.Input active size="large" style={{ width: 180, marginBottom: 12 }} />
+          <br />
+          <Skeleton.Input active size="small" style={{ width: 520 }} />
+        </div>
+        <div className="sources-skeleton-grid">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="source-card">
+              <Skeleton active paragraph={{ rows: 2 }} title />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }
+
+  const total = sources?.length || 0;
 
   return (
     <div className="sources-page">
@@ -279,7 +303,11 @@ export default function SourcesPage() {
         <title>数据源导航 | 佛津</title>
         <meta
           name="description"
-          content={`聚合全球 ${sources?.length || 40}+ 佛教数字资源，覆盖图书馆、大学、研究机构、数字项目等。`}
+          content={
+            total > 0
+              ? `聚合全球 ${total} 个佛教数字资源，覆盖图书馆、大学、研究机构、数字项目等。`
+              : "聚合全球佛教数字资源，覆盖图书馆、大学、研究机构、数字项目等。"
+          }
         />
         <link rel="canonical" href="https://fojin.app/sources" />
         <link rel="alternate" hrefLang="x-default" href="https://fojin.app/sources" />
@@ -288,9 +316,30 @@ export default function SourcesPage() {
       <div className="sources-header">
         <h1 className="sources-title">数据源导航</h1>
         <p className="sources-desc">
-          聚合全球 {sources?.length || 0} 个佛教数字资源：
+          聚合全球 {total} 个佛教数字资源：
           {counters.directSearch} 可搜索 · {counters.local} 已入库全文 · {counters.remote} 外站全文 · {counters.iiif} 影像 · {counters.api} API
         </p>
+      </div>
+
+      <div className="sources-hero-search">
+        <div className="sources-hero-search-head">
+          <ThunderboltOutlined className="sources-hero-search-icon" />
+          <div className="sources-hero-search-copy">
+            <div className="sources-hero-search-title">一次输入，直达 {counters.directSearch} 个可搜索数据源</div>
+            <div className="sources-hero-search-sub">
+              敲入一个关键词，下方每张卡片会生成对应数据源的站内搜索直链
+            </div>
+          </div>
+        </div>
+        <Input.Search
+          placeholder="例：般若、涅槃、慈悲、阿含"
+          size="large"
+          enterButton="生成直达"
+          allowClear
+          value={tryInput}
+          onChange={(e) => setTryInput(e.target.value)}
+          onSearch={(v) => setSearchQuery(v)}
+        />
       </div>
 
       <div className="sources-trust">
@@ -368,42 +417,51 @@ export default function SourcesPage() {
             { value: "lang", label: "按语种" },
           ]}
         />
-
-        <div className="sources-try-search">
-          <Input.Search
-            placeholder="输入关键词试搜"
-            size="small"
-            allowClear
-            value={tryInput}
-            onChange={(e) => setTryInput(e.target.value)}
-            onSearch={(v) => setSearchQuery(v)}
-            style={{ width: 200 }}
-          />
-        </div>
       </div>
 
       <div className="sources-stats-bar">
-        当前显示 <strong>{filtered.length}</strong> / {sources?.length || 0} 个数据源
+        当前显示 <strong>{filtered.length}</strong> / {total} 个数据源
         {groupBy !== "region" && ` · ${grouped.length} 个分组`}
+        {groupBy !== "region" && (
+          <span className="sources-stats-hint">（一个数据源可归属多个{groupBy === "field" ? "研究领域" : "语种"}）</span>
+        )}
       </div>
 
       {filtered.length === 0 ? (
         <Empty description="无匹配数据源" style={{ marginTop: 60 }} />
       ) : (
         <div className="sources-groups">
-          {grouped.map(([groupName, items]) => (
-            <div key={groupName} className="sources-group">
-              <div className="sources-group-header">
-                <span className="sources-group-name">{groupName}</span>
-                <span className="sources-group-count">{items.length}</span>
+          {grouped.map(([groupName, items]) => {
+            const isExpanded = expandedGroups[groupName] ?? false;
+            const shouldCollapse = items.length > GROUP_COLLAPSE_LIMIT;
+            const visible =
+              shouldCollapse && !isExpanded ? items.slice(0, GROUP_COLLAPSE_LIMIT) : items;
+            return (
+              <div key={groupName} className="sources-group">
+                <div className="sources-group-header">
+                  <span className="sources-group-name">{groupName}</span>
+                  <span className="sources-group-count">{items.length}</span>
+                </div>
+                <div className="sources-grid">
+                  {visible.map((s) => (
+                    <SourceCard key={s.code} source={s} searchQuery={searchQuery} />
+                  ))}
+                </div>
+                {shouldCollapse && (
+                  <button
+                    type="button"
+                    className="sources-group-toggle"
+                    onClick={() => toggleGroup(groupName)}
+                    aria-expanded={isExpanded}
+                  >
+                    {isExpanded
+                      ? `收起 ${groupName}`
+                      : `展开全部 ${items.length} 个 (还有 ${items.length - GROUP_COLLAPSE_LIMIT} 个)`}
+                  </button>
+                )}
               </div>
-              <div className="sources-grid">
-                {items.map((s) => (
-                  <SourceCard key={s.code} source={s} searchQuery={searchQuery} />
-                ))}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -28,6 +28,68 @@
   margin: 0;
 }
 
+/* ---------- 跨源搜索 Hero ---------- */
+.sources-hero-search {
+  background: linear-gradient(135deg, #fdf7ea 0%, #fbeed0 100%);
+  border: 1px solid #e9d9a8;
+  border-radius: 10px;
+  padding: 18px 22px;
+  margin: 0 0 18px;
+}
+
+.sources-hero-search-head {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.sources-hero-search-icon {
+  font-size: 22px;
+  color: var(--fj-gold, #b08d57);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.sources-hero-search-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.sources-hero-search-title {
+  font-family: "Noto Serif SC", serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fj-ink);
+  line-height: 1.4;
+}
+
+.sources-hero-search-sub {
+  font-size: 12.5px;
+  color: var(--fj-ink-muted);
+  margin-top: 3px;
+  line-height: 1.5;
+}
+
+@media (max-width: 520px) {
+  .sources-hero-search {
+    padding: 14px 14px;
+  }
+  .sources-hero-search-head {
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+  .sources-hero-search-icon {
+    font-size: 18px;
+  }
+  .sources-hero-search-title {
+    font-size: 14.5px;
+  }
+  .sources-hero-search-sub {
+    font-size: 12px;
+  }
+}
+
 /* ---------- 工具栏 ---------- */
 .sources-toolbar {
   display: flex;
@@ -41,15 +103,47 @@
   margin-bottom: 16px;
 }
 
-.sources-try-search {
-  margin-left: auto;
-}
-
 .sources-stats-bar {
   font-size: 13px;
   color: var(--fj-ink-muted);
   margin-bottom: 20px;
   padding-left: 4px;
+}
+
+.sources-stats-hint {
+  margin-left: 6px;
+  font-size: 12px;
+  color: var(--fj-ink-light, #998a73);
+}
+
+/* ---------- 骨架屏 ---------- */
+.sources-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+  margin-top: 24px;
+}
+
+/* ---------- 分组展开按钮 ---------- */
+.sources-group-toggle {
+  margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: transparent;
+  border: 1px dashed var(--fj-border);
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--fj-ink-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.sources-group-toggle:hover {
+  border-color: var(--fj-gold, #b08d57);
+  color: var(--fj-accent, #8a6b3a);
+  background: #fdf8ec;
 }
 
 .sources-stats-bar strong {


### PR DESCRIPTION
## Summary

P0 items from the /sources page audit (532 数据源).

### Frontend
- Hero CTA banner promotes the cross-source try-search (was buried in toolbar)
- Per-group collapse: groups > 12 cards show top 12 + "展开全部 N 个" button. Cuts default-view DOM from ~500 cards to ~150
- `expandedGroups` resets on groupBy change (group names collide across region/field/lang, e.g. "其他")
- Skeleton grid replaces Spin loader (no CLS)
- Fixes misleading "40+" fallback → real count
- Mobile @media (max-width: 520px) tightens hero padding/typography

### Backend (alembic 0122)
- `蒙古` → `蒙古国` normalization (3 rows)
- Recompute `has_local_fulltext` from actual `buddhist_texts.has_content` (was 2/532, now reflects ingestion reality; idempotent)
- Region fill for 21 sources with unambiguous institutional provenance (DILA/buddhaspace → 中国台湾, Cologne CDSL → 德国, PTS → 英国, rangjung-yeshe → 国际)
- Ambiguous single-work dictionaries left null pending a "工具书" category decision

## Test plan
- [x] `tsc -b` clean
- [x] `vite build` clean
- [ ] Deploy to VPS, run `alembic upgrade head`, verify /sources:
  - [ ] 蒙古国 group shows 4 entries, 蒙古 gone
  - [ ] `counters.local` > 2 in header
  - [ ] null-region group shrinks (36 → ~15)
  - [ ] Large groups show "展开全部 N 个" button
  - [ ] Try-search banner prominent above toolbar
- [ ] Mobile screenshot at 375px