### PR TITLE
fix(sources): only show search button when direct template exists

### DIFF
--- a/frontend/src/components/ExternalSourceLinks.tsx
+++ b/frontend/src/components/ExternalSourceLinks.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Typography } from "antd";
 import { LinkOutlined, DownOutlined, UpOutlined } from "@ant-design/icons";
 import type { DataSource } from "../api/client";
-import { buildSearchUrlWithFallback } from "../utils/sourceUrls";
+import { buildSearchUrl } from "../utils/sourceUrls";
 
 interface ExternalSourceLinksProps {
   sources: DataSource[];
@@ -16,10 +16,12 @@ export default function ExternalSourceLinks({ sources, query }: ExternalSourceLi
 
   const externalSources = sources.filter((s) => s.access_type === "external" && s.base_url);
 
-  // Group by region
+  // Group by region. Only include sources with a registered direct-search
+  // template; the previous Google site: fallback returned 0 results for
+  // un-indexed mirror sites and misled users.
   const grouped: Record<string, Array<{ source: DataSource; url: string }>> = {};
   for (const s of externalSources) {
-    const url = buildSearchUrlWithFallback(s.code, s.base_url, query);
+    const url = buildSearchUrl(s.code, query);
     if (!url) continue;
     const region = s.region || "其他";
     if (!grouped[region]) grouped[region] = [];

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -5,7 +5,7 @@ import { Helmet } from "react-helmet-async";
 import { Empty, Input, Select, Skeleton } from "antd";
 import { SearchOutlined, ThunderboltOutlined, VerticalAlignTopOutlined } from "@ant-design/icons";
 import { getSources, type DataSource } from "../api/client";
-import { getLangName, normalizeLangCode } from "../utils/sourceUrls";
+import { getLangName, hasDirectSearchUrl, normalizeLangCode } from "../utils/sourceUrls";
 import SourceCard from "./sources/SourceCard";
 import SuggestSourceForm from "./sources/SuggestSourceForm";
 import {
@@ -270,7 +270,10 @@ export default function SourcesPage() {
     return {
       local: all.filter((s) => s.has_local_fulltext).length,
       remote: all.filter((s) => s.has_remote_fulltext).length,
-      directSearch: all.filter((s) => s.supports_search).length,
+      // Count sources with a registered direct-search template, not the DB
+      // `supports_search` flag — the flag means "site has a search page" but
+      // doesn't guarantee we know the query URL template.
+      directSearch: all.filter((s) => hasDirectSearchUrl(s.code)).length,
       iiif: all.filter((s) => s.supports_iiif).length,
       api: all.filter((s) => s.supports_api).length,
     };

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -8,7 +8,7 @@ import {
   SearchOutlined,
 } from "@ant-design/icons";
 import type { DataSource } from "../../api/client";
-import { buildSearchUrlWithFallback, getLangName } from "../../utils/sourceUrls";
+import { buildSearchUrl, getLangName } from "../../utils/sourceUrls";
 import { LANG_ORDER, getChannelLabel, trackSourceClick } from "./constants";
 
 interface SourceCardProps {
@@ -32,9 +32,11 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
   });
 
   const distributions = (s.distributions || []).filter((d) => d.is_active).slice(0, 5);
-  const searchUrl = searchQuery
-    ? buildSearchUrlWithFallback(s.code, s.base_url, searchQuery)
-    : null;
+  // Only offer the "搜索" button when we have a registered direct-search template
+  // for this source. The previous Google site: fallback produced empty results
+  // for download mirrors and un-indexed sites (e.g. archive.cbetaonline.cn),
+  // misleading users. If a source lacks a template, the button is hidden.
+  const searchUrl = searchQuery ? buildSearchUrl(s.code, searchQuery) : null;
 
   return (
     <div className="source-card">

--- a/frontend/src/utils/sourceUrls.ts
+++ b/frontend/src/utils/sourceUrls.ts
@@ -20,21 +20,7 @@ export function buildSearchUrl(code: string, query: string): string | null {
 }
 
 /**
- * 为指定数据源和查询词生成搜索 URL，如果没有已知模板则回退到 Google site: 搜索
- */
-export function buildSearchUrlWithFallback(code: string, baseUrl: string | null, query: string): string | null {
-  const url = buildSearchUrl(code, query);
-  if (url) return url;
-  if (baseUrl) {
-    const domain = baseUrl.replace(/https?:\/\//, "").replace(/\/.*/, "");
-    const q = encodeURIComponent(query);
-    return `https://www.google.com/search?q=site:${domain}+${q}`;
-  }
-  return null;
-}
-
-/**
- * 判断数据源是否有直接搜索 URL（非 Google 回退）
+ * 判断数据源是否有直接搜索 URL（已注册的站内搜索模板）
  */
 export function hasDirectSearchUrl(code: string): boolean {
   return code in SEARCH_TEMPLATES;


### PR DESCRIPTION
## Summary
Repro (user screenshot): click \`搜索『智慧』\` on CBETA 大陆档案站 card → opens \`google.com/search?q=site:archive.cbetaonline.cn+智慧\` → 0 results.

Cause: \`buildSearchUrlWithFallback\` only checks \`base_url\`, not whether a direct search template is registered. For the 131 sources with \`supports_search=true\` but no template entry, and ~dozens more with \`supports_search=false\` but a \`base_url\`, it returns a Google \`site:\` URL that often yields nothing (download mirror, un-indexed site, etc.).

Fix: remove the Google fallback entirely. Button renders only when \`hasDirectSearchUrl(code)\` is true (template exists). Hero counter also switches from DB \`supports_search\` to real template coverage — 284 → 153 (honest number).

## Test plan
- [x] tsc + vite build
- [ ] Deploy → CBETA 大陆档案站 card has no 搜索 button
- [ ] CBETA (main) still shows 搜索 button linking to cbetaonline.dila.edu.tw/zh/search?q=...
- [ ] Hero banner shows "直达 153 个可搜索数据源"

Follow-up: the 131 sources with flag-but-no-template should either get templates added to \`searchPatterns.json\` or have the DB flag corrected. Not in scope here.