### PR TITLE
fix(sources): scroll to cards + banner after 生成直达

### DIFF
--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -348,15 +348,16 @@ export default function SourcesPage() {
               // on the hero — users don't see the per-card direct links and
               // think the button did nothing.
               requestAnimationFrame(() => {
+                const prefersReduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
                 document
                   .querySelector(".sources-toolbar")
-                  ?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  ?.scrollIntoView({ behavior: prefersReduced ? "auto" : "smooth", block: "start" });
               });
             }
           }}
         />
         {searchQuery && (
-          <div className="sources-hero-search-result">
+          <div className="sources-hero-search-result" role="status" aria-live="polite">
             已为 {counters.directSearch} 个数据源生成「{searchQuery}」直达链接 —— 下滑查看每张卡片的「搜索」按钮
           </div>
         )}

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -341,8 +341,25 @@ export default function SourcesPage() {
           allowClear
           value={tryInput}
           onChange={(e) => setTryInput(e.target.value)}
-          onSearch={(v) => setSearchQuery(v)}
+          onSearch={(v) => {
+            setSearchQuery(v);
+            if (v) {
+              // Without this the URL updates silently but the viewport stays
+              // on the hero — users don't see the per-card direct links and
+              // think the button did nothing.
+              requestAnimationFrame(() => {
+                document
+                  .querySelector(".sources-toolbar")
+                  ?.scrollIntoView({ behavior: "smooth", block: "start" });
+              });
+            }
+          }}
         />
+        {searchQuery && (
+          <div className="sources-hero-search-result">
+            已为 {counters.directSearch} 个数据源生成「{searchQuery}」直达链接 —— 下滑查看每张卡片的「搜索」按钮
+          </div>
+        )}
       </div>
 
       <div className="sources-trust">

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -71,6 +71,17 @@
   line-height: 1.5;
 }
 
+.sources-hero-search-result {
+  margin-top: 10px;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--fj-ink);
+  background: rgba(24, 144, 255, 0.08);
+  border-left: 3px solid #1890ff;
+  border-radius: 4px;
+  line-height: 1.5;
+}
+
 @media (max-width: 520px) {
   .sources-hero-search {
     padding: 14px 14px;


### PR DESCRIPTION
## 问题
`/sources` 页 hero 里的"生成直达"按钮用户报告"点了没反应"。

实测（线上 https://fojin.app/sources）：
- 按钮**确实**触发 onSearch → URL 写入 `?try=...` ✅
- 215 张卡片**确实**生成了站内搜索直达链接 ✅
- **但**视口停留在 hero，hero 本身零反馈 → 用户看不到任何变化

## 改动
1. `onSearch` 里加 `scrollIntoView('.sources-toolbar')`，让卡片区域滑入视口
2. Hero 底部在 `searchQuery` 非空时显示蓝色反馈条：「已为 N 个数据源生成「X」直达链接 —— 下滑查看每张卡片的「搜索」按钮」

## Test plan
- [x] `npm run build` 通过
- [ ] 部署后验证：输入关键词点按钮，页面平滑滚动到卡片区域
- [ ] hero 下方出现反馈条
- [ ] 回车和按钮点击行为一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)