### PR TITLE
feat(sources): batch 1 — DILA authority & glossaries direct-search

### DIFF
--- a/frontend/src/config/searchPatterns.json
+++ b/frontend/src/config/searchPatterns.json
@@ -151,5 +151,7 @@
   "utokyo-tobunken-nlc": "http://read.nlc.cn/allSearch/searchList?searchType=6&keyword={q}",
   "utokyo-shuanghong": "https://shuanghong.ioc.u-tokyo.ac.jp/search?q={q}",
   "russian-nel-guji": "https://rusneb.ru/search/?q={q}",
-  "hdcg-wenyuan": "https://wenyuan.aliyun.com/hdcg/search?q={q}"
+  "hdcg-wenyuan": "https://wenyuan.aliyun.com/hdcg/search?q={q}",
+  "dila-authority": "https://authority.dila.edu.tw/person/search.php?per={q}&isLikeSearch=1",
+  "dila-glossaries": "https://glossaries.dila.edu.tw/search?locale=zh-TW&term={q}"
 }


### PR DESCRIPTION
## 目标
填补 133 个"后端说可搜索但前端无直达模板"的缺口，第 1 批 DILA/CBETA 全家桶。

## 实测原则
遵循 #488 honest search：**浏览器真实打过且能 URL 直达的才入库**，不能做只能硬拍模板。

## 本批 5 选 2
| code | 结果 | 证据 |
|---|---|---|
| dila-authority | ✅ | `search.php?per={q}&isLikeSearch=1` — curl 返回 33KB、44 处"龍樹" |
| dila-glossaries | ✅ | `search?locale=zh-TW&term={q}` — curl 返回 115KB、634 处"般若" |
| buddhistlexicon-dila | ❌ | 2012 老站，仅分类导航，无关键词搜索 |
| cbeta-concordance | ❌ | SPA 内部状态搜索（browser 实测搜到 70K 条「般若」但 URL 不变） |
| cbeta-tripitaka | ❌ | 按部类目录，无搜索功能 |

## 影响
Hero 计数 `{counters.directSearch}`：**153 → 155**。

## Test plan
- [x] `npm run build` 通过
- [ ] 部署后在 /sources 搜索"般若"，DILA Authority 和 DILA Glossaries 卡片出现搜索链接
- [ ] 点击链接抵达对应站内结果页
- [ ] 其他 3 个 DILA/CBETA 卡片**仍无**搜索按钮（正确）

🤖 Generated with [Claude Code](https://claude.com/claude-code)