### PR TITLE
feat(sources): batch 2 — VRI Tipitaka direct-search templates

### DIFF
--- a/frontend/src/config/searchPatterns.json
+++ b/frontend/src/config/searchPatterns.json
@@ -153,5 +153,7 @@
   "russian-nel-guji": "https://rusneb.ru/search/?q={q}",
   "hdcg-wenyuan": "https://wenyuan.aliyun.com/hdcg/search?q={q}",
   "dila-authority": "https://authority.dila.edu.tw/person/search.php?per={q}&isLikeSearch=1",
-  "dila-glossaries": "https://glossaries.dila.edu.tw/search?locale=zh-TW&term={q}"
+  "dila-glossaries": "https://glossaries.dila.edu.tw/search?locale=zh-TW&term={q}",
+  "vri": "https://search.tipitaka.org/solr/web?q={q}",
+  "vri-tipitaka": "https://www.vridhamma.org/search/site/{q}"
 }


### PR DESCRIPTION
## 批次 2 总结
目标是 84000 全家桶 + VRI + DPPN + Access to Insight。实测 5 选 2。

| code | 结果 | 证据 |
|---|---|---|
| vri | ✅ | \`search.tipitaka.org/solr/web?q={q}\` — "dhamma" 返回 16 条 vs bogus 6 条 |
| vri-tipitaka | ✅ | \`www.vridhamma.org/search/site/{q}\` — 差分：真词无 "no results" 提示 |
| 84000-glossary | ❌ 跳过 | 搜索在 \`84000.vercel.app\` iframe 里，parent \`?search=\` 被忽略 |
| dppn | ❌ 跳过 | 后端 \`base_url: null\`，应先补数据层 |
| accesstoinsight / 84000 | — 已有模板 |

## 影响
Hero: **155 → 157**。

## 累计进度 (P0 批次 1+2)
| 起点 | 批次 1 | 批次 2 | 当前 |
|---|---|---|---|
| 153 | +2 DILA | +2 VRI | **157** |

## Test plan
- [x] \`npm run build\` 通过
- [ ] 部署后 /sources 搜索"dhamma"，VRI 两卡片亮起搜索链接
- [ ] 点击链接抵达真实结果页

🤖 Generated with [Claude Code](https://claude.com/claude-code)