### PR TITLE
feat(sources): restore dhammatalks & audiodharma with correct URLs

### DIFF
--- a/frontend/src/config/searchPatterns.json
+++ b/frontend/src/config/searchPatterns.json
@@ -96,5 +96,7 @@
   "dila-authority": "https://authority.dila.edu.tw/person/search.php?per={q}&isLikeSearch=1",
   "dila-glossaries": "https://glossaries.dila.edu.tw/search?locale=zh-TW&term={q}",
   "vri": "https://search.tipitaka.org/solr/web?q={q}",
-  "vri-tipitaka": "https://www.vridhamma.org/search/site/{q}"
+  "vri-tipitaka": "https://www.vridhamma.org/search/site/{q}",
+  "dhammatalks": "https://www.dhammatalks.org/search/?q={q}",
+  "audiodharma": "https://www.audiodharma.org/playables/search?query={q}"
 }


### PR DESCRIPTION
## Step 3 部分成果
PR #494 下架的 404 模板里，挑高价值的逐个 curl 实测真实搜索 URL。

### 本 PR 恢复 2 条
| code | 旧（坏）URL | 新（可用）URL |
|---|---|---|
| dhammatalks | /search.html?q= (404) | \`/search/?q={q}\` |
| audiodharma | /search?search= (404) | \`/playables/search?query={q}\` |

### 验证方法
- dhammatalks: \`compassion\` 返回 37KB 含 result items，bogus 返回 10KB 且含 "no results" 标记
- audiodharma: \`compassion\` 有 53 个 talk-result vs bogus 11（都是 UI 骨架），差分显著

### 尝试但无法恢复的
| code | 问题 |
|---|---|
| 84000 / read.84000.co | 搜索是 SPA，curl 不可验 |
| dharmamitra | SPA，/search/* 404 |
| wisdom-lib | POST-only，不能 GET 深链 |
| inbuds | search.php 吃参数不变 |
| palace-museum / fgs-digital / dzj-fosss | POST 或 ASP.NET 或 360.so 外挂 |
| palikanon | 403 / 复杂 |

这些要么等浏览器测（84000/dharmamitra），要么站本身不支持深链。

## 影响
Hero: **98 → 100**

## Test plan
- [x] \`npm run build\` 通过
- [ ] 部署后 /sources 搜"compassion"，dhammatalks 和 audiodharma 卡片生成搜索链接
- [ ] 点击跳过去能看到对应结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)