### PR TITLE
fix(sources): restore dhammatalks with corrected /search/ URL (98→99)

### DIFF
--- a/frontend/src/config/searchPatterns.json
+++ b/frontend/src/config/searchPatterns.json
@@ -96,5 +96,6 @@
   "dila-authority": "https://authority.dila.edu.tw/person/search.php?per={q}&isLikeSearch=1",
   "dila-glossaries": "https://glossaries.dila.edu.tw/search?locale=zh-TW&term={q}",
   "vri": "https://search.tipitaka.org/solr/web?q={q}",
-  "vri-tipitaka": "https://www.vridhamma.org/search/site/{q}"
+  "vri-tipitaka": "https://www.vridhamma.org/search/site/{q}",
+  "dhammatalks": "https://www.dhammatalks.org/search/?q={q}"
 }


### PR DESCRIPTION
## Context

Earlier today user flagged /sources shows "一键直达 98 个数据源" and asked if we could add high-quality new entries. Ran an end-to-end probe against a curated A-tier candidate list of 15 uncovered sources. Only **one** passed the same quality bar used by #494 (real/bogus control query); committing that alone — honesty over numbers.

## What was wrong

PR #494 pruned `dhammatalks` because `https://www.dhammatalks.org/search.html?q={q}` 404'd. Turned out the endpoint had moved — the site's own nav form actually posts to `/search/?q=`. The resource (Ajahn Geoff's canonical Pali talks & books) was mis-classified as permanently broken.

## Verification

```
q=buddha         → 200, 40269 bytes, title "Search results for: buddha"
                   contains search-result cards
q=zzzzqwerxyz42  → 200, 10637 bytes, explicit "No results"
```

Real vs. bogus differs by ~4x response size + explicit negative marker → passes the #494 delivery test.

## What did NOT make the cut

Probed 14 other A-tier candidates (CBETA-tripitaka, DILA sub-projects, GRETIL, Muller/DDB, wisdomlib, brill-buddhism, etc.). All either:
- SPA with hash routing / client-side only search (cbeta-concordance, mavb-dila, dunhuang-academy, etc.)
- Cloudflare/anti-bot blocking (wisdom-lib, dsbc)
- Auth-required (buddhism-dict.net DDB returns 401)
- Dead/stale entry forms (yuezang returns 0 results for any query)

Each would need manual browser reverse-engineering to produce a template that'd pass the same quality bar. Deferred for a future curated batch.

## Counter impact

directSearch: 98 → 99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
