### PR TITLE
perf(home): defer /api/sources fetch; save 77KB on 35% of traffic

### DIFF
--- a/backend/app/api/texts.py
+++ b/backend/app/api/texts.py
@@ -2,12 +2,13 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_optional_user
 from app.core.exceptions import TextNotFoundError
 from app.database import get_db
+from app.models.source import DataSource
 from app.models.text import BuddhistText
 from app.models.user import ReadingHistory, User
 from app.schemas.text import JuanContentResponse, JuanLanguagesResponse, JuanListResponse, TextResponseBase
@@ -133,11 +134,16 @@ async def read_juan(
 
 @router.get("/stats")
 async def stats(db: AsyncSession = Depends(get_db)):
-    """Get platform-wide statistics (total text count).
+    """Get platform-wide statistics (total text count + active source count).
 
     获取平台统计数据。"""
     count = await get_text_count(db)
-    return {"total_texts": count}
+    source_count = (
+        await db.execute(
+            select(func.count(DataSource.id)).where(DataSource.is_active.is_(True))
+        )
+    ).scalar() or 0
+    return {"total_texts": count, "source_count": int(source_count)}
 
 
 @router.get("/texts/{text_id}/juans/{juan_num}/similar", response_model=SimilarPassagesResponse)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -218,6 +218,7 @@ export interface Filters {
 
 export interface Stats {
   total_texts: number;
+  source_count: number;
 }
 
 export interface TextIdentifierInfo {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -31,7 +31,7 @@ export default function HomePage() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { data: stats } = useQuery({ queryKey: ["stats"], queryFn: getStats });
-  const { data: sources } = useQuery({ queryKey: ["sources"], queryFn: getSources });
+  const { data: sources } = useQuery({ queryKey: ["sources"], queryFn: getSources, enabled: sourceOpen });
   const { data: filters } = useQuery({ queryKey: ["filters"], queryFn: getFilters });
 
   const handleSearch = (q?: string) => {
@@ -52,7 +52,7 @@ export default function HomePage() {
   const langAllCount = filters?.languages_all
     ? new Set(filters.languages_all.map(getLangName)).size
     : 0;
-  const srcCount = sources?.length || 0;
+  const srcCount = stats?.source_count ?? 0;
   const srcLabel = selectedSources.size > 0
     ? t("home.selected_sources", { count: selectedSources.size })
     : t("home.all_sources");


### PR DESCRIPTION
## Context

Umami shows `/` at 35% of total traffic and `/search` at 14% — together ~half of visits. Audited their first-paint cost. The fattest single deferrable load is `/api/sources`: 77 KB gzipped / 532 rows, fetched eagerly on `/` only to render a count badge.

## Problem

HomePage.tsx:34 fires `getSources()` on every visit. The result is only consumed:
- HomePage.tsx:55 — `sources?.length` → number badge
- HomePage.tsx:111 — SourceSelector, **conditional on `sourceOpen` state** (expansion panel)

Per Umami, most homepage visitors never expand the panel. So 77 KB and one DB `SELECT * FROM sources` are paid every visit for a value used ~1% of the time.

## Fix

1. **Backend** `/api/stats` — return `source_count` alongside `total_texts`. One cheap `COUNT(*) WHERE is_active` replaces the full SELECT that HomePage was previously doing.
2. **HomePage** — add `enabled: sourceOpen` guard on the sources query, switch the badge to read `stats.source_count`.

React Query's shared cache means the sources payload is still populated once any consumer actually needs it (SourceSelector open, or user navigates to `/search`).

## Impact

- 77 KB gzip + ~200–400 ms saved on first paint for 35% of all visits
- `GET /api/sources` QPS drops in proportion to how often the panel is opened (small fraction per traffic data)
- `srcCount` now reflects **is_active=true** sources only — minor accuracy improvement over the former `sources.length`

## Not included

Originally proposed also adding 250 ms debounce to SearchPage. Audit showed it's not needed:
- SearchPage `query` only changes on submit / history-click / did-you-mean-click (already debounced by UX)
- Autocomplete suggestions already have a 300 ms `setTimeout` debounce (SearchPage.tsx:57)

The "per-keystroke fires 3–4 API calls" claim in my earlier analysis was wrong. Dropped that work item rather than add a useless debounce layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
