### PR TITLE
feat(chat): make desktop sidebar collapsible (claude.ai-style)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -191,5 +191,7 @@
   "chat.hot_question_category_plain_translation": "Plain translation",
   "chat.hot_question_category_scripture_exegesis": "Scripture exegesis",
   "chat.hot_question_category_comparison": "Comparison",
-  "chat.hot_question_category_buddhist_history": "Buddhist history"
+  "chat.hot_question_category_buddhist_history": "Buddhist history",
+  "chat.collapse_sidebar": "Collapse sidebar",
+  "chat.expand_sidebar": "Expand sidebar"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -191,5 +191,7 @@
   "chat.hot_question_category_plain_translation": "白話翻譯",
   "chat.hot_question_category_scripture_exegesis": "經文解讀",
   "chat.hot_question_category_comparison": "對比辨析",
-  "chat.hot_question_category_buddhist_history": "佛教史話"
+  "chat.hot_question_category_buddhist_history": "佛教史話",
+  "chat.collapse_sidebar": "收起側欄",
+  "chat.expand_sidebar": "展開側欄"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -191,5 +191,7 @@
   "chat.hot_question_category_plain_translation": "白话翻译",
   "chat.hot_question_category_scripture_exegesis": "经文解读",
   "chat.hot_question_category_comparison": "对比辨析",
-  "chat.hot_question_category_buddhist_history": "佛教史话"
+  "chat.hot_question_category_buddhist_history": "佛教史话",
+  "chat.collapse_sidebar": "收起侧栏",
+  "chat.expand_sidebar": "展开侧栏"
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -15,6 +15,8 @@ import {
   PlusOutlined,
   SettingOutlined,
   MenuOutlined,
+  MenuFoldOutlined,
+  MenuUnfoldOutlined,
   DownloadOutlined,
   StopOutlined,
   CopyOutlined,
@@ -251,6 +253,17 @@ export default function ChatPage() {
   const [messages, setMessages] = useState<ChatMessageItem[]>([]);
   const [sending, setSending] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem("fojin.chat.sidebarCollapsed") === "1";
+  });
+  const toggleSidebarCollapsed = () => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      try { window.localStorage.setItem("fojin.chat.sidebarCollapsed", next ? "1" : "0"); } catch { /* ignore */ }
+      return next;
+    });
+  };
   const [sessionFilter, setSessionFilter] = useState("");
   const tabIndexRef = useRef(-1);
   const [hasOlderMessages, setHasOlderMessages] = useState(false);
@@ -740,15 +753,30 @@ export default function ChatPage() {
         )}
 
         {/* Sidebar (desktop, logged in only) */}
-        {user && <div style={{ width: 220, flexShrink: 0, display: "flex", flexDirection: "column", gap: 8 }}
-             className="chat-sidebar">
-          <Button icon={<PlusOutlined />} block onClick={handleNewChat}>{t("chat.new_chat")}</Button>
-          <Button icon={<SettingOutlined />} block type="text" size="small"
+        {user && <div style={{ width: sidebarCollapsed ? 48 : 220, flexShrink: 0, display: "flex", flexDirection: "column", gap: 8, transition: "width 0.18s ease" }}
+             className="chat-sidebar"
+             data-collapsed={sidebarCollapsed || undefined}>
+          <Tooltip title={sidebarCollapsed ? t("chat.expand_sidebar") : t("chat.collapse_sidebar")} placement="right">
+            <Button
+              type="text"
+              size="small"
+              icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+              onClick={toggleSidebarCollapsed}
+              aria-label={sidebarCollapsed ? t("chat.expand_sidebar") : t("chat.collapse_sidebar")}
+              style={{ alignSelf: sidebarCollapsed ? "center" : "flex-end", color: "var(--fj-ink-muted)" }}
+            />
+          </Tooltip>
+          <Tooltip title={sidebarCollapsed ? t("chat.new_chat") : ""} placement="right">
+            <Button icon={<PlusOutlined />} block={!sidebarCollapsed} onClick={handleNewChat} aria-label={t("chat.new_chat")}>
+              {!sidebarCollapsed && t("chat.new_chat")}
+            </Button>
+          </Tooltip>
+          {!sidebarCollapsed && <Button icon={<SettingOutlined />} block type="text" size="small"
             style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
             onClick={() => navigate("/profile?tab=apikey")}>
             {keyStatus?.has_api_key ? `${t("chat.key_configured")} (${keyStatus.provider})` : t("chat.configure_key")}
-          </Button>
-          {sessions && sessions.length > 5 && (
+          </Button>}
+          {!sidebarCollapsed && sessions && sessions.length > 5 && (
             <Input
               placeholder="搜索会话..."
               size="small"
@@ -758,7 +786,7 @@ export default function ChatPage() {
               style={{ marginTop: 4, fontSize: 12 }}
             />
           )}
-          <div style={{ flex: 1, overflow: "auto", marginTop: 8 }}>
+          {!sidebarCollapsed && <div style={{ flex: 1, overflow: "auto", marginTop: 8 }}>
             {groupedSessions.map((group) => (
               <div key={group.label}>
                 <div style={{ fontSize: 11, color: "var(--fj-ink-muted)", opacity: 0.6, padding: "6px 12px 2px", fontWeight: 500 }}>
@@ -790,7 +818,7 @@ export default function ChatPage() {
                 ))}
               </div>
             ))}
-          </div>
+          </div>}
         </div>}
 
         {/* Chat area */}


### PR DESCRIPTION
## What

Makes the desktop chat-history sidebar on `/chat` collapsible, mirroring the claude.ai pattern.

## Why

User request — on narrow laptop screens the fixed 220 px sidebar eats too much horizontal space. Want to be able to hide it and reclaim the room for the reading/chat area, then bring it back in one click when switching sessions.

## Behavior

- Collapse/expand icon-button at the top-right of the sidebar (MenuFoldOutlined / MenuUnfoldOutlined)
- Expanded (default): current behaviour — 220 px wide, full history list, search, key-status
- Collapsed: **48 px** wide, showing only the toggle and the "＋ new chat" button (icon-only, tooltipped). Everything else (search input, key-config button, session list) is hidden
- Preference is persisted in `localStorage["fojin.chat.sidebarCollapsed"]` so it sticks across page refreshes
- Width change animates (180 ms)
- Mobile drawer behaviour unchanged — this only affects the desktop flex sidebar (`@media >= 769 px`)

## Accessibility

- Toggle button has `aria-label` that flips between "collapse sidebar" / "expand sidebar" (translated in zh / zh-Hant / en)
- Collapsed "＋ new chat" keeps its `aria-label` so screen readers still announce it

## Not affected

- Mobile drawer (`sidebarOpen`) logic is untouched
- i18n added in 3 locales; other languages fall through to `zh` default per existing i18n config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
