### PR TITLE
chore(llm): switch default model to DeepSeek V4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ FRONTEND_PORT=3000
 # LLM (OpenAI-compatible)
 LLM_API_KEY=sk-your-llm-api-key
 LLM_API_URL=https://api.deepseek.com/v1
+# Model selection (uncomment to override the gpt-4o-mini default in config.py)
+#   deepseek-v4-flash : fast tier, $0.28/1M output  (replaces legacy deepseek-chat)
+#   deepseek-v4-pro   : pro tier,  $0.87/1M output  (75% promo until 2026-05-31; post-promo $3.48/1M)
+# LLM_MODEL=deepseek-v4-pro
 
 # Embedding
 EMBEDDING_API_KEY=sk-your-embedding-api-key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to FoJin will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+- Default DeepSeek model alias `deepseek-chat` → `deepseek-v4-flash` (legacy ID still works as alias). Production `LLM_MODEL` upgraded to `deepseek-v4-pro` to leverage 75% promotional pricing through 2026-05-31; revisit before promo ends to avoid 4× cost increase.
+- Updated `build_alignments.py` price table with `deepseek-v4-flash` ($0.28/1M output) and `deepseek-v4-pro` ($0.87/1M output, promo).
+
 ## [3.4.0] — 2026-03-23
 
 ### Added

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -55,7 +55,7 @@ PROVIDER_URLS = {
 # Provider → default model
 PROVIDER_DEFAULT_MODELS = {
     # 国内
-    "deepseek": "deepseek-chat",
+    "deepseek": "deepseek-v4-flash",
     "dashscope": "qwen-plus",
     "zhipu": "glm-4-flash",
     "moonshot": "moonshot-v1-8k",

--- a/backend/scripts/build_alignments.py
+++ b/backend/scripts/build_alignments.py
@@ -80,8 +80,10 @@ LLM_PRICE_PER_1K = {
     "claude-haiku-4-5-20251001": 0.0008,
     "gpt-4o-mini": 0.00015,
     "qwen-plus": 0.0004,
-    "deepseek-chat": 0.00027,    # FoJin's current main LLM (DeepSeek V3)
-    "deepseek-reasoner": 0.0014,
+    "deepseek-chat": 0.00028,         # legacy alias → deepseek-v4-flash (non-thinking)
+    "deepseek-reasoner": 0.0014,      # legacy alias → deepseek-v4-flash (thinking)
+    "deepseek-v4-flash": 0.00028,     # output $0.28/1M tokens
+    "deepseek-v4-pro": 0.00087,       # output $0.87/1M @ 75% promo until 2026-05-31 15:59 UTC; post-promo $3.48/1M (4×) — REVISIT BEFORE 2026-05-31
 }
 DEFAULT_PRICE_PER_1K = 0.0008    # unknown model → use Haiku estimate
 


### PR DESCRIPTION
## Summary

- Update `PROVIDER_DEFAULT_MODELS["deepseek"]` from `deepseek-chat` → `deepseek-v4-flash`. The legacy `deepseek-chat` ID continues to work as an upstream alias, so BYOK users with custom configs are unaffected. Same cost (~\$0.28/1M output).
- Add `deepseek-v4-flash` and `deepseek-v4-pro` to `build_alignments.py` price table with promotional pricing notes.
- Document `LLM_MODEL=deepseek-v4-pro` override in `.env.example`.
- CHANGELOG `[Unreleased]` entry.

## Production rollout

Production `.env` on the VPS will set `LLM_MODEL=deepseek-v4-pro` to leverage the **75% promotional pricing** (output \$0.87/1M, valid until **2026-05-31 15:59 UTC**). Post-promo list price is 4× (\$3.48/1M output) — must revisit before the window closes. The `REVISIT BEFORE 2026-05-31` comment in the price table is the in-code reminder.

## Why two tiers

| | flash (default) | pro (production) |
|---|---|---|
| Output | \$0.28/1M | \$0.87/1M (promo) → \$3.48/1M (list) |
| Use | BYOK fallback, self-hosters | Platform-served chat, build_alignments |

Self-hosters defaulting to `flash` keeps their bills predictable when promo expires.

## Test plan

- [x] Code defaults are config strings only — no runtime call needed for unit verification
- [ ] After merge, set `LLM_MODEL=deepseek-v4-pro` in production `.env`, restart `fojin-backend`
- [ ] Smoke-test 3 chat flows (general QA / master persona / meta-question)
- [ ] Spot-check `build_alignments.py --dry-run` cost estimate uses new price

🤖 Generated with [Claude Code](https://claude.com/claude-code)