### PR TITLE
feat(byok): recommended model chips for DeepSeek

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -9,6 +9,16 @@ import { getBookmarks, getHistory, getApiKeyStatus, saveApiKey, deleteApiKey, ch
 
 const { Title } = Typography;
 
+// Recommended model presets per provider — clicking a chip fills the model field.
+// Users can still type any custom model ID. Keep prices accurate; revisit when
+// providers change pricing or release new model tiers.
+const PROVIDER_MODELS: Record<string, Array<{ value: string; label: string; hint: string }>> = {
+  deepseek: [
+    { value: "deepseek-v4-flash", label: "V4 Flash", hint: "$0.28/1M output · 推荐日常" },
+    { value: "deepseek-v4-pro", label: "V4 Pro", hint: "$0.87/1M output · 75% 促销至 2026-05-31" },
+  ],
+};
+
 const PROVIDERS = [
   // 国内
   { value: "deepseek", label: "DeepSeek" },
@@ -329,6 +339,26 @@ export default function ProfilePage() {
                         placeholder="留空使用默认模型"
                         style={{ marginTop: 4 }}
                       />
+                      {PROVIDER_MODELS[provider] && (
+                        <Space wrap size={[6, 6]} style={{ marginTop: 8 }}>
+                          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                            推荐：
+                          </Typography.Text>
+                          {PROVIDER_MODELS[provider].map((m) => (
+                            <Tag.CheckableTag
+                              key={m.value}
+                              checked={apiModel === m.value}
+                              onChange={() => setApiModel(m.value)}
+                              style={{ cursor: "pointer", border: "1px solid #d9d9d9" }}
+                            >
+                              <span style={{ fontWeight: 500 }}>{m.label}</span>
+                              <span style={{ marginLeft: 6, color: "#8c8c8c", fontSize: 11 }}>
+                                {m.hint}
+                              </span>
+                            </Tag.CheckableTag>
+                          ))}
+                        </Space>
+                      )}
                     </div>
                     <Button type="primary" loading={saving} onClick={handleSaveKey}>
                       保存 API Key


### PR DESCRIPTION
## Summary

The BYOK 模型 field was a blank \`Input\` — users had no idea what model ID string to type. Add clickable preset chips that auto-fill the input.

- New \`PROVIDER_MODELS\` map (currently only \`deepseek\`)
- Renders \`Tag.CheckableTag\` chips below the model input when the selected provider has recommendations
- Each chip shows tier name + price hint (e.g. \"V4 Pro · \$0.87/1M output · 75% 促销至 2026-05-31\")
- Click → sets \`apiModel\`; users can still type a custom ID
- Other providers unchanged (extensible: add a key to \`PROVIDER_MODELS\` to enable chips)

## Test plan

- [x] tsc clean
- [ ] /profile → API Key 标签 → 选 DeepSeek → 看到两个 chip
- [ ] 点 V4 Pro chip → 输入框填 \`deepseek-v4-pro\`
- [ ] 切其他 provider → chip 消失（不污染）
- [ ] 手动输入自定义 ID 仍生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)