### PR TITLE
feat(sources): backfill 28 fields + 仅看全文 toggle

### DIFF
--- a/backend/alembic/versions/0123_backfill_source_research_fields.py
+++ b/backend/alembic/versions/0123_backfill_source_research_fields.py
@@ -1,0 +1,71 @@
+"""Backfill research_fields for 28 sources flagged by the audit.
+
+Sources page audit (2026-05-01) found 28 active sources with NULL
+research_fields, mostly classical Chinese Buddhist dictionaries and a few
+multilingual reference works. Without a tag they vanish from the eight-
+category research filter on /sources.
+
+Buckets:
+- 'dictionary,han'       : 21 classical Chinese dictionaries / reference works
+- 'dictionary,theravada' : DPPN (Pali proper names)
+- 'dictionary,theravada,han'   : Buddhadatta Pali → Chinese
+- 'dictionary,sanskrit'  : Apte Sanskrit-English
+- 'dictionary,sanskrit,han'    : Mahāvyutpatti (Sa↔Zh)
+- 'dictionary,han,sanskrit'    : Siyi Hebi (Sa/Mn/Mnc/Zh polyglot)
+- 'dictionary,han,tibetan,sanskrit' : Pentaglot
+- 'art'                  : Cambridge Digital Library (manuscript images)
+
+Revision ID: 0123
+Revises: 0122
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0123"
+down_revision = "0122"
+branch_labels = None
+depends_on = None
+
+BUCKETS: dict[str, list[str]] = {
+    "dictionary,han": [
+        "foguang", "zhonghua-baike", "bs-faxiang", "weishi", "tiantai",
+        "dila-nanshanlu", "abhidharma", "sanzang-fashu", "fanyi-mingyi",
+        "suyu-foyuan", "bs-yiqiejing-yinyi", "bs-xu-yinyi", "bs-suihan-lu",
+        "bs-fanfanyu", "bs-agama", "bs-changjianci", "fxcd-tongbian",
+        "zuting-shiyuan", "chanzong-tiyao", "shishi-yaolan", "yuezang-zhijin",
+    ],
+    "dictionary,theravada": ["dppn"],
+    "dictionary,theravada,han": ["dila-plc"],
+    "dictionary,sanskrit": ["cdsl-apte"],
+    "dictionary,sanskrit,han": ["dila-mvp"],
+    "dictionary,han,sanskrit": ["siyi-hebi"],
+    "dictionary,han,tibetan,sanskrit": ["dila-ptg"],
+    "art": ["cudl"],
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # Idempotent: only fill when current value is NULL or empty, never overwrite
+    # an explicit choice made later.
+    for fields, codes in BUCKETS.items():
+        conn.execute(
+            text(
+                "UPDATE buddhist_sources "
+                "SET research_fields = :fields "
+                "WHERE code = ANY(:codes) "
+                "AND (research_fields IS NULL OR research_fields = '')"
+            ),
+            {"fields": fields, "codes": codes},
+        )
+
+
+def downgrade() -> None:
+    # Reverting blanks all 28 back to NULL.
+    conn = op.get_bind()
+    all_codes = [c for codes in BUCKETS.values() for c in codes]
+    conn.execute(
+        text("UPDATE buddhist_sources SET research_fields = NULL WHERE code = ANY(:codes)"),
+        {"codes": all_codes},
+    )

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -28,6 +28,7 @@ export default function SourcesPage() {
   const regionFilter = searchParams.get("region") ?? "all";
   const langFilter = searchParams.get("lang") ?? "all";
   const fieldFilter = searchParams.get("field") ?? "all";
+  const fulltextOnly = searchParams.get("fulltext") === "1";
   const searchQuery = searchParams.get("try") ?? "";
   const rawGroupBy = searchParams.get("group") ?? "";
   const groupBy: GroupBy = (VALID_GROUP_BY as readonly string[]).includes(rawGroupBy)
@@ -63,6 +64,10 @@ export default function SourcesPage() {
   );
   const setFieldFilter = useCallback(
     (v: string) => updateParam("field", v, "all"),
+    [updateParam],
+  );
+  const setFulltextOnly = useCallback(
+    (v: boolean) => updateParam("fulltext", v ? "1" : "", ""),
     [updateParam],
   );
   const setSearchQuery = useCallback(
@@ -201,9 +206,12 @@ export default function SourcesPage() {
         const fields = (s.research_fields || "").split(",").map((f) => f.trim());
         if (!fields.includes(fieldFilter)) return false;
       }
+      if (fulltextOnly && !s.has_local_fulltext && !s.has_remote_fulltext) {
+        return false;
+      }
       return true;
     });
-  }, [sources, search, regionFilter, langFilter, fieldFilter]);
+  }, [sources, search, regionFilter, langFilter, fieldFilter, fulltextOnly]);
 
   const grouped = useMemo(() => {
     const map: Record<string, DataSource[]> = {};
@@ -428,6 +436,14 @@ export default function SourcesPage() {
             ...researchFields.map((f) => ({ value: f, label: FIELD_NAMES[f] || f })),
           ]}
         />
+        <button
+          type="button"
+          className={`sources-toggle-chip${fulltextOnly ? " is-active" : ""}`}
+          onClick={() => setFulltextOnly(!fulltextOnly)}
+          title="只显示已入库或外站可读全文的源（隐藏纯链接目录）"
+        >
+          {fulltextOnly ? "✓ " : ""}仅看全文 ({counters.local + counters.remote})
+        </button>
         <Select
           value={groupBy}
           onChange={setGroupBy}

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -502,6 +502,32 @@
   font-size: 16px;
 }
 
+/* ---------- 过滤切换 chip ---------- */
+.sources-toggle-chip {
+  height: 32px;
+  padding: 0 14px;
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 13px;
+  color: #595959;
+  cursor: pointer;
+  transition: all 0.18s;
+  white-space: nowrap;
+}
+
+.sources-toggle-chip:hover {
+  border-color: var(--fj-gold);
+  color: var(--fj-gold);
+}
+
+.sources-toggle-chip.is-active {
+  background: var(--fj-gold);
+  border-color: var(--fj-gold);
+  color: #fff;
+  font-weight: 500;
+}
+
 /* ---------- 响应式 ---------- */
 @media (max-width: 768px) {
   .sources-toolbar {


### PR DESCRIPTION
## Why

Audit of /sources (\`fojin.app/api/sources?size=1000\` + \`/api/sources/stats\`) revealed:

- **28 active sources have NULL \`research_fields\`** → invisible to the 8-category research filter. Mostly classical Chinese dictionaries: foguang, zhonghua-baike, weishi, tiantai, abhidharma, bs-yiqiejing-yinyi, fanyi-mingyi, suyu-foyuan, fxcd-tongbian, zuting-shiyuan, chanzong-tiyao, etc. (21 \`dictionary,han\`); plus dppn (\`dictionary,theravada\`), dila-plc, dila-mvp, dila-ptg, siyi-hebi, cdsl-apte, cudl.
- **532 listed sources but only ~30 have local OR remote fulltext** — the page conflates substantive content sources with link directories. No way for a user to focus on the former.

## Changes

### Backend — migration 0123

Idempotent UPDATEs by code → research_fields bucket. \`WHERE research_fields IS NULL OR research_fields = ''\` so a manually-set value is never overwritten. Downgrade reverts to NULL.

### Frontend — \`?fulltext=1\` toggle

A single chip in the filter row: **「仅看全文 (N)」**. Filters to \`has_local_fulltext || has_remote_fulltext\`. URL-synced for shareable links.

## Test plan

- [x] Python AST parse OK
- [x] ruff clean
- [x] tsc clean
- [ ] After migration: \`/sources?field=dictionary\` should now show all 21+ Chinese Buddhist dictionaries
- [ ] \`/sources?fulltext=1\` should collapse the list to ~30 sources with actual content
- [ ] Combining filters (e.g. \`field=theravada&fulltext=1\`) should AND correctly

## Out of scope (future)

- Source URL health monitoring cron (HEAD checker → \`last_check_at/status\` columns)
- Fix VRI / kanseki-repo char_count stats bug (\`text_count > 0\` but \`char_count = 0\`)
- 主动 ingest 列表（DSBC / Gandhari / 高麗藏 / DPD）

🤖 Generated with [Claude Code](https://claude.com/claude-code)