### PR TITLE
feat(sources): add Plum Village Mindfulness Gems data source

### DIFF
--- a/backend/alembic/versions/0124_add_plumvillage_gems_source.py
+++ b/backend/alembic/versions/0124_add_plumvillage_gems_source.py
@@ -1,0 +1,53 @@
+"""Add Plum Village Mindfulness Gems as a new data source.
+
+User-requested addition (2026-05-01). Distinct from the existing
+'lang-mai-archive' (plumvillage.org/library/) — /gems/ is the curated
+daily-wisdom feed of Thich Nhat Hanh's short teachings, themed quote
+collection. Useful as an entry-point for Engaged Buddhism / mindfulness
+practitioners and shorter than full-talk archive.
+
+Revision ID: 0124
+Revises: 0123
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0124"
+down_revision = "0123"
+branch_labels = None
+depends_on = None
+
+SOURCE = {
+    "code": "plumvillage-gems",
+    "name_zh": "梅村正念之珠（一行禅师每日法语）",
+    "name_en": "Plum Village Mindfulness Gems",
+    "base_url": "https://plumvillage.org/gems/",
+    "description": "梅村官方策展的一行禅师短法语合集，按正念、慈悲、相即、苦与转化等主题分类，含图文与音频，面向入世佛教与正念修习者",
+    "region": "法国",
+    "languages": "en,vi,fr",
+    "research_fields": "han,theravada",
+    "access_type": "open",
+}
+
+
+def upgrade() -> None:
+    s = SOURCE
+    name_en = f"'{s['name_en']}'" if s["name_en"] else "NULL"
+    desc = s["description"].replace("'", "''")
+    name_zh = s["name_zh"].replace("'", "''")
+    op.execute(
+        text(
+            f"INSERT INTO data_sources "
+            f"(code, name_zh, name_en, base_url, description, "
+            f"access_type, region, languages, research_fields, sort_order, is_active) "
+            f"VALUES ('{s['code']}', '{name_zh}', {name_en}, '{s['base_url']}', "
+            f"'{desc}', '{s['access_type']}', '{s['region']}', "
+            f"'{s['languages']}', '{s['research_fields']}', 0, true) "
+            f"ON CONFLICT (code) DO NOTHING"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(text(f"DELETE FROM data_sources WHERE code = '{SOURCE['code']}'"))


### PR DESCRIPTION
## Summary
- 新增数据源 `plumvillage-gems` (https://plumvillage.org/gems/) — 梅村官方策展的一行禅师每日法语主题集合
- 与已有 `lang-mai-archive` (/library/) 互补：library 是全集档案，gems 是按主题（正念、慈悲、相即、苦与转化）策展的短法语入口
- 字段：region=法国，languages=en,vi,fr，research_fields=han,theravada，access_type=open

## Migration
- `0124_add_plumvillage_gems_source.py`（链：0123 → 0124）
- 单条 INSERT，`ON CONFLICT (code) DO NOTHING`，downgrade 仅删该 code

## Test plan
- [x] 本地 ast 语法检查通过
- [ ] merge 后 webhook 触发 backend 重启 → entrypoint `alembic upgrade head` 生效
- [ ] 验证 /sources 页出现「梅村正念之珠」条目（region=法国，研究方向：汉传/南传）

🤖 Generated with [Claude Code](https://claude.com/claude-code)