### PR TITLE
feat(sources): clickable capability chips + badge tooltips (P0 UX)

### DIFF
--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -17,8 +17,18 @@ import {
 import "../styles/sources.css";
 
 type GroupBy = "region" | "field" | "lang";
+type Capability = "direct" | "local" | "remote" | "iiif" | "api";
 
 const VALID_GROUP_BY: readonly GroupBy[] = ["region", "field", "lang"] as const;
+const VALID_CAPABILITY: readonly Capability[] = ["direct", "local", "remote", "iiif", "api"] as const;
+
+const CAPABILITY_LABELS: Record<Capability, { label: string; tip: string }> = {
+  direct: { label: "可一键直达", tip: "已注册站内搜索模板，点击卡片「搜索」即可跳到对应站点的结果页" },
+  local: { label: "已入库全文", tip: "正文已入库 FoJin 数据库，可在站内直接阅读、引用与全文检索" },
+  remote: { label: "外站全文", tip: "全文托管在原站，跳转后可阅读，本站仅做导航与去重" },
+  iiif: { label: "影像", tip: "提供 IIIF 或高清扫描影像，适合写本、刻本、绘画等视觉资源" },
+  api: { label: "API", tip: "提供机读 API（REST / RDF / IIIF 等），可程序化调用" },
+};
 
 export default function SourcesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -34,6 +44,10 @@ export default function SourcesPage() {
   const groupBy: GroupBy = (VALID_GROUP_BY as readonly string[]).includes(rawGroupBy)
     ? (rawGroupBy as GroupBy)
     : "region";
+  const rawCap = searchParams.get("cap") ?? "";
+  const capability: Capability | null = (VALID_CAPABILITY as readonly string[]).includes(rawCap)
+    ? (rawCap as Capability)
+    : null;
 
   const updateParam = useCallback(
     (key: string, value: string, defaultValue: string) => {
@@ -73,6 +87,14 @@ export default function SourcesPage() {
   const setSearchQuery = useCallback(
     (v: string) => updateParam("try", v, ""),
     [updateParam],
+  );
+  const setCapability = useCallback(
+    (v: Capability | null) => updateParam("cap", v ?? "", ""),
+    [updateParam],
+  );
+  const toggleCapability = useCallback(
+    (v: Capability) => setCapability(capability === v ? null : v),
+    [capability, setCapability],
   );
   const setGroupBy = useCallback(
     (v: GroupBy) => {
@@ -209,9 +231,16 @@ export default function SourcesPage() {
       if (fulltextOnly && !s.has_local_fulltext && !s.has_remote_fulltext) {
         return false;
       }
+      if (capability) {
+        if (capability === "direct" && !hasDirectSearchUrl(s.code)) return false;
+        if (capability === "local" && !s.has_local_fulltext) return false;
+        if (capability === "remote" && !s.has_remote_fulltext) return false;
+        if (capability === "iiif" && !s.supports_iiif) return false;
+        if (capability === "api" && !s.supports_api) return false;
+      }
       return true;
     });
-  }, [sources, search, regionFilter, langFilter, fieldFilter, fulltextOnly]);
+  }, [sources, search, regionFilter, langFilter, fieldFilter, fulltextOnly, capability]);
 
   const grouped = useMemo(() => {
     const map: Record<string, DataSource[]> = {};
@@ -326,10 +355,43 @@ export default function SourcesPage() {
       </Helmet>
       <div className="sources-header">
         <h1 className="sources-title">数据源导航</h1>
-        <p className="sources-desc">
-          聚合全球 {total} 个佛教数字资源：
-          {counters.directSearch} 可一键直达 · {counters.local} 已入库全文 · {counters.remote} 外站全文 · {counters.iiif} 影像 · {counters.api} API
-        </p>
+        <p className="sources-desc">聚合全球 {total} 个佛教数字资源 · 点击下方能力筛选</p>
+        <div className="sources-cap-chips" role="group" aria-label="按能力过滤">
+          {(
+            [
+              { key: "direct", count: counters.directSearch },
+              { key: "local", count: counters.local },
+              { key: "remote", count: counters.remote },
+              { key: "iiif", count: counters.iiif },
+              { key: "api", count: counters.api },
+            ] as { key: Capability; count: number }[]
+          ).map(({ key, count }) => {
+            const active = capability === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                className={`sources-cap-chip sources-cap-chip-${key}${active ? " is-active" : ""}`}
+                onClick={() => toggleCapability(key)}
+                title={CAPABILITY_LABELS[key].tip}
+                aria-pressed={active}
+              >
+                <strong>{count}</strong>
+                <span>{CAPABILITY_LABELS[key].label}</span>
+              </button>
+            );
+          })}
+          {capability && (
+            <button
+              type="button"
+              className="sources-cap-chip-clear"
+              onClick={() => setCapability(null)}
+              aria-label="清除能力筛选"
+            >
+              清除
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="sources-hero-search">

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -1,4 +1,4 @@
-import { Tag } from "antd";
+import { Tag, Tooltip } from "antd";
 import {
   ApiOutlined,
   FileImageOutlined,
@@ -50,29 +50,39 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
         </div>
         <div className="source-card-badges">
           {s.has_local_fulltext && (
-            <Tag color="green" className="source-card-badge">
-              <ReadOutlined /> 已入库
-            </Tag>
+            <Tooltip title="正文已入库 FoJin 数据库，可在站内直接阅读、引用与全文检索">
+              <Tag color="green" className="source-card-badge">
+                <ReadOutlined /> 已入库
+              </Tag>
+            </Tooltip>
           )}
           {s.has_remote_fulltext && !s.has_local_fulltext && (
-            <Tag color="cyan" className="source-card-badge">
-              <ReadOutlined /> 外站全文
-            </Tag>
+            <Tooltip title="全文托管在原站，跳转后可阅读，本站仅做导航与去重">
+              <Tag color="cyan" className="source-card-badge">
+                <ReadOutlined /> 外站全文
+              </Tag>
+            </Tooltip>
           )}
           {s.supports_search && (
-            <Tag color="blue" className="source-card-badge">
-              <SearchOutlined /> 可搜索
-            </Tag>
+            <Tooltip title="原站提供搜索功能；若已注册 URL 模板，下方会出现「搜索」直达按钮">
+              <Tag color="blue" className="source-card-badge">
+                <SearchOutlined /> 可搜索
+              </Tag>
+            </Tooltip>
           )}
           {s.supports_iiif && (
-            <Tag color="purple" className="source-card-badge">
-              <FileImageOutlined /> 影像
-            </Tag>
+            <Tooltip title="提供 IIIF 或高清扫描影像（写本、刻本、绘画等）">
+              <Tag color="purple" className="source-card-badge">
+                <FileImageOutlined /> 影像
+              </Tag>
+            </Tooltip>
           )}
           {s.supports_api && (
-            <Tag color="orange" className="source-card-badge">
-              <ApiOutlined /> API
-            </Tag>
+            <Tooltip title="提供机读 API（REST / RDF / IIIF 等），可程序化调用">
+              <Tag color="orange" className="source-card-badge">
+                <ApiOutlined /> API
+              </Tag>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -25,7 +25,86 @@
 .sources-desc {
   font-size: 14px;
   color: var(--fj-ink-muted);
-  margin: 0;
+  margin: 0 0 10px;
+}
+
+/* ---------- 顶部能力 chip ---------- */
+.sources-cap-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.sources-cap-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid #e5dccb;
+  background: #fff;
+  cursor: pointer;
+  font-size: 13px;
+  color: #595959;
+  transition: all 0.18s;
+  line-height: 1.2;
+}
+
+.sources-cap-chip strong {
+  font-family: "Noto Serif SC", serif;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.sources-cap-chip:hover {
+  border-color: var(--fj-gold, #b08d57);
+  color: var(--fj-ink);
+}
+
+.sources-cap-chip:focus-visible,
+.sources-cap-chip-clear:focus-visible {
+  outline: 2px solid var(--fj-gold, #b08d57);
+  outline-offset: 2px;
+}
+
+.sources-cap-chip.is-active {
+  background: var(--fj-gold, #b08d57);
+  border-color: var(--fj-gold, #b08d57);
+  color: #fff;
+}
+
+.sources-cap-chip.is-active strong {
+  color: #fff;
+}
+
+/* color hints (inactive only — left border accent matches the badge color) */
+.sources-cap-chip-direct  { border-left: 3px solid #2f6fb1; }
+.sources-cap-chip-local   { border-left: 3px solid #389e0d; }
+.sources-cap-chip-remote  { border-left: 3px solid #08979c; }
+.sources-cap-chip-iiif    { border-left: 3px solid #722ed1; }
+.sources-cap-chip-api     { border-left: 3px solid #d4720c; }
+
+.sources-cap-chip.is-active.sources-cap-chip-direct,
+.sources-cap-chip.is-active.sources-cap-chip-local,
+.sources-cap-chip.is-active.sources-cap-chip-remote,
+.sources-cap-chip.is-active.sources-cap-chip-iiif,
+.sources-cap-chip.is-active.sources-cap-chip-api {
+  border-left-color: rgba(255, 255, 255, 0.5);
+}
+
+.sources-cap-chip-clear {
+  border: none;
+  background: transparent;
+  color: var(--fj-ink-muted);
+  cursor: pointer;
+  font-size: 12.5px;
+  padding: 4px 8px;
+  text-decoration: underline;
+}
+
+.sources-cap-chip-clear:hover {
+  color: var(--fj-gold, #b08d57);
 }
 
 /* ---------- 跨源搜索 Hero ---------- */


### PR DESCRIPTION
## Summary
P0 UX upgrades to /sources, surfaced from analysis of fojin.app/sources:

- **可点击能力 chips**：把顶部统计行（"X 可一键直达 · Y 已入库全文 · …"）变成 5 个可切换的能力筛选 chips，绑定到新 URL 参数 `cap=direct|local|remote|iiif|api`。再次点击同一 chip 或点「清除」即取消。
- **徽章 tooltip**：SourceCard 里的 5 种 badge（已入库 / 外站全文 / 可搜索 / 影像 / API）全部用 antd `<Tooltip>` 包起来，hover 显示定义，避免新用户混淆"已入库 vs 外站全文"。
- 顺手补 `:focus-visible` 让键盘用户能看到焦点环。

筛选融入现有 `filtered` useMemo，与 groupBy / 自由文本搜索 / 仅看全文 等其他筛选 AND 组合；分享链接 `?cap=iiif` 可直接复现状态。

## Test plan
- [x] `npx tsc --noEmit` 通过
- [x] `npm run build` 通过
- [x] dev 环境点击 chip → URL 更新到 `?cap=direct`，`.is-active` 样式应用
- [x] 再次点击 → URL 清空，active 态消失
- [x] 「清除」按钮在有 active chip 时出现，点击恢复全部
- [ ] 部署后真实数据下肉眼检查每个 chip 计数与筛选结果一致
- [ ] 手机端 chip 横向 wrap 是否拥挤

🤖 Generated with [Claude Code](https://claude.com/claude-code)