### PR TITLE
chore(sources): sort capability chips by count desc

### DIFF
--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -365,7 +365,10 @@ export default function SourcesPage() {
               { key: "iiif", count: counters.iiif },
               { key: "api", count: counters.api },
             ] as { key: Capability; count: number }[]
-          ).map(({ key, count }) => {
+          )
+            .slice()
+            .sort((a, b) => b.count - a.count)
+            .map(({ key, count }) => {
             const active = capability === key;
             return (
               <button


### PR DESCRIPTION
## Summary
顶部能力 chip 改为按数量降序排列：**100 可一键直达 / 69 外站全文 / 44 影像 / 18 API / 4 已入库全文**。原顺序按插入序，把"4 已入库全文"夹在两个大数中间，视觉跳跃。

## Test plan
- [x] tsc 通过
- [ ] 部署后 chip 顺序为 100→69→44→18→4