### PR TITLE
fix(0125): escape single quotes in all text columns

### DIFF
--- a/backend/alembic/versions/0125_add_8_text_focused_sources.py
+++ b/backend/alembic/versions/0125_add_8_text_focused_sources.py
@@ -141,9 +141,15 @@ SOURCES = [
 
 def upgrade() -> None:
     for s in SOURCES:
-        name_en = f"'{s['name_en']}'" if s["name_en"] else "NULL"
-        desc = s["description"].replace("'", "''")
-        name_zh = s["name_zh"].replace("'", "''")
+        # Escape single quotes in every text field — Tāranātha's apostrophe
+        # broke the previous attempt because only name_zh/description were
+        # escaped before. Cheaper than parameterized queries and matches the
+        # 0121/0124 idiom; just needs to cover every quoted column.
+        def q(v: str | None) -> str:
+            if v is None:
+                return "NULL"
+            return "'" + v.replace("'", "''") + "'"
+
         supports_search = "true" if s.get("supports_search") else "false"
         has_remote_fulltext = "true" if s.get("has_remote_fulltext") else "false"
         op.execute(
@@ -153,9 +159,9 @@ def upgrade() -> None:
                 f"access_type, region, languages, research_fields, "
                 f"supports_search, has_remote_fulltext, "
                 f"sort_order, is_active) "
-                f"VALUES ('{s['code']}', '{name_zh}', {name_en}, '{s['base_url']}', "
-                f"'{desc}', 'open', '{s['region']}', "
-                f"'{s['languages']}', '{s['research_fields']}', "
+                f"VALUES ({q(s['code'])}, {q(s['name_zh'])}, {q(s['name_en'])}, "
+                f"{q(s['base_url'])}, {q(s['description'])}, 'open', "
+                f"{q(s['region'])}, {q(s['languages'])}, {q(s['research_fields'])}, "
                 f"{supports_search}, {has_remote_fulltext}, "
                 f"0, true) "
                 f"ON CONFLICT (code) DO NOTHING"


### PR DESCRIPTION
## Summary
PR #511 (migration 0125) failed at runtime with PostgreSQL syntax error on \`Tāranātha's Collected Works\` — the apostrophe in name_en was not escaped because the previous escape helper only covered name_zh and description.

Backend log:
\`\`\`
sqlalchemy.exc.ProgrammingError: ... syntax error at or near "s"
[SQL: INSERT INTO data_sources (...) VALUES ('taranatha-works', '多罗那他全集（觉囊派）', 'Tāranātha's Collected Works', ...)]
\`\`\`

Fix: introduce a tiny \`q()\` helper that escapes single quotes for every text column (code, name_zh, name_en, base_url, description, region, languages, research_fields). Same idiom as 0121/0124, just applied uniformly.

\`alembic current\` on prod is still at 0124 — nothing got inserted because alembic rolled back the transaction. After this PR merges, deploy.sh will re-attempt \`alembic upgrade head\` and apply 0125 cleanly. Idempotent via \`ON CONFLICT (code) DO NOTHING\`.

## Test plan
- [x] Local simulation: 8 INSERTs generated, Tāranātha row contains \`Tāranātha''s\` (correct PG escape)
- [ ] Deploy: webhook → backend restart → alembic upgrade head → 0125 applies
- [ ] /api/sources count goes from 536 → 544

🤖 Generated with [Claude Code](https://claude.com/claude-code)