### PR TITLE
fix(0126): activate pre-existing schoyen-collection row

### DIFF
--- a/backend/alembic/versions/0126_activate_schoyen_collection.py
+++ b/backend/alembic/versions/0126_activate_schoyen_collection.py
@@ -1,0 +1,42 @@
+"""Activate the pre-existing schoyen-collection row.
+
+When 0125 added 8 new sources, the `schoyen-collection` INSERT was
+silently skipped by ON CONFLICT (code) DO NOTHING because a row with
+that code had existed since 2026-03-02 with is_active=false. The row
+was never surfaced in fojin.app/api/sources, which is why dedup against
+the public list missed it.
+
+Flip is_active=true and turn on supports_search so the row joins the
+other seven additions from 0125 and the public count goes from 543 → 544.
+
+Revision ID: 0126
+Revises: 0125
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0126"
+down_revision = "0125"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            "UPDATE data_sources "
+            "SET is_active = true, supports_search = true "
+            "WHERE code = 'schoyen-collection'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        text(
+            "UPDATE data_sources "
+            "SET is_active = false, supports_search = false "
+            "WHERE code = 'schoyen-collection'"
+        )
+    )


### PR DESCRIPTION
## Summary
0125 added 8 sources but only 7 became publicly visible. The 8th — \`schoyen-collection\` — already existed in DB since 2026-03-02 with \`is_active=false\`, so 0125's INSERT got swallowed by \`ON CONFLICT (code) DO NOTHING\`. My dedup file came from \`/api/sources\` which filters by is_active, so I never saw the existing row.

Migration 0126 just flips \`is_active=true\` + \`supports_search=true\` on the existing row. After deploy + Redis cache bust, /api/sources should show count=544 and all 8 codes from PR #511 visible.

Keeps the existing \`name_zh\` ('斯科延收藏佛教写本') rather than renaming, to avoid breaking any existing references.

## Test plan
- [x] Migration is a single UPDATE, no new fields
- [ ] Deploy → alembic 0126 applies → bust \`sources:list:v1\` Redis key → API returns count=544 with all 8 codes