### PR TITLE
ci: alembic upgrade head dry-run against pgvector/pg15

### DIFF
--- a/.github/workflows/alembic-dry-run.yml
+++ b/.github/workflows/alembic-dry-run.yml
@@ -1,0 +1,99 @@
+name: Alembic dry-run
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "backend/alembic/**"
+      - "backend/app/models/**"
+      - "backend/app/database.py"
+      - "backend/requirements*.txt"
+      - ".github/workflows/alembic-dry-run.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  alembic-dry-run:
+    name: Alembic upgrade head (dry-run)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: fojin
+          POSTGRES_PASSWORD: fojin
+          POSTGRES_DB: fojin_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U fojin -d fojin_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: fojin
+      POSTGRES_PASSWORD: fojin
+      POSTGRES_DB: fojin_test
+      # backend/app/config.py builds DATABASE_URL from POSTGRES_* above.
+      # Provide harmless defaults for any settings the import path may touch.
+      JWT_SECRET_KEY: ci-dummy-secret
+      REDIS_HOST: localhost
+      REDIS_PORT: "6379"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Wait for Postgres
+        run: |
+          for i in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 -U fojin -d fojin_test; then
+              echo "postgres ready"; exit 0
+            fi
+            sleep 2
+          done
+          echo "postgres did not become ready"; exit 1
+
+      - name: Ensure pgvector extension
+        env:
+          PGPASSWORD: fojin
+        run: |
+          psql -h localhost -U fojin -d fojin_test -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          psql -h localhost -U fojin -d fojin_test -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+
+      - name: Alembic upgrade head
+        run: alembic upgrade head
+
+      - name: Alembic downgrade -1 (best-effort)
+        id: downgrade
+        continue-on-error: true
+        run: alembic downgrade -1
+
+      - name: Note irreversible migration (warning only)
+        if: steps.downgrade.outcome == 'failure'
+        run: |
+          echo "::warning::alembic downgrade -1 failed; latest migration may be irreversible. Treating as non-fatal."
+
+      - name: Alembic upgrade head (re-apply)
+        run: alembic upgrade head
+
+      - name: Show final alembic state
+        run: alembic current


### PR DESCRIPTION
## Summary

Add a CI job (`alembic-dry-run`) that boots a `pgvector/pgvector:pg15` service, installs backend deps, and runs `alembic upgrade head` end to end on every PR that touches `backend/alembic/**`, models, or backend deps. Then attempts `alembic downgrade -1` (non-fatal — irreversible migrations only emit a warning) and re-applies head.

## Why

Within the last 30 days we took prod down once (PR #505, fixed by hotfixes 0124/0125/0126) because migration `0123_backfill_source_research_fields` referenced `buddhist_sources` instead of the actual table name `data_sources`. Existing CI (`ci.yml`) covers ruff + pytest + frontend build, but **never executes alembic against a real DB**, so the typo only surfaced in production.

This job would have failed PR #505 in CI before merge. It also catches:
- Wrong table / column names in new migrations
- Missing `pgvector` / `pg_trgm` extensions
- Broken downgrades on top of the latest revision (warning only)

> If this PR exposes that an already-merged migration cannot run cleanly from scratch, this PR's own CI will fail — and that is exactly the value: it reveals the latent failure that would otherwise only show up the next time someone bootstraps a fresh DB.

## Scope

- Only `.github/workflows/alembic-dry-run.yml` added (99 lines). No business code touched.
- Runs in parallel with existing `ci.yml`; gated by `paths:` so unrelated PRs aren't slowed down.

## Test plan

- [ ] CI runs the new `alembic-dry-run` job on this PR
- [ ] Job goes green (or surfaces a real, pre-existing problem worth fixing)
- [ ] On a follow-up PR with an intentionally bad migration, this job fails

## Follow-ups (separate PR)

- `0124_add_plumvillage_gems_source.py` and `0125_add_8_text_focused_sources.py` use f-string interpolation in `DELETE FROM data_sources WHERE code = '{...}'` downgrades. Currently safe (constants), but should be parameterized for hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)