### PR TITLE
fix(search): 0 结果 UX — 跳过 skeleton + 外链卡视觉层级修正

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -85,6 +85,8 @@
   "notfound.back": "Back to home",
   "search.no_results_for": "No results found for \"{{query}}\"",
   "search.did_you_mean": "Did you mean",
+  "search.empty_state_external": "No on-site matches. You can continue searching the external sources below.",
+  "search.external_card_prefix": "Search on external site: {{query}}",
   "language.zh": "中文",
   "language.zh-Hant": "中文（繁體）",
   "language.en": "English",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -85,6 +85,8 @@
   "notfound.back": "返回首頁",
   "search.no_results_for": "沒有找到「{{query}}」的結果",
   "search.did_you_mean": "您是否想搜尋",
+  "search.empty_state_external": "無站內匹配，可在以下外部資料源繼續搜尋",
+  "search.external_card_prefix": "在外站搜尋：{{query}}",
   "language.zh": "中文簡體",
   "language.zh-Hant": "中文繁體",
   "language.en": "English",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -85,7 +85,7 @@
   "notfound.back": "返回首页",
   "search.no_results_for": "没有找到「{{query}}」的结果",
   "search.did_you_mean": "您是否想搜索",
-  "search.empty_state_external": "无站内匹配，可在以下外部数据源继续搜",
+  "search.empty_state_external": "无站内匹配，可在以下外部数据源继续搜索",
   "search.external_card_prefix": "在外站搜索：{{query}}",
   "language.zh": "中文简体",
   "language.zh-Hant": "中文繁體",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -85,6 +85,8 @@
   "notfound.back": "返回首页",
   "search.no_results_for": "没有找到「{{query}}」的结果",
   "search.did_you_mean": "您是否想搜索",
+  "search.empty_state_external": "无站内匹配，可在以下外部数据源继续搜",
+  "search.external_card_prefix": "在外站搜索：{{query}}",
   "language.zh": "中文简体",
   "language.zh-Hant": "中文繁體",
   "language.en": "English",

--- a/frontend/src/components/search/ExternalCard.tsx
+++ b/frontend/src/components/search/ExternalCard.tsx
@@ -1,15 +1,20 @@
 import { Tag } from "antd";
 import { LinkOutlined, EyeOutlined } from "@ant-design/icons";
+import { useTranslation } from "react-i18next";
 import { buildSearchUrl } from "../../utils/sourceUrls";
 import type { DataSource } from "../../api/client";
 
 export default function ExternalCard({ source, query, rank }: { source: DataSource; query: string; rank: number }) {
+  const { t } = useTranslation();
   const url = buildSearchUrl(source.code, query) || "#";
   return (
     <div className="s-card s-card-ext">
       <div className="s-card-rank">排序<br />#{rank}</div>
       <div className="s-card-body">
-        <div className="s-card-title">{query}</div>
+        <div className="s-card-ext-prefix" style={{ fontSize: 12, color: "#9a8e7a", marginBottom: 2 }}>
+          {t("search.external_card_prefix", { query })}
+        </div>
+        <div className="s-card-title">{source.name_zh}</div>
         <div className="s-card-tags">
           <Tag color="blue" style={{ fontSize: 11 }}>{source.name_zh}</Tag>
           <Tag style={{ fontSize: 11 }}>外链跳转</Tag>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -218,7 +218,16 @@ export default function SearchPage() {
   };
 
   const loading = tab === "catalog" ? (isLoading || crossLangLoading) : tab === "content" ? (contentLoading || semanticLoading) : dictLoading;
+  // Primary query loading state (excluding secondary cross-language / semantic queries),
+  // used to bail out of skeleton rendering once the main result count is known to be 0.
+  const primaryLoading = tab === "catalog" ? isLoading : tab === "content" ? contentLoading : dictLoading;
   const localTotal = tab === "catalog" ? (data?.total || 0) : tab === "content" ? (contentData?.total || 0) : (dictData?.total || 0);
+  const hasSecondaryResults = tab === "catalog"
+    ? (crossLangData?.results.length || 0) > 0
+    : tab === "content"
+    ? (semanticData?.results.length || 0) > 0
+    : false;
+  const showEmptyState = !primaryLoading && localTotal === 0 && !hasSecondaryResults;
   const extTotal = query.length > 0 ? filteredExtSources.length : 0;
 
   const sortedRegions = useMemo(() => {
@@ -468,7 +477,7 @@ export default function SearchPage() {
               </div>
             )}
 
-            {loading && Array.from({ length: 5 }).map((_, i) => (
+            {loading && !showEmptyState && Array.from({ length: 5 }).map((_, i) => (
               <div className="s-card" key={`skel-${i}`}>
                 <div className="s-card-rank">
                   <Skeleton.Button active size="small" style={{ width: 28, height: 14 }} />
@@ -559,8 +568,15 @@ export default function SearchPage() {
               </div>
             )}
 
+            {/* 站内 0 结果显式空状态：避免与外部源卡片混淆 */}
+            {showEmptyState && tab !== "dictionary" && (
+              <div className="s-empty-state" style={{ margin: "24px 0 12px", padding: "16px 20px", background: "var(--fj-sand-light, #faf7f2)", border: "1px solid #e8e0d4", borderRadius: 6, color: "#6b5d4a", fontSize: 14 }}>
+                {t("search.empty_state_external")}
+              </div>
+            )}
+
             {/* 外部数据源结果 */}
-            {!loading && tab !== "dictionary" && query.length > 0 && filteredExtSources.length > 0 && (
+            {(!loading || showEmptyState) && tab !== "dictionary" && query.length > 0 && filteredExtSources.length > 0 && (
               <>
                 <div className="s-ext-divider">
                   以下 {extTotal} 个外部数据源可继续搜索「{query}」

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -96,13 +96,13 @@ export default function SearchPage() {
     enabled: query.length > 0 && tab === "catalog",
   });
 
-  const { data: contentData, isLoading: contentLoading } = useQuery({
+  const { data: contentData, isLoading: contentLoading, isError: contentError } = useQuery({
     queryKey: ["searchContent", query, page, selectedSources, langFilter],
     queryFn: () => searchContent({ q: query, page, size: 20, sources: selectedSources || undefined, lang: langFilter || undefined }),
     enabled: query.length > 0 && tab === "content",
   });
 
-  const { data: dictData, isLoading: dictLoading } = useQuery({
+  const { data: dictData, isLoading: dictLoading, isError: dictError } = useQuery({
     queryKey: ["searchDict", query, dictPage, dictLang],
     queryFn: () => searchDictionary({ q: query, page: dictPage, size: 20, lang: dictLang || undefined }),
     enabled: query.length > 0 && tab === "dictionary",
@@ -227,7 +227,11 @@ export default function SearchPage() {
     : tab === "content"
     ? (semanticData?.results.length || 0) > 0
     : false;
-  const showEmptyState = !primaryLoading && localTotal === 0 && !hasSecondaryResults;
+  // Don't fire the empty state when the primary query failed — the existing
+  // error UI handles that case. Without this guard, an API error renders
+  // both the error block AND the "no on-site matches" copy.
+  const primaryError = tab === "catalog" ? isError : tab === "content" ? contentError : dictError;
+  const showEmptyState = !primaryLoading && !primaryError && localTotal === 0 && !hasSecondaryResults;
   const extTotal = query.length > 0 ? filteredExtSources.length : 0;
 
   const sortedRegions = useMemo(() => {


### PR DESCRIPTION
## 问题

`/search?q=zzzznoresult123`（站内 0 命中）时存在两个 UX bug：

1. 顶部已经显示「找到 0 条结果」，但下方仍渲染 3+ 个灰色 skeleton 占位卡，4 秒后仍未消失
2. 91 张外部数据源卡片大字号显示用户查询词作为标题，看起来像每家库都「找到了」，视觉层级反转

## 修复

### `SearchPage.tsx`
- 区分 `primaryLoading`（主查询）与 `loading`（含次级跨语言/语义查询），
  当主查询完成且 `localTotal === 0` 且无次级结果时进入 `showEmptyState` 分支，
  早返回不渲染 skeleton
- 在外部数据源列表前插入显式空状态卡片，文案 `search.empty_state_external`
- 修改外部源渲染条件，确保 0 结果时仍展示外站继续搜的入口

### `ExternalCard.tsx`
- 主标题（`s-card-title`）从 `query` 改为 `source.name_zh`
- 查询词降级为 muted 小字 prefix `「在外站搜索：{query}」`，使用 `useTranslation`

### i18n（zh / zh-Hant / en）
- `search.empty_state_external` — 空状态文案
- `search.external_card_prefix` — 外链卡顶部 prefix

## 验证

- `npm run lint`：改动文件 0 warning（仓库其他文件 39 处 pre-existing warning）
- `npm run build`：通过 (`tsc -b && vite build`)

## 视觉差异

| 区域 | 改前 | 改后 |
|---|---|---|
| 0 结果时 result 区下方 | 3+ skeleton 占位卡持续 4s+ | 直接显示空状态卡 + 外部数据源 |
| ExternalCard 大标题 | 用户输入的查询词 | 数据源名称（CBETA / Taisho 等） |
| ExternalCard 顶部小字 | 无 | muted「在外站搜索：{query}」 |

## 范围控制

- 仅 frontend/，未触 backend
- 未 refactor 整个 SearchPage，scope 限于 0 结果分支 + ExternalCard 视觉层级
- 未新增 npm 依赖

🤖 Generated with [Claude Code](https://claude.com/claude-code)