### PR TITLE
security(auth): one-time code exchange for OAuth callback (no JWT in URL)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,6 +1,8 @@
+import json
+import logging
 import secrets
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,6 +16,7 @@ from app.schemas.user import (
     ApiKeyRequest,
     ApiKeyStatus,
     ChangePasswordRequest,
+    OAuthExchangeRequest,
     TokenResponse,
     UserLogin,
     UserProfile,
@@ -29,6 +32,32 @@ from app.services.oauth import (
     sms_login,
     verify_sms_code,
 )
+
+logger = logging.getLogger(__name__)
+
+# One-time OAuth exchange code lifetime (seconds). Short by design — the
+# frontend should redeem the code immediately after redirect.
+OAUTH_EXCHANGE_TTL = 5
+OAUTH_EXCHANGE_PREFIX = "oauth:exchange:"
+
+
+async def _store_oauth_exchange(redis_client, token_resp: TokenResponse, provider: str) -> str:
+    """Stash a token in Redis under a one-time code; return the code.
+
+    The code is short-lived (OAUTH_EXCHANGE_TTL) and is consumed atomically
+    via GETDEL on the exchange endpoint.
+    """
+    code = secrets.token_urlsafe(16)
+    payload = json.dumps(
+        {
+            "access_token": token_resp.access_token,
+            "token_type": token_resp.token_type,
+            "provider": provider,
+        }
+    )
+    await redis_client.set(f"{OAUTH_EXCHANGE_PREFIX}{code}", payload, ex=OAUTH_EXCHANGE_TTL)
+    return code
+
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -182,9 +211,8 @@ async def github_oauth_callback(
 
     try:
         token_resp = await github_callback(code, db)
-        return RedirectResponse(
-            url=f"{settings.oauth_redirect_base}/login?token={token_resp.access_token}&provider=github"
-        )
+        exchange_code = await _store_oauth_exchange(redis_client, token_resp, "github")
+        return RedirectResponse(url=f"{settings.oauth_redirect_base}/login?provider=github&code={exchange_code}")
     except Exception:
         return RedirectResponse(url=f"{settings.oauth_redirect_base}/login?error=github_failed")
 
@@ -217,11 +245,86 @@ async def google_oauth_callback(
 
     try:
         token_resp = await google_callback(code, db)
-        return RedirectResponse(
-            url=f"{settings.oauth_redirect_base}/login?token={token_resp.access_token}&provider=google"
-        )
+        exchange_code = await _store_oauth_exchange(redis_client, token_resp, "google")
+        return RedirectResponse(url=f"{settings.oauth_redirect_base}/login?provider=google&code={exchange_code}")
     except Exception:
         return RedirectResponse(url=f"{settings.oauth_redirect_base}/login?error=google_failed")
+
+
+# ── OAuth: one-time code exchange ────────────────────────────
+
+
+@router.post("/oauth/exchange", response_model=TokenResponse)
+async def oauth_exchange(
+    data: OAuthExchangeRequest,
+    request: Request,
+):
+    """Exchange a short-lived OAuth code for a JWT.
+
+    The OAuth provider callback redirects the browser to the frontend with
+    only an opaque code in the URL. The frontend POSTs that code here to
+    obtain the actual JWT — keeping the JWT out of nginx access logs,
+    browser history, and Referer headers.
+
+    The code is consumed atomically (GETDEL) and is single-use.
+    """
+    redis_client = request.app.state.redis
+    key = f"{OAUTH_EXCHANGE_PREFIX}{data.code}"
+
+    # Atomic get-and-delete. Falls back to GET+DELETE on older Redis.
+    raw = None
+    try:
+        raw = await redis_client.getdel(key)
+    except AttributeError:
+        raw = await redis_client.get(key)
+        if raw is not None:
+            await redis_client.delete(key)
+
+    if not raw:
+        raise HTTPException(status_code=401, detail="code expired or invalid")
+
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=401, detail="code expired or invalid") from exc
+
+    access_token = payload.get("access_token")
+    provider = payload.get("provider")
+    if not access_token:
+        raise HTTPException(status_code=401, detail="code expired or invalid")
+
+    # Audit log: provider + user_id (decoded from JWT) + client IP. Never
+    # log the exchange code itself.
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        client_ip = forwarded.split(",")[0].strip()
+    elif request.client:
+        client_ip = request.client.host
+    else:
+        client_ip = None
+
+    user_id = None
+    try:
+        from app.core.auth import verify_token
+
+        verified = verify_token(access_token)
+        if verified is not None:
+            user_id = verified[0]
+    except Exception:
+        # Audit logging must not break the exchange.
+        pass
+
+    logger.info(
+        "oauth_exchange success provider=%s user_id=%s ip=%s",
+        provider,
+        user_id,
+        client_ip,
+    )
+
+    return TokenResponse(
+        access_token=access_token,
+        token_type=payload.get("token_type", "bearer"),
+    )
 
 
 # ── SMS Login ────────────────────────────────────────────────
@@ -261,5 +364,6 @@ async def sms_verification_login(
     valid = await verify_sms_code(data.phone, data.code, redis_client)
     if not valid:
         from fastapi import HTTPException
+
         raise HTTPException(status_code=400, detail="验证码错误或已过期")
     return await sms_login(data.phone, db)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -48,6 +48,21 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
+class OAuthExchangeRequest(BaseModel):
+    code: str
+
+    @field_validator("code")
+    @classmethod
+    def code_format(cls, v: str) -> str:
+        # secrets.token_urlsafe(16) → 22 chars, urlsafe alphabet.
+        # Be lenient on length but reject anything obviously malformed.
+        if not v or len(v) < 16 or len(v) > 64:
+            raise ValueError("invalid code format")
+        if not re.fullmatch(r"[A-Za-z0-9_\-]+", v):
+            raise ValueError("invalid code format")
+        return v
+
+
 class UserProfile(BaseModel):
     id: int
     username: str

--- a/backend/tests/test_oauth_exchange.py
+++ b/backend/tests/test_oauth_exchange.py
@@ -1,0 +1,210 @@
+"""Tests for the one-time OAuth code-exchange endpoint.
+
+Verifies that the OAuth callback flow no longer puts a JWT in the
+redirect URL — instead, the frontend POSTs an opaque code to
+/auth/oauth/exchange to obtain the JWT.
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.auth import OAUTH_EXCHANGE_PREFIX
+
+
+def _install_redis(client, *, getdel_return=None, get_return=None):
+    """Install a fresh AsyncMock as app.state.redis with deterministic behavior."""
+    from app.main import app
+
+    redis_mock = AsyncMock()
+    redis_mock.getdel = AsyncMock(return_value=getdel_return)
+    redis_mock.get = AsyncMock(return_value=get_return)
+    redis_mock.delete = AsyncMock(return_value=1)
+    redis_mock.set = AsyncMock(return_value=True)
+    redis_mock.ping = AsyncMock(return_value=True)
+    redis_mock.incr = AsyncMock(return_value=1)
+    redis_mock.expire = AsyncMock(return_value=True)
+    app.state.redis = redis_mock
+    return redis_mock
+
+
+@pytest.mark.anyio
+async def test_oauth_exchange_happy_path(client):
+    """Valid code → returns JWT, and code is consumed (GETDEL)."""
+    payload = json.dumps(
+        {
+            "access_token": "fake.jwt.token",
+            "token_type": "bearer",
+            "provider": "github",
+        }
+    )
+    redis_mock = _install_redis(client, getdel_return=payload)
+
+    resp = await client.post(
+        "/api/auth/oauth/exchange",
+        json={"code": "abcdefghijklmnopqrstuv"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "fake.jwt.token"
+    assert data["token_type"] == "bearer"
+
+    # GETDEL was called against the namespaced key — atomic single-use.
+    redis_mock.getdel.assert_awaited_once_with(f"{OAUTH_EXCHANGE_PREFIX}abcdefghijklmnopqrstuv")
+
+
+@pytest.mark.anyio
+async def test_oauth_exchange_expired_code_returns_401(client):
+    """Code not present in Redis (TTL expired or never written) → 401."""
+    _install_redis(client, getdel_return=None)
+
+    resp = await client.post(
+        "/api/auth/oauth/exchange",
+        json={"code": "expiredcodeabcdefghijk"},
+    )
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "code expired or invalid"
+
+
+@pytest.mark.anyio
+async def test_oauth_exchange_replay_returns_401(client):
+    """Second exchange of the same code → 401 (single-use guarantee).
+
+    Simulated by GETDEL returning the payload first, then None.
+    """
+    payload = json.dumps(
+        {
+            "access_token": "fake.jwt.token",
+            "token_type": "bearer",
+            "provider": "github",
+        }
+    )
+    from app.main import app
+
+    redis_mock = AsyncMock()
+    redis_mock.getdel = AsyncMock(side_effect=[payload, None])
+    redis_mock.delete = AsyncMock(return_value=1)
+    redis_mock.set = AsyncMock(return_value=True)
+    redis_mock.incr = AsyncMock(return_value=1)
+    redis_mock.expire = AsyncMock(return_value=True)
+    app.state.redis = redis_mock
+
+    code = "replaytestcodeabcdefgh"
+
+    first = await client.post("/api/auth/oauth/exchange", json={"code": code})
+    assert first.status_code == 200
+
+    second = await client.post("/api/auth/oauth/exchange", json={"code": code})
+    assert second.status_code == 401
+    assert second.json()["detail"] == "code expired or invalid"
+
+    assert redis_mock.getdel.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_oauth_exchange_malformed_code_returns_422(client):
+    """Code with invalid characters or wrong length → 422 from Pydantic."""
+    _install_redis(client, getdel_return=None)
+
+    # Too short
+    resp = await client.post("/api/auth/oauth/exchange", json={"code": "short"})
+    assert resp.status_code == 422
+
+    # Bad characters (spaces, punctuation)
+    resp = await client.post(
+        "/api/auth/oauth/exchange",
+        json={"code": "has spaces and !@# chars"},
+    )
+    assert resp.status_code == 422
+
+    # Empty
+    resp = await client.post("/api/auth/oauth/exchange", json={"code": ""})
+    assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_oauth_exchange_corrupt_payload_returns_401(client):
+    """Redis returned a non-JSON string → treat as invalid (no 500)."""
+    _install_redis(client, getdel_return="not-valid-json{")
+
+    resp = await client.post(
+        "/api/auth/oauth/exchange",
+        json={"code": "validlookingcode123abc"},
+    )
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_oauth_exchange_falls_back_when_getdel_unavailable(client):
+    """Older Redis without GETDEL → fall back to GET + DELETE."""
+    payload = json.dumps(
+        {
+            "access_token": "fake.jwt.token",
+            "token_type": "bearer",
+            "provider": "google",
+        }
+    )
+    from app.main import app
+
+    redis_mock = AsyncMock()
+    # AttributeError on getdel → fallback path.
+    redis_mock.getdel = AsyncMock(side_effect=AttributeError("no getdel"))
+    redis_mock.get = AsyncMock(return_value=payload)
+    redis_mock.delete = AsyncMock(return_value=1)
+    redis_mock.set = AsyncMock(return_value=True)
+    redis_mock.incr = AsyncMock(return_value=1)
+    redis_mock.expire = AsyncMock(return_value=True)
+    app.state.redis = redis_mock
+
+    resp = await client.post(
+        "/api/auth/oauth/exchange",
+        json={"code": "fallbackcodeabcdefghij"},
+    )
+
+    assert resp.status_code == 200
+    redis_mock.get.assert_awaited_once()
+    redis_mock.delete.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_github_callback_no_longer_leaks_token_in_url(client):
+    """OAuth callback redirects with ?provider=...&code=... — NOT ?token=..."""
+    import app.api.auth as auth_module
+    from app.main import app
+    from app.schemas.user import TokenResponse
+
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(return_value="github")  # state matches
+    redis_mock.delete = AsyncMock(return_value=1)
+    redis_mock.set = AsyncMock(return_value=True)
+    redis_mock.incr = AsyncMock(return_value=1)
+    redis_mock.expire = AsyncMock(return_value=True)
+    app.state.redis = redis_mock
+
+    fake_token = TokenResponse(access_token="should.never.appear.in.url", token_type="bearer")
+
+    original = auth_module.github_callback
+
+    async def fake_callback(code, db):
+        return fake_token
+
+    auth_module.github_callback = fake_callback
+    try:
+        resp = await client.get(
+            "/api/auth/github/callback",
+            params={"code": "gh-oauth-code", "state": "abc123"},
+            follow_redirects=False,
+        )
+    finally:
+        auth_module.github_callback = original
+
+    assert resp.status_code in (302, 307)
+    location = resp.headers["location"]
+    assert "token=" not in location
+    assert "should.never.appear.in.url" not in location
+    assert "code=" in location
+    assert "provider=github" in location

--- a/backend/tests/test_oauth_exchange.py
+++ b/backend/tests/test_oauth_exchange.py
@@ -13,6 +13,32 @@ import pytest
 from app.api.auth import OAUTH_EXCHANGE_PREFIX
 
 
+@pytest.fixture(autouse=True)
+def _isolate_app_state_redis():
+    """Snapshot and restore ``app.state.redis`` around every test.
+
+    The OAuth exchange endpoint reads ``request.app.state.redis``, so
+    these tests have to install a mock there. Without this fixture, the
+    mock leaks into subsequent tests in the same pytest session — for
+    example ``tests/test_smoke.py::test_sources_include_distributions``
+    starts seeing AsyncMock-returned bytes where it expects real Redis
+    output, and fails with ``json.decoder.JSONDecodeError`` on the next
+    HTTP response.
+    """
+    from app.main import app
+
+    sentinel = object()
+    original = getattr(app.state, "redis", sentinel)
+    try:
+        yield
+    finally:
+        if original is sentinel:
+            if hasattr(app.state, "redis"):
+                delattr(app.state, "redis")
+        else:
+            app.state.redis = original
+
+
 def _install_redis(client, *, getdel_return=None, get_return=None):
     """Install a fresh AsyncMock as app.state.redis with deterministic behavior."""
     from app.main import app

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -16,9 +16,11 @@ export default function LoginPage() {
   const [activeTab, setActiveTab] = useState("login");
   const [searchParams] = useSearchParams();
 
-  // Handle OAuth callback: ?token=xxx&provider=github
+  // Handle OAuth callback: ?provider=github&code=xxx
+  // The backend redirects with a one-time exchange code (NOT a JWT) to
+  // keep tokens out of nginx access logs, browser history, and Referer.
   useEffect(() => {
-    const token = searchParams.get("token");
+    const code = searchParams.get("code");
     const provider = searchParams.get("provider");
     const error = searchParams.get("error");
 
@@ -27,10 +29,11 @@ export default function LoginPage() {
       return;
     }
 
-    if (token && provider) {
-      // Got token from OAuth callback, fetch user info
+    if (code && provider) {
       (async () => {
         try {
+          const { data: tokenData } = await api.post("/auth/oauth/exchange", { code });
+          const token = tokenData.access_token;
           const { data: user } = await api.get("/auth/me", {
             headers: { Authorization: `Bearer ${token}` },
           });
@@ -38,7 +41,8 @@ export default function LoginPage() {
           message.success(`${provider === "github" ? "GitHub" : "Google"} 登录成功`);
           navigate("/", { replace: true });
         } catch {
-          message.error("登录失败，请重试");
+          message.error("第三方登录失败，请重试");
+          navigate("/login", { replace: true });
         }
       })();
     }


### PR DESCRIPTION
## Problem

The GitHub and Google OAuth callbacks redirect with the JWT in the URL query string:

```
RedirectResponse(url=f"{base}/login?token={token_resp.access_token}&provider=github")
```

This puts the JWT into:
1. **nginx access logs** — same disk that previously leaked secrets via `bash_history` (handled in 04-17), so the threat model is real
2. **Browser history** — local-attacker / shared-machine path
3. **Same-origin `Referer`** — anything the SPA loads after the redirect can carry it

Token TTL is finite, but every leaked snapshot is a horizontal-access window for that user.

## Fix

Replace the in-URL JWT with a **one-time exchange code**:

| Step | Before | After |
|---|---|---|
| Callback redirect | `?token={JWT}&provider=github` | `?provider=github&code={opaque}` |
| Code storage | — | Redis `oauth:exchange:{code}` (TTL **5s**) |
| Frontend reads | `token` from URL | `code` from URL |
| Frontend → backend | (already had token) | `POST /api/auth/oauth/exchange` body `{code}` |
| Code lifecycle | n/a | atomic **GETDEL** (single-use, replay returns 401) |

JWT internals, password login, SMS login are untouched.

## Files

- `backend/app/api/auth.py` — extract `_store_oauth_exchange`, swap both callback redirects, add `/oauth/exchange` endpoint with audit log (provider, decoded user_id, IP — never the code)
- `backend/app/schemas/user.py` — `OAuthExchangeRequest` with charset/length validation matching `secrets.token_urlsafe(16)`
- `frontend/src/pages/LoginPage.tsx` — read `code`, POST exchange, fall back to `/login` on failure
- `backend/tests/test_oauth_exchange.py` — 7 cases × 2 async runners = 14 passing

## Tests

```
backend/tests/test_oauth_exchange.py::test_oauth_exchange_happy_path[asyncio] PASSED
backend/tests/test_oauth_exchange.py::test_oauth_exchange_expired_code_returns_401[asyncio] PASSED
backend/tests/test_oauth_exchange.py::test_oauth_exchange_replay_returns_401[asyncio] PASSED
backend/tests/test_oauth_exchange.py::test_oauth_exchange_malformed_code_returns_422[asyncio] PASSED
backend/tests/test_oauth_exchange.py::test_oauth_exchange_corrupt_payload_returns_401[asyncio] PASSED
backend/tests/test_oauth_exchange.py::test_oauth_exchange_falls_back_when_getdel_unavailable[asyncio] PASSED
backend/tests/test_oauth_exchange.py::test_github_callback_no_longer_leaks_token_in_url[asyncio] PASSED
... (same 7 tests under [trio])
============================== 14 passed in 1.30s ==============================
```

`ruff check` and `ruff format --check` pass.

## Verification after deploy

```bash
# 1. Trigger GitHub OAuth login from a real browser
# 2. nginx access log should show:
#    GET /api/auth/github/callback... 302
#    GET /login?provider=github&code=xxxxxxxx... 200
#    POST /api/auth/oauth/exchange ... 200
#    NO line containing token= for the redirect
```

## Notes

- TTL = 5s is intentional. Frontend exchange completes in < 100ms; longer TTL widens the attack window without UX benefit.
- Audit log writes `provider, user_id, ip` — never the code itself, never the JWT.
- Pydantic validator rejects non-urlsafe chars and length outside [16, 64] before the Redis lookup, so malformed codes return 422 not 401.
- GETDEL falls back to GET+DELETE on Redis < 6.2 (defensive, fojin runs 7 but cheap to keep).

cc'd nobody since this is solo-dev.