### PR TITLE
fix(scripts): correct settings attribute names in sync_pg_to_es.py

### DIFF
--- a/backend/scripts/sync_pg_to_es.py
+++ b/backend/scripts/sync_pg_to_es.py
@@ -19,17 +19,17 @@ from app.core.elasticsearch import INDEX_NAME
 
 
 async def main():
-    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    engine = create_async_engine(settings.database_url, echo=False)
     session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
-    es = AsyncElasticsearch(settings.ELASTICSEARCH_URL)
+    es = AsyncElasticsearch(settings.es_host)
 
     async with session_factory() as session:
         result = await session.execute(text("""
             SELECT bt.id, bt.taisho_id, bt.cbeta_id, bt.title_zh, bt.title_en,
                    bt.title_sa, bt.title_bo, bt.title_pi, bt.translator,
                    bt.dynasty, bt.category, bt.subcategory, bt.fascicle_count,
-                   bt.cbeta_url, bt.has_content, bt.lang,
+                   bt.cbeta_url, bt.has_content, bt.content_char_count, bt.lang,
                    ds.code as source_code
             FROM buddhist_texts bt
             LEFT JOIN data_sources ds ON bt.source_id = ds.id
@@ -55,7 +55,8 @@ async def main():
                 "subcategory": row.subcategory,
                 "fascicle_count": row.fascicle_count,
                 "cbeta_url": row.cbeta_url,
-                "has_content": row.has_content or False,
+                "has_content": bool(row.has_content),
+                "content_char_count": row.content_char_count or 0,
                 "lang": row.lang or "lzh",
                 "source_code": row.source_code,
             }


### PR DESCRIPTION
## Problem

`backend/scripts/sync_pg_to_es.py` was using legacy settings attribute names that no longer exist on the pydantic Settings model:

```python
engine = create_async_engine(settings.DATABASE_URL, echo=False)   # ❌ AttributeError
es = AsyncElasticsearch(settings.ELASTICSEARCH_URL)               # ❌ AttributeError
```

The model actually exposes `settings.database_url` and `settings.es_host` (lowercase). The script has therefore crashed on startup since whenever those names changed, and PG→ES sync has silently never run.

**User-visible symptom**: ES documents lacked the `has_content` field, so the SearchPage's `tab=content` filter returned zero results for core texts (e.g. T0251 心經) even though the underlying PostgreSQL rows were correct (1282 chars). That's the "在 0 部经典中找到匹配" bleeding the recent audit flagged.

## Fix

- `settings.DATABASE_URL` → `settings.database_url`
- `settings.ELASTICSEARCH_URL` → `settings.es_host`
- Add `content_char_count` to the SELECT and the indexed doc, so the API can surface real lengths instead of `None`
- `bool(row.has_content)` instead of `row.has_content or False` to make the bool explicit (defensive against integer-typed columns; same semantics for booleans)

## Verification

Already verified in production today (2026-05-06) by running an inline-patched copy of the script:

```
Found 10531 texts in PostgreSQL
ES: indexed 10531, errors 0
Index size: 10531
```

After re-sync, T0251 correctly reports `has_content=true content_char_count=1282` in the search API response, and the SearchPage tab=content path now returns 82 results instead of 0.

## Notes

- This is the script that the recent project memory `feedback_fojin_t0251_stale_data` traced back to: T0251 心經 "data shown as stale" wasn't a parser bug or stale data — the underlying PG row was always correct, the ES index was just out of sync because this script never ran successfully.
- After merging this PR, scheduling `sync_pg_to_es.py` in cron (or as a step in the deploy script) would catch the next divergence automatically. Out of scope for this PR.