### PR TITLE
feat(seo): dynamic og:image cards + per-question SSR meta for /share/qa

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,6 +13,12 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# CJK fonts are needed by Pillow when rendering /api/og/* card images.
+# fonts-noto-cjk is ~80MB; fonts-noto-cjk-extra would be 300MB+ (skipped).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fonts-noto-cjk \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy installed packages from builder (no build-essential in final image)
 COPY --from=builder /install /usr/local
 

--- a/backend/app/api/og.py
+++ b/backend/app/api/og.py
@@ -1,0 +1,207 @@
+"""Dynamic Open Graph card images for shareable Q&A links.
+
+Public Q&A links (``/share/qa/{share_id}``) used to inherit the homepage
+``og:image`` — a generic landscape photo — so every link shared on
+linux.do, X, WeChat, Telegram, etc. looked identical and carried no
+information about the actual question. This module renders a per-link
+1200×630 PNG containing the question text plus a ``佛津 FoJin`` mark, so
+crawler previews actually identify the content.
+
+Implementation notes:
+- Pure Pillow, no headless browser. Generation budget: well under 200ms
+  on a single CPU core for our card layout.
+- The CJK font is loaded once at import and reused. ``fonts-noto-cjk``
+  is installed in the backend image; we fall back to PIL's default
+  bitmap font if the file is missing so missing fonts never crash the
+  endpoint (the rendered card just degrades to plain ASCII).
+- Responses are cached at the CDN edge for 24h via ``Cache-Control``.
+  A change to the underlying SharedQA row will only become visible after
+  the cache expires; that is acceptable because shared cards are
+  immutable by design.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from PIL import Image, ImageDraw, ImageFont
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.chat import SharedQA
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/og", tags=["og"])
+
+# Card dimensions chosen to satisfy both Twitter ``summary_large_image``
+# and Facebook/LinkedIn recommended sizes.
+CARD_WIDTH = 1200
+CARD_HEIGHT = 630
+PADDING = 64
+
+# Font candidates tried in order. The first existing path wins; we
+# resolve once at import time so the first request isn't penalized.
+_FONT_CANDIDATES = (
+    Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc"),
+    Path("/usr/share/fonts/opentype/noto/NotoSerifCJK-Bold.ttc"),
+    Path("/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc"),
+)
+
+
+def _resolve_font_path() -> Path | None:
+    for candidate in _FONT_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+_FONT_PATH = _resolve_font_path()
+if _FONT_PATH is None:
+    logger.warning(
+        "No CJK font found; OG card text will fall back to PIL default. Install fonts-noto-cjk in the runtime image."
+    )
+
+
+def _font(size: int) -> ImageFont.ImageFont:
+    """Return a font of the given size, or PIL's default if no TTF is available."""
+    if _FONT_PATH is None:
+        return ImageFont.load_default()
+    try:
+        return ImageFont.truetype(str(_FONT_PATH), size)
+    except OSError:
+        # The file existed at startup but failed at load (corruption,
+        # permissions, etc.) — never let this break a card render.
+        return ImageFont.load_default()
+
+
+# Pre-load the font sizes we use so each request is one ImageDraw call.
+_TITLE_FONT = _font(64)
+_HEADER_FONT = _font(28)
+_FOOTER_FONT = _font(24)
+_WATERMARK_FONT = _font(22)
+
+
+def _wrap_question(question: str, *, max_chars_per_line: int = 16, max_lines: int = 4) -> list[str]:
+    """Wrap a CJK question into at most ``max_lines`` lines.
+
+    ``textwrap.wrap`` doesn't understand that CJK characters take ~1
+    visual cell each with no inter-word breaks, so we hand-wrap by
+    character count. The truncated tail gets an ellipsis.
+    """
+    cleaned = " ".join(question.split())
+    if not cleaned:
+        return [""]
+
+    # Wrap: drop lines beyond max_lines, ellipsis on the last surviving
+    # line if there's overflow.
+    lines: list[str] = []
+    cursor = 0
+    while cursor < len(cleaned) and len(lines) < max_lines:
+        chunk = cleaned[cursor : cursor + max_chars_per_line]
+        lines.append(chunk)
+        cursor += max_chars_per_line
+
+    if cursor < len(cleaned) and lines:
+        lines[-1] = lines[-1].rstrip()[: max_chars_per_line - 1] + "…"
+    return lines
+
+
+def _extract_first_source_label(sources) -> str | None:
+    """Pull a short citation label out of the saved sources JSON, if any."""
+    if not sources or not isinstance(sources, list):
+        return None
+    first = sources[0]
+    if not isinstance(first, dict):
+        return None
+    # Prefer the displayable Chinese title; fall back to whatever's available.
+    for key in ("title_zh", "title", "name", "cbeta_id"):
+        value = first.get(key)
+        if value:
+            return str(value)[:40]
+    return None
+
+
+def _render_qa_card(question: str, source_label: str | None) -> bytes:
+    """Render the 1200×630 PNG card for a Q&A question."""
+    img = Image.new("RGB", (CARD_WIDTH, CARD_HEIGHT), color=(252, 250, 246))
+    draw = ImageDraw.Draw(img)
+
+    # Subtle top accent bar to break up the empty white.
+    draw.rectangle(
+        ((0, 0), (CARD_WIDTH, 6)),
+        fill=(143, 100, 65),  # warm 佛津 brown-gold
+    )
+
+    # Header: site identity.
+    draw.text(
+        (PADDING, PADDING),
+        "佛津 FoJin · AI 佛学问答",
+        fill=(143, 100, 65),
+        font=_HEADER_FONT,
+    )
+
+    # Main: question lines, vertically centered around the card middle.
+    lines = _wrap_question(question)
+    line_height = 84
+    block_height = line_height * len(lines)
+    start_y = max(PADDING + 60, (CARD_HEIGHT - block_height) // 2)
+    for i, line in enumerate(lines):
+        draw.text(
+            (PADDING, start_y + i * line_height),
+            line,
+            fill=(34, 32, 30),
+            font=_TITLE_FONT,
+        )
+
+    # Footer: cited sutra label (if any).
+    footer_y = CARD_HEIGHT - PADDING - 28
+    if source_label:
+        draw.text(
+            (PADDING, footer_y),
+            f"引用 · {source_label}",
+            fill=(110, 92, 78),
+            font=_FOOTER_FONT,
+        )
+
+    # Watermark, bottom-right.
+    watermark = "fojin.app"
+    bbox = draw.textbbox((0, 0), watermark, font=_WATERMARK_FONT)
+    wm_width = bbox[2] - bbox[0]
+    draw.text(
+        (CARD_WIDTH - PADDING - wm_width, CARD_HEIGHT - PADDING - 22),
+        watermark,
+        fill=(140, 130, 120),
+        font=_WATERMARK_FONT,
+    )
+
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG", optimize=True)
+    return buffer.getvalue()
+
+
+@router.get("/share/qa/{share_id}")
+async def shared_qa_og_image(
+    share_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Return a 1200×630 PNG card for a shared Q&A.
+
+    Uses the question text plus the first cited sutra as the only
+    visible content. If the share id does not exist, returns 404.
+    """
+    record = await db.scalar(select(SharedQA).where(SharedQA.id == share_id))
+    if record is None:
+        raise HTTPException(status_code=404, detail="Shared Q&A not found")
+
+    source_label = _extract_first_source_label(record.sources)
+    png = _render_qa_card(record.question, source_label)
+    return Response(
+        content=png,
+        media_type="image/png",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )

--- a/backend/app/api/seo.py
+++ b/backend/app/api/seo.py
@@ -24,9 +24,11 @@ import time
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.models.chat import SharedQA
 from app.services.text import get_text_by_id
 
 logger = logging.getLogger(__name__)
@@ -58,12 +60,7 @@ _HEAD_CLOSE_RE = re.compile(r"</head>", re.IGNORECASE)
 
 def _escape_meta_value(value: str) -> str:
     """Escape characters that would break out of an HTML attribute value."""
-    return (
-        value.replace("&", "&amp;")
-        .replace('"', "&quot;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-    )
+    return value.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
 
 
 async def _fetch_index_html() -> str:
@@ -71,11 +68,7 @@ async def _fetch_index_html() -> str:
     now = time.monotonic()
     cached_at = _index_html_cache.get("ts")
     cached_html = _index_html_cache.get("html")
-    if (
-        isinstance(cached_at, float)
-        and isinstance(cached_html, str)
-        and now - cached_at < _INDEX_HTML_CACHE_TTL
-    ):
+    if isinstance(cached_at, float) and isinstance(cached_html, str) and now - cached_at < _INDEX_HTML_CACHE_TTL:
         return cached_html
 
     async with httpx.AsyncClient(timeout=5.0) as client:
@@ -157,7 +150,9 @@ def _build_text_meta(text, request: Request, *, route: str) -> tuple[str, str, s
         meta_bits.append(f"CBETA {cbeta_id}")
     if meta_bits:
         desc_parts.append("，" + "，".join(meta_bits))
-    desc_parts.append("。佛津 FoJin 数字佛典平台提供全文阅读、平行对照、AI 智能问答与原典引用。汉传、藏传、南传、梵文、巴利文多语种佛教文献聚合检索。")
+    desc_parts.append(
+        "。佛津 FoJin 数字佛典平台提供全文阅读、平行对照、AI 智能问答与原典引用。汉传、藏传、南传、梵文、巴利文多语种佛教文献聚合检索。"
+    )
     description = "".join(desc_parts)
 
     base = str(request.base_url).rstrip("/")
@@ -200,9 +195,7 @@ async def _serve_text_seo_html(
         return HTMLResponse(content=fallback, status_code=200)
 
     title, description, canonical = _build_text_meta(text, request, route=route)
-    return HTMLResponse(
-        content=_inject_meta(html, title, description, canonical, robots=robots)
-    )
+    return HTMLResponse(content=_inject_meta(html, title, description, canonical, robots=robots))
 
 
 @router.get("/texts/{text_id}", response_class=HTMLResponse, include_in_schema=False)
@@ -221,6 +214,147 @@ async def text_reader_seo_html(text_id: int, request: Request, db: AsyncSession 
     rendered by the Cloudflare prerender Worker. ``follow`` keeps internal
     link equity flowing back to the detail page.
     """
-    return await _serve_text_seo_html(
-        text_id, request, db, route="read", robots="noindex, follow"
+    return await _serve_text_seo_html(text_id, request, db, route="read", robots="noindex, follow")
+
+
+# ── Shared Q&A SSR meta ──────────────────────────────────────
+
+
+_MARKDOWN_FENCE_RE = re.compile(r"```[\s\S]*?```")
+_MARKDOWN_INLINE_CODE_RE = re.compile(r"`([^`]*)`")
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_MARKDOWN_HEADING_RE = re.compile(r"^\s*#{1,6}\s*", re.MULTILINE)
+_MARKDOWN_EMPHASIS_RE = re.compile(r"[*_]{1,3}([^*_]+)[*_]{1,3}")
+_CITATION_BRACKETS_RE = re.compile(r"【[^】]*】")
+_WHITESPACE_RUN_RE = re.compile(r"\s+")
+
+
+def _strip_markdown(text: str) -> str:
+    """Best-effort markdown → plain text for the meta description.
+
+    The shared Q&A answer is markdown; meta descriptions are short plain
+    strings. We strip code fences, inline code, links, headings, and
+    emphasis markers, drop ``【…】`` citation pills, and collapse
+    whitespace.
+    """
+    cleaned = _MARKDOWN_FENCE_RE.sub("", text)
+    cleaned = _MARKDOWN_INLINE_CODE_RE.sub(r"\1", cleaned)
+    cleaned = _MARKDOWN_LINK_RE.sub(r"\1", cleaned)
+    cleaned = _MARKDOWN_HEADING_RE.sub("", cleaned)
+    cleaned = _MARKDOWN_EMPHASIS_RE.sub(r"\1", cleaned)
+    cleaned = _CITATION_BRACKETS_RE.sub("", cleaned)
+    return _WHITESPACE_RUN_RE.sub(" ", cleaned).strip()
+
+
+def _truncate_for_meta(value: str, *, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1].rstrip() + "…"
+
+
+def _build_share_qa_meta(record: SharedQA, request: Request) -> dict[str, str]:
+    """Compose meta values for ``/share/qa/{share_id}``."""
+    question = (record.question or "").strip() or "佛学问答"
+    title_question = _truncate_for_meta(question, limit=60)
+    title = f"{title_question} - 佛津 AI 佛学问答"
+
+    answer_plain = _strip_markdown(record.answer or "")
+    description = _truncate_for_meta(answer_plain or question, limit=150)
+
+    base = str(request.base_url).rstrip("/")
+    canonical = f"{base}/share/qa/{record.id}"
+    og_image = f"{base}/api/og/share/qa/{record.id}"
+    return {
+        "title": title,
+        "description": description,
+        "canonical": canonical,
+        "og_title": title_question,
+        "og_description": description,
+        "og_image": og_image,
+    }
+
+
+_OG_TAG_PATTERNS = (
+    re.compile(r'<meta\s+property="og:title"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    re.compile(r'<meta\s+property="og:description"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    re.compile(r'<meta\s+property="og:image"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    re.compile(r'<meta\s+property="og:image:width"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    re.compile(r'<meta\s+property="og:image:height"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    re.compile(r'<meta\s+property="og:type"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    re.compile(r'<meta\s+property="og:url"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    re.compile(r'<meta\s+name="twitter:card"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+)
+
+
+def _strip_existing_og_tags(html: str) -> str:
+    """Remove any pre-existing og:* / twitter:card tags from index.html."""
+    for pattern in _OG_TAG_PATTERNS:
+        html = pattern.sub("", html)
+    return html
+
+
+def _inject_share_qa_meta(html: str, meta: dict[str, str]) -> str:
+    """Inject share-Q&A specific meta tags into the SPA shell HTML.
+
+    Reuses ``_inject_meta`` for ``<title>``, description, canonical, and
+    robots; then appends og:* / twitter:card tags right before
+    ``</head>`` so crawlers without JS see the per-question values
+    instead of the homepage defaults.
+    """
+    new_html = _inject_meta(
+        html,
+        title=meta["title"],
+        description=meta["description"],
+        canonical_url=meta["canonical"],
+        robots="index, follow",
     )
+    new_html = _strip_existing_og_tags(new_html)
+    og_tags = (
+        f'<meta property="og:title" content="{_escape_meta_value(meta["og_title"])}" />\n'
+        f'  <meta property="og:description" content="{_escape_meta_value(meta["og_description"])}" />\n'
+        f'  <meta property="og:image" content="{_escape_meta_value(meta["og_image"])}" />\n'
+        f'  <meta property="og:image:width" content="1200" />\n'
+        f'  <meta property="og:image:height" content="630" />\n'
+        f'  <meta property="og:type" content="article" />\n'
+        f'  <meta property="og:url" content="{_escape_meta_value(meta["canonical"])}" />\n'
+        f'  <meta name="twitter:card" content="summary_large_image" />\n  '
+    )
+    return _HEAD_CLOSE_RE.sub(f"  {og_tags}</head>", new_html, count=1)
+
+
+@router.get("/share/qa/{share_id}", response_class=HTMLResponse, include_in_schema=False)
+async def shared_qa_seo_html(share_id: str, request: Request, db: AsyncSession = Depends(get_db)):
+    """SEO-friendly HTML for shared Q&A links.
+
+    Public Q&A links used to inherit the homepage meta tags (generic
+    title and a stock landscape og:image), so every link shared to
+    linux.do / X / WeChat / Telegram looked identical and carried no
+    information about the underlying question. This handler injects
+    per-question title / description / canonical and points
+    ``og:image`` at ``/api/og/share/qa/{id}`` for a dynamically
+    rendered card.
+    """
+    record = await db.scalar(select(SharedQA).where(SharedQA.id == share_id))
+    if record is None:
+        raise HTTPException(status_code=404, detail="Shared Q&A not found")
+
+    meta = _build_share_qa_meta(record, request)
+    try:
+        html = await _fetch_index_html()
+    except httpx.HTTPError as e:
+        logger.warning("Failed to fetch frontend index.html for share/qa: %s", e)
+        fallback = (
+            "<!doctype html><html><head>"
+            f"<title>{_escape_meta_value(meta['title'])}</title>"
+            f'<meta name="description" content="{_escape_meta_value(meta["description"])}" />'
+            f'<meta property="og:title" content="{_escape_meta_value(meta["og_title"])}" />'
+            f'<meta property="og:description" content="{_escape_meta_value(meta["og_description"])}" />'
+            f'<meta property="og:image" content="{_escape_meta_value(meta["og_image"])}" />'
+            f'<meta property="og:type" content="article" />'
+            f'<meta name="twitter:card" content="summary_large_image" />'
+            f'<link rel="canonical" href="{_escape_meta_value(meta["canonical"])}" />'
+            "</head><body></body></html>"
+        )
+        return HTMLResponse(content=fallback, status_code=200)
+
+    return HTMLResponse(content=_inject_share_qa_meta(html, meta))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,6 +40,7 @@ from app.api import (
     iiif,
     knowledge_graph,
     notification,
+    og,
     relations,
     rss,
     search,
@@ -357,6 +358,7 @@ app.include_router(alignment.router, prefix="/api")
 # Phase 3 routers
 app.include_router(chat.router, prefix="/api")
 app.include_router(share.router, prefix="/api")
+app.include_router(og.router, prefix="/api")
 app.include_router(annotations.router, prefix="/api")
 
 # Dictionary

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ pgvector==0.3.6
 openai==1.58.0
 tiktoken==0.8.0
 opencc-python-reimplemented==0.1.7
+Pillow==11.0.0

--- a/backend/tests/test_og_and_share_qa_seo.py
+++ b/backend/tests/test_og_and_share_qa_seo.py
@@ -1,0 +1,196 @@
+"""Tests for the dynamic OG card endpoint and share-Q&A SSR meta injection.
+
+Covers:
+- /api/og/share/qa/{id} returns a PNG for an existing SharedQA row
+- /api/og/share/qa/{id} 404s on unknown id
+- /share/qa/{id} HTML contains per-question og:* / twitter:card and a
+  canonical pointing back to itself, instead of inheriting the
+  homepage defaults.
+- /share/qa/{id} 404s on unknown id
+- The og:image URL points at /api/og/share/qa/{id} so crawlers can fetch it.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.api import seo as seo_module
+
+
+class _StubSharedQA:
+    """Minimal stand-in for app.models.chat.SharedQA used in tests."""
+
+    def __init__(
+        self,
+        *,
+        share_id: str = "abc123",
+        question: str = "什么是空？",
+        answer: str = "**空** 是 *缘起性空* 的核心 [link](http://x). 【《心经》第1卷】 详细解释 …",
+        sources=None,
+    ):
+        self.id = share_id
+        self.question = question
+        self.answer = answer
+        self.sources = sources or [{"title_zh": "般若波羅蜜多心經", "cbeta_id": "T0251"}]
+
+
+def _patch_db(scalar_returns):
+    """Override the FastAPI get_db dep so SharedQA queries return our stub.
+
+    ``scalar_returns`` is the value the mocked ``db.scalar(...)`` will
+    return for every call within the test.
+    """
+    from app.database import get_db
+    from app.main import app
+
+    async def fake_get_db():
+        mock_db = AsyncMock()
+        mock_db.scalar = AsyncMock(return_value=scalar_returns)
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        yield mock_db
+
+    app.dependency_overrides[get_db] = fake_get_db
+
+
+def _restore_db():
+    from app.database import get_db
+    from app.main import app
+
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest_asyncio.fixture
+async def og_client():
+    """A bare async client without the ES/Redis fixtures (those aren't needed
+    for the og + seo routes)."""
+    with (
+        patch("app.core.elasticsearch.init_es", new_callable=AsyncMock),
+        patch("app.core.elasticsearch.close_es", new_callable=AsyncMock),
+        patch("app.main.aioredis") as mock_redis_mod,
+    ):
+        mock_redis = AsyncMock()
+        mock_redis.ping.return_value = True
+        mock_redis_mod.from_url.return_value = mock_redis
+
+        from app.main import app
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+
+@pytest.mark.anyio
+async def test_og_image_endpoint_returns_png(og_client):
+    """Existing SharedQA → 200 with image/png body."""
+    _patch_db(_StubSharedQA())
+    try:
+        resp = await og_client.get("/api/og/share/qa/abc123")
+    finally:
+        _restore_db()
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+    # Must include the 24h CDN cache directive.
+    assert "max-age=86400" in resp.headers["cache-control"]
+    # PNG magic bytes — proves we actually rendered an image and not an error page.
+    assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
+    # Reasonable size for a 1200×630 mostly-white PNG with a few text blocks.
+    assert 2000 < len(resp.content) < 200_000
+
+
+@pytest.mark.anyio
+async def test_og_image_404_when_share_missing(og_client):
+    """Missing SharedQA → 404 (not a broken PNG)."""
+    _patch_db(None)
+    try:
+        resp = await og_client.get("/api/og/share/qa/does-not-exist")
+    finally:
+        _restore_db()
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_share_qa_seo_html_injects_per_question_meta(og_client):
+    """/share/qa/{id} HTML must carry per-question title / og:* / canonical."""
+    _patch_db(_StubSharedQA(question="第二次结集为何分裂？"))
+
+    fake_index = (
+        "<!doctype html><html><head>"
+        "<title>佛津 FoJin</title>"
+        '<meta name="description" content="生 generic" />'
+        '<meta property="og:image" content="/landscape-bg.png" />'
+        "</head><body></body></html>"
+    )
+
+    async def _fake_fetch():
+        return fake_index
+
+    try:
+        with patch.object(seo_module, "_fetch_index_html", _fake_fetch):
+            resp = await og_client.get("/share/qa/abc123")
+    finally:
+        _restore_db()
+
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Title now reflects the question, not the homepage.
+    assert "<title>第二次结集为何分裂？" in body
+
+    # Per-question og:* tags present.
+    assert 'property="og:title"' in body
+    assert "第二次结集为何分裂？" in body
+    assert 'property="og:image"' in body
+    # og:image points at the dynamic card endpoint, not the static landscape.
+    assert "/api/og/share/qa/abc123" in body
+    assert "/landscape-bg.png" not in body  # legacy static image was stripped
+
+    # twitter:card and canonical pointing back to ourselves.
+    assert 'name="twitter:card"' in body and "summary_large_image" in body
+    assert 'rel="canonical"' in body
+    assert "/share/qa/abc123" in body
+
+    # Markdown was stripped from the description (no leading **).
+    assert "**空**" not in body
+    # Citation pills (【…】) and inline link markup gone.
+    assert "【《心经》第1卷】" not in body
+
+
+@pytest.mark.anyio
+async def test_share_qa_seo_html_404_when_share_missing(og_client):
+    """/share/qa/{id} returns 404 when the row doesn't exist."""
+    _patch_db(None)
+    try:
+        resp = await og_client.get("/share/qa/no-such-id")
+    finally:
+        _restore_db()
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_share_qa_seo_falls_back_when_frontend_unreachable(og_client):
+    """If frontend nginx is down, we still return readable HTML for crawlers."""
+    import httpx
+
+    _patch_db(_StubSharedQA(question="缘起是什么？"))
+
+    async def _explode():
+        raise httpx.HTTPError("frontend down")
+
+    try:
+        with patch.object(seo_module, "_fetch_index_html", _explode):
+            resp = await og_client.get("/share/qa/abc123")
+    finally:
+        _restore_db()
+
+    assert resp.status_code == 200
+    body = resp.text
+    # Fallback HTML still carries the per-question og: tags.
+    assert "缘起是什么？" in body
+    assert 'property="og:image"' in body
+    assert "/api/og/share/qa/abc123" in body

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -91,6 +91,19 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
 
+    # Shared Q&A deep links — backend injects per-question og:* / og:image
+    # so Twitter / WeChat / Telegram crawlers don't see the homepage
+    # landscape image for every shared link. Share IDs are 16-char
+    # url-safe base64; loosened to [A-Za-z0-9_-] for forward compat.
+    location ~ ^/share/qa/[A-Za-z0-9_-]+$ {
+        proxy_pass $upstream_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
     # Pre-built SEO pages — serve their own index.html with correct meta tags
     location = /search {
         try_files /search/index.html /index.html;


### PR DESCRIPTION
## Problem

Every public Q&A link (`/share/qa/{id}`, introduced in #428) inherits the homepage `og:image` — `/landscape-bg.png`, a generic stock landscape photo. Sharing a link on linux.do / X / WeChat / Telegram produces an identical card no matter which question it points at, with **zero identifying information**. Recent推广 帖子 each carry the same image; click-through rate is reportedly cut to a fraction of what a content-aware card would deliver.

The same pages also inherit the homepage `<title>` / `<meta description>` because the SSR meta injector in `seo.py` only handles `/texts/{id}` and `/texts/{id}/read` today.

## Fix

Two coordinated changes — both gated by nginx routing only `/share/qa/{id}` to the backend:

### 1. Dynamic OG card (`/api/og/share/qa/{id}`)

Renders a 1200×630 PNG via Pillow:

- White card body (252,250,246), warm 佛津 brown-gold (143,100,65) accent bar at the top
- Header: "佛津 FoJin · AI 佛学问答"
- Body: the question, hand-wrapped at ~16 CJK chars per line, max 4 lines, ellipsized if longer
- Footer (optional): `引用 · {first cited sutra title}` if the saved `sources` JSON contains one
- Watermark: `fojin.app` bottom-right
- `Cache-Control: public, max-age=86400` so Cloudflare caches the card for a day

Measured render: **~15ms** locally, well under the 200ms budget. `fonts-noto-cjk` is installed in the Dockerfile (~80MB) so Pillow has glyph coverage; if the font is missing the endpoint logs a warning and falls back to PIL's default font rather than crashing.

### 2. SSR meta for `/share/qa/{id}`

Extends `seo.py`:

- Title: truncated question + " - 佛津 AI 佛学问答"
- Description: markdown-stripped answer (code fences, inline code, links, headings, emphasis, and 【…】 citation pills all dropped), truncated to 150 chars
- `og:title` / `og:description` / `og:image` (points at the new `/api/og/...` endpoint) / `og:image:width=1200` / `og:image:height=630` / `og:type=article` / `og:url`
- `twitter:card=summary_large_image`
- Self-referential `<link rel="canonical">`

Pre-existing `og:*` / `twitter:card` tags in the SPA shell are stripped before injection so crawlers without JS don't see two competing sets. The user's browser still loads the same hashed JS bundle and React mounts on top.

### 3. nginx routing

`frontend/nginx.conf`: route `/share/qa/[A-Za-z0-9_-]+` to the backend (parallel to the existing `/texts/{id}` rule).

## Tests

`backend/tests/test_og_and_share_qa_seo.py` — 5 cases × 2 async runners = **10 passing**:

- `test_og_image_endpoint_returns_png` — real PNG (magic bytes verified) with `max-age=86400`
- `test_og_image_404_when_share_missing`
- `test_share_qa_seo_html_injects_per_question_meta` — verifies per-question `<title>`, `og:title`, `og:image` pointing at the dynamic endpoint, `twitter:card=summary_large_image`, self-canonical, and that markdown / 【…】 pills are stripped from the description, and that the legacy `/landscape-bg.png` is **not** present
- `test_share_qa_seo_html_404_when_share_missing`
- `test_share_qa_seo_falls_back_when_frontend_unreachable` — frontend nginx down → still serves a minimal HTML fallback that carries the per-question meta so crawlers don't see the homepage default

`ruff check` and `ruff format --check` pass on the touched files.

## Verification after deploy

```bash
# 1. Pick any existing share id
curl -sI https://fojin.app/api/og/share/qa/<id> | head
#   → expect: 200, content-type: image/png, cache-control: public, max-age=86400

# 2. Inspect the SSR meta
curl -s https://fojin.app/share/qa/<id> | grep -oE '<(title|meta|link)[^>]*>' | head
#   → expect: per-question title and og:* tags pointing at /api/og/share/qa/<id>

# 3. Twitter / Facebook validators (open in browser)
#   https://cards-dev.twitter.com/validator
#   https://developers.facebook.com/tools/debug/
```

## Notes

- This PR scope is intentionally just the `/share/qa` route. The audit also flagged the homepage `og:image` as generic — that's a separate (smaller) follow-up since it doesn't need a database lookup. Deferred.
- The 24h CDN cache is fine for shared Q&A because the underlying answer is immutable by design (created once via the share endpoint, not edited).