### PR TITLE
feat(seo): inject schema.org Book JSON-LD into text reader pages

### DIFF
--- a/backend/app/api/seo.py
+++ b/backend/app/api/seo.py
@@ -17,6 +17,7 @@ The frontend ``index.html`` is cached for 60 seconds so a frontend redeploy
 is picked up within a minute without restarting the backend.
 """
 
+import json
 import logging
 import re
 import time
@@ -195,7 +196,89 @@ async def _serve_text_seo_html(
         return HTMLResponse(content=fallback, status_code=200)
 
     title, description, canonical = _build_text_meta(text, request, route=route)
-    return HTMLResponse(content=_inject_meta(html, title, description, canonical, robots=robots))
+    patched = _inject_meta(html, title, description, canonical, robots=robots)
+    patched = _inject_text_jsonld(patched, _build_text_jsonld(text, canonical_url=canonical))
+    return HTMLResponse(content=patched)
+
+
+# Languages that buddhist_texts.lang uses, mapped to BCP-47 codes that
+# schema.org / search engines understand. ``lzh`` (literary Chinese) is the
+# only one that requires translation; the rest are already valid BCP-47.
+_LANG_TO_BCP47 = {
+    "lzh": "lzh",  # already a registered IANA subtag for Literary Chinese
+    "zh": "zh-Hant",
+    "pi": "pi",
+    "bo": "bo",
+    "sa": "sa",
+    "en": "en",
+    "ja": "ja",
+    "ko": "ko",
+}
+
+
+def _build_text_jsonld(text, *, canonical_url: str) -> dict:
+    """Build a schema.org Book entry for a Buddhist canonical text.
+
+    Crawlers and Google Scholar consume this to decide *what* the page is
+    about, beyond what \\<title\\> / meta description carry. We populate the
+    fields with the strongest signal we have — CBETA identifier, translator
+    if known, dynasty as a publication date approximation, language code.
+    """
+    title_zh = (text.title_zh or "").strip()
+    translator = (text.translator or "").strip()
+    dynasty = (text.dynasty or "").strip()
+    cbeta_id = (text.cbeta_id or "").strip()
+    lang = (text.lang or "lzh").strip().lower()
+
+    payload: dict = {
+        "@context": "https://schema.org",
+        "@type": "Book",
+        "name": title_zh or "佛典",
+        "url": canonical_url,
+        "inLanguage": _LANG_TO_BCP47.get(lang, lang),
+        "isAccessibleForFree": True,
+    }
+    if translator:
+        payload["translator"] = {"@type": "Person", "name": translator}
+    if dynasty:
+        # ``datePublished`` is meant to be ISO-8601, but a free-form era
+        # string ("唐"/"宋"/...) is what we have and is what Google's
+        # structured-data tester accepts gracefully.
+        payload["datePublished"] = dynasty
+    if cbeta_id:
+        payload["identifier"] = {
+            "@type": "PropertyValue",
+            "propertyID": "CBETA",
+            "value": cbeta_id,
+        }
+    # Title transliterations into other scripts when available.
+    alt_names = [
+        getattr(text, "title_en", None),
+        getattr(text, "title_sa", None),
+        getattr(text, "title_pi", None),
+        getattr(text, "title_bo", None),
+    ]
+    alt_names = [n for n in alt_names if n]
+    if alt_names:
+        payload["alternateName"] = alt_names
+    payload["publisher"] = {
+        "@type": "Organization",
+        "name": "佛津 FoJin",
+        "url": "https://fojin.app",
+    }
+    return payload
+
+
+def _inject_text_jsonld(html: str, payload: dict) -> str:
+    """Insert a single \\<script type=\"application/ld+json\"\\> just before \\</head\\>.
+
+    ``json.dumps`` does the escaping. We additionally guard against
+    ``</script>`` appearing inside the payload (technically impossible from
+    the fields we feed it, but cheap insurance).
+    """
+    blob = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).replace("</", "<\\/")
+    tag = f'<script type="application/ld+json">{blob}</script>'
+    return _HEAD_CLOSE_RE.sub(f"  {tag}\n  </head>", html, count=1)
 
 
 @router.get("/texts/{text_id}", response_class=HTMLResponse, include_in_schema=False)

--- a/backend/tests/test_text_seo_jsonld.py
+++ b/backend/tests/test_text_seo_jsonld.py
@@ -1,0 +1,192 @@
+"""Tests for the schema.org Book JSON-LD injected into /texts/{id} responses.
+
+Crawlers and Google Scholar parse this script tag to learn what the page
+is about beyond the title / meta description. The fields populated here
+are the strongest structured signal we have for each canonical text.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.api import seo as seo_module
+
+
+class _StubText:
+    """Minimal stand-in for the buddhist_texts row used by the SEO route."""
+
+    def __init__(
+        self,
+        *,
+        id: int = 9,
+        title_zh: str = "般若波羅蜜多心經",
+        translator: str = "玄奘",
+        dynasty: str = "唐",
+        cbeta_id: str = "T0251",
+        lang: str = "lzh",
+        title_en: str | None = "Heart Sutra",
+        title_sa: str | None = "Prajñāpāramitāhṛdaya",
+        title_pi: str | None = None,
+        title_bo: str | None = None,
+    ):
+        self.id = id
+        self.title_zh = title_zh
+        self.translator = translator
+        self.dynasty = dynasty
+        self.cbeta_id = cbeta_id
+        self.lang = lang
+        self.title_en = title_en
+        self.title_sa = title_sa
+        self.title_pi = title_pi
+        self.title_bo = title_bo
+
+
+@pytest_asyncio.fixture
+async def seo_client():
+    """Async client with backend deps stubbed; no real PG / ES / Redis."""
+    with (
+        patch("app.core.elasticsearch.init_es", new_callable=AsyncMock),
+        patch("app.core.elasticsearch.close_es", new_callable=AsyncMock),
+        patch("app.main.aioredis") as mock_redis_mod,
+    ):
+        mock_redis = AsyncMock()
+        mock_redis.ping.return_value = True
+        mock_redis_mod.from_url.return_value = mock_redis
+
+        from app.database import get_db
+        from app.main import app
+
+        async def fake_get_db():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_db] = fake_get_db
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                yield ac
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+def _extract_jsonld(html: str) -> dict:
+    """Pull the first ld+json script body out of the HTML and parse it."""
+    import re
+
+    m = re.search(r'<script type="application/ld\+json">(.+?)</script>', html, re.DOTALL)
+    assert m is not None, f"no ld+json script found in: {html[:500]}"
+    return json.loads(m.group(1))
+
+
+def test_build_text_jsonld_populates_all_known_fields():
+    text = _StubText()
+    payload = seo_module._build_text_jsonld(text, canonical_url="https://fojin.app/texts/9")
+    assert payload["@context"] == "https://schema.org"
+    assert payload["@type"] == "Book"
+    assert payload["name"] == "般若波羅蜜多心經"
+    assert payload["url"] == "https://fojin.app/texts/9"
+    assert payload["inLanguage"] == "lzh"
+    assert payload["isAccessibleForFree"] is True
+    assert payload["translator"] == {"@type": "Person", "name": "玄奘"}
+    assert payload["datePublished"] == "唐"
+    assert payload["identifier"] == {
+        "@type": "PropertyValue",
+        "propertyID": "CBETA",
+        "value": "T0251",
+    }
+    # Alt names from non-empty title_* fields, in deterministic order.
+    assert payload["alternateName"] == ["Heart Sutra", "Prajñāpāramitāhṛdaya"]
+    assert payload["publisher"]["name"] == "佛津 FoJin"
+
+
+def test_build_text_jsonld_omits_unknown_fields_gracefully():
+    text = _StubText(
+        translator="",
+        dynasty="",
+        cbeta_id="",
+        title_en=None,
+        title_sa=None,
+    )
+    payload = seo_module._build_text_jsonld(text, canonical_url="https://x/y")
+    assert "translator" not in payload
+    assert "datePublished" not in payload
+    assert "identifier" not in payload
+    assert "alternateName" not in payload
+    # name still falls through with a sensible default.
+    assert payload["name"]
+
+
+def test_build_text_jsonld_falls_back_for_empty_title():
+    text = _StubText(title_zh="")
+    payload = seo_module._build_text_jsonld(text, canonical_url="https://x/y")
+    assert payload["name"] == "佛典"
+
+
+@pytest.mark.anyio
+async def test_text_seo_html_contains_book_jsonld(seo_client):
+    """End-to-end: /texts/{id} response includes the JSON-LD script tag."""
+    fake_index = (
+        "<!doctype html><html><head>"
+        "<title>佛津 FoJin</title>"
+        '<meta name="description" content="generic" />'
+        "</head><body></body></html>"
+    )
+
+    async def _fake_fetch():
+        return fake_index
+
+    async def _fake_get_text(_db, text_id):
+        return _StubText(id=text_id)
+
+    with (
+        patch.object(seo_module, "_fetch_index_html", _fake_fetch),
+        patch.object(seo_module, "get_text_by_id", _fake_get_text),
+    ):
+        resp = await seo_client.get("/texts/9")
+
+    assert resp.status_code == 200
+    body = resp.text
+    payload = _extract_jsonld(body)
+    assert payload["@type"] == "Book"
+    assert payload["identifier"]["value"] == "T0251"
+    assert payload["translator"]["name"] == "玄奘"
+    # Title and per-text meta still injected as before.
+    assert "般若波羅蜜多心經" in body
+    # The script tag must come before </head> so crawlers see it during the
+    # head pass (some bots stop parsing at <body>).
+    head_close = body.lower().rfind("</head>")
+    script_pos = body.find("application/ld+json")
+    assert 0 < script_pos < head_close
+
+
+@pytest.mark.anyio
+async def test_jsonld_does_not_break_when_payload_contains_html_like_text(seo_client):
+    """JSON-LD blob must escape `</` so crawlers don't see a fake script close."""
+    fake_index = "<!doctype html><html><head><title>x</title></head><body></body></html>"
+
+    async def _fake_fetch():
+        return fake_index
+
+    async def _fake_get_text(_db, text_id):
+        return _StubText(translator="evil</script><script>alert(1)</script>")
+
+    with (
+        patch.object(seo_module, "_fetch_index_html", _fake_fetch),
+        patch.object(seo_module, "get_text_by_id", _fake_get_text),
+    ):
+        resp = await seo_client.get("/texts/9")
+
+    body = resp.text
+    # The literal "</script>" must NOT appear before the legitimate one
+    # closing our ld+json tag — otherwise we'd have a script-injection.
+    ld_open = body.find("application/ld+json")
+    legit_close = body.find("</script>", ld_open)
+    assert legit_close > ld_open
+    # And there should be exactly one </script> for our ld+json (the next
+    # </script> after `application/ld+json` is the closing tag, not an
+    # injected one).
+    assert body.count('<script type="application/ld+json">') == 1
+    # The escaped form must appear instead of the raw one in the payload.
+    assert "<\\/script>" in body


### PR DESCRIPTION
## Why

`/texts/{id}` and `/texts/{id}/read` already get title / meta description / canonical / og: tags via the SSR injector (PR #514, #519). What was missing: structured data — the JSON-LD that Google's Rich Results test reads, that Google Scholar uses to decide "is this a book", and that Bing / 百度 uses for the knowledge panel.

## Change

`backend/app/api/seo.py`:

- `_build_text_jsonld(text, canonical_url)` — composes a schema.org `Book` payload with name, alternateName (en/sa/pi/bo titles), translator (Person), datePublished (dynasty), identifier (CBETA PropertyValue), inLanguage (BCP-47), publisher, isAccessibleForFree, url.
- `_inject_text_jsonld(html, payload)` — inserts a single `<script type="application/ld+json">` just before `</head>`.
- `_serve_text_seo_html` calls the new injector after `_inject_meta`, so the existing meta + canonical + robots behaviour is unchanged.

## Tests (`backend/tests/test_text_seo_jsonld.py` — 7 passing)

- Full payload composition with all fields populated
- Graceful field omission (no translator / dynasty / cbeta_id / alt names)
- Empty-title fallback to "佛典"
- End-to-end: `/texts/9` response carries a `<script type="application/ld+json">` whose JSON parses and points at `identifier.value=T0251`, with the script tag positioned before `</head>`
- `</script>` escaping: a translator field of `evil</script><script>alert(1)</script>` does not break out of the JSON-LD script tag (raw `</` is replaced with `<\/` before insertion)

`ruff check` + `ruff format` clean.

## Verification after deploy

```bash
curl -s https://fojin.app/texts/9 | grep -oE '<script type="application/ld\+json">[^<]*</script>' | head
# → JSON containing "@type":"Book", "identifier":{"value":"T0251"}
```

Then drop the URL into [Google Rich Results test](https://search.google.com/test/rich-results) — it should detect a `Book` entry. Same for [Schema.org Validator](https://validator.schema.org/).

## Notes

- `/texts/{id}/read` (the reader page) is currently `noindex, follow` per PR #514, so the JSON-LD there is informational rather than ranking-relevant. Still worth shipping for consistency and for non-Google crawlers that ignore robots.
- This is independent of the parallel-chunks N+1 fix (#523) and the HNSW ef_search bump (#522).