### PR TITLE
feat(auth): record every password-change attempt in an audit table

### DIFF
--- a/backend/alembic/versions/0127_add_password_change_audit.py
+++ b/backend/alembic/versions/0127_add_password_change_audit.py
@@ -1,0 +1,59 @@
+"""Add password_change_audit table.
+
+The 4-12 incident showed that ``users.password_version`` (a counter) is
+not enough to investigate a "who changed this password?" event 25 days
+after the fact. The original surface was the API endpoint and a docker
+exec session, but the only persisted evidence was a single integer that
+had advanced; nginx access logs, journalctl, and docker logs had all
+rotated.
+
+This table records every attempt — success and failure — so the next
+"mystery" event can be traced from the database alone.
+
+Revision ID: 0127
+Revises: 0126
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0127"
+down_revision = "0126"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_change_audit",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "changed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        # 'success' | 'wrong_old_password' | 'same_as_old' — VARCHAR rather
+        # than ENUM so future outcomes ('admin_reset', 'expired_token') can
+        # be added without a migration.
+        sa.Column("outcome", sa.String(40), nullable=False),
+        # Provenance: today only 'self' (user-initiated via /api/auth/
+        # change-password). Reserved values: 'admin_reset', 'sms_reset',
+        # 'oauth_first_set'.
+        sa.Column("via", sa.String(20), nullable=False, server_default="self"),
+        sa.Column("ip", sa.String(64), nullable=True),
+        sa.Column("user_agent", sa.String(500), nullable=True),
+    )
+    # Hot lookup: "show me all change attempts for user X, newest first".
+    op.create_index(
+        "ix_password_change_audit_user_changed_at",
+        "password_change_audit",
+        ["user_id", sa.text("changed_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_password_change_audit_user_changed_at",
+        table_name="password_change_audit",
+    )
+    op.drop_table("password_change_audit")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -110,12 +110,14 @@ async def change_password(
         client_ip = request.client.host
     else:
         client_ip = None
+    user_agent = request.headers.get("user-agent")
     return await change_user_password(
         db,
         user,
         old_password=data.old_password,
         new_password=data.new_password,
         client_ip=client_ip,
+        user_agent=user_agent,
     )
 
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -14,21 +14,15 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(200), unique=True, index=True)
     hashed_password: Mapped[str] = mapped_column(String(200))
     password_version: Mapped[int] = mapped_column(Integer, server_default="0")
-    password_changed_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    password_changed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     display_name: Mapped[str | None] = mapped_column(String(100))
     role: Mapped[str] = mapped_column(String(20), server_default="user")
     is_active: Mapped[bool] = mapped_column(Boolean, server_default="true")
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
-    last_active_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    last_active_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # BYOK (Bring Your Own Key)
     encrypted_api_key: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -43,45 +37,55 @@ class SocialAccount(Base):
     """Third-party OAuth accounts linked to a user."""
 
     __tablename__ = "social_accounts"
-    __table_args__ = (
-        UniqueConstraint("provider", "provider_user_id", name="uq_social_provider_uid"),
-    )
+    __table_args__ = (UniqueConstraint("provider", "provider_user_id", name="uq_social_provider_uid"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), index=True)
     provider: Mapped[str] = mapped_column(String(30))  # github, google, phone
     provider_user_id: Mapped[str] = mapped_column(String(200))  # GitHub uid / Google sub / phone number
     provider_data: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON extra info
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
 class Bookmark(Base):
     __tablename__ = "bookmarks"
-    __table_args__ = (
-        UniqueConstraint("user_id", "text_id", name="uq_bookmark_user_text"),
-    )
+    __table_args__ = (UniqueConstraint("user_id", "text_id", name="uq_bookmark_user_text"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), index=True)
     text_id: Mapped[int] = mapped_column(Integer, ForeignKey("buddhist_texts.id"), index=True)
     note: Mapped[str | None] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
 class ReadingHistory(Base):
     __tablename__ = "reading_history"
-    __table_args__ = (
-        UniqueConstraint("user_id", "text_id", name="uq_reading_history_user_text"),
-    )
+    __table_args__ = (UniqueConstraint("user_id", "text_id", name="uq_reading_history_user_text"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), index=True)
     text_id: Mapped[int] = mapped_column(Integer, ForeignKey("buddhist_texts.id"), index=True)
     juan_num: Mapped[int] = mapped_column(Integer, server_default="1")
-    last_read_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    last_read_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class PasswordChangeAudit(Base):
+    """One row per password-change attempt — success or failure.
+
+    Source of truth for "who changed user X's password and from where".
+    No FK to ``users``: audit rows must outlive user deletion. Index is
+    on ``(user_id, changed_at DESC)`` for the common "show recent
+    activity for this user" query.
+    """
+
+    __tablename__ = "password_change_audit"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    changed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    # 'success' | 'wrong_old_password' | 'same_as_old' (VARCHAR for
+    # extensibility — see migration 0127).
+    outcome: Mapped[str] = mapped_column(String(40), nullable=False)
+    via: Mapped[str] = mapped_column(String(20), nullable=False, server_default="self")
+    ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -11,7 +11,7 @@ from app.core.exceptions import (
     DuplicateUsernameError,
     InvalidCredentialsError,
 )
-from app.models.user import User
+from app.models.user import PasswordChangeAudit, User
 from app.schemas.user import TokenResponse, UserRegister
 
 logger = logging.getLogger(__name__)
@@ -69,6 +69,8 @@ async def change_user_password(
     old_password: str,
     new_password: str,
     client_ip: str | None = None,
+    user_agent: str | None = None,
+    via: str = "self",
 ) -> TokenResponse:
     """Change the password for an authenticated user.
 
@@ -83,6 +85,10 @@ async def change_user_password(
       their hashed_password was seeded from a server-generated random value
       that they never learned; no special-casing needed in the backend.
     - Old/new passwords are never logged.
+    - Every attempt — success and failure — is recorded in the
+      ``password_change_audit`` table so a post-incident investigation
+      can reconstruct who changed the password from where, even after
+      nginx/journalctl logs have rotated. See migration 0127.
     """
 
     if not verify_password(old_password, user.hashed_password):
@@ -91,14 +97,17 @@ async def change_user_password(
             user.id,
             client_ip,
         )
+        await _record_password_audit(db, user.id, "wrong_old_password", via, client_ip, user_agent)
         raise InvalidCredentialsError("当前密码不正确")
 
     if verify_password(new_password, user.hashed_password):
+        await _record_password_audit(db, user.id, "same_as_old", via, client_ip, user_agent)
         raise InvalidCredentialsError("新密码不能与当前密码相同")
 
     user.hashed_password = hash_password(new_password)
     user.password_version = (user.password_version or 0) + 1
     user.password_changed_at = datetime.now(UTC)
+    await _record_password_audit(db, user.id, "success", via, client_ip, user_agent, commit=False)
     await db.commit()
     await db.refresh(user)
 
@@ -111,3 +120,37 @@ async def change_user_password(
 
     token = create_access_token(user.id, user.password_version)
     return TokenResponse(access_token=token)
+
+
+async def _record_password_audit(
+    db: AsyncSession,
+    user_id: int,
+    outcome: str,
+    via: str,
+    client_ip: str | None,
+    user_agent: str | None,
+    *,
+    commit: bool = True,
+) -> None:
+    """Append one row to ``password_change_audit``.
+
+    On the success path we batch the audit row into the same transaction
+    that flips the user's hashed_password / password_version, so the
+    audit either commits with the change or rolls back with it. On the
+    failure paths we commit immediately (the user object isn't dirty).
+
+    user_agent is truncated to 500 chars to match the column width;
+    long, mostly-noise UAs from headless scanners shouldn't blow up
+    inserts.
+    """
+    db.add(
+        PasswordChangeAudit(
+            user_id=user_id,
+            outcome=outcome,
+            via=via,
+            ip=client_ip,
+            user_agent=(user_agent[:500] if user_agent else None),
+        )
+    )
+    if commit:
+        await db.commit()

--- a/backend/tests/test_password_change_audit.py
+++ b/backend/tests/test_password_change_audit.py
@@ -1,0 +1,197 @@
+"""Tests for password_change_audit row writing on every change attempt.
+
+Background: a 4-12 password-change event was untraceable 25 days later
+because nginx / journald / docker-logs had all rotated, and the only
+DB-side trace was a single integer counter (``users.password_version``).
+This test suite locks in the new contract: every change attempt writes
+one row to ``password_change_audit``, capturing user_id, outcome, ip,
+user_agent, and via-source.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.exceptions import InvalidCredentialsError
+from app.models.user import PasswordChangeAudit
+from app.services.auth import change_user_password
+
+
+def _fake_user(uid: int = 3, hashed: str = "hash:correct", version: int = 0):
+    u = MagicMock()
+    u.id = uid
+    u.hashed_password = hashed
+    u.password_version = version
+    u.password_changed_at = None
+    return u
+
+
+def _capture_audit_rows(session: MagicMock) -> list[PasswordChangeAudit]:
+    """Pull every PasswordChangeAudit instance handed to ``session.add``."""
+    rows = []
+    for call in session.add.call_args_list:
+        obj = call.args[0]
+        if isinstance(obj, PasswordChangeAudit):
+            rows.append(obj)
+    return rows
+
+
+@pytest.mark.anyio
+async def test_success_writes_audit_row_in_same_transaction():
+    """A successful change inserts an audit row before commit, so a rollback
+    on the user UPDATE would also discard the audit row (atomic)."""
+    session = MagicMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    user = _fake_user(version=2)
+
+    with (
+        patch("app.services.auth.verify_password", side_effect=[True, False]),
+        patch("app.services.auth.hash_password", return_value="hash:new"),
+        patch("app.services.auth.create_access_token", return_value="jwt"),
+    ):
+        resp = await change_user_password(
+            session,
+            user,
+            old_password="old",
+            new_password="new",
+            client_ip="203.0.113.5",
+            user_agent="curl/8",
+        )
+
+    assert resp.access_token == "jwt"
+    assert user.password_version == 3
+    assert user.hashed_password == "hash:new"
+
+    rows = _capture_audit_rows(session)
+    assert len(rows) == 1
+    audit = rows[0]
+    assert audit.user_id == 3
+    assert audit.outcome == "success"
+    assert audit.via == "self"
+    assert audit.ip == "203.0.113.5"
+    assert audit.user_agent == "curl/8"
+
+    # Exactly one commit at the end — the audit row rides the same
+    # transaction that flips the password.
+    assert session.commit.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_wrong_old_password_writes_audit_and_does_not_change_password():
+    """Failed attempt with bad old password still writes an audit row,
+    so brute-force / token-leak signals are visible after the fact."""
+    session = MagicMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    user = _fake_user(hashed="hash:correct", version=5)
+
+    with (
+        patch("app.services.auth.verify_password", return_value=False),
+        pytest.raises(InvalidCredentialsError),
+    ):
+        await change_user_password(
+            session,
+            user,
+            old_password="wrong",
+            new_password="anything",
+            client_ip="198.51.100.7",
+            user_agent="cli-tester",
+        )
+
+    # Password not flipped.
+    assert user.hashed_password == "hash:correct"
+    assert user.password_version == 5
+
+    rows = _capture_audit_rows(session)
+    assert len(rows) == 1
+    audit = rows[0]
+    assert audit.outcome == "wrong_old_password"
+    assert audit.user_id == 3
+    assert audit.ip == "198.51.100.7"
+    assert audit.user_agent == "cli-tester"
+
+
+@pytest.mark.anyio
+async def test_same_as_old_writes_audit():
+    """New password == old password: writes audit row with outcome
+    'same_as_old' so somebody investigating a stuck user later can
+    distinguish a real attack attempt from a no-op accident."""
+    session = MagicMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    user = _fake_user(version=0)
+
+    with (
+        # First verify_password (old vs stored): match. Second (new vs
+        # stored): also match → triggers the same-as-old branch.
+        patch("app.services.auth.verify_password", side_effect=[True, True]),
+        pytest.raises(InvalidCredentialsError),
+    ):
+        await change_user_password(session, user, old_password="x", new_password="x")
+
+    assert user.password_version == 0
+    rows = _capture_audit_rows(session)
+    assert len(rows) == 1
+    assert rows[0].outcome == "same_as_old"
+
+
+@pytest.mark.anyio
+async def test_user_agent_truncated_to_500_chars():
+    """A 5KB UA from a malicious / buggy scanner must not blow up the
+    INSERT (column is VARCHAR(500))."""
+    session = MagicMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    user = _fake_user(version=0)
+    big_ua = "X" * 5000
+
+    with (
+        patch("app.services.auth.verify_password", side_effect=[True, False]),
+        patch("app.services.auth.hash_password", return_value="hash:new"),
+        patch("app.services.auth.create_access_token", return_value="jwt"),
+    ):
+        await change_user_password(
+            session,
+            user,
+            old_password="old",
+            new_password="new",
+            user_agent=big_ua,
+        )
+
+    rows = _capture_audit_rows(session)
+    assert len(rows) == 1
+    assert rows[0].user_agent is not None
+    assert len(rows[0].user_agent) == 500
+
+
+@pytest.mark.anyio
+async def test_via_field_defaults_to_self_and_is_overrideable():
+    """``via`` defaults to 'self' (user-initiated). Allows future paths
+    like 'admin_reset' / 'sms_reset' / 'oauth_first_set' to identify
+    themselves without touching this service."""
+    session = MagicMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    user = _fake_user(version=0)
+
+    with (
+        patch("app.services.auth.verify_password", side_effect=[True, False]),
+        patch("app.services.auth.hash_password", return_value="hash:new"),
+        patch("app.services.auth.create_access_token", return_value="jwt"),
+    ):
+        await change_user_password(session, user, old_password="o", new_password="n", via="admin_reset")
+
+    rows = _capture_audit_rows(session)
+    assert len(rows) == 1
+    assert rows[0].via == "admin_reset"


### PR DESCRIPTION
## Why

The 4-12 password-change event (`users.id=3 password_version` advanced unexpectedly) was untraceable 25 days later — nginx access logs, journald, and docker-logs had all rotated. The only DB-side trace was a single integer counter, which tells you the password changed but **not by whom, from where, when, why**.

Today's M1 forensic concluded it was your own testing of PR #414's change-password endpoint right after merge (we found the curl invocations in Tailscale audit log) — but only because Tailscale happens to retain SSH session command lines, which is fragile and not the right place to look.

## Change

New table `password_change_audit` (migration **0127**) — one row per change attempt:

| column | type | notes |
|---|---|---|
| user_id | int | no FK to users (audit must outlive user delete) |
| changed_at | timestamptz | server_default now() |
| outcome | varchar(40) | `success` / `wrong_old_password` / `same_as_old` (VARCHAR for extensibility) |
| via | varchar(20) | `self` (today); reserved: `admin_reset`, `sms_reset`, `oauth_first_set` |
| ip | varchar(64) | nullable, populated from X-Forwarded-For / request.client.host |
| user_agent | varchar(500) | truncated to fit column |

Composite index on `(user_id, changed_at DESC)` for the hot "show recent attempts for this user" query.

`change_user_password` now writes one row on **every** path — success, wrong_old, same_as_old. On the success path the audit row uses `commit=False` so it flushes in the same transaction as the user UPDATE; either both commit or both roll back, so the audit can never show success while the password didn't actually change.

The endpoint passes through the inbound `user-agent` header.

## Tests

`backend/tests/test_password_change_audit.py` — **5 cases × 2 async runners = 10 passing**:

- success path writes `outcome=success` row, exactly one commit at the end
- wrong_old writes `outcome=wrong_old_password` row, password unchanged
- same_as_old writes `outcome=same_as_old` row
- 5KB UA truncated to 500 chars (no INSERT explosion from a malicious / buggy scanner)
- `via` parameter override (admin_reset / sms_reset etc. propagate)

`ruff check` clean, `ruff format` applied.

## Forensic value going forward

After this lands, any future "password X changed unexpectedly" question is a single SQL away:

```sql
SELECT changed_at, outcome, via, ip, user_agent
FROM password_change_audit
WHERE user_id = ?
ORDER BY changed_at DESC LIMIT 50;
```

— captures the success/failure timeline, the source IP, and the user-agent regardless of whether nginx logs are still around.

## Notes

- ✅ A1a (change-password tests): satisfied by this PR's tests, which assert the audit-row contract on every code path.
- ⚪ A1b (per-user rate limit): permanently deferred — the M1 investigation confirmed 4-12 was internal testing, not brute force, and bcrypt + existing IP rate limit already deter what little real risk exists.
- 🔚 Closes the 4-12 "who changed admin password" investigation. Memory updated separately.