### PR TITLE
feat(provenance): add source_tier / source_version / ingested_at to kg_entities

### DIFF
--- a/backend/alembic/versions/0128_add_kg_entity_provenance.py
+++ b/backend/alembic/versions/0128_add_kg_entity_provenance.py
@@ -1,0 +1,83 @@
+"""Add provenance tracking to kg_entities.
+
+Today the only ingestion-lineage signal on a kg_entity row is ``created_at``
+(strictly: when the row was first inserted). This is not enough to answer
+the operational questions that have already cost real time:
+
+- "T0251 心经 was full of preface text — which other rows are still on the
+  pre-fix import and need a re-run?"  Currently: full-table grep.
+- "DeepSeek extraction misfired on 2026-04-16; which kg_entities did it
+  pollute and how do we roll back?"  Currently: no answer.
+- "CBETA / Wikidata published a new dump; how do we re-import only the
+  authoritative rows without overwriting the human-curated ones?"
+  Currently: full-overwrite or skip.
+
+Three columns close all three gaps:
+
+- ``source_tier``: trust band of the row's ultimate source.
+    'authoritative' — DILA / CBETA / canonical catalogs
+    'curated'       — Wikipedia / community-edited references
+    'derived'       — automated scrapers (Amap, OSM)
+    'inferred'      — LLM-assisted extraction (DeepSeek, GPT)
+
+  VARCHAR not ENUM so future tiers can be added without a migration
+  (matches the convention set in 0127).
+
+- ``source_version``: a free-form tag identifying the *snapshot* the row
+  came from — 'cbeta-2025q1', 'wikidata-dump-20260301',
+  'deepseek-chat-2026-04-15'. Lets a sync script select rows older than
+  a given snapshot for differential re-import.
+
+- ``ingested_at``: wall-clock time of the most recent ingestion that
+  wrote/refreshed this row. Backfilled from ``created_at`` for legacy
+  rows so ``ingested_at`` is never NULL after this migration; a row with
+  no provenance still has at least an approximate floor.
+
+Composite index on (entity_type, source_tier) supports the common
+audit query "show all person rows with tier='inferred'", which is the
+shape we'll most often run after a noisy LLM extraction.
+
+Revision ID: 0128
+Revises: 0127
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0128"
+down_revision = "0127"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "kg_entities",
+        sa.Column("source_tier", sa.String(20), nullable=True),
+    )
+    op.add_column(
+        "kg_entities",
+        sa.Column("source_version", sa.String(80), nullable=True),
+    )
+    op.add_column(
+        "kg_entities",
+        sa.Column("ingested_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # Backfill: legacy rows get ingested_at = created_at so the column has
+    # a non-NULL floor everywhere. source_tier / source_version stay NULL
+    # (= "unknown lineage") until each ingestion script is wired.
+    op.execute(
+        "UPDATE kg_entities SET ingested_at = created_at WHERE ingested_at IS NULL"
+    )
+
+    op.create_index(
+        "ix_kg_entities_type_tier",
+        "kg_entities",
+        ["entity_type", "source_tier"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_kg_entities_type_tier", table_name="kg_entities")
+    op.drop_column("kg_entities", "ingested_at")
+    op.drop_column("kg_entities", "source_version")
+    op.drop_column("kg_entities", "source_tier")

--- a/backend/app/models/knowledge_graph.py
+++ b/backend/app/models/knowledge_graph.py
@@ -23,6 +23,14 @@ class KGEntity(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
+    # Provenance — see migration 0128. Together these answer
+    # "where did this row come from, how trusted is it, and is it stale?"
+    # Written exclusively via app.services.provenance.apply_provenance —
+    # no server defaults, so a script that forgets to tag a row leaves
+    # NULLs that audit queries can spot.
+    source_tier: Mapped[str | None] = mapped_column(String(20))
+    source_version: Mapped[str | None] = mapped_column(String(80))
+    ingested_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     # Relations where this entity is the subject
     outgoing_relations: Mapped[list["KGRelation"]] = relationship(

--- a/backend/app/services/provenance.py
+++ b/backend/app/services/provenance.py
@@ -1,0 +1,75 @@
+"""Provenance tagging for kg_entities (and any other table that adopts
+the same triple — source_tier / source_version / ingested_at).
+
+Every ingestion path that creates or refreshes a ``KGEntity`` row should
+funnel through ``apply_provenance`` so that the trust band, snapshot
+identifier, and ingestion timestamp are set in one place. This is what
+makes "show me everything DeepSeek inferred this week" or "rebuild every
+row that's older than wikidata-2026Q1" a one-line query instead of an
+archaeology project.
+
+Tier semantics (kept short on purpose — VARCHAR not ENUM, so new tiers
+land here without a migration):
+
+- ``authoritative`` — primary canonical sources whose authority is the
+  reason the project exists at all: DILA, CBETA, Taishō catalogues.
+- ``curated`` — community-maintained references with editorial review:
+  Wikipedia, Wikidata curated items.
+- ``derived``     — automated scrapers against third-party APIs whose
+  shape we do not control: Amap, OSM, BDRC.
+- ``inferred``    — LLM-assisted extraction. Highest variance; the UI
+  should mark these distinctly.
+"""
+
+from datetime import UTC, datetime
+
+from app.models.knowledge_graph import KGEntity
+
+SOURCE_TIER_AUTHORITATIVE = "authoritative"
+SOURCE_TIER_CURATED = "curated"
+SOURCE_TIER_DERIVED = "derived"
+SOURCE_TIER_INFERRED = "inferred"
+
+VALID_SOURCE_TIERS: frozenset[str] = frozenset(
+    {
+        SOURCE_TIER_AUTHORITATIVE,
+        SOURCE_TIER_CURATED,
+        SOURCE_TIER_DERIVED,
+        SOURCE_TIER_INFERRED,
+    }
+)
+
+
+def apply_provenance(
+    entity: KGEntity,
+    *,
+    tier: str,
+    source_version: str,
+    ingested_at: datetime | None = None,
+) -> KGEntity:
+    """Stamp a ``KGEntity`` with provenance metadata.
+
+    ``tier`` must be one of :data:`VALID_SOURCE_TIERS`; an unknown tier
+    is rejected loudly so a typo at an ingestion site does not silently
+    create an unfilterable record.
+
+    ``source_version`` is required (never blank) — a row tagged with no
+    snapshot identifier is indistinguishable from a legacy un-tagged row
+    and defeats the purpose of the column. Use a stable string like
+    ``'cbeta-2025q1'`` or ``'wikidata-dump-20260301'``.
+
+    ``ingested_at`` defaults to ``datetime.now(UTC)``; pass an explicit
+    value when backfilling so the timestamp reflects the underlying
+    snapshot, not the moment the script ran.
+    """
+    if tier not in VALID_SOURCE_TIERS:
+        raise ValueError(
+            f"unknown source_tier {tier!r}; expected one of {sorted(VALID_SOURCE_TIERS)}"
+        )
+    if not source_version or not source_version.strip():
+        raise ValueError("source_version must be a non-empty identifier")
+
+    entity.source_tier = tier
+    entity.source_version = source_version
+    entity.ingested_at = ingested_at or datetime.now(UTC)
+    return entity

--- a/backend/tests/test_provenance.py
+++ b/backend/tests/test_provenance.py
@@ -1,0 +1,95 @@
+"""Tests for the provenance helper.
+
+The helper is the choke point every ingestion script will route through,
+so the rejection paths matter as much as the happy path: a typo in
+``tier`` at any ingestion site must surface as a hard error, not as a
+quietly mis-tagged row that pollutes audit queries forever.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.models.knowledge_graph import KGEntity
+from app.services.provenance import (
+    SOURCE_TIER_AUTHORITATIVE,
+    SOURCE_TIER_INFERRED,
+    VALID_SOURCE_TIERS,
+    apply_provenance,
+)
+
+
+def _bare_entity() -> KGEntity:
+    return KGEntity(entity_type="person", name_zh="测试")
+
+
+def test_apply_provenance_sets_all_three_fields_with_default_timestamp():
+    e = _bare_entity()
+    before = datetime.now(UTC)
+    apply_provenance(e, tier=SOURCE_TIER_AUTHORITATIVE, source_version="dila-2025q1")
+    after = datetime.now(UTC)
+
+    assert e.source_tier == SOURCE_TIER_AUTHORITATIVE
+    assert e.source_version == "dila-2025q1"
+    assert e.ingested_at is not None
+    assert before <= e.ingested_at <= after
+
+
+def test_apply_provenance_accepts_explicit_ingested_at_for_backfill():
+    """Backfill scripts must be able to set ``ingested_at`` to the
+    snapshot's date, not the moment the script happened to run."""
+    e = _bare_entity()
+    snapshot_date = datetime(2024, 6, 1, tzinfo=UTC)
+    apply_provenance(
+        e,
+        tier=SOURCE_TIER_INFERRED,
+        source_version="deepseek-chat-2024-06",
+        ingested_at=snapshot_date,
+    )
+    assert e.ingested_at == snapshot_date
+
+
+def test_apply_provenance_rejects_unknown_tier():
+    e = _bare_entity()
+    with pytest.raises(ValueError, match="unknown source_tier"):
+        apply_provenance(e, tier="trustworthy", source_version="x-2025")
+    # Entity must remain untouched on error so a caller cannot half-tag
+    # a row by passing a typo.
+    assert e.source_tier is None
+    assert e.source_version is None
+    assert e.ingested_at is None
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_apply_provenance_rejects_blank_source_version(blank: str):
+    e = _bare_entity()
+    with pytest.raises(ValueError, match="source_version"):
+        apply_provenance(e, tier=SOURCE_TIER_AUTHORITATIVE, source_version=blank)
+
+
+def test_valid_tiers_constant_is_immutable_and_complete():
+    """Lock in the four tiers we ship with. Adding a new tier should be
+    a deliberate code change that fails this test until updated."""
+    assert isinstance(VALID_SOURCE_TIERS, frozenset)
+    assert {
+        "authoritative",
+        "curated",
+        "derived",
+        "inferred",
+    } == VALID_SOURCE_TIERS
+
+
+def test_apply_provenance_returns_same_entity_for_chaining():
+    e = _bare_entity()
+    result = apply_provenance(e, tier="curated", source_version="wikipedia-2026-05")
+    assert result is e
+
+
+def test_default_ingested_at_is_utc_aware():
+    """A naive datetime would break comparisons against the
+    timezone-aware columns the migration created."""
+    e = _bare_entity()
+    apply_provenance(e, tier="derived", source_version="amap-v3-2026")
+    assert e.ingested_at.tzinfo is not None
+    # Should be very recent — guard against a pathological default.
+    assert datetime.now(UTC) - e.ingested_at < timedelta(seconds=5)


### PR DESCRIPTION
## Why

The only ingestion-lineage signal on a `kg_entity` row today is `created_at`, which can't answer the questions that have already cost real time on this project:

- "T0251 心经 was full of preface text — which other rows are still on the pre-fix import?"  Currently: full-table grep.
- "DeepSeek extraction misfired on 2026-04-16 — which rows did it pollute and how do we roll back?"  Currently: no answer.
- "CBETA / Wikidata published a new dump — how do we re-import only authoritative rows without overwriting human curation?"  Currently: full-overwrite or skip.

## What

Migration **0128** adds three columns to `kg_entities`:

| column | type | meaning |
|---|---|---|
| `source_tier` | varchar(20) | `authoritative` / `curated` / `derived` / `inferred` |
| `source_version` | varchar(80) | snapshot tag, e.g. `cbeta-2025q1`, `wikidata-dump-20260301` |
| `ingested_at` | timestamptz | wall-clock time of most recent ingestion |

Plus a composite index `(entity_type, source_tier)` for the audit query "show all `person` rows with tier=`inferred`". Backfills `ingested_at` from `created_at` so legacy rows have a non-NULL floor immediately.

`source_tier` is `VARCHAR` not `ENUM` so additional tiers can land without a migration (matching the convention from #526 / migration 0127).

A single helper, `app/services/provenance.apply_provenance(entity, *, tier, source_version, ingested_at=None)`, becomes the choke point every ingestion script will route through. It rejects unknown tiers and blank source_versions loudly so a typo at one ingestion site cannot silently mis-tag a row.

## Scope (deliberately narrow)

This PR ships **infrastructure only**. Wiring the existing ingestion scripts (`import_suttacentral_places`, `import_osm_temples`, `fetch_amap_temples_v3`, `fetch_wikidata_persons_extended`, DeepSeek extraction, ...) is left to per-source follow-up PRs so each change can be reviewed in isolation and the data this PR ships with stays untouched.

## Migration safety

- `ADD COLUMN ... NULL` is metadata-only on PG 11+ (instant).
- Backfill `UPDATE` on ~44k rows is sub-second; PG does not escalate row locks.
- `CREATE INDEX` (non-concurrent) takes `ShareLock` blocking writes — fine at this size.

## Test plan

- [x] 9/9 new tests pass (`tests/test_provenance.py`)
- [x] Ruff clean
- [x] Pre-existing `annotations_workflow` + 1 smoke failure on master unaffected (verified on master same failures)
- [ ] Post-merge: alembic upgrade head on staging, spot-check `SELECT count(*) FROM kg_entities WHERE ingested_at IS NULL` → 0
- [ ] Post-merge: open follow-up PR wiring `apply_provenance` into the first ingestion script (suggest DILA / Wikidata persons since they're the most authoritative)

## Reviewer notes

- Reviewed by `superpowers:code-reviewer` pre-push: **APPROVE**, P2-only suggestions (one applied — model column comment).
- Auto-merge **deliberately not enabled** — #526 was front-run by auto-merge before reviewer feedback could land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)