### PR TITLE
feat(citation-guard): block hallucinated 【经名/卷号】 before they reach the user

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -20,6 +20,7 @@ from app.models.chat import ChatMessage, ChatSession
 from app.models.hot_question import HotQuestion
 from app.models.user import User
 from app.schemas.chat import ChatResponse, ChatSource
+from app.services.citation_guard import enforce_citation_whitelist, log_mutations
 from app.services.master_profiles import get_master
 from app.services.rag_retrieval import retrieve_rag_context
 
@@ -816,8 +817,15 @@ async def send_message(
         logger.exception("LLM call failed")
         answer = "抱歉，AI 服务暂时不可用，请稍后重试。"
 
+    # Citation guard: rewrite any 【《X》第N卷】 the model produced that is
+    # not anchored in the retrieved sources. See app/services/citation_guard
+    # for the full rationale — this is the deterministic backstop after the
+    # prompt's moral one.
+    answer, _citation_mutations = enforce_citation_whitelist(answer, sources)
+
     if chat_session:
         await _save_messages(db, chat_session.id, message, answer, sources)
+        log_mutations(chat_session.id, _citation_mutations)
 
         # Auto-generate a better session title for new sessions (first message)
         if chat_session.title == message[:50]:
@@ -984,12 +992,39 @@ async def send_message_stream(
         yield f"data: {json.dumps({'type': 'error', 'message': error_msg}, ensure_ascii=False)}\n\n"
         full_answer = full_answer or error_msg
 
+    # Citation guard: rewrite any 【《X》第N卷】 not anchored in the
+    # retrieved sources. The user has already seen the raw stream; we
+    # emit a final 'citation_correction' event so the frontend can swap
+    # the visible message to the corrected version, then persist only
+    # the corrected version to chat_messages so reload + history are
+    # canonical.
+    #
+    # SSE event ordering contract (must be preserved if events are
+    # re-ordered later): no `token` events are emitted after
+    # `citation_correction`. Frontend stream consumers in
+    # frontend/src/pages/ChatPage.tsx and src/components/ReaderAIPanel.tsx
+    # rely on this — once they swap the visible message to the corrected
+    # text, a late `token` would re-append the LLM's raw output and
+    # silently re-introduce the hallucination this guard exists to
+    # prevent.
+    corrected_answer, _citation_mutations = enforce_citation_whitelist(full_answer, sources)
+    if _citation_mutations:
+        yield (
+            "data: "
+            + json.dumps(
+                {"type": "citation_correction", "content": corrected_answer},
+                ensure_ascii=False,
+            )
+            + "\n\n"
+        )
+
     # 回答完成后显示引用来源——先论点后论据，自然阅读顺序
     if sources:
         yield f"data: {json.dumps({'type': 'sources', 'sources': [s.model_dump() for s in sources]}, ensure_ascii=False)}\n\n"
 
     if chat_session:
-        await _save_messages(db, chat_session.id, message, full_answer, sources)
+        await _save_messages(db, chat_session.id, message, corrected_answer, sources)
+        log_mutations(chat_session.id, _citation_mutations)
     yield f"data: {json.dumps({'type': 'done'})}\n\n"
 
 

--- a/backend/app/services/citation_guard.py
+++ b/backend/app/services/citation_guard.py
@@ -1,0 +1,199 @@
+"""Citation whitelist enforcement.
+
+Background — every assistant answer flows through this guard before being
+streamed to the user / persisted to ``chat_messages``. The LLM's system
+prompt forbids citing texts that aren't in the retrieved context, but
+"forbidden" is not "prevented": when the model slips, the user sees a
+plausible-looking ``【《伪造经名》第N卷】`` reference, which is the single
+worst failure mode for a scholarly tool. This module is the deterministic
+backstop after the prompt's moral one.
+
+Two failure modes are caught:
+
+1. **Hallucinated title** — ``【《X》第N卷】`` where ``X`` does not appear
+   in the retrieved sources or their aligned parallels. Rewritten to
+   ``《X》（未在检索结果中验证，请谨慎）`` so the user keeps the model's
+   intent but loses the false air of authority a 【】 reference carries.
+
+2. **Wrong fascicle** — title ``X`` is in the whitelist but ``N`` does
+   not match any source's ``juan_num`` for that title. Rewritten to use
+   the closest matching source's actual fascicle number, so the citation
+   link the frontend generates points at a real fascicle of the real
+   text instead of a 404.
+
+The whitelist is the union of the primary RAG hits' (title_zh, juan_num)
+pairs and every aligned ``parallel_chunks[]`` (title, juan_num) — when
+the LLM legitimately cites a Pali / Tibetan parallel that arrived via
+alignment_pairs, that should still count as "in the retrieved context".
+
+Sources with ``text_id <= 0`` are excluded from the whitelist for
+symmetry with the frontend's ``injectCitationLinks`` guard, which drops
+them too.
+"""
+
+import logging
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from app.schemas.chat import ChatSource
+
+logger = logging.getLogger(__name__)
+
+
+# Matches 【《<title>》第<digits>卷】 or 【《<title>》】.
+# Mirrors the frontend regex in ReaderAIPanel.tsx#injectCitationLinks so a
+# citation that survives this guard is exactly the citation the frontend
+# will rewrite into a clickable link.
+_CITATION_RE = re.compile(r"【《([^》]+)》(?:第(\d+)卷)?】")
+
+
+@dataclass(frozen=True)
+class CitationMutation:
+    """Audit record for a single rewrite. Logged for now; a future
+    migration can persist these alongside chat_messages for replay."""
+
+    kind: str  # 'unverified_title' | 'fascicle_corrected'
+    original: str
+    replacement: str
+    title: str
+    original_juan: int | None
+    corrected_juan: int | None
+
+
+def _build_whitelist(sources: Iterable[ChatSource]) -> dict[str, set[int]]:
+    """Build {title -> {juan_num,...}} from sources + their aligned parallels.
+
+    A title with no associated juan_num maps to an empty set, which means
+    "title is real but no fascicle was retrieved" — citations of that
+    title without a fascicle pass; with a fascicle get corrected to None.
+    """
+    wl: dict[str, set[int]] = {}
+    for s in sources:
+        if s.text_id <= 0 or not s.title_zh:
+            continue
+        wl.setdefault(s.title_zh, set()).add(s.juan_num)
+        for p in s.parallel_chunks:
+            if p.text_id <= 0 or not p.title:
+                continue
+            wl.setdefault(p.title, set()).add(p.juan_num)
+    return wl
+
+
+def enforce_citation_whitelist(
+    answer: str,
+    sources: list[ChatSource],
+) -> tuple[str, list[CitationMutation]]:
+    """Rewrite citations in ``answer`` to match the source whitelist.
+
+    Returns the corrected answer and a list of mutations the caller can
+    log / persist. An answer with no 【】 references — or one whose
+    citations all check out — is returned unchanged with an empty list.
+    """
+    if not answer or "【《" not in answer:
+        return answer, []
+
+    whitelist = _build_whitelist(sources)
+    if not whitelist:
+        # No usable sources at all: every 【】 reference is unverifiable.
+        # Strip the brackets but keep the title so the user can still see
+        # what the model meant, with a clear caveat.
+        mutations: list[CitationMutation] = []
+
+        def _strip(match: re.Match[str]) -> str:
+            title = match.group(1)
+            juan_str = match.group(2)
+            juan = int(juan_str) if juan_str else None
+            replacement = f"《{title}》（未在检索结果中验证，请谨慎）"
+            mutations.append(
+                CitationMutation(
+                    kind="unverified_title",
+                    original=match.group(0),
+                    replacement=replacement,
+                    title=title,
+                    original_juan=juan,
+                    corrected_juan=None,
+                )
+            )
+            return replacement
+
+        return _CITATION_RE.sub(_strip, answer), mutations
+
+    mutations = []
+
+    def _rewrite(match: re.Match[str]) -> str:
+        original = match.group(0)
+        title = match.group(1)
+        juan_str = match.group(2)
+        original_juan = int(juan_str) if juan_str else None
+
+        if title not in whitelist:
+            replacement = f"《{title}》（未在检索结果中验证，请谨慎）"
+            mutations.append(
+                CitationMutation(
+                    kind="unverified_title",
+                    original=original,
+                    replacement=replacement,
+                    title=title,
+                    original_juan=original_juan,
+                    corrected_juan=None,
+                )
+            )
+            return replacement
+
+        valid_juans = whitelist[title]
+        # Title-only citation (【《X》】 with no fascicle) is always allowed
+        # when the title is real — it points at the text as a whole.
+        if original_juan is None:
+            return original
+        if original_juan in valid_juans:
+            return original
+
+        # Title is real, fascicle is wrong. Pick the smallest retrieved
+        # fascicle as the deterministic replacement — picking any one is
+        # better than picking none, and "smallest" is stable across runs.
+        if not valid_juans:
+            # Title was retrieved but with no fascicle context. Drop the
+            # fascicle from the citation rather than invent one.
+            replacement = f"【《{title}》】"
+            corrected_juan = None
+        else:
+            corrected_juan = min(valid_juans)
+            replacement = f"【《{title}》第{corrected_juan}卷】"
+
+        mutations.append(
+            CitationMutation(
+                kind="fascicle_corrected",
+                original=original,
+                replacement=replacement,
+                title=title,
+                original_juan=original_juan,
+                corrected_juan=corrected_juan,
+            )
+        )
+        return replacement
+
+    corrected = _CITATION_RE.sub(_rewrite, answer)
+    return corrected, mutations
+
+
+def log_mutations(
+    chat_message_id: int | None,
+    mutations: list[CitationMutation],
+) -> None:
+    """Emit one log line per mutation so a grep over backend logs can
+    surface model citation drift before a database column is wired up."""
+    if not mutations:
+        return
+    for m in mutations:
+        logger.warning(
+            "citation_guard %s msg_id=%s title=%r orig=%r repl=%r "
+            "orig_juan=%s corrected_juan=%s",
+            m.kind,
+            chat_message_id,
+            m.title,
+            m.original,
+            m.replacement,
+            m.original_juan,
+            m.corrected_juan,
+        )

--- a/backend/tests/test_citation_guard.py
+++ b/backend/tests/test_citation_guard.py
@@ -1,0 +1,180 @@
+"""Tests for citation_guard.
+
+The guard is the deterministic backstop after the prompt's moral one;
+its tests should therefore exercise every failure mode the prompt is
+explicitly trying to forbid in chat.py — hallucinated titles, wrong
+fascicle numbers — plus the shape variations the LLM commonly emits.
+"""
+
+from app.schemas.chat import ChatSource, ParallelChunk
+from app.services.citation_guard import (
+    CitationMutation,
+    enforce_citation_whitelist,
+)
+
+
+def _src(text_id: int, title: str, juan: int, lang: str = "lzh") -> ChatSource:
+    return ChatSource(
+        text_id=text_id,
+        juan_num=juan,
+        chunk_index=0,
+        chunk_text="…",
+        score=0.9,
+        title_zh=title,
+        lang=lang,
+    )
+
+
+def test_passes_through_when_no_citation_brackets():
+    answer = "般若是空，色即是空。"
+    out, muts = enforce_citation_whitelist(answer, [_src(1, "心经", 1)])
+    assert out == answer
+    assert muts == []
+
+
+def test_keeps_legitimate_citation_unchanged():
+    answer = "见【《心经》第1卷】所说。"
+    out, muts = enforce_citation_whitelist(answer, [_src(7, "心经", 1)])
+    assert out == answer
+    assert muts == []
+
+
+def test_rewrites_unknown_title_when_whitelist_has_other_titles():
+    answer = "依据【《某伪经》第3卷】所述。"
+    sources = [_src(7, "心经", 1)]
+    out, muts = enforce_citation_whitelist(answer, sources)
+    assert "【《某伪经》第3卷】" not in out
+    assert "《某伪经》（未在检索结果中验证，请谨慎）" in out
+    assert len(muts) == 1
+    assert muts[0].kind == "unverified_title"
+    assert muts[0].title == "某伪经"
+    assert muts[0].original_juan == 3
+
+
+def test_corrects_fascicle_when_title_real_but_juan_wrong():
+    """《心经》is in sources at juan=1; LLM cited 第99卷."""
+    answer = "如【《心经》第99卷】所言。"
+    out, muts = enforce_citation_whitelist(answer, [_src(7, "心经", 1)])
+    assert "【《心经》第1卷】" in out
+    assert "第99卷" not in out
+    assert len(muts) == 1
+    assert muts[0].kind == "fascicle_corrected"
+    assert muts[0].original_juan == 99
+    assert muts[0].corrected_juan == 1
+
+
+def test_picks_smallest_fascicle_for_deterministic_replacement():
+    """Title appears in multiple sources at different juans — the rewriter
+    must be deterministic, not score-dependent, so two reruns of the same
+    answer produce the same output."""
+    answer = "【《大般若经》第999卷】"
+    sources = [
+        _src(10, "大般若经", 50),
+        _src(11, "大般若经", 100),
+        _src(12, "大般若经", 200),
+    ]
+    out, _ = enforce_citation_whitelist(answer, sources)
+    assert "【《大般若经》第50卷】" in out
+
+
+def test_title_only_citation_passes_when_title_is_real():
+    """【《X》】 (no fascicle) should be left alone if the title was retrieved
+    — it's a legitimate "the text as a whole" reference."""
+    answer = "参见【《心经》】整体大意。"
+    out, muts = enforce_citation_whitelist(answer, [_src(7, "心经", 1)])
+    assert out == answer
+    assert muts == []
+
+
+def test_title_only_citation_for_unknown_title_is_flagged():
+    answer = "参见【《不存在经》】。"
+    out, muts = enforce_citation_whitelist(answer, [_src(7, "心经", 1)])
+    assert "【《不存在经》】" not in out
+    assert "《不存在经》（未在检索结果中验证，请谨慎）" in out
+    assert muts[0].original_juan is None
+
+
+def test_parallel_chunk_titles_count_as_whitelisted():
+    """A Pali parallel arrived via alignment_pairs and is attached as
+    parallel_chunks — citing it should pass even though it isn't a top-level
+    source."""
+    src = ChatSource(
+        text_id=7, juan_num=1, chunk_index=0, chunk_text="…", score=0.9,
+        title_zh="心经", lang="lzh",
+        parallel_chunks=[
+            ParallelChunk(
+                text_id=99, juan_num=2, chunk_index=0, chunk_text="…",
+                lang="pi", title="Mahāparinibbāna Sutta",
+            )
+        ],
+    )
+    answer = "见【《Mahāparinibbāna Sutta》第2卷】对应。"
+    out, muts = enforce_citation_whitelist(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_empty_sources_strips_all_citations_with_caveats():
+    """No sources at all means every 【】 is unverifiable. Strip them rather
+    than leaving them as-is, since the frontend would render them as
+    plain-text but visually-authoritative ghost-citations."""
+    answer = "如【《心经》第1卷】与【《金刚经》】所言。"
+    out, muts = enforce_citation_whitelist(answer, [])
+    assert "【《" not in out
+    assert "《心经》（未在检索结果中验证，请谨慎）" in out
+    assert "《金刚经》（未在检索结果中验证，请谨慎）" in out
+    assert len(muts) == 2
+    assert {m.kind for m in muts} == {"unverified_title"}
+
+
+def test_text_id_zero_sources_excluded_from_whitelist():
+    """The frontend's injectCitationLinks drops text_id <= 0; the guard must
+    do the same so the backend and frontend agree on what 'verified' means."""
+    answer = "依据【《心经》第1卷】所述。"
+    out, muts = enforce_citation_whitelist(answer, [_src(0, "心经", 1)])
+    assert "【《心经》第1卷】" not in out
+    assert "《心经》（未在检索结果中验证，请谨慎）" in out
+    assert muts[0].kind == "unverified_title"
+
+
+def test_handles_multiple_citations_in_one_answer():
+    answer = "如【《心经》第1卷】所言，又见【《伪经》第2卷】，再读【《金刚经》第3卷】。"
+    sources = [_src(7, "心经", 1), _src(8, "金刚经", 3)]
+    out, muts = enforce_citation_whitelist(answer, sources)
+    assert "【《心经》第1卷】" in out
+    assert "【《金刚经》第3卷】" in out
+    assert "【《伪经》第2卷】" not in out
+    assert len(muts) == 1
+    assert muts[0].title == "伪经"
+
+
+def test_fascicle_correction_falls_back_to_title_only_when_juan_set_empty():
+    """A defensive case: if a future code path adds a title to the whitelist
+    with no juan attached, citing it with a wrong juan should drop to a
+    safe title-only form rather than hallucinate a fascicle."""
+    src = ChatSource(
+        text_id=7, juan_num=0, chunk_index=0, chunk_text="…",
+        score=0.9, title_zh="心经", lang="lzh",
+    )
+    # juan_num=0 is falsy-but-valid; whitelist will hold {0}, so a juan=5
+    # citation must be corrected to "0" (the only retrieved fascicle).
+    answer = "见【《心经》第5卷】"
+    out, muts = enforce_citation_whitelist(answer, [src])
+    assert "【《心经》第0卷】" in out
+    assert muts[0].corrected_juan == 0
+
+
+def test_mutation_is_dataclass_with_full_audit_fields():
+    """Locks the audit shape so a future migration that persists these
+    rows has a stable schema to bind to."""
+    answer = "【《伪经》第1卷】"
+    _, muts = enforce_citation_whitelist(answer, [])
+    assert len(muts) == 1
+    m = muts[0]
+    assert isinstance(m, CitationMutation)
+    assert m.kind == "unverified_title"
+    assert m.original == "【《伪经》第1卷】"
+    assert m.title == "伪经"
+    assert m.original_juan == 1
+    assert m.corrected_juan is None
+    assert "未在检索结果中验证" in m.replacement

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1349,6 +1349,14 @@ export interface StreamCallbacks {
   onSources: (sources: ChatSource[]) => void;
   onSessionId: (sessionId: number) => void;
   onSearching?: (message: string) => void;
+  /**
+   * Backend has rewritten one or more 【《X》第N卷】 references in the
+   * answer to anchor them to retrieved sources. The full corrected
+   * answer is provided; the consumer should replace the visible
+   * message body with this value so reload + the just-streamed view
+   * stay consistent with what was persisted.
+   */
+  onCitationCorrection?: (correctedAnswer: string) => void;
   onError: (message: string) => void;
   onDone: () => void;
 }
@@ -1411,6 +1419,9 @@ export function sendChatMessageStream(
               break;
             case "searching":
               callbacks?.onSearching?.(event.message);
+              break;
+            case "citation_correction":
+              callbacks?.onCitationCorrection?.(event.content);
               break;
             case "error":
               callbacks.onError(event.message);

--- a/frontend/src/components/ReaderAIPanel.tsx
+++ b/frontend/src/components/ReaderAIPanel.tsx
@@ -158,6 +158,15 @@ export default function ReaderAIPanel({
         );
         scrollToBottom();
       },
+      onCitationCorrection: (correctedAnswer: string) => {
+        // Backend contract (see send_message_stream): no `token` events
+        // arrive after `citation_correction`. If that contract is ever
+        // broken, a late chunk would append to the corrected answer and
+        // re-introduce the hallucination we just stripped.
+        setMessages((prev) =>
+          prev.map((m) => m.id === assistantId ? { ...m, content: correctedAnswer } : m),
+        );
+      },
       onSources: (sources: ChatSource[]) => {
         setMessages((prev) =>
           prev.map((m) => m.id === assistantId ? { ...m, sources } : m),

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -563,6 +563,17 @@ export default function ChatPage() {
         );
         scrollToBottom();
       },
+      onCitationCorrection: (correctedAnswer: string) => {
+        // Backend contract (see send_message_stream): no `token` events
+        // arrive after `citation_correction`. If that contract is ever
+        // broken, a late chunk would append to the corrected answer and
+        // re-introduce the hallucination we just stripped.
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId ? { ...m, content: correctedAnswer } : m,
+          ),
+        );
+      },
       onSources: (sources: ChatSource[]) => {
         setMessages((prev) =>
           prev.map((m) =>


### PR DESCRIPTION
## Why

System prompt forbids LLM from citing texts not in retrieved RAG context, but **forbidden ≠ prevented**. When the model slips, the user sees a plausible-looking `【《伪造经名》第N卷】` pointing at a 404. For a scholarly tool whose competitive edge is "every citation traces to real source", this is the **single worst failure mode**.

This PR adds the deterministic backstop after the prompt's moral one.

## What it does

- **Unknown title** → `《X》（未在检索结果中验证，请谨慎）` (strips 【】, keeps intent visible, drops false-authority brackets — frontend regex no longer matches so no clickable link)
- **Wrong fascicle** → `【《X》第K卷】` where K = smallest retrieved fascicle for that title (deterministic for replay stability)
- **Title-only `【《X》】`** → pass when X is real, flag when not
- **Whitelist** = sources.title_zh ∪ each source.parallel_chunks[].title (Pali/Tibetan parallels riding via alignment_pairs are legitimate)

## Architecture

| File | Role |
|---|---|
| `backend/app/services/citation_guard.py` | Pure function `enforce_citation_whitelist(answer, sources) -> (corrected, mutations)` + `CitationMutation` audit dataclass + `log_mutations` |
| `backend/app/services/chat.py` | Wired into both non-stream and stream paths after answer assembly, before persistence |
| `frontend/src/api/client.ts` | New `onCitationCorrection` callback + SSE switch case |
| `ChatPage.tsx` / `ReaderAIPanel.tsx` | Swap visible message body when correction event arrives |

## Stream path semantics

User has already seen raw tokens. After full answer assembled:
1. Run guard
2. If mutations exist, emit `citation_correction` SSE event with corrected full answer
3. Persist **only** the corrected version (history is canonical)
4. **Contract: no token events after citation_correction** (documented in code; React consumers comment the assumption)

Trade-off accepted: brief visible flash on correction. Buffer-then-flush would kill the streaming UX for the common case (zero corrections).

## Audit trail

`CitationMutation` fields: `kind` ('unverified_title' | 'fascicle_corrected'), `original`, `replacement`, `title`, `original_juan`, `corrected_juan`. Logged via `logger.warning` for now — `grep "citation_guard"` over backend logs surfaces drift volume. Persisting these to a DB column is a follow-up after we see real volume.

## Test plan

- [x] 13 unit tests covering: title-only, multi-citation, parallel-chunks, empty sources, text_id<=0 symmetry with frontend, juan=0 falsy-but-valid edge, deterministic min-juan replacement, audit-shape lock-in
- [x] Backend ruff clean
- [x] Frontend `npm run build` (tsc -b + vite) passes
- [x] Reviewed by `superpowers:code-reviewer` pre-push: **APPROVE**, P1 docs already absorbed
- [ ] Post-merge: tail backend logs for `citation_guard` lines first 24h to gauge baseline drift volume
- [ ] Post-merge: manual smoke — ask LLM a question likely to provoke hallucination ("引用三部唐代经论"), verify any drift gets caught

## Reviewer notes

Auto-merge **deliberately not enabled** (#526 lesson). Pre-existing master CI failures (alembic dry-run, bandit, dep audit) are unrelated and known.

Follow-up scope (P2):
- Empty-title regex case test
- NFC normalization for parallel titles (Pali/Sanskrit diacritic-mismatch)
- Stream-path integration smoke test
- Database column for persisted mutations once drift volume justifies it

🤖 Generated with [Claude Code](https://claude.com/claude-code)