### PR TITLE
feat(feedback): real chat_messages.id on stream + reader-panel feedback UI

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -599,8 +599,14 @@ def _strip_followup_suggestions(text: str) -> str:
 
 async def _save_messages(
     db: AsyncSession, session_id: int, message: str, answer: str, sources: list[ChatSource]
-) -> None:
-    """Persist user + assistant messages to the database."""
+) -> int | None:
+    """Persist user + assistant messages and return the assistant message's id.
+
+    The id lets the streaming caller emit a `message_id` SSE event so the
+    frontend can attach the feedback / share buttons to the real
+    chat_messages row instead of the local `Date.now()` placeholder it
+    used while streaming. Returns None when the message cannot be
+    persisted (defensive — current callers always supply a session)."""
     user_msg = ChatMessage(session_id=session_id, role="user", content=message)
     assistant_msg = ChatMessage(
         session_id=session_id,
@@ -611,6 +617,8 @@ async def _save_messages(
     db.add(user_msg)
     db.add(assistant_msg)
     await db.commit()
+    await db.refresh(assistant_msg)
+    return assistant_msg.id
 
 
 async def _generate_session_title(
@@ -1023,8 +1031,21 @@ async def send_message_stream(
         yield f"data: {json.dumps({'type': 'sources', 'sources': [s.model_dump() for s in sources]}, ensure_ascii=False)}\n\n"
 
     if chat_session:
-        await _save_messages(db, chat_session.id, message, corrected_answer, sources)
+        assistant_msg_id = await _save_messages(
+            db, chat_session.id, message, corrected_answer, sources
+        )
         log_mutations(chat_session.id, _citation_mutations)
+        # Emit the real chat_messages.id so the frontend can swap the
+        # in-flight Date.now() placeholder. Without this, feedback /
+        # share buttons on a freshly-streamed message PUT to a
+        # nonexistent id — which is why the production feedback rate
+        # has been zero despite the UI being wired in ChatPage.
+        if assistant_msg_id is not None:
+            yield (
+                "data: "
+                + json.dumps({"type": "message_id", "id": assistant_msg_id})
+                + "\n\n"
+            )
     yield f"data: {json.dumps({'type': 'done'})}\n\n"
 
 

--- a/backend/tests/test_chat_sources_order.py
+++ b/backend/tests/test_chat_sources_order.py
@@ -106,7 +106,7 @@ async def test_sources_after_tokens():
     mock_client_cls = _make_mock_httpx_client(["般若", "是智慧"])
 
     with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
-         patch("app.services.chat._save_messages", new_callable=AsyncMock), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
          patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
 
         from app.services.chat import send_message_stream
@@ -153,7 +153,7 @@ async def test_empty_sources_not_emitted():
     mock_client_cls = _make_mock_httpx_client(["佛", "法"])
 
     with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
-         patch("app.services.chat._save_messages", new_callable=AsyncMock), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
          patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
 
         from app.services.chat import send_message_stream
@@ -184,7 +184,7 @@ async def test_session_id_value_correct():
     mock_client_cls = _make_mock_httpx_client(["OK"])
 
     with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
-         patch("app.services.chat._save_messages", new_callable=AsyncMock), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
          patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
 
         from app.services.chat import send_message_stream

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1357,6 +1357,14 @@ export interface StreamCallbacks {
    * stay consistent with what was persisted.
    */
   onCitationCorrection?: (correctedAnswer: string) => void;
+  /**
+   * Real chat_messages.id of the just-persisted assistant reply. Arrives
+   * after the stream is otherwise complete (after sources/correction,
+   * before done). Consumers must swap their in-flight Date.now()
+   * placeholder id with this real id, so the feedback / share buttons
+   * target the correct row.
+   */
+  onMessageId?: (assistantMessageId: number) => void;
   onError: (message: string) => void;
   onDone: () => void;
 }
@@ -1422,6 +1430,9 @@ export function sendChatMessageStream(
               break;
             case "citation_correction":
               callbacks?.onCitationCorrection?.(event.content);
+              break;
+            case "message_id":
+              callbacks?.onMessageId?.(event.id);
               break;
             case "error":
               callbacks.onError(event.message);

--- a/frontend/src/components/ReaderAIPanel.tsx
+++ b/frontend/src/components/ReaderAIPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { Link } from "react-router-dom";
-import { Input, Button, message, Spin } from "antd";
+import { Input, Button, message, Spin, Tooltip } from "antd";
 import {
   SendOutlined,
   RobotOutlined,
@@ -9,11 +9,15 @@ import {
   ReadOutlined,
   ClearOutlined,
   CopyOutlined,
+  LikeOutlined,
+  LikeFilled,
+  DislikeOutlined,
+  DislikeFilled,
 } from "@ant-design/icons";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
-import { sendChatMessageStream } from "../api/client";
+import { sendChatMessageStream, updateChatMessageFeedback } from "../api/client";
 import type { ChatSource, ChatMessageItem, ReadingContext } from "../api/client";
 import type { ReactNode } from "react";
 
@@ -167,6 +171,15 @@ export default function ReaderAIPanel({
           prev.map((m) => m.id === assistantId ? { ...m, content: correctedAnswer } : m),
         );
       },
+      onMessageId: (realId: number) => {
+        // Swap Date.now() placeholder for real chat_messages.id so the
+        // feedback button below targets the correct row. Without this
+        // every freshly-streamed message's feedback PUT 404'd silently
+        // — see ChatPage for the full context.
+        setMessages((prev) =>
+          prev.map((m) => (m.id === assistantId ? { ...m, id: realId } : m)),
+        );
+      },
       onSources: (sources: ChatSource[]) => {
         setMessages((prev) =>
           prev.map((m) => m.id === assistantId ? { ...m, sources } : m),
@@ -291,6 +304,62 @@ export default function ReaderAIPanel({
                               {q}
                             </span>
                           ))}
+                        </div>
+                      )}
+                      {/* Feedback row — only after streaming completes
+                          and only on a real persisted message id (the
+                          backend swaps the local Date.now() placeholder
+                          via the message_id SSE event). Mirrors
+                          ChatPage's pattern so the two chat surfaces
+                          collect feedback uniformly. */}
+                      {!isStreaming && m.id < 1e12 && (
+                        <div style={{ marginTop: 8, display: "flex", gap: 4 }}>
+                          <Tooltip title="有帮助">
+                            <Button
+                              type="text"
+                              size="small"
+                              icon={m.feedback === "up" ? <LikeFilled /> : <LikeOutlined />}
+                              style={{
+                                color: m.feedback === "up" ? "var(--fj-accent)" : "var(--fj-ink-muted)",
+                                fontSize: 12,
+                              }}
+                              onClick={() => {
+                                const newFeedback = m.feedback === "up" ? null : "up";
+                                const prevFeedback = m.feedback;
+                                setMessages((prev) =>
+                                  prev.map((x) => (x.id === m.id ? { ...x, feedback: newFeedback } : x)),
+                                );
+                                updateChatMessageFeedback(m.id, newFeedback as "up" | "down" | null).catch(() => {
+                                  setMessages((prev) =>
+                                    prev.map((x) => (x.id === m.id ? { ...x, feedback: prevFeedback } : x)),
+                                  );
+                                });
+                              }}
+                            />
+                          </Tooltip>
+                          <Tooltip title="没帮助">
+                            <Button
+                              type="text"
+                              size="small"
+                              icon={m.feedback === "down" ? <DislikeFilled /> : <DislikeOutlined />}
+                              style={{
+                                color: m.feedback === "down" ? "#e74c3c" : "var(--fj-ink-muted)",
+                                fontSize: 12,
+                              }}
+                              onClick={() => {
+                                const newFeedback = m.feedback === "down" ? null : "down";
+                                const prevFeedback = m.feedback;
+                                setMessages((prev) =>
+                                  prev.map((x) => (x.id === m.id ? { ...x, feedback: newFeedback } : x)),
+                                );
+                                updateChatMessageFeedback(m.id, newFeedback as "up" | "down" | null).catch(() => {
+                                  setMessages((prev) =>
+                                    prev.map((x) => (x.id === m.id ? { ...x, feedback: prevFeedback } : x)),
+                                  );
+                                });
+                              }}
+                            />
+                          </Tooltip>
                         </div>
                       )}
                     </>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -594,6 +594,16 @@ export default function ChatPage() {
       onSearching: (_searchMsg: string) => {
         // 搜索状态由初始占位符 "正在检索经文并生成回答..." 显示，不覆盖 content
       },
+      onMessageId: (realId: number) => {
+        // Replace the in-flight Date.now() placeholder with the real
+        // chat_messages.id so feedback / share buttons target the
+        // correct row. Without this, every freshly-streamed message
+        // would PUT feedback to a nonexistent id, which is why
+        // production feedback rate is currently zero.
+        setMessages((prev) =>
+          prev.map((m) => (m.id === assistantId ? { ...m, id: realId } : m)),
+        );
+      },
       onSessionId: (newSessionId: number) => {
         if (!sessionId) {
           setSessionId(newSessionId);
@@ -1072,7 +1082,13 @@ export default function ChatPage() {
                           />
                         </Tooltip>
                       )}
-                      {m.role === "assistant" && user && (
+                      {m.role === "assistant" && user && m.id < 1e12 && (
+                        // Hide feedback affordances until the real
+                        // chat_messages.id has replaced the in-flight
+                        // Date.now() placeholder (Date.now() ≥ ~1.7e12,
+                        // real DB ids ≪ 1e12). A click during the
+                        // streaming-but-not-yet-saved window would PUT
+                        // to a nonexistent id and 404 silently.
                         <>
                           <Tooltip title="有帮助">
                             <Button


### PR DESCRIPTION
## Why

**Production feedback rate is 0/2,094 assistant answers.** Two independent bugs combined:

1. **Backend never emits real id during streaming.** Both ChatPage and ReaderAIPanel use \`Date.now()\` as in-flight message id while streaming. After \`_save_messages\` commits, no SSE event tells the frontend the real \`chat_messages.id\`. Feedback button → \`PUT /chat/messages/{Date.now()}/feedback\` → 404 silently.
2. **ReaderAIPanel has no feedback UI at all.** Only ChatPage had like/dislike — and even that was broken by #1 except for messages reloaded from session history.

ReaderAIPanel is the reader-page chat surface, almost certainly the highest-volume entry point given user behavior data (academic users reading + asking questions inline).

## Changes

### Backend
- \`_save_messages\` now returns \`int | None\` (the assistant message's id)
- \`send_message_stream\` emits new \`message_id\` SSE event after \`_save_messages\`, after sources/correction, before done

### Frontend
- \`client.ts\`: optional \`onMessageId\` in StreamCallbacks + \`case \"message_id\"\` in switch
- \`ChatPage.tsx\`: wire \`onMessageId\` to swap Date.now() for real id; **add \`m.id < 1e12\` guard** to feedback row (Date.now() ≥ ~1.7e12, real DB ids ≪ 1e12)
- \`ReaderAIPanel.tsx\`: add Tooltip imports + Like/Dislike icons; wire \`onMessageId\`; add complete feedback row mirroring ChatPage's optimistic-update + rollback-on-error pattern

## Test plan

- [x] Backend ruff clean
- [x] 62 carry-forward backend tests pass (citation_guard + precise_retrieval)
- [x] Frontend \`npm run build\` (tsc -b + vite) passes
- [x] \`superpowers:code-reviewer\` pre-push: APPROVE; one fix absorbed (ChatPage guard)
- [ ] Post-deploy smoke: stream a message, click 👍, reload, verify feedback persists
- [ ] Post-deploy smoke: same on Reader page (was zero UI before)
- [ ] 24h: verify feedback rate > 0 in \`SELECT count(*) FROM chat_messages WHERE feedback IS NOT NULL\`

## Reviewer notes

P1 from review absorbed: ChatPage feedback row also needed the \`m.id < 1e12\` guard (was rendered always-broken before, now rendered always-broken-during-streaming-window without the fix).

Pre-existing master CI failures (alembic dry-run, bandit, dep audit) unrelated. Auto-merge **not enabled** (#526 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)