### PR TITLE
feat(precise-retrieval): alias map + 简→繁 + canonical-translator pick

### DIFF
--- a/backend/app/services/precise_retrieval.py
+++ b/backend/app/services/precise_retrieval.py
@@ -30,6 +30,7 @@ Design constraints:
 import logging
 import re
 
+from opencc import OpenCC
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -37,6 +38,106 @@ from app.models.text import BuddhistText, TextContent
 from app.schemas.chat import ChatSource
 
 logger = logging.getLogger(__name__)
+
+
+# Canonical short-name → full Taishō title aliases.
+#
+# Real users type the short conversational name (心经, 金刚经, 楞严经) but
+# buddhist_texts.title_zh stores the full canonical title in
+# traditional script. Without a translation table the precise short-
+# circuit misses every common scripture — initial production telemetry
+# (2026-05-07) showed `《心经》第1卷` falling through to vector RAG and
+# returning thematically-similar 注疏 instead of 心经 itself.
+#
+# Both simplified and traditional short forms map to the same canonical
+# title so the lookup is a single dictionary read regardless of the
+# user's input encoding. New entries should be vetted against the
+# production DB — not every nickname has an unambiguous canonical
+# target (e.g. "般若经" could mean 摩訶般若波羅蜜經 or 大般若波羅蜜多經
+# depending on context, so we deliberately don't include it).
+_TITLE_ALIASES: dict[str, str] = {
+    # 心经
+    "心经": "般若波羅蜜多心經",
+    "心經": "般若波羅蜜多心經",
+    # 金刚经
+    "金刚经": "金剛般若波羅蜜經",
+    "金剛經": "金剛般若波羅蜜經",
+    # 楞严经
+    "楞严经": "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經",
+    "楞嚴經": "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經",
+    # 法华经
+    "法华经": "妙法蓮華經",
+    "法華經": "妙法蓮華經",
+    # 华严经
+    "华严经": "大方廣佛華嚴經",
+    "華嚴經": "大方廣佛華嚴經",
+    # 维摩经
+    "维摩经": "維摩詰所說經",
+    "維摩經": "維摩詰所說經",
+    # 圆觉经
+    "圆觉经": "大方廣圓覺修多羅了義經",
+    "圓覺經": "大方廣圓覺修多羅了義經",
+    # 涅槃经
+    "涅槃经": "大般涅槃經",
+    "涅槃經": "大般涅槃經",
+    # 楞伽经
+    "楞伽经": "楞伽阿跋多羅寶經",
+    "楞伽經": "楞伽阿跋多羅寶經",
+    # 起信论
+    "起信论": "大乘起信論",
+    "起信論": "大乘起信論",
+}
+
+
+# OpenCC simplified → traditional converter. Matches what the rest of
+# the RAG stack already uses (see rag_retrieval.py). Lazy-instantiated
+# so import-time cost stays zero for callers that never trigger.
+
+
+class _IdentityConverter:
+    """Drop-in replacement for OpenCC when the real one fails to
+    initialise. ``convert`` is identity, so the alias path still works
+    even if 简→繁 normalisation is unavailable — a broken OpenCC must
+    never block the chat."""
+
+    def convert(self, x: str) -> str:
+        return x
+
+
+_s2t_converter: OpenCC | _IdentityConverter | None = None
+
+
+def _to_traditional(s: str) -> str:
+    """Best-effort 简→繁 normalization. Falls back to identity on any
+    OpenCC failure — this is a normalization helper, not a critical
+    path; misconverting is still better than crashing the chat."""
+    global _s2t_converter
+    if _s2t_converter is None:
+        try:
+            _s2t_converter = OpenCC("s2t")
+        except Exception:
+            logger.exception("OpenCC s2t init failed; precise lookup will not 简→繁 normalize")
+            _s2t_converter = _IdentityConverter()
+    try:
+        return _s2t_converter.convert(s)
+    except Exception:
+        return s
+
+
+def _resolve_title(title: str) -> str:
+    """Map a short / simplified user-facing title to the canonical
+    traditional title stored in ``buddhist_texts.title_zh``.
+
+    Order matters: alias lookup first (covers the high-frequency named
+    canon — 心经 → 般若波羅蜜多心經 — that pure 简→繁 conversion
+    cannot, since 心经/心經 isn't itself a row in the DB), then
+    OpenCC s2t for everything else (covers the long tail of titles
+    like 楞伽阿跋多羅寶經 that users may type in simplified script).
+    """
+    title = title.strip()
+    if title in _TITLE_ALIASES:
+        return _TITLE_ALIASES[title]
+    return _to_traditional(title)
 
 
 # Maximum characters of a fascicle's content to inline into the
@@ -171,31 +272,55 @@ async def try_precise_text_retrieval(
     detected = _detect_title_juan(query)
     if detected is None:
         return None
-    title, juan_num = detected
+    raw_title, juan_num = detected
+    resolved_title = _resolve_title(raw_title)
 
-    # 1. Resolve the title to a buddhist_texts row. Exact match only;
-    #    case is irrelevant for CJK but trim whitespace to be safe.
+    # 1. Exact match against the canonical title. Most popular sutras
+    #    have multiple translator-rows under the same title (心经×4,
+    #    金刚经×6, etc), so we accept >1 candidates and pick the
+    #    canonical one deterministically below — this is different from
+    #    the original conservative-on-ambiguity behaviour: now the
+    #    ambiguity is *expected* for famous texts and we resolve it
+    #    rather than punt.
+    # Invariant: CBETA primary corpus has source_id=1 (lowest in DB).
+    # If a new source ever ingests with source_id=0 this picker breaks
+    # silently and a non-canonical translator wins. Guarded by
+    # data_sources seed (CBETA pinned at id=1) — keep that pinning.
     text_q = await db.execute(
         select(BuddhistText)
-        .where(func.trim(BuddhistText.title_zh) == title)
-        .limit(2)
+        .where(func.trim(BuddhistText.title_zh) == resolved_title)
+        .order_by(BuddhistText.source_id, BuddhistText.id)
+        .limit(20)
     )
     candidates = list(text_q.scalars())
-    if len(candidates) != 1:
-        # Zero hits: title not in canon. Multiple hits: ambiguous (some
-        # titles legitimately exist in more than one source); let RAG
-        # disambiguate via score.
+    if not candidates:
         logger.debug(
-            "precise_retrieval miss: title=%r juan=%d candidates=%d",
-            title, juan_num, len(candidates),
+            "precise_retrieval miss: raw=%r resolved=%r juan=%d candidates=0",
+            raw_title, resolved_title, juan_num,
         )
         return None
+
+    # Deterministic disambiguation: ORDER BY (source_id, id) above means
+    # candidates[0] is the lowest-source-id (CBETA primary = source_id=1
+    # in this corpus) lowest-id row — which empirically corresponds to
+    # the canonical translator (玄奘 心经, 鳩摩羅什 金刚经, 等). Keeps
+    # behaviour stable across reruns.
     bt = candidates[0]
+    if len(candidates) > 1:
+        # INFO not DEBUG so the alias-hit-rate telemetry is visible in
+        # production logs without flipping global log level. The
+        # 2026-05-07 alias-miss bug went undetected for hours because
+        # the previous log line was DEBUG.
+        logger.info(
+            "precise_retrieval picked canonical: raw=%r resolved=%r "
+            "chosen_id=%d translator=%r out_of=%d candidates",
+            raw_title, resolved_title, bt.id, bt.translator, len(candidates),
+        )
 
     if scope_text_ids is not None and bt.id not in scope_text_ids:
         logger.debug(
             "precise_retrieval out-of-scope: text_id=%d title=%r not in master scope",
-            bt.id, title,
+            bt.id, resolved_title,
         )
         return None
 

--- a/backend/tests/test_precise_retrieval.py
+++ b/backend/tests/test_precise_retrieval.py
@@ -14,6 +14,7 @@ from app.services.precise_retrieval import (
     _cjk_to_int,
     _detect_title_juan,
     _parse_juan_number,
+    _resolve_title,
     try_precise_text_retrieval,
 )
 
@@ -186,16 +187,133 @@ async def test_truncates_long_content_with_marker():
 
 
 @pytest.mark.anyio
-async def test_ambiguous_title_falls_back_to_none():
-    """Two BuddhistText rows with the same title: don't guess; let
-    vector RAG handle it via score."""
+async def test_multiple_candidates_picks_first_deterministically():
+    """Famous sutras have multiple translator-rows under the same title
+    (心经×4, 金刚经×6). The query orders by (source_id, id) so
+    candidates[0] is the canonical translation; precise retrieval
+    must use that rather than punt to vector — punting is the bug
+    this PR is fixing."""
     db = MagicMock()
-    bt1, bt2 = MagicMock(), MagicMock()
+    canonical = MagicMock()
+    canonical.id = 9
+    canonical.title_zh = "般若波羅蜜多心經"
+    canonical.lang = "lzh"
+    canonical.source_id = 1
+    canonical.translator = "玄奘"
+
+    other = MagicMock()
+    other.id = 6504
+    other.title_zh = "般若波羅蜜多心經"
+    other.lang = "lzh"
+    other.source_id = 1
+    other.translator = "般若共利言等"
+
+    tc = MagicMock()
+    tc.text_id = 9
+    tc.juan_num = 1
+    tc.content = "般若波羅蜜多。"
+    tc.lang = "lzh"
+
     text_result = MagicMock()
-    text_result.scalars = MagicMock(return_value=iter([bt1, bt2]))
+    text_result.scalars = MagicMock(return_value=iter([canonical, other]))
+    content_result = MagicMock()
+    content_result.scalar_one_or_none = MagicMock(return_value=tc)
+    db.execute = AsyncMock(side_effect=[text_result, content_result])
+
+    result = await try_precise_text_retrieval(db, "《般若波羅蜜多心經》第1卷")
+    assert result is not None
+    assert result[0].text_id == 9  # canonical (玄奘) wins via SQL ORDER BY
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Title resolution: aliases + 简→繁 normalization
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Common short names — both simplified and traditional must
+        # resolve to the same canonical traditional title that lives in
+        # the production DB.
+        ("心经", "般若波羅蜜多心經"),
+        ("心經", "般若波羅蜜多心經"),
+        ("金刚经", "金剛般若波羅蜜經"),
+        ("金剛經", "金剛般若波羅蜜經"),
+        ("楞严经", "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經"),
+        ("楞嚴經", "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經"),
+        ("法华经", "妙法蓮華經"),
+        ("华严经", "大方廣佛華嚴經"),
+        ("圆觉经", "大方廣圓覺修多羅了義經"),
+        ("涅槃经", "大般涅槃經"),
+        ("起信论", "大乘起信論"),
+        # Whitespace must not affect resolution.
+        (" 心经 ", "般若波羅蜜多心經"),
+    ],
+)
+def test_resolve_title_aliases(raw, expected):
+    assert _resolve_title(raw) == expected
+
+
+def test_resolve_title_falls_back_to_simplified_to_traditional():
+    """Titles not in the alias table get OpenCC s2t conversion. This
+    handles the long tail of less-common scriptures the user might
+    type in simplified script (e.g. 楞伽阿跋多罗宝经 →
+    楞伽阿跋多羅寶經) without each one needing a hand-curated entry."""
+    # 楞伽阿跋多罗宝经 contains chars that differ across encodings
+    # (罗→羅, 宝→寶); s2t should convert them.
+    out = _resolve_title("楞伽阿跋多罗宝经")
+    assert "羅" in out
+    assert "寶" in out
+
+
+def test_resolve_title_passthrough_for_already_traditional():
+    """A title that's already in the canonical traditional form should
+    survive resolution unchanged — neither alias nor s2t should
+    mangle it."""
+    canonical = "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經"
+    assert _resolve_title(canonical) == canonical
+
+
+@pytest.mark.anyio
+async def test_zero_candidates_returns_none():
+    """Title doesn't resolve to any DB row — must fall back to vector
+    RAG, never invent a result."""
+    db = MagicMock()
+    text_result = MagicMock()
+    text_result.scalars = MagicMock(return_value=iter([]))
     db.execute = AsyncMock(side_effect=[text_result])
-    result = await try_precise_text_retrieval(db, "《心经》第1卷")
+    result = await try_precise_text_retrieval(db, "《不存在经》第1卷")
     assert result is None
+
+
+@pytest.mark.anyio
+async def test_alias_resolution_drives_lookup_query():
+    """When the user types a short alias like 《心经》第1卷, the SQL
+    lookup must execute against the resolved canonical title, not the
+    raw input — otherwise the alias table is purely decorative."""
+    db = MagicMock()
+    bt = MagicMock()
+    bt.id = 9
+    bt.title_zh = "般若波羅蜜多心經"
+    bt.lang = "lzh"
+    bt.source_id = 1
+    bt.translator = "玄奘"
+    tc = MagicMock()
+    tc.text_id = 9
+    tc.juan_num = 1
+    tc.content = "般若波羅蜜多。"
+    tc.lang = "lzh"
+    text_result = MagicMock()
+    text_result.scalars = MagicMock(return_value=iter([bt]))
+    content_result = MagicMock()
+    content_result.scalar_one_or_none = MagicMock(return_value=tc)
+    db.execute = AsyncMock(side_effect=[text_result, content_result])
+
+    result = await try_precise_text_retrieval(db, "《心经》第1卷")
+    assert result is not None
+    assert result[0].title_zh == "般若波羅蜜多心經"
+    assert result[0].text_id == 9
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Why

Production telemetry from 2026-05-07 showed precise retrieval had effectively zero hit rate on common queries:

- User types `《心经》第1卷` → exact match against `buddhist_texts.title_zh = '心经'` returns 0 → falls through to vector RAG → returns thematically-similar 注疏 instead of 心经 itself

Three layered causes:

1. DB stores canonical traditional title (`般若波羅蜜多心經`), not the conversational name
2. Even after 简→繁, "心經" isn't itself a row
3. Famous sutras have multi-translator rows (心经×4, 金刚经×6) and original code bailed on `len > 1`

## What

### Alias table (`_TITLE_ALIASES`)
10 entries × {简, 繁} = 20 keys for the high-frequency named canon. Each verified against production DB before inclusion:

| 短称 | Canonical |
|---|---|
| 心经 / 心經 | 般若波羅蜜多心經 |
| 金刚经 / 金剛經 | 金剛般若波羅蜜經 |
| 楞严经 / 楞嚴經 | 大佛頂如來密因修證了義諸菩薩萬行首楞嚴經 |
| 法华经 / 法華經 | 妙法蓮華經 |
| 华严经 / 華嚴經 | 大方廣佛華嚴經 |
| 维摩经 / 維摩經 | 維摩詰所說經 |
| 圆觉经 / 圓覺經 | 大方廣圓覺修多羅了義經 |
| 涅槃经 / 涅槃經 | 大般涅槃經 |
| 楞伽经 / 楞伽經 | 楞伽阿跋多羅寶經 |
| 起信论 / 起信論 | 大乘起信論 |

Deliberately **not** included: nicknames with no unambiguous canonical target (e.g. 般若经 could mean 摩訶般若波羅蜜經 or 大般若波羅蜜多經 depending on context).

### Long-tail fallback
Titles outside the alias table go through OpenCC s2t — handles less-common scriptures the user types in simplified script (`楞伽阿跋多罗宝经` → `楞伽阿跋多羅寶經`). OpenCC is already a backend dep (rag_retrieval.py). Lazy-init + identity-fallback class so a broken OpenCC never blocks the chat.

### Canonical disambiguation
`ORDER BY (source_id, id) LIMIT 20` — picks the smallest-source-id (CBETA primary = 1) lowest-id row. Empirically corresponds to canonical translator (玄奘 心经, 鳩摩羅什 金刚经) because corpus was loaded canonical-first. Documented invariant on the order_by clause.

### Observability bump
Multi-candidate canonical pick log line promoted from DEBUG → INFO — was the missing piece for catching the 2026-05-07 miss bug. Production log level is INFO, alias-hit-rate now visible without flipping global level.

## Test plan

- [x] 65 tests passing (20 new): alias mapping, OpenCC long-tail conversion, traditional-passthrough, multi-candidate canonical pick, alias-drives-SQL-query end-to-end
- [x] Backend ruff clean
- [x] Reviewer pre-push: APPROVE; punch list items 1, 2, 4 absorbed (invariant comment, IdentityConverter sentinel, INFO log level)
- [ ] Post-deploy: re-run `《心经》第1卷` query, verify single ChatSource (text_id=9 玄奘) with score=1.0
- [ ] Post-deploy: backend log should show `precise_retrieval picked canonical: ... chosen_id=9 translator='玄奘' out_of=4 candidates`

## Reviewer notes

P1 punch list items 3 (test gaps for OpenCC failure / scope filter / LIMIT 20 boundary) and 5 (changelog reasoning) tracked for follow-up — not blocking.

Pre-existing master CI failures (alembic dry-run, bandit, dep audit) unrelated. Auto-merge **not enabled** (#526 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)