### PR TITLE
feat(quote-verifier): flag fabricated quoted passages even when citation is real

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -22,6 +22,7 @@ from app.models.user import User
 from app.schemas.chat import ChatResponse, ChatSource
 from app.services.citation_guard import enforce_citation_whitelist, log_mutations
 from app.services.master_profiles import get_master
+from app.services.quote_verifier import log_quote_mutations, verify_quoted_content
 from app.services.rag_retrieval import retrieve_rag_context
 
 logger = logging.getLogger(__name__)
@@ -830,10 +831,15 @@ async def send_message(
     # for the full rationale — this is the deterministic backstop after the
     # prompt's moral one.
     answer, _citation_mutations = enforce_citation_whitelist(answer, sources)
+    # Quote verifier runs after the citation guard so quotes attached
+    # to citations the guard already stripped don't get double-flagged.
+    # See app/services/quote_verifier for the substring-match contract.
+    answer, _quote_mutations = verify_quoted_content(answer, sources)
 
     if chat_session:
         await _save_messages(db, chat_session.id, message, answer, sources)
         log_mutations(chat_session.id, _citation_mutations)
+        log_quote_mutations(chat_session.id, _quote_mutations)
 
         # Auto-generate a better session title for new sessions (first message)
         if chat_session.title == message[:50]:
@@ -1016,7 +1022,13 @@ async def send_message_stream(
     # silently re-introduce the hallucination this guard exists to
     # prevent.
     corrected_answer, _citation_mutations = enforce_citation_whitelist(full_answer, sources)
-    if _citation_mutations:
+    # Quote verifier runs after citation_guard so flagged-and-stripped
+    # citations don't carry their quotes into a second annotation.
+    corrected_answer, _quote_mutations = verify_quoted_content(corrected_answer, sources)
+    # Emit one merged `citation_correction` event covering both
+    # rewrites (citation + quote annotations) so the frontend swap is a
+    # single state mutation rather than two.
+    if _citation_mutations or _quote_mutations:
         yield (
             "data: "
             + json.dumps(
@@ -1035,6 +1047,7 @@ async def send_message_stream(
             db, chat_session.id, message, corrected_answer, sources
         )
         log_mutations(chat_session.id, _citation_mutations)
+        log_quote_mutations(chat_session.id, _quote_mutations)
         # Emit the real chat_messages.id so the frontend can swap the
         # in-flight Date.now() placeholder. Without this, feedback /
         # share buttons on a freshly-streamed message PUT to a

--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -1,0 +1,253 @@
+"""Quoted-content verification for LLM answers.
+
+The citation guard catches one class of hallucination: an answer that
+wraps a fabricated reference in ``【《X》第N卷】`` form. This module
+catches the other class: an answer whose ``【…】`` reference is real
+but whose **quoted passage** before it is invented.
+
+Production sample (2026-05-07): an answer correctly cited
+``【《大般若经》第600卷】`` (which the guard then rejected because the
+title wasn't retrieved), but the same answer also offered exact-looking
+``"…乃至四句偈等，为他人说，其福胜彼"`` quotes — those passages came
+from the LLM's training data, not from the retrieved fascicle. A
+scholarly user verifying a citation will click through, find the
+reference is real, and trust the quoted text — at which point any
+substring of the quote that the LLM invented becomes laundered fake
+data.
+
+The check is deliberately conservative:
+
+- We only verify quotes immediately attached to a ``【《X》第N卷】``
+  reference (within ``MAX_QUOTE_CITATION_GAP_CHARS``). A loose mention
+  of a passage somewhere else in the answer isn't bound to a specific
+  source and so isn't checkable.
+- We require the quoted segment to be at least ``MIN_QUOTE_CHARS``
+  long. Short fragments produce too much normalisation noise (LLMs
+  paraphrase short passages constantly).
+- We normalise (NFKC fold + whitespace + punctuation strip) before
+  the substring test. Anything that survives this and is still missing
+  from the cited chunk's text is almost certainly invented, not
+  paraphrased. We deliberately do **not** apply 简→繁 here: the cited
+  source is canonical traditional, and an LLM that emits a 简-script
+  quote inside a 繁-script source citation has already lost the
+  attribution chain it claimed to preserve, so failing the check is
+  the correct behaviour.
+- On miss we **annotate inline** rather than rewrite — preserving the
+  LLM's prose lets the user see what was claimed while making the
+  unverified status obvious.
+
+The verifier is wired *after* ``enforce_citation_whitelist`` so quotes
+attached to citations the guard already stripped (unverified titles)
+don't get double-flagged.
+"""
+
+import logging
+import re
+import unicodedata
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from app.schemas.chat import ChatSource
+
+logger = logging.getLogger(__name__)
+
+
+# Minimum length of a quoted segment we'll subject to verification.
+# Below this, paraphrase noise dominates and false positives explode —
+# LLMs routinely shorten "色不异空，空不异色" to "色不异空" and we don't
+# want to flag that.
+MIN_QUOTE_CHARS = 12
+
+# Maximum distance (chars) between the closing quote and the start of
+# the trailing 【《X》第N卷】 reference for them to count as bound. A
+# user inserting two sentences of commentary between quote and
+# citation would push the pair past this threshold and we'd skip
+# verification — preferring under-verification to misattribution.
+MAX_QUOTE_CITATION_GAP_CHARS = 80
+
+# Match a CJK quote-mark pair followed within the gap window by a
+# bracketed citation. Three quote-mark families are covered:
+#
+#   「…」  curly Chinese quotes (most common in classical citation)
+#   『…』  Chinese inner quotes (frequent in nested 引文)
+#   "…"   ASCII straight quotes — LLMs that emit full-width 「」 also
+#         emit ASCII " in the same answer; both must match
+#
+# Markdown blockquote (``> …``) is intentionally out of scope here —
+# its multi-line structure needs a different scanner; if it becomes
+# the dominant production form a follow-up can extend this module.
+_QUOTE_CITATION_RE = re.compile(
+    r"[「『\"]"
+    r"(?P<quote>.{" + str(MIN_QUOTE_CHARS) + r",400}?)"
+    r"[」』\"]"
+    r".{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}?"
+    r"【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】",
+    re.DOTALL,
+)
+
+
+# Punctuation we strip from both sides of the substring test. Includes
+# CJK and ASCII forms of every mark that might survive the LLM's
+# tokeniser without surviving CBETA's. Whitespace handled separately.
+_STRIP_PUNCT_RE = re.compile(
+    r"[\s,.!?;:\"'\(\)\[\]\-_~`<>"
+    r"，。！？、；：「」『』\"\"''《》〈〉…—（）\[\]【】·•～　]+"
+)
+
+
+@dataclass(frozen=True)
+class QuoteMutation:
+    """Audit record for a single quote that failed verification."""
+
+    quote: str
+    title: str
+    juan: int | None
+    reason: str  # 'no_matching_source' | 'quote_not_in_source'
+
+
+def _normalise(s: str) -> str:
+    """Aggressive normalisation for the substring test.
+
+    Goals:
+      1. NFKC fold so half/full-width forms compare equal
+      2. Strip every punctuation and whitespace character so that an
+         LLM that drops a comma doesn't false-positive
+      3. Lowercase (no effect on CJK but covers stray Latin)
+
+    What this does *not* do: 简→繁 conversion. The cited source is
+    already traditional (CBETA stores 繁 only); if the LLM emits 简
+    inside its own quote it deserves to fail verification — quoting
+    a canonical text in 简 isn't preserving the citation either.
+    """
+    s = unicodedata.normalize("NFKC", s)
+    s = _STRIP_PUNCT_RE.sub("", s)
+    return s.lower()
+
+
+def _find_source(
+    sources: Iterable[ChatSource], title: str, juan: int | None
+) -> ChatSource | None:
+    """Locate the source whose ``title_zh`` and ``juan_num`` match.
+
+    Falls back to title-only match (any juan) when the user-supplied
+    juan can't be found — the verifier's job is to check the quote
+    against *some* legitimate retrieval of that text, and the LLM
+    occasionally cites the right text with a slightly off fascicle
+    number that the citation guard already corrected.
+    """
+    title_match: ChatSource | None = None
+    parallel_title_match: ChatSource | None = None
+    for s in sources:
+        if s.title_zh == title:
+            if juan is not None and s.juan_num == juan:
+                return s
+            if title_match is None:
+                title_match = s
+        # Always check parallels — a Pali / Tibetan parallel arrives
+        # via alignment_pairs as a child of an unrelated lzh source,
+        # so the parent's title_zh is never the parallel's title.
+        for p in s.parallel_chunks:
+            if p.title != title:
+                continue
+            if juan is None or p.juan_num == juan:
+                # Adapt the parallel chunk into a ChatSource-shaped
+                # carrier so the substring test reads its chunk_text.
+                return ChatSource(
+                    text_id=p.text_id,
+                    juan_num=p.juan_num,
+                    chunk_index=p.chunk_index,
+                    chunk_text=p.chunk_text,
+                    score=1.0,
+                    title_zh=p.title,
+                    lang=p.lang,
+                )
+            if parallel_title_match is None:
+                parallel_title_match = ChatSource(
+                    text_id=p.text_id, juan_num=p.juan_num,
+                    chunk_index=p.chunk_index, chunk_text=p.chunk_text,
+                    score=1.0, title_zh=p.title, lang=p.lang,
+                )
+    return title_match or parallel_title_match
+
+
+def verify_quoted_content(
+    answer: str, sources: list[ChatSource]
+) -> tuple[str, list[QuoteMutation]]:
+    """Annotate quoted segments that aren't substrings of the cited
+    source's chunk_text. Unchanged answers (no quote-citation pairs,
+    or all quotes verified) are returned identical, with empty
+    mutations list.
+
+    Implementation: regex scans for ``「…」【《X》第N卷】`` proximity
+    pairs, normalises both sides, and inserts an inline ⚠️ marker
+    after any failing pair. Multiple failing pairs in one answer get
+    individual annotations.
+    """
+    if not answer or "【《" not in answer:
+        return answer, []
+
+    mutations: list[QuoteMutation] = []
+    annotations: list[tuple[int, str]] = []  # (insert_at_index, marker)
+
+    for m in _QUOTE_CITATION_RE.finditer(answer):
+        quote = m.group("quote").strip()
+        title = m.group("title")
+        juan_str = m.group("juan")
+        juan = int(juan_str) if juan_str else None
+        if len(quote) < MIN_QUOTE_CHARS:
+            continue
+
+        source = _find_source(sources, title, juan)
+        if source is None:
+            mutations.append(
+                QuoteMutation(
+                    quote=quote, title=title, juan=juan,
+                    reason="no_matching_source",
+                )
+            )
+            annotations.append(
+                (m.end(), "[⚠️ 引文出处未在检索结果中找到]")
+            )
+            continue
+
+        normalised_quote = _normalise(quote)
+        normalised_source = _normalise(source.chunk_text)
+        if normalised_quote not in normalised_source:
+            mutations.append(
+                QuoteMutation(
+                    quote=quote, title=title, juan=juan,
+                    reason="quote_not_in_source",
+                )
+            )
+            annotations.append(
+                (m.end(), "[⚠️ 引文未在该卷原文中验证到，请谨慎引用]")
+            )
+
+    if not annotations:
+        return answer, mutations
+
+    # Insert markers from right-to-left so earlier indices stay valid.
+    annotated = answer
+    for index, marker in sorted(annotations, key=lambda x: x[0], reverse=True):
+        annotated = annotated[:index] + marker + annotated[index:]
+    return annotated, mutations
+
+
+def log_quote_mutations(
+    chat_message_id: int | None,
+    mutations: list[QuoteMutation],
+) -> None:
+    """One log line per failed quote so a future ``grep
+    quote_verifier`` over backend logs surfaces volume + shape before
+    a database column is wired up."""
+    for m in mutations:
+        logger.warning(
+            "quote_verifier %s msg_id=%s title=%r juan=%s "
+            "quote_len=%d quote_head=%r",
+            m.reason,
+            chat_message_id,
+            m.title,
+            m.juan,
+            len(m.quote),
+            m.quote[:40],
+        )

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -1,0 +1,199 @@
+"""Tests for quote_verifier.
+
+The verifier's job is to flag quoted passages whose **content** is
+fabricated even when the surrounding ``【《X》第N卷】`` reference is
+real. Tests therefore exercise both the happy path (quote really is in
+chunk_text → no annotation) and the failure shapes the LLM is known to
+produce (paraphrase, fabrication, wrong-juan citation).
+"""
+
+from app.schemas.chat import ChatSource, ParallelChunk
+from app.services.quote_verifier import (
+    QuoteMutation,
+    _normalise,
+    verify_quoted_content,
+)
+
+
+def _src(text_id: int, title: str, juan: int, chunk_text: str) -> ChatSource:
+    return ChatSource(
+        text_id=text_id,
+        juan_num=juan,
+        chunk_index=0,
+        chunk_text=chunk_text,
+        score=0.9,
+        title_zh=title,
+        lang="lzh",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Normaliser
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_normalise_strips_punct_and_whitespace():
+    assert _normalise("色不异空，空不异色。") == "色不异空空不异色"
+
+
+def test_normalise_handles_full_width_quotes_and_brackets():
+    assert _normalise("「色不异空」") == "色不异空"
+    assert _normalise("『色不异空』") == "色不异空"
+    assert _normalise('"色不异空"') == "色不异空"
+
+
+def test_normalise_nfkc_folds_full_to_half_width():
+    """Half-width and full-width digits/letters in the LLM's output
+    must compare equal to the canonical text after normalisation."""
+    assert _normalise("般若123") == _normalise("般若１２３")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Verifier — happy paths
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_pass_through_when_no_citations():
+    answer = "般若波罗蜜多。色即是空。"
+    out, muts = verify_quoted_content(answer, [_src(1, "心經", 1, "色即是空，空即是色。")])
+    assert out == answer
+    assert muts == []
+
+
+def test_quote_in_source_does_not_annotate():
+    """A literal quote that appears as a substring of the cited
+    chunk_text must pass without annotation. Otherwise we'd
+    false-positive on every well-grounded answer."""
+    chunk = "色不異空，空不異色，色即是空，空即是色，受想行識亦復如是。"
+    src = _src(7, "心經", 1, chunk)
+    answer = "经文说：「色不異空，空不異色，色即是空」【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_quote_with_extra_punctuation_in_llm_output_still_passes():
+    """LLMs often copy a quote with stray full-width commas; the
+    normaliser must absorb those without causing a false positive."""
+    chunk = "色不異空空不異色色即是空空即是色"  # canonical without punct
+    src = _src(7, "心經", 1, chunk)
+    answer = '经云："色不異空，空不異色，色即是空。"【《心經》第1卷】'
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_quote_too_short_is_skipped():
+    """Quotes below MIN_QUOTE_CHARS are paraphrase-noise prone; the
+    verifier deliberately does not flag them."""
+    src = _src(7, "心經", 1, "completely different content here")
+    answer = "经云：「色即是空」【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Verifier — failure paths
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_quote_not_in_source_gets_annotated():
+    """The flagship case: LLM cites a real source but the quote
+    inside the 「…」 was never in that chunk."""
+    src = _src(7, "心經", 1, "实际原文：般若波罗蜜多，照见五蕴皆空。")
+    answer = "经文明示：「众生皆有佛性，如来藏不空妙有」【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert "⚠️" in out
+    assert "未在该卷原文中验证到" in out
+    assert len(muts) == 1
+    assert muts[0].reason == "quote_not_in_source"
+    assert muts[0].title == "心經"
+    assert muts[0].juan == 1
+
+
+def test_no_matching_source_gets_annotated_differently():
+    """The quote is bound to a citation whose title isn't in sources
+    at all (e.g. citation_guard didn't catch it because it was
+    title-only). The verifier flags as 'no_matching_source' so the
+    audit trail distinguishes 'wrong text' from 'wrong content'."""
+    src = _src(7, "心經", 1, "...")
+    answer = "云：「众生皆有佛性，如来藏不空妙有」【《不存在经》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert "⚠️" in out
+    assert "出处未在检索结果中找到" in out
+    assert len(muts) == 1
+    assert muts[0].reason == "no_matching_source"
+
+
+def test_juan_mismatch_falls_back_to_title_match():
+    """Source has 心經 juan=1; LLM cites juan=2. If the quote is
+    actually in the title's juan=1 chunk, the verifier accepts the
+    title-only match — citation_guard handles fascicle correction
+    separately, and double-flagging here would noise the user."""
+    src = _src(7, "心經", 1, "色不異空空不異色色即是空。")
+    answer = "经云：「色不異空空不異色色即是空」【《心經》第2卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_parallel_chunk_quotes_are_checkable():
+    """A Pali parallel arrived via alignment_pairs; if the LLM cites
+    the parallel's title and the quote is in the parallel's
+    chunk_text, that should pass — parallel sources are legitimate
+    targets for citation."""
+    src = ChatSource(
+        text_id=7, juan_num=1, chunk_index=0, chunk_text="...", score=0.9,
+        title_zh="心經", lang="lzh",
+        parallel_chunks=[
+            ParallelChunk(
+                text_id=99, juan_num=2, chunk_index=0,
+                chunk_text="evaṃ me sutaṃ ekaṃ samayaṃ bhagavā",
+                lang="pi", title="Mahāparinibbāna Sutta",
+            )
+        ],
+    )
+    answer = "云：「evaṃ me sutaṃ ekaṃ samayaṃ bhagavā」【《Mahāparinibbāna Sutta》第2卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_multiple_failing_quotes_all_annotated():
+    """Two fabricated quotes in one answer must both be marked, and
+    the markers must not interfere with each other (right-to-left
+    insertion preserves earlier indices)."""
+    src = _src(7, "心經", 1, "无关原文")
+    answer = (
+        "云：「假引文片段一假引文片段一假引文片段一」【《心經》第1卷】然后："
+        "「假引文片段二假引文片段二假引文片段二」【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert out.count("⚠️") == 2
+    assert len(muts) == 2
+
+
+def test_distant_quote_and_citation_not_treated_as_pair():
+    """If a quote is far from the trailing citation (commentary
+    paragraph in between), they aren't bound — the verifier
+    intentionally under-verifies to avoid over-flagging."""
+    src = _src(7, "心經", 1, "无关原文")
+    far = " " * 200  # > MAX_QUOTE_CITATION_GAP_CHARS
+    answer = f"开始：「假引文一假引文二假引文三」{far}然后【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert "⚠️" not in out
+    assert muts == []
+
+
+def test_returns_dataclass_with_audit_fields():
+    """Lock the audit shape so a future migration that persists these
+    rows has a stable schema."""
+    src = _src(7, "心經", 1, "")
+    answer = "云：「假引文假引文假引文假引文」【《心經》第1卷】"
+    _, muts = verify_quoted_content(answer, [src])
+    assert isinstance(muts[0], QuoteMutation)
+    assert muts[0].quote.startswith("假引文")
+    assert muts[0].title == "心經"
+    assert muts[0].juan == 1
+    assert muts[0].reason == "quote_not_in_source"


### PR DESCRIPTION
## Why

Citation guard catches one class of hallucination: an answer that wraps a fabricated reference in `【《X》第N卷】`. This module catches the other class — **the answer's `【…】` reference is real but the quoted passage before it was invented from training data**.

A scholarly user clicks through to verify, finds the citation is real, and **trusts the quoted text**. Anything the LLM invented inside the quote is then laundered into "verified" content. For an academically-credible AI tool this is the worst-case scenario.

## What

`verify_quoted_content(answer, sources) -> (annotated_answer, mutations)`:

- Regex finds `「...」` / `『...』` / `"..."` quote within 80 chars before `【《X》第N卷】`
- Quote ≥ 12 chars (skip paraphrase noise)
- Normalise both quote and source.chunk_text (NFKC fold + punct/whitespace strip; no 简→繁 by design)
- If quote NOT substring of source → **annotate inline** with ⚠️ marker
- Two annotation kinds: `quote_not_in_source` and `no_matching_source`

Wired **after** `enforce_citation_whitelist` so quotes attached to citations the guard already stripped don't get double-flagged. Stream path emits a single merged `citation_correction` event covering both rewriters.

## Conservative-by-design

| Choice | Rationale |
|---|---|
| MIN_QUOTE_CHARS=12 | Below this, paraphrase noise dominates; LLMs routinely shorten "色不异空，空不异色" → "色不异空" |
| MAX_GAP=80 | Loose pairs (commentary paragraph between quote and citation) aren't bound — under-verify rather than misattribute |
| Inline annotation, not rewrite | Preserves LLM's voice; user sees the claim and the warning |
| No 简→繁 in normalisation | Cited source is canonical 繁; LLM emitting 简 inside quote has already lost attribution — fail correctly |
| Markdown blockquote out of scope | Multi-line scanner needed; follow-up if it becomes dominant |

## Architecture

```
SSE stream:
  ...tokens... 
  → enforce_citation_whitelist (strips fake titles)
  → verify_quoted_content      (annotates fabricated quotes)
  → emit citation_correction (one merged event)
  → emit sources, message_id, done
  → persist corrected version to DB
```

Parallel chunks (alignment_pairs Pali / Tibetan) are checkable: a Pali quote attached to the parallel's title verifies against the parallel's chunk_text.

## Test plan

- [x] 14 unit tests covering: pass-through (no citations / quote in chunk / extra punctuation tolerated / quote too short skipped), failures (quote not in source / no matching source / juan-mismatch falls back to title-only / multiple failures / distant pair not bound), parallel-chunks, audit-shape lock-in
- [x] 80 backend tests pass total (verifier + carry-forward citation_guard + precise_retrieval + chat_sources_order)
- [x] Backend ruff clean
- [x] Reviewer pre-push: REQUEST_CHANGES → docstring 简→繁 contradiction fixed; quote-mark comment vs regex aligned
- [ ] Post-deploy: manually craft answer with fabricated quote attached to real citation, verify ⚠️ marker appears in DB-persisted content
- [ ] Post-deploy: monitor `grep quote_verifier` in backend logs for first-week mutation volume

## Reviewer notes

P1 punch list item 2 (juan_mismatch fallback audit gap — mutation doesn't record `verified_against_juan` when title-only fallback succeeded) tracked for follow-up. Pre-existing master CI failures unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)