### PR TITLE
fix(quote-verifier): match curly “…” quotes (production hallucination escape)

### DIFF
--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -66,20 +66,30 @@ MIN_QUOTE_CHARS = 12
 MAX_QUOTE_CITATION_GAP_CHARS = 80
 
 # Match a CJK quote-mark pair followed within the gap window by a
-# bracketed citation. Three quote-mark families are covered:
+# bracketed citation. Five quote-mark families are covered:
 #
-#   「…」  curly Chinese quotes (most common in classical citation)
-#   『…』  Chinese inner quotes (frequent in nested 引文)
-#   "…"   ASCII straight quotes — LLMs that emit full-width 「」 also
-#         emit ASCII " in the same answer; both must match
+#   「…」    Chinese L-brackets (most common in 古典 引文)
+#   『…』    Chinese double L-brackets (nested 引文)
+#   “…”     Typographic curly double quotes (U+201C / U+201D) —
+#             Markdown-rendered LLM output uses these by default
+#   ‘…’     Typographic curly single quotes (U+2018 / U+2019)
+#   "…"     ASCII straight quotes (LLMs occasionally emit these in
+#             code-fenced / programmatic content)
+#
+# Production sample 2026-05-07 showed DeepSeek answers using U+201C /
+# U+201D exclusively for inline quotes — an earlier scanner that only
+# matched 「」 + ASCII `"` was silent on every production
+# hallucination, defeating the entire module. Adding the curly forms
+# is the fix.
 #
 # Markdown blockquote (``> …``) is intentionally out of scope here —
-# its multi-line structure needs a different scanner; if it becomes
-# the dominant production form a follow-up can extend this module.
+# its multi-line structure needs a different scanner.
+_QUOTE_OPEN = "「『“‘\""
+_QUOTE_CLOSE = "」』”’\""
 _QUOTE_CITATION_RE = re.compile(
-    r"[「『\"]"
+    r"[" + re.escape(_QUOTE_OPEN) + r"]"
     r"(?P<quote>.{" + str(MIN_QUOTE_CHARS) + r",400}?)"
-    r"[」』\"]"
+    r"[" + re.escape(_QUOTE_CLOSE) + r"]"
     r".{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}?"
     r"【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】",
     re.DOTALL,
@@ -90,8 +100,8 @@ _QUOTE_CITATION_RE = re.compile(
 # CJK and ASCII forms of every mark that might survive the LLM's
 # tokeniser without surviving CBETA's. Whitespace handled separately.
 _STRIP_PUNCT_RE = re.compile(
-    r"[\s,.!?;:\"'\(\)\[\]\-_~`<>"
-    r"，。！？、；：「」『』\"\"''《》〈〉…—（）\[\]【】·•～　]+"
+    r"[\s,.!?;:\"'\(\)\[\]\-_~`<>*"
+    r"，。！？、；：「」『』“”‘’《》〈〉…—（）\[\]【】·•～　]+"
 )
 
 

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -186,6 +186,40 @@ def test_distant_quote_and_citation_not_treated_as_pair():
     assert muts == []
 
 
+def test_curly_double_quotes_match_quote_pattern():
+    """Production sample 2026-05-07: DeepSeek emits typographic curly
+    double quotes (U+201C / U+201D) for inline citations, never the
+    ASCII " or 「」 forms. The regex must match them or the entire
+    module is silent on real production output."""
+    src = _src(7, "心經", 1, "无关原文，没有这段引文。")
+    answer = "经云：“色不异空，空不异色，色即是空，色即是色”【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert "⚠️" in out
+    assert len(muts) == 1
+    assert muts[0].reason == "quote_not_in_source"
+
+
+def test_markdown_bold_inside_curly_quotes_strips_to_compare_content():
+    """Common LLM output: “**色不異空**” — bold markers and
+    curly quotes must both be normalised away so the substring check
+    sees only the content, otherwise every formatted quote
+    false-positives."""
+    chunk = "色不異空空不異色色即是空空即是色"
+    src = _src(7, "心經", 1, chunk)
+    answer = "经云：“**色不異空，空不異色，色即是空，空即是色**”【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert "⚠️" not in out
+    assert muts == []
+
+
+def test_curly_single_quotes_also_supported():
+    src = _src(7, "心經", 1, "实际原文：色即是空空即是色。")
+    answer = "经云：‘伪造引文段落很长伪造引文段落很长’【《心經》第1卷】"
+    _out, muts = verify_quoted_content(answer, [src])
+    assert len(muts) == 1
+    assert muts[0].reason == "quote_not_in_source"
+
+
 def test_returns_dataclass_with_audit_fields():
     """Lock the audit shape so a future migration that persists these
     rows has a stable schema."""


### PR DESCRIPTION
## Why

Production verification of #532 on 2026-05-07 found the verifier silent on real LLM output. **DeepSeek emits typographic curly double quotes** `“…”` (U+201C/201D) for inline citations, **not** the ASCII `"` or `「…」` forms #532 matched. Result: every fabricated quote bound to a real `【…】` citation passed through unflagged in production, defeating the entire module.

Manual repro:
- Local unit tests in #532 used `"..."` / `「...」` → all green
- Live curl against fojin.app → LLM emits `“…”` → regex misses → 0 mutations on a known-fabricated quote

This is a half-shipped feature: the unit tests passed because they used quote forms the production LLM doesn't emit. The fix closes the gap.

## What

1. **Quote-pattern regex** extended from 3 → 5 quote families:
   - `「…」` Chinese L-brackets (original)
   - `『…』` nested 引文 (original)
   - **`“…”` typographic double, U+201C/201D — the production form**
   - `‘…’` typographic single, U+2018/2019
   - `"…"` ASCII straight (original)

2. **Punctuation-strip class** extended to include `*` (Markdown bold) and the curly quote characters. Without this, `“**色不異空**”` normalises with `**` + curly quotes intact, false-positiving on every Markdown-formatted real quote.

## Test plan

- [x] 17 unit tests passing (3 new):
  - `test_curly_double_quotes_match_quote_pattern` — the production regression
  - `test_markdown_bold_inside_curly_quotes_strips_to_compare_content` — real quote with **bold** must pass
  - `test_curly_single_quotes_also_supported` — the curly single form
- [x] Backend ruff clean
- [ ] Post-deploy: re-run "心经的核心思想..." query that previously slipped, expect ⚠️ marker if fabricated, no marker if real

## Reviewer notes

This is a P0 follow-up to #532 — the original PR's verifier was effectively a no-op on production traffic. Pre-existing master CI failures unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)