### PR TITLE
fix(chat): preserve empty fojin_text_ids so precise retrieval honours master scope

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -191,6 +191,41 @@ _META_KEYWORDS = (
 )
 
 
+def _master_scope_text_ids(master) -> list[int] | None:  # type: ignore[no-untyped-def]
+    """Build the ``scope_text_ids`` value retrieve_rag_context expects.
+
+    Asymmetric three-state contract — see also
+    ``app/services/precise_retrieval.try_precise_text_retrieval`` and
+    ``app/services/embedding.similarity_search`` for the consumer side:
+
+    - ``master is None`` → return ``None``: no scope, full-corpus RAG.
+    - ``master.fojin_text_ids == []`` → return ``[]``: master has no
+      indexed corpus (Ajahn Chah, Hsing Yun, Yin Shun, Gampopa). The
+      empty list is *deliberately preserved* — downstream
+      ``similarity_search`` treats it as falsy and so leaves the
+      vector path unfiltered (full-corpus RAG, the design intent),
+      while ``try_precise_text_retrieval`` rejects every text_id
+      against ``not in []`` and so disables precise retrieval. This
+      asymmetry is the whole point: vector RAG runs across all texts
+      because the master has no indexed corpus to scope against, but
+      the precise short-circuit must NOT serve a 《大乘经》第N卷 query
+      under a Theravada master and leak that text's chunk_text into
+      the LLM's context.
+    - ``master.fojin_text_ids == [ids…]`` → return the list: scoped
+      vector + precise retrieval to those text_ids.
+
+    Production trace 2026-05-07 (msg 4437): the previous
+    falsy-coalesce ``master.fojin_text_ids if master and
+    master.fojin_text_ids else None`` collapsed empty list → None,
+    silently bypassing the precise scope check and serving 楞严经 to
+    Ajahn Chah master mode. Only the persona prompt's prose refusal
+    hid the breach from the user. Don't reintroduce ``or None``.
+    """
+    if master is None:
+        return None
+    return master.fojin_text_ids
+
+
 def _is_meta_question(message: str) -> bool:
     """Detect meta questions about the assistant itself (vs. Buddhist content)."""
     msg = message.strip().lower()
@@ -721,7 +756,7 @@ async def _prepare_chat(
     if _is_meta_question(message) and not master_id and not text_id:
         sources, context_text = [], ""
     else:
-        scope_text_ids = master.fojin_text_ids if master and master.fojin_text_ids else None
+        scope_text_ids = _master_scope_text_ids(master)
         sources, context_text = await retrieve_rag_context(
             db, message, prev_query=prev_user_msg, scope_text_ids=scope_text_ids,
         )

--- a/backend/app/services/embedding.py
+++ b/backend/app/services/embedding.py
@@ -152,6 +152,13 @@ async def similarity_search(
         "WHERE te.embedding IS NOT NULL"
     )
     filters: list[str] = []
+    # Asymmetric scope contract — see chat.py wiring docstring. Empty
+    # list intentionally falsy here: master with no indexed corpus
+    # (Ajahn Chah, Hsing Yun, …) wants vector RAG over the full
+    # corpus while precise retrieval is *disabled* by the same empty
+    # list. Don't switch to `is not None` without rereading that
+    # docstring — you'll force unindexed-master sessions to return
+    # empty SQL results.
     if scope_text_ids:
         placeholders = ",".join(str(tid) for tid in scope_text_ids)
         filters.append(f"te.text_id IN ({placeholders})")  # nosec B608 — hardcoded MasterProfile IDs

--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -461,7 +461,12 @@ async def retrieve_rag_context(
         t1 = time.monotonic()
         logger.debug("TIMING: Embedding took %.2fs", t1 - t0)
 
-        # Text chunk retrieval: two modes depending on ENABLE_PARALLEL_RAG
+        # Text chunk retrieval: two modes depending on ENABLE_PARALLEL_RAG.
+        # Asymmetric scope contract — see chat.py wiring docstring.
+        # Empty list is intentionally treated as "no scope" here so
+        # masters with no indexed corpus (Ajahn Chah, Hsing Yun, …) get
+        # full-corpus parallel RAG; the same empty list disables
+        # precise retrieval (see precise_retrieval.try_precise_text_retrieval).
         if ENABLE_PARALLEL_RAG and not scope_text_ids:
             # Per-language top-k retrieval, then alignment-aware merging.
             # scope_text_ids (master persona mode) bypasses parallel mode

--- a/backend/tests/test_chat_master_scope_wiring.py
+++ b/backend/tests/test_chat_master_scope_wiring.py
@@ -1,0 +1,39 @@
+"""Boundary tests for ``chat._master_scope_text_ids``.
+
+Tests the chat.py boundary helper that translates a MasterProfile into
+the scope value retrieve_rag_context expects. The contract this guards
+is the three-state asymmetric semantic documented in the helper's
+docstring; the bug this defends against is production trace 2026-05-07
+msg 4437, where falsy-coalescing collapsed an empty list to None and
+silently leaked 楞严经 chunks into the Ajahn Chah master's LLM context.
+
+`test_precise_retrieval` already covers the consumer-side contract
+(``scope_text_ids=[]`` blocks every hit). These tests cover the
+*producer* side so a future refactor of chat.py that reintroduces
+``or None`` fails loudly here, before it reaches the contract test.
+"""
+
+from unittest.mock import MagicMock
+
+from app.services.chat import _master_scope_text_ids
+
+
+def test_no_master_returns_none():
+    assert _master_scope_text_ids(None) is None
+
+
+def test_master_with_empty_text_ids_returns_empty_list_not_none():
+    """The exact regression that production msg 4437 exposed. Empty
+    list must NOT be coalesced to None — see helper docstring for the
+    three-state contract."""
+    m = MagicMock()
+    m.fojin_text_ids = []
+    result = _master_scope_text_ids(m)
+    assert result == []
+    assert result is not None  # belt and suspenders against future ``or None``
+
+
+def test_master_with_nonempty_text_ids_returns_list_unchanged():
+    m = MagicMock()
+    m.fojin_text_ids = [53, 52, 8085, 6513]
+    assert _master_scope_text_ids(m) == [53, 52, 8085, 6513]

--- a/backend/tests/test_precise_retrieval.py
+++ b/backend/tests/test_precise_retrieval.py
@@ -373,11 +373,28 @@ async def test_scope_text_ids_passes_in_scope_hit():
 @pytest.mark.anyio
 async def test_scope_text_ids_none_means_unrestricted():
     """None (the default) preserves the non-master-mode behaviour: all
-    texts are in scope. Empty list, by contrast, would correctly reject
-    every hit — but that's the caller's responsibility to construct."""
+    texts are in scope. Empty list, by contrast, rejects every hit —
+    that's the contract callers like chat.py rely on for masters
+    whose corpus index isn't loaded yet (Ajahn Chah, etc)."""
     db, _, _ = _mock_db_with_text_and_content(text_id=42)
     result = await try_precise_text_retrieval(db, "《心经》第1卷", scope_text_ids=None)
     assert result is not None
+
+
+@pytest.mark.anyio
+async def test_scope_text_ids_empty_list_blocks_every_hit():
+    """Empty list = "this master uses full-corpus vector RAG but
+    precise retrieval is disabled". This was the contract Ajahn
+    Chah's master profile relied on but chat.py's falsy-coalesce
+    silently broke it (an empty list collapsed to None, which means
+    'unrestricted'). Production sample 2026-05-07: Ajahn Chah master
+    answered `《楞严经》第一卷` with the chunk_text of 楞严经
+    silently sitting in the LLM's context — the persona prose hid
+    it, but the bypass was real. This test locks the empty-list
+    contract so a future regression can't undo the chat.py fix."""
+    db, _, _ = _mock_db_with_text_and_content(text_id=42)
+    result = await try_precise_text_retrieval(db, "《心经》第1卷", scope_text_ids=[])
+    assert result is None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Production trace

```sql
-- 2026-05-07 msg 4437: user typed 《楞严经》第一卷 in Ajahn Chah master mode.
-- User-visible answer correctly refused via persona prose.
-- But sources field showed precise retrieval HAD served 楞严经 chunk_text:
SELECT sources::jsonb FROM chat_messages WHERE id=4437;
→ [{"title_zh":"大佛頂如來密因修證了義諸菩薩萬行首楞嚴經","score":1.0,"text_id":65}]
```

The 8K-char chunk was fed to the LLM context and persisted to `chat_messages.sources`. Only the master prompt's prose refusal hid it from the user — a contract that this LLM happens to honour today, but that **must not be relied on as the only safety boundary**. Future model swaps or BYOK users with their own LLMs would expose the leak immediately.

## Root cause

`chat.py` coalesced empty list to None:

```python
scope_text_ids = master.fojin_text_ids if master and master.fojin_text_ids else None
```

Master profiles with `fojin_text_ids=[]` (Ajahn Chah, Hsing Yun, Yin Shun, Gampopa — masters whose source corpus isn't indexed) became `scope_text_ids=None`, which downstream means "unrestricted". Precise retrieval then served any `《大乘经》第N卷` query under a Theravada master.

## Fix — three-state asymmetric contract

| `master.fojin_text_ids` | scope value | precise retrieval | vector RAG |
|---|---|---|---|
| (no master) | `None` | unrestricted | unrestricted |
| `[]` | `[]` | **disabled** (no text_id ∈ `[]`) | full corpus (`if scope_text_ids:` falsy) |
| `[1, 2, 3]` | `[1, 2, 3]` | scoped | scoped |

The asymmetry is intentional: vector RAG runs across all texts because the master has no indexed corpus to scope against, but the precise short-circuit must NOT serve a 《大乘经》第N卷 query under a Theravada master.

## Architecture

- `chat.py` — single-line behavioural change, refactored into `_master_scope_text_ids` helper with full contract docstring (~25 lines)
- `embedding.py:155` and `rag_retrieval.py:465` — added cross-reference comments so the asymmetry is greppable from any of the three sites (reviewer P2)
- 3 boundary tests in `test_chat_master_scope_wiring.py` (None, empty, non-empty)
- 1 contract test in `test_precise_retrieval.py` (`test_scope_text_ids_empty_list_blocks_every_hit`)

## Test plan

- [x] 69 backend tests pass (3 new boundary + 1 new contract)
- [x] ruff clean
- [x] `superpowers:code-reviewer` pre-push: APPROVE; both P2 items absorbed (cross-ref comments + chat-wiring test)
- [ ] Post-deploy: re-run `《楞严经》第一卷` in Ajahn Chah mode, verify `chat_messages.sources` no longer contains 楞严经 (vector RAG runs full-corpus, returns Pali-related sources, no precise hit)

## Reviewer notes

Pre-existing master CI failures unrelated. Auto-merge **not enabled** (#526 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)