### PR TITLE
feat(chat): model selector dropdown + attachment stub (PR-A of 3)

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -102,7 +102,7 @@ async def list_chat_models(
     """Return curated catalog of selectable models, with availability flag.
 
     返回前端可选的精选模型列表（含可用性标记）。"""
-    from app.services.chat import PROVIDER_URLS
+    from app.services.chat import _platform_provider_matches
     from app.services.llm_catalog import CATALOG
 
     items = []
@@ -113,13 +113,7 @@ async def list_chat_models(
             and user.encrypted_api_key
             and (user.api_provider or "openai") == opt.provider
         )
-        platform_url = settings.llm_api_url or ""
-        expected_url = PROVIDER_URLS.get(opt.provider, "")
-        platform_ok = bool(
-            expected_url
-            and (expected_url in platform_url or platform_url in expected_url)
-            and settings.llm_api_key
-        )
+        platform_ok = bool(_platform_provider_matches(opt.provider) and settings.llm_api_key)
         items.append({
             "id": opt.id,
             "provider": opt.provider,

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.core.deps import get_current_user, get_optional_user
 from app.database import get_db
 from app.models.user import User
@@ -60,7 +61,7 @@ async def chat(
         db, user_id, data.message, data.session_id, user=user,
         client_ip=client_ip, redis=redis, master_id=data.master_id,
         text_id=data.text_id, juan_num=data.juan_num, selected_text=data.selected_text, page_content=data.page_content,
-        hot_question_id=data.hot_question_id,
+        hot_question_id=data.hot_question_id, model_id=data.model_id,
     )
 
 
@@ -82,7 +83,7 @@ async def chat_stream(
             db, user_id, data.message, data.session_id, user=user,
             client_ip=client_ip, redis=redis, master_id=data.master_id,
             text_id=data.text_id, juan_num=data.juan_num, selected_text=data.selected_text, page_content=data.page_content,
-            hot_question_id=data.hot_question_id,
+            hot_question_id=data.hot_question_id, model_id=data.model_id,
         ),
         media_type="text/event-stream",
         headers={
@@ -92,6 +93,43 @@ async def chat_stream(
             "Connection": "keep-alive",
         },
     )
+
+
+@router.get("/models", response_model=list[dict])
+async def list_chat_models(
+    user: User | None = Depends(get_optional_user),
+):
+    """Return curated catalog of selectable models, with availability flag.
+
+    返回前端可选的精选模型列表（含可用性标记）。"""
+    from app.services.chat import PROVIDER_URLS
+    from app.services.llm_catalog import CATALOG
+
+    items = []
+    for opt in CATALOG:
+        # available if user BYOK matches OR platform key configured for this provider
+        byok_ok = bool(
+            user
+            and user.encrypted_api_key
+            and (user.api_provider or "openai") == opt.provider
+        )
+        platform_url = settings.llm_api_url or ""
+        expected_url = PROVIDER_URLS.get(opt.provider, "")
+        platform_ok = bool(
+            expected_url
+            and (expected_url in platform_url or platform_url in expected_url)
+            and settings.llm_api_key
+        )
+        items.append({
+            "id": opt.id,
+            "provider": opt.provider,
+            "label": opt.label,
+            "description": opt.description,
+            "vision": opt.vision,
+            "available": byok_ok or platform_ok,
+            "requires_byok": not platform_ok,
+        })
+    return items
 
 
 @router.get("/masters")

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -17,6 +17,9 @@ class ChatRequest(BaseModel):
     # the LLM for the matching hot-question prompt template, keeping the
     # natural display_text in history/RAG.
     hot_question_id: int | None = None
+    # Per-message model override — id from llm_catalog.CATALOG (e.g. "deepseek:v4-flash").
+    # Unknown ids fall back gracefully so stale localStorage doesn't break chat.
+    model_id: str | None = None
 
 
 class HotQuestionCard(BaseModel):

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -495,19 +495,32 @@ def _resolve_with_model_override(
             logger.warning("Failed to decrypt user %s API key: %s", user.id, exc)
             raise ServiceError("您的 API Key 解密失败，请在个人中心重新配置。") from None
     # Platform path — only works when the platform-configured llm_api_url
-    # matches this provider
-    platform_url = settings.llm_api_url or ""
-    expected_url = PROVIDER_URLS.get(opt.provider, "")
-    if (
-        expected_url
-        and (expected_url in platform_url or platform_url in expected_url)
-        and settings.llm_api_key
-    ):
+    # matches this provider. Match by host prefix (rstrip trailing slashes)
+    # to avoid false positives where one URL is a substring of another
+    # (e.g. operator setting LLM_API_URL=https://api. would otherwise
+    # match every provider).
+    if _platform_provider_matches(opt.provider) and settings.llm_api_key:
+        expected_url = PROVIDER_URLS[opt.provider]
         return expected_url, settings.llm_api_key, opt.model, False, opt.provider
     # Provider not available on platform; user has no matching BYOK
     raise ServiceError(
         f"所选模型「{opt.label}」需要在个人中心配置 {opt.provider} 服务商的 API Key 后使用。"
     )
+
+
+def _platform_provider_matches(provider: str) -> bool:
+    """True iff the platform-configured llm_api_url points at this provider.
+
+    Uses host-anchored matching (after stripping trailing slashes) so that
+    e.g. ``https://api.deepseek.com/v1`` and ``https://api.deepseek.com``
+    both count as deepseek, but ``https://api.`` does not match every
+    provider.
+    """
+    expected = PROVIDER_URLS.get(provider, "").rstrip("/")
+    platform = (settings.llm_api_url or "").rstrip("/")
+    if not expected or not platform:
+        return False
+    return platform == expected or platform.startswith(expected + "/") or expected.startswith(platform + "/")
 
 
 def _resolve_fallback_llm_config() -> tuple[str, str, str, str] | None:

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -458,6 +458,58 @@ def _resolve_llm_config(user: User | None) -> tuple[str, str, str, bool, str]:
     return url, settings.llm_api_key, model, False, "openai"
 
 
+def _resolve_with_model_override(
+    user: User | None, model_id: str | None
+) -> tuple[str, str, str, bool, str]:
+    """Same as _resolve_llm_config but allows a per-message model override.
+
+    Selection precedence:
+    1. model_id from request → look up CATALOG → if user has BYOK matching the
+       same provider, use BYOK key with the catalog model. Else use platform
+       key (only works for providers with a configured platform key —
+       DeepSeek today).
+    2. No model_id → fall back to _resolve_llm_config (BYOK or platform default).
+
+    Raises ServiceError when model_id refers to a provider for which neither
+    BYOK nor a platform key is available.
+    """
+    from app.services.llm_catalog import CATALOG_BY_ID  # local import to avoid cycle if any
+
+    if not model_id:
+        return _resolve_llm_config(user)
+    opt = CATALOG_BY_ID.get(model_id)
+    if not opt:
+        # unknown id — silently fall back rather than 400, so a stale
+        # localStorage value doesn't break chat
+        logger.info("Unknown model_id %r from client; falling back to default", model_id)
+        return _resolve_llm_config(user)
+    # BYOK matching the catalog provider → use user's key, override model
+    if user and user.encrypted_api_key:
+        try:
+            user_provider = user.api_provider or "openai"
+            if user_provider == opt.provider:
+                key = decrypt_api_key(user.encrypted_api_key)
+                url = PROVIDER_URLS.get(opt.provider, settings.llm_api_url)
+                return url, key, opt.model, True, opt.provider
+        except Exception as exc:  # pragma: no cover — same handling as _resolve_llm_config
+            logger.warning("Failed to decrypt user %s API key: %s", user.id, exc)
+            raise ServiceError("您的 API Key 解密失败，请在个人中心重新配置。") from None
+    # Platform path — only works when the platform-configured llm_api_url
+    # matches this provider
+    platform_url = settings.llm_api_url or ""
+    expected_url = PROVIDER_URLS.get(opt.provider, "")
+    if (
+        expected_url
+        and (expected_url in platform_url or platform_url in expected_url)
+        and settings.llm_api_key
+    ):
+        return expected_url, settings.llm_api_key, opt.model, False, opt.provider
+    # Provider not available on platform; user has no matching BYOK
+    raise ServiceError(
+        f"所选模型「{opt.label}」需要在个人中心配置 {opt.provider} 服务商的 API Key 后使用。"
+    )
+
+
 def _resolve_fallback_llm_config() -> tuple[str, str, str, str] | None:
     """Platform fallback LLM, used only when the primary platform model fails
     before any tokens have been streamed. Returns (url, key, model, provider)
@@ -701,6 +753,7 @@ async def _prepare_chat(
     selected_text: str | None = None,
     page_content: str | None = None,
     hot_question_id: int | None = None,
+    model_id: str | None = None,
 ) -> tuple[ChatSession | None, str, str, str, bool, str, list[ChatSource], list[dict[str, str]]]:
     """Shared setup for send_message and send_message_stream.
 
@@ -726,7 +779,7 @@ async def _prepare_chat(
     if user_id is not None:
         chat_session = await _resolve_session(db, user_id, message, session_id)
 
-    api_url, api_key, model, is_byok, provider = _resolve_llm_config(user)
+    api_url, api_key, model, is_byok, provider = _resolve_with_model_override(user, model_id)
 
     if not is_byok and not api_key:
         raise ServiceError("平台 AI 服务暂未配置。请在个人中心配置自己的 API Key 使用 AI 问答功能。")
@@ -796,12 +849,13 @@ async def send_message(
     selected_text: str | None = None,
     page_content: str | None = None,
     hot_question_id: int | None = None,
+    model_id: str | None = None,
 ) -> ChatResponse:
     _t0 = _time.monotonic()
     chat_session, api_url, api_key, model, is_byok, provider, sources, llm_messages = await _prepare_chat(
         db, user_id, message, session_id, user, client_ip=client_ip, redis=redis, master_id=master_id,
         text_id=text_id, juan_num=juan_num, selected_text=selected_text, page_content=page_content,
-        hot_question_id=hot_question_id,
+        hot_question_id=hot_question_id, model_id=model_id,
     )
     _t1 = _time.monotonic()
     logger.debug("TIMING: _prepare_chat took %.2fs", _t1 - _t0)
@@ -904,6 +958,7 @@ async def send_message_stream(
     selected_text: str | None = None,
     page_content: str | None = None,
     hot_question_id: int | None = None,
+    model_id: str | None = None,
 ):
     """Async generator yielding SSE events for streaming chat responses.
 
@@ -921,7 +976,7 @@ async def send_message_stream(
         chat_session, api_url, api_key, model, is_byok, provider, sources, llm_messages = await _prepare_chat(
             db, user_id, message, session_id, user, client_ip=client_ip, redis=redis, master_id=master_id,
             text_id=text_id, juan_num=juan_num, selected_text=selected_text, page_content=page_content,
-            hot_question_id=hot_question_id,
+            hot_question_id=hot_question_id, model_id=model_id,
         )
     except (ValidationError, QuotaExceededError, AccessDeniedError, ServiceError) as exc:
         yield f"data: {json.dumps({'type': 'error', 'message': str(exc)}, ensure_ascii=False)}\n\n"

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -58,9 +58,9 @@ PROVIDER_URLS = {
 PROVIDER_DEFAULT_MODELS = {
     # 国内
     "deepseek": "deepseek-v4-flash",
-    "dashscope": "qwen-plus",
-    "zhipu": "glm-4-flash",
-    "moonshot": "moonshot-v1-8k",
+    "dashscope": "qwen3.6-plus",
+    "zhipu": "glm-5.1",
+    "moonshot": "kimi-k2.6",
     "doubao": "doubao-1.5-pro-32k",
     "minimax": "MiniMax-Text-01",
     "stepfun": "step-1-8k",

--- a/backend/app/services/llm_catalog.py
+++ b/backend/app/services/llm_catalog.py
@@ -1,0 +1,44 @@
+"""Curated list of LLMs the user can choose from in the chat dropdown.
+
+This is a small, opinionated subset of PROVIDER_DEFAULT_MODELS in
+chat.py — those are server-side defaults; this catalog is what the
+frontend dropdown shows. Each entry maps a stable `id` to a
+(provider, model) pair plus UI metadata.
+
+vision: True means the model accepts image inputs (used by PR-C image
+upload to gate routing — for PR-A this is just data).
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelOption:
+    id: str           # stable key sent from frontend (e.g. "deepseek:v4-flash")
+    provider: str     # matches PROVIDER_URLS keys in chat.py
+    model: str        # actual API model id
+    label: str        # display name for dropdown
+    description: str  # short tooltip text
+    vision: bool
+
+
+# Order matters — first entry is the default when no localStorage value exists.
+CATALOG: list[ModelOption] = [
+    ModelOption("deepseek:v4-flash", "deepseek", "deepseek-v4-flash",
+                "DeepSeek V4 Flash", "经济快速，日常问答首选", False),
+    ModelOption("deepseek:v4-pro", "deepseek", "deepseek-v4-pro",
+                "DeepSeek V4 Pro", "1.6T 参数旗舰，复杂推理（5-31 前 75% 折扣）", False),
+    ModelOption("dashscope:qwen3.6-plus", "dashscope", "qwen3.6-plus",
+                "通义千问 Qwen3.6 Plus", "阿里最新文本旗舰", False),
+    ModelOption("dashscope:qwen3-vl-flash", "dashscope", "qwen3-vl-flash-2026-01-22",
+                "通义千问 Qwen3-VL Flash", "支持图片识别（PR-C 启用）", True),
+    ModelOption("moonshot:kimi-k2.6", "moonshot", "kimi-k2.6",
+                "Kimi K2.6", "Moonshot 原生多模态，支持图片", True),
+    ModelOption("zhipu:glm-5.1", "zhipu", "glm-5.1",
+                "智谱 GLM-5.1", "744B 参数，编码与推理强", False),
+    ModelOption("zhipu:glm-4.6v", "zhipu", "glm-4.6v",
+                "智谱 GLM-4.6V", "智谱视觉模型，支持图片", True),
+]
+
+CATALOG_BY_ID = {opt.id: opt for opt in CATALOG}
+
+DEFAULT_MODEL_ID = "deepseek:v4-flash"

--- a/backend/tests/test_llm_catalog.py
+++ b/backend/tests/test_llm_catalog.py
@@ -1,0 +1,123 @@
+"""Tests for the curated LLM catalog and the per-message model override.
+
+Guards two contracts:
+
+1. ``CATALOG`` ids are stable and unique — frontend localStorage relies on
+   these strings.
+2. ``_resolve_with_model_override`` selects the right (url, key, model)
+   triple based on BYOK vs platform availability, and falls back gracefully
+   on unknown ids so a stale localStorage value never breaks chat.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.core.exceptions import ServiceError
+from app.services import chat as chat_module
+from app.services.chat import (
+    PROVIDER_URLS,
+    _resolve_llm_config,
+    _resolve_with_model_override,
+)
+from app.services.llm_catalog import CATALOG, CATALOG_BY_ID, DEFAULT_MODEL_ID
+
+
+def test_catalog_ids_are_unique():
+    ids = [opt.id for opt in CATALOG]
+    assert len(ids) == len(set(ids)), "Duplicate ids in CATALOG"
+
+
+def test_catalog_by_id_matches_catalog():
+    assert set(CATALOG_BY_ID.keys()) == {opt.id for opt in CATALOG}
+
+
+def test_default_model_id_is_in_catalog():
+    assert DEFAULT_MODEL_ID in CATALOG_BY_ID
+
+
+def test_resolve_with_no_model_id_falls_back_to_default(monkeypatch):
+    """No model_id → behave exactly like _resolve_llm_config(user)."""
+    monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
+    monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
+    monkeypatch.setattr(chat_module.settings, "llm_model", "deepseek-v4-flash")
+
+    assert _resolve_with_model_override(None, None) == _resolve_llm_config(None)
+
+
+def test_resolve_with_unknown_model_id_falls_back_gracefully(monkeypatch):
+    """Stale localStorage id must not 400 — fall back to default."""
+    monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
+    monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
+    monkeypatch.setattr(chat_module.settings, "llm_model", "deepseek-v4-flash")
+
+    result = _resolve_with_model_override(None, "vendor:nonsense-model")
+    assert result == _resolve_llm_config(None)
+
+
+def test_resolve_platform_deepseek_pro(monkeypatch):
+    """DeepSeek V4 Pro on platform key → returns deepseek URL + override model."""
+    monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
+    monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
+
+    url, key, model, is_byok, provider = _resolve_with_model_override(None, "deepseek:v4-pro")
+    assert url == PROVIDER_URLS["deepseek"]
+    assert key == "platform-key"
+    assert model == "deepseek-v4-pro"
+    assert is_byok is False
+    assert provider == "deepseek"
+
+
+def test_resolve_platform_mismatch_raises(monkeypatch):
+    """Platform configured as DeepSeek, user picks Moonshot, no BYOK → ServiceError."""
+    monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
+    monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
+
+    with pytest.raises(ServiceError) as exc_info:
+        _resolve_with_model_override(None, "moonshot:kimi-k2.6")
+    # User-facing message must mention the provider so user knows which key to add
+    assert "moonshot" in str(exc_info.value).lower() or "Kimi" in str(exc_info.value)
+
+
+def test_resolve_byok_matching_provider_overrides_model(monkeypatch):
+    """User has Moonshot BYOK, picks Moonshot model → use BYOK key + override model."""
+    monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
+    monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
+    monkeypatch.setattr(
+        chat_module, "decrypt_api_key", lambda blob: "user-moonshot-key"
+    )
+
+    user = MagicMock()
+    user.id = 42
+    user.encrypted_api_key = b"encrypted-blob"
+    user.api_provider = "moonshot"
+    user.api_model = "kimi-something-stale"
+
+    url, key, model, is_byok, provider = _resolve_with_model_override(
+        user, "moonshot:kimi-k2.6"
+    )
+    assert url == PROVIDER_URLS["moonshot"]
+    assert key == "user-moonshot-key"
+    assert model == "kimi-k2.6"
+    assert is_byok is True
+    assert provider == "moonshot"
+
+
+def test_resolve_byok_provider_mismatch_falls_to_platform(monkeypatch):
+    """User has Moonshot BYOK but picks DeepSeek → platform path (DeepSeek configured)."""
+    monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
+    monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
+
+    user = MagicMock()
+    user.id = 42
+    user.encrypted_api_key = b"encrypted-blob"
+    user.api_provider = "moonshot"
+
+    url, key, model, is_byok, provider = _resolve_with_model_override(
+        user, "deepseek:v4-flash"
+    )
+    assert url == PROVIDER_URLS["deepseek"]
+    assert key == "platform-key"
+    assert model == "deepseek-v4-flash"
+    assert is_byok is False
+    assert provider == "deepseek"

--- a/frontend/src/api/chatModels.ts
+++ b/frontend/src/api/chatModels.ts
@@ -1,0 +1,16 @@
+import api from "./client";
+
+export interface ChatModelOption {
+  id: string;
+  provider: string;
+  label: string;
+  description: string;
+  vision: boolean;
+  available: boolean;
+  requires_byok: boolean;
+}
+
+export async function fetchChatModels(): Promise<ChatModelOption[]> {
+  const { data } = await api.get<ChatModelOption[]>("/chat/models");
+  return data;
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1384,6 +1384,7 @@ export function sendChatMessageStream(
   signal?: AbortSignal,
   readingContext?: ReadingContext,
   hotQuestionId?: number | null,
+  modelId?: string | null,
 ): Promise<void> {
   return new Promise<void>((resolve) => {
     // Get auth token from localStorage (same pattern as axios interceptor)
@@ -1507,6 +1508,7 @@ export function sendChatMessageStream(
       message,
       session_id: sessionId ?? null,
       master_id: masterId,
+      ...(modelId ? { model_id: modelId } : {}),
       ...(hotQuestionId != null ? { hot_question_id: hotQuestionId } : {}),
       ...(readingContext ? {
         text_id: readingContext.text_id,

--- a/frontend/src/components/ChatModelSelector.tsx
+++ b/frontend/src/components/ChatModelSelector.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useState } from "react";
+import { Select, Tooltip } from "antd";
+import { PictureOutlined } from "@ant-design/icons";
+import { fetchChatModels, type ChatModelOption } from "../api/chatModels";
+
+interface ChatModelSelectorProps {
+  value: string;
+  onChange: (modelId: string) => void;
+}
+
+const FALLBACK_OPTIONS: ChatModelOption[] = [
+  {
+    id: "deepseek:v4-flash",
+    provider: "deepseek",
+    label: "DeepSeek V4 Flash",
+    description: "默认模型",
+    vision: false,
+    available: true,
+    requires_byok: false,
+  },
+];
+
+interface SelectOption {
+  value: string;
+  label: React.ReactNode;
+  title: string;
+  disabled?: boolean;
+}
+
+interface SelectGroup {
+  label: string;
+  title: string;
+  options: SelectOption[];
+}
+
+function buildLabel(model: ChatModelOption): React.ReactNode {
+  const suffix = model.available ? "" : "（需配置 Key）";
+  const text = `${model.label}${suffix}`;
+  return (
+    <Tooltip title={model.description} placement="left" mouseEnterDelay={0.2}>
+      <span>
+        {text}
+        {model.vision && (
+          <PictureOutlined style={{ marginLeft: 4, color: "#8b7355" }} />
+        )}
+      </span>
+    </Tooltip>
+  );
+}
+
+function groupByProvider(models: ChatModelOption[]): SelectGroup[] {
+  const groups = new Map<string, ChatModelOption[]>();
+  for (const m of models) {
+    const arr = groups.get(m.provider) ?? [];
+    arr.push(m);
+    groups.set(m.provider, arr);
+  }
+  const result: SelectGroup[] = [];
+  for (const [provider, items] of groups) {
+    result.push({
+      label: provider,
+      title: provider,
+      options: items.map((m) => ({
+        value: m.id,
+        label: buildLabel(m),
+        title: m.description,
+        disabled: !m.available,
+      })),
+    });
+  }
+  return result;
+}
+
+export default function ChatModelSelector({ value, onChange }: ChatModelSelectorProps) {
+  const [models, setModels] = useState<ChatModelOption[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchChatModels()
+      .then((list) => {
+        if (cancelled) return;
+        setModels(list.length > 0 ? list : FALLBACK_OPTIONS);
+      })
+      .catch((err) => {
+        // Fallback so chat keeps working when /chat/models is unavailable.
+        console.error("[ChatModelSelector] fetchChatModels failed", err);
+        if (!cancelled) setModels(FALLBACK_OPTIONS);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const groupedOptions = useMemo<SelectGroup[]>(() => {
+    if (!models) return [];
+    return groupByProvider(models);
+  }, [models]);
+
+  return (
+    <Select
+      size="small"
+      style={{ minWidth: 180 }}
+      loading={loading}
+      disabled={loading}
+      value={value}
+      onChange={onChange}
+      options={groupedOptions}
+    />
+  );
+}

--- a/frontend/src/components/ChatModelSelector.tsx
+++ b/frontend/src/components/ChatModelSelector.tsx
@@ -80,7 +80,15 @@ export default function ChatModelSelector({ value, onChange }: ChatModelSelector
     fetchChatModels()
       .then((list) => {
         if (cancelled) return;
-        setModels(list.length > 0 ? list : FALLBACK_OPTIONS);
+        const next = list.length > 0 ? list : FALLBACK_OPTIONS;
+        setModels(next);
+        // Reconcile a stale localStorage choice (e.g. a model that's
+        // since been removed from the catalog) so the dropdown never
+        // displays a blank value while still POSTing the stale id.
+        if (!next.some((m) => m.id === value)) {
+          const firstAvailable = next.find((m) => m.available) ?? next[0];
+          if (firstAvailable) onChange(firstAvailable.id);
+        }
       })
       .catch((err) => {
         // Fallback so chat keeps working when /chat/models is unavailable.
@@ -93,6 +101,8 @@ export default function ChatModelSelector({ value, onChange }: ChatModelSelector
     return () => {
       cancelled = true;
     };
+    // value/onChange intentionally excluded — we only reconcile once per fetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const groupedOptions = useMemo<SelectGroup[]>(() => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -636,7 +636,13 @@ export default function ChatPage() {
         setSending(false);
         refetchQuota();
       },
-    }, abortController.signal, undefined, hotQuestionId, modelId);
+      // Only send model_id when the user has explicitly picked a non-default
+      // model. Treating the default as "no override" lets _resolve_llm_config
+      // pick the platform default for whatever LLM_API_URL is configured —
+      // important for non-deepseek deployments where forcing a deepseek
+      // catalog id would otherwise raise.
+    }, abortController.signal, undefined, hotQuestionId,
+       modelId === "deepseek:v4-flash" ? null : modelId);
   }, [sending, sessionId, masterId, modelId, user, refetchSessions, refetchQuota, queryClient]);
 
   const handleSend = useCallback(async () => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -29,6 +29,7 @@ import {
 } from "@ant-design/icons";
 const ShareCard = lazy(() => import("../components/ShareCard"));
 const CitationDrawer = lazy(() => import("../components/CitationDrawer"));
+import ChatModelSelector from "../components/ChatModelSelector";
 import type { CitationTarget } from "../components/CitationDrawer";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -249,6 +250,14 @@ export default function ChatPage() {
   const { user } = useAuthStore();
   const [input, setInput] = useState("");
   const [masterId, setMasterId] = useState<string | null>(null);
+  const [modelId, setModelId] = useState<string>(() => {
+    if (typeof window === "undefined") return "deepseek:v4-flash";
+    return window.localStorage.getItem("fojin.chat.modelId") || "deepseek:v4-flash";
+  });
+  const handleModelChange = useCallback((id: string) => {
+    setModelId(id);
+    try { window.localStorage.setItem("fojin.chat.modelId", id); } catch { /* ignore */ }
+  }, []);
   const [sessionId, setSessionId] = useState<number | undefined>();
   const [messages, setMessages] = useState<ChatMessageItem[]>([]);
   const [sending, setSending] = useState(false);
@@ -627,8 +636,8 @@ export default function ChatPage() {
         setSending(false);
         refetchQuota();
       },
-    }, abortController.signal, undefined, hotQuestionId);
-  }, [sending, sessionId, masterId, user, refetchSessions, refetchQuota, queryClient]);
+    }, abortController.signal, undefined, hotQuestionId, modelId);
+  }, [sending, sessionId, masterId, modelId, user, refetchSessions, refetchQuota, queryClient]);
 
   const handleSend = useCallback(async () => {
     await handleSendMessage(input);
@@ -1232,6 +1241,23 @@ export default function ChatPage() {
                 />
               )}
             </Space.Compact>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                marginTop: 8,
+                gap: 8,
+              }}
+            >
+              <Button
+                size="small"
+                icon={<PlusOutlined />}
+                disabled
+                title="附件上传（即将上线）"
+              />
+              <ChatModelSelector value={modelId} onChange={handleModelChange} />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

PR-A of a 3-part series wiring **Claude.ai-style chat input** to fojin:
adds a model selector dropdown (bottom-right) and reserves the "+"
attachment slot (bottom-left, disabled until PR-B/PR-C land).

- `feat(chat): refresh provider default models to 2026 latest versions` — qwen3.6-plus / glm-5.1 / kimi-k2.6 (DeepSeek default stays v4-flash for cost)
- `feat(chat): add llm_catalog and per-message model_id override` — curated 7-entry CATALOG, GET /chat/models endpoint, `_resolve_with_model_override` honours BYOK match or platform key, unknown ids fall back silently
- `feat(chat): add model selector dropdown and attachment stub to chat input` — antd Select grouped by provider, vision badge, "需配置 Key" disabled state, localStorage persistence, "+" button placeholder

Vision flag on catalog entries is data-only here — PR-C will use it to
route image uploads to vision-capable providers (Qwen3-VL / Kimi K2.6 /
GLM-4.6V).

PR-B (file upload PDF/TXT/MD/DOCX/CSV/HTML) and PR-C (image + vision
routing) follow.

## Test plan

- [x] `ruff check` clean on changed files
- [x] `pytest tests/test_llm_catalog.py` — 9/9 pass
- [x] full pytest unaffected (238 pass; 7 pre-existing failures on master, unrelated)
- [x] `eslint` 0 errors on changed files
- [x] `tsc -b --noEmit` clean
- [ ] manual: load fojin.app/chat, dropdown shows DeepSeek entries available, others marked "需配置 Key"; selection persists across reload; sending uses selected model
- [ ] manual: BYOK user with `api_provider=moonshot` sees Kimi K2.6 as available

🤖 Generated with [Claude Code](https://claude.com/claude-code)