### PR TITLE
chore(chat): PR-B reviewer follow-ups (sanitize 422, retry chips, mobile)

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -198,9 +198,15 @@ async def upload_chat_attachment(
         # the user.  We still emit the id in the body so the client
         # can choose to attach it anyway (with the parse_error inlined
         # by the chat service).
+        # The parse_error string in DB keeps the raw exc text for
+        # debugging, but the user-facing detail is stripped to its
+        # Chinese prefix to avoid leaking pypdf / docx internal
+        # exception traces. Parser errors all use the form
+        # "<friendly Chinese reason>：<library detail>".
+        user_facing = parse_error.split("：", 1)[0] if "：" in parse_error else "文件解析失败"
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"上传成功但解析失败：{parse_error}",
+            detail=f"上传成功但解析失败：{user_facing}",
         )
 
     preview = (parsed_text or "")[:200]

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -598,11 +598,12 @@ export default function ChatPage() {
     setMessages((prev) => [...prev, userMsg, assistantMsg]);
     setInput("");
     setSending(true);
-    // Snapshot attachment ids for this send and clear the chip row. Backend
-    // marks them consumed by id; clearing here prevents the next message from
-    // accidentally re-sending the same attachment_ids.
+    // Snapshot attachment ids for this send. Don't clear chips yet —
+    // if the stream errors before the backend marks them consumed,
+    // keeping the chips lets the user retry by hitting Send again
+    // (consumed_at IS NULL on the backend means re-use is safe).
+    // Cleared in onDone (success path) below.
     const attachmentIdsForSend = attachments.map((a) => a.id);
-    setAttachments([]);
     scrollToBottom();
 
     const abortController = new AbortController();
@@ -684,6 +685,11 @@ export default function ChatPage() {
         abortRef.current = null;
         streamingIdRef.current = 0;
         setSending(false);
+        // Clear attachment chips only after successful stream completion.
+        // On error the chips stay so the user can retry without re-uploading.
+        if (attachmentIdsForSend.length > 0) {
+          setAttachments((prev) => prev.filter((a) => !attachmentIdsForSend.includes(a.id)));
+        }
         refetchQuota();
       },
     }, {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -163,6 +163,20 @@ em {
 .chat-input-toolbar > .chat-input-spacer {
   flex: 1;
 }
+/* On narrow viewports the model selector + Send + "+" can squeeze the
+   spacer to zero and overflow to the right. Allow the toolbar to wrap
+   so the Send button drops to a second row below the model selector
+   instead of horizontally clipping. */
+@media (max-width: 480px) {
+  .chat-input-toolbar {
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+  .chat-input-toolbar > .chat-input-spacer {
+    flex-basis: 100%;
+    height: 0;
+  }
+}
 
 /* ========== Chat Markdown ========== */
 /* Override bubble's pre-wrap so markdown controls its own whitespace */


### PR DESCRIPTION
Three small reviewer follow-ups from PR-B (#536):

1. **Sanitize attachment 422 detail** — strip library-specific exception suffixes from the user-facing message, keep DB column raw for debugging.
2. **Keep attachment chips on stream error** — clear only on successful onDone so a failed send can be retried without re-uploading.
3. **Mobile toolbar wrap** — flex-wrap on viewports ≤480px so Send doesn't clip past the input shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)