### PR TITLE
fix(alembic): repair migration chain after DianJin removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,9 @@ docs/promotion/
 backend/app/api/dianjin.py
 backend/app/schemas/dianjin.py
 backend/app/services/dianjin.py
-backend/alembic/versions/0027_seed_dianjin_sources.py
-backend/alembic/versions/0032_import_dianjin_datasources.py
-backend/alembic/versions/0035_supplement_dianjin_cross_reference.py
+backend/alembic/versions/0130_seed_dianjin_sources.py
+backend/alembic/versions/0131_import_dianjin_datasources.py
+backend/alembic/versions/0132_supplement_dianjin_cross_reference.py
 frontend/src/api/dianjin.ts
 frontend/src/components/search/DianjinCard.tsx
 frontend/src/pages/DianjinBrowserPage.tsx

--- a/backend/alembic/versions/0028_split_fulltext_semantics.py
+++ b/backend/alembic/versions/0028_split_fulltext_semantics.py
@@ -1,7 +1,7 @@
 """split supports_fulltext into has_local_fulltext and has_remote_fulltext
 
 Revision ID: 0028
-Revises: 0027
+Revises: 0026
 Create Date: 2026-03-02
 """
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "0028"
-down_revision: Union[str, None] = "0027"
+down_revision: Union[str, None] = "0026"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/0033_import_google_discovered_sources.py
+++ b/backend/alembic/versions/0033_import_google_discovered_sources.py
@@ -11,7 +11,7 @@
 Data discovered 2026-03-02 via Apify Google Search Scraper.
 
 Revision ID: 0033
-Revises: 0032
+Revises: 0031
 Create Date: 2026-03-02
 """
 
@@ -21,7 +21,7 @@ from alembic import op
 from sqlalchemy import text as sa_text
 
 revision: str = "0033"
-down_revision: Union[str, None] = "0032"
+down_revision: Union[str, None] = "0031"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/0036_add_kg_relation_dedup_index.py
+++ b/backend/alembic/versions/0036_add_kg_relation_dedup_index.py
@@ -5,7 +5,7 @@ WHERE source IS NOT NULL. Enforces idempotent auto-extraction
 while leaving manually-created (source=NULL) relations unconstrained.
 
 Revision ID: 0036
-Revises: 0035
+Revises: 0034
 Create Date: 2026-03-03
 """
 
@@ -14,7 +14,7 @@ from typing import Sequence, Union
 from alembic import op
 
 revision: str = "0036"
-down_revision: Union[str, None] = "0035"
+down_revision: Union[str, None] = "0034"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Problem

Commit a86229e (\`refactor: remove DianJin (典津) integration from public repo\`) removed migrations \`0027\`, \`0032\`, \`0035\` from tracking but left \`0028\`, \`0033\`, \`0036\` pointing at them via \`down_revision\`. Every \`alembic upgrade head\` on the public chain has been failing in CI ever since:

\`\`\`
KeyError: '0027'
Revision 0027 referenced from 0027 -> 0028 (head), split supports_fulltext into has_local_fulltext and has_remote_fulltext is not present
\`\`\`

This is why the **Alembic dry-run** workflow has been red on every master push.

## Fix

Re-link the public chain past the removed revisions:

| Migration | Old \`down_revision\` | New \`down_revision\` |
|-----------|-----------|-----------|
| 0028 | 0027 (gone) | 0026 |
| 0033 | 0032 (gone) | 0031 |
| 0036 | 0035 (gone) | 0034 |

## Local DianJin compatibility

If you keep DianJin migrations locally (gitignored), rename them to extend after the current head (0129) so they don't collide with the public chain. \`.gitignore\` is updated to reflect the new local filenames:

\`\`\`
0027_seed_dianjin_sources.py        → 0130_seed_dianjin_sources.py        (rev 0130, down 0129)
0032_import_dianjin_datasources.py  → 0131_import_dianjin_datasources.py  (rev 0131, down 0130)
0035_supplement_dianjin_cross_reference.py → 0132_supplement_..._reference.py (rev 0132, down 0131)
\`\`\`

## Verification

\`ScriptDirectory.walk_revisions()\` on both scenarios:

- **Public CI (no DianJin files):** single head \`0129\`, 125 revisions, no branches. ✅
- **Local with DianJin renamed:** single head \`0132\`, 128 revisions, no branches. ✅

## Test plan

- [x] Public-only chain walks cleanly (single head, no orphans)
- [x] Local DianJin chain still works after rename
- [ ] CI \`Alembic dry-run\` workflow turns green