### PR TITLE
security: drop uvicorn --proxy-headers to fix access-log spoofing

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -8,14 +8,14 @@ echo "[FoJin] Seeding hot questions..."
 python -m scripts.seed_hot_questions || echo "[FoJin] hot question seed failed — continuing"
 
 echo "[FoJin] Starting backend server..."
-# --proxy-headers: trust X-Forwarded-* set by upstream nginx so
-# request.client.host and request.url.scheme reflect the real client
-# rather than the docker bridge IP.
-# --forwarded-allow-ips: only trust XFF/XFP from the docker bridge
-# (nginx container). Defaults to 127.0.0.1 which would silently ignore
-# proxy headers since nginx connects from a private docker IP.
+# Intentionally NOT passing --proxy-headers. nginx forwards
+# X-Forwarded-For via $proxy_add_x_forwarded_for which APPENDS the real
+# client IP to the right of any client-supplied value. uvicorn's
+# --proxy-headers picks the LEFTMOST entry, which is exactly the
+# spoofable claim. Application code reads the real IP via
+# app.core.client_ip.get_real_client_ip (last entry of XFF). Access
+# logs will show the docker bridge IP instead of the real client —
+# acceptable trade for not trusting client-supplied headers.
 exec uvicorn app.main:app \
     --host 0.0.0.0 \
-    --port 8000 \
-    --proxy-headers \
-    --forwarded-allow-ips="${FORWARDED_ALLOW_IPS:-*}"
+    --port 8000


### PR DESCRIPTION
## Summary

Follow-up to #544.

The original P1-2 fix added `--proxy-headers --forwarded-allow-ips=*` to uvicorn so `request.client.host` would reflect the real client. But uvicorn's `--proxy-headers` picks the **leftmost** `X-Forwarded-For` entry — and nginx's `$proxy_add_x_forwarded_for` **appends** the real client IP to the right of any client-supplied value. So the leftmost is exactly the spoofable claim.

**Verified post-deploy on prod**: `curl -H 'X-Forwarded-For: 1.2.3.4'` logged `1.2.3.4:0` as the client in uvicorn access logs.

This is an observability regression rather than a security regression — application-layer rate limit and password audit already read the real IP via `app.core.client_ip.get_real_client_ip` (last XFF entry), so the security goals of #544 hold. But access logs being spoofable is its own problem.

## Fix

Remove `--proxy-headers --forwarded-allow-ips` from `entrypoint.sh`. uvicorn falls back to the docker bridge IP for `request.client.host`, which is non-informative but not spoofable. Application code keeps using the helper.

## Test plan
- [x] Local `bash -n entrypoint.sh` passes
- [x] CI: bandit / ruff / Backend smoke / Frontend build / secrets / GitGuardian
- [ ] Post-deploy: `curl -H 'X-Forwarded-For: 1.2.3.4' https://fojin.app/api/health`, expect uvicorn access log to NOT show `1.2.3.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)