### PR TITLE
chore: P1 deps bump (multipart/pillow/lxml) + compose secret hardening

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -102,12 +102,9 @@ jobs:
       - name: Display pip-audit results
         if: always()
         # CVE-2026-4539: existing waiver.
-        # CVE-2026-41066 (lxml 5.3.0 XXE): only triggers via untrusted iterparse/
-        #   ETCompatXMLParser inputs; FoJin only parses trusted CBETA/SC fixtures.
-        #   Tracking lxml>=6.1 upgrade as a separate dep PR.
         # CVE-2026-3219 (pip 26.0.1 archive confusion): affects `pip install` on
         #   crafted archives only; CI uses pinned wheels from PyPI.
-        run: pip-audit --desc --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-41066 --ignore-vuln CVE-2026-3219
+        run: pip-audit --desc --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
 
       - name: Upload pip-audit report
         if: always()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,13 +12,13 @@ PyJWT==2.12.1
 cryptography==46.0.7
 bcrypt==4.1.1
 defusedxml==0.7.1
-lxml==5.3.0
+lxml==6.1.0
 pgvector==0.3.6
 openai==1.58.0
 tiktoken==0.8.0
 opencc-python-reimplemented==0.1.7
-Pillow==11.0.0
-python-multipart==0.0.20
+Pillow==12.2.0
+python-multipart==0.0.27
 pypdf==6.10.2
 python-docx==1.1.2
 beautifulsoup4==4.12.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       ES_HOST: http://elasticsearch:9200
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      JWT_SECRET_KEY: ${JWT_SECRET_KEY:-changeme-in-production}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:?Set JWT_SECRET_KEY in .env (32+ chars)}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173,http://localhost:5174}
       LLM_API_URL: ${LLM_API_URL:-}
       LLM_API_KEY: ${LLM_API_KEY:-}
@@ -132,7 +132,7 @@ services:
     cpus: 0.5
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-fojin}:${POSTGRES_PASSWORD}@postgres:5432/umami
-      APP_SECRET: ${UMAMI_APP_SECRET:-change-me-in-production}
+      APP_SECRET: ${UMAMI_APP_SECRET:?Set UMAMI_APP_SECRET in .env}
       BASE_PATH: /umami
     ports:
       - "127.0.0.1:3001:3000"


### PR DESCRIPTION
## Summary

- Bumps 3 Python deps flagged P1 in `AUDIT-REPORT.md`:
  - `python-multipart` 0.0.20 → 0.0.27 (CVE-2026-24486 / -40347 / -42561, P1-3)
  - `Pillow` 11.0.0 → 12.2.0 (5 image-decoding CVEs, P1-4)
  - `lxml` 5.3.0 → 6.1.0 (CVE-2026-41066 XXE, P1-5)
- Drops the matching `--ignore-vuln CVE-2026-41066` waiver from `.github/workflows/security.yml` since lxml is now patched.
- Hardens 2 secret defaults in `docker-compose.yml` to fail-fast (P2-1):
  - `JWT_SECRET_KEY` and `UMAMI_APP_SECRET` switch from `${VAR:-placeholder}` to `${VAR:?Set ... in .env}`, matching the existing `POSTGRES_PASSWORD` pattern.

## Test plan

- [x] `pip install -r backend/requirements.txt` resolves cleanly in a fresh venv (no dependency conflicts, `pip check` clean).
- [x] `pytest tests/test_chat_attachments.py tests/test_attachment_parser.py tests/test_og_and_share_qa_seo.py` — 22/22 pass with new `python-multipart`, `Pillow`, `lxml`.
- [x] No tests directly exercise `lxml.etree` — defusedxml wraps everything; trusted CBETA/SC fixtures only.
- [x] Confirmed pre-existing failures (`test_annotations_workflow`, `test_smoke::test_kg_entity_detail`) reproduce on `master@7408d3a`, so they are out of scope for this PR.
- [ ] CI Security Scan / pip-audit / npm-audit / bandit pass.
- [ ] Post-merge: redeploy backend on sg-vps and hit `/api/health` + `/api/search?q=慈悲`.

## Refs

- `AUDIT-REPORT.md` items P1-3, P1-4, P1-5, P2-1.
- Note: scope intentionally excludes `backend/app/core/crypto.py`, `backend/app/config.py`, and `backend/alembic/versions/` (P0-1 KDF migration is a separate parallel track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)