### PR TITLE
security: per-encryption-key BYOK with v1→v2 migration (P0-1 → P1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ REDIS_PORT=6379
 JWT_SECRET_KEY=change-me-generate-a-random-secret
 JWT_EXPIRE_MINUTES=10080
 
+# BYOK API key encryption (independent of JWT_SECRET_KEY).
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# Required in production. In dev, an ephemeral key is generated per boot
+# (stored ciphertexts won't survive a restart — by design).
+API_KEY_ENCRYPTION_KEY=
+
 # 端口映射（Docker 宿主机端口）
 BACKEND_PORT=8000
 FRONTEND_PORT=3000

--- a/backend/alembic/versions/0130_add_api_key_kdf_version.py
+++ b/backend/alembic/versions/0130_add_api_key_kdf_version.py
@@ -1,0 +1,81 @@
+"""Add users.api_key_kdf_version + api_key_migration_failures table.
+
+Part of P0-1: split the BYOK encryption key from JWT_SECRET_KEY so that
+rotating the JWT secret no longer silently destroys every stored API
+key.  The version column lets the read path dispatch between the legacy
+KDF (v1, derived from JWT secret) and the new KDF (v2, standalone
+``API_KEY_ENCRYPTION_KEY``) until ``scripts/migrate_api_keys.py``
+re-encrypts the existing rows in place.
+
+Backfill rules:
+
+* Rows with ``encrypted_api_key IS NULL`` → ``api_key_kdf_version = 2``.
+  No ciphertext exists, so we can claim the new version up front and the
+  next BYOK save just works.
+* Rows with a stored ciphertext stay at ``1`` (the column default).  The
+  migrate script will pick them up and flip them to ``2`` after a
+  successful re-encrypt, one row per transaction.
+
+The companion ``api_key_migration_failures`` table records rows the
+migrate script could not re-encrypt — almost always "v1 decrypt failed"
+which means the stored blob was sealed with a now-rotated JWT secret
+and the user must rotate their key from the UI.
+
+Revision ID: 0130
+Revises: 0129
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0130"
+down_revision = "0129"
+
+
+def upgrade() -> None:
+    # 1) Add the version column with a server-side default so existing
+    #    rows get ``1`` automatically — matches the legacy ciphertext
+    #    they're holding.
+    op.add_column(
+        "users",
+        sa.Column(
+            "api_key_kdf_version",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default="1",
+        ),
+    )
+
+    # 2) Bump rows with no ciphertext to v2 directly.  They have nothing
+    #    to migrate, so claiming v2 up-front means every future write
+    #    goes through the new KDF without the script touching them.
+    op.execute(
+        sa.text(
+            "UPDATE users SET api_key_kdf_version = 2 "
+            "WHERE encrypted_api_key IS NULL"
+        )
+    )
+
+    # 3) Failures sink for the migrate script.  Append-only; ops greps
+    #    it after running the script to see which users still need to
+    #    rotate their key from the UI.
+    op.create_table(
+        "api_key_migration_failures",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.Integer(), nullable=False, index=True),
+        # Free-form: today either the v1 InvalidToken message or the
+        # SQLAlchemy error from the per-row UPDATE.  Truncated to 500
+        # chars so a runaway stack trace doesn't bloat the table.
+        sa.Column("error", sa.String(500), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api_key_migration_failures")
+    op.drop_column("users", "api_key_kdf_version")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -132,7 +132,9 @@ async def save_api_key(
     db: AsyncSession = Depends(get_db),
 ):
     """保存用户自己的 API Key（加密存储）。"""
-    user.encrypted_api_key = encrypt_api_key(data.api_key)
+    cipher, kdf_ver = encrypt_api_key(data.api_key)
+    user.encrypted_api_key = cipher
+    user.api_key_kdf_version = kdf_ver
     user.api_provider = data.provider
     user.api_model = data.model
     user.api_custom_url = data.custom_url if data.provider == "custom" else None
@@ -153,7 +155,7 @@ async def get_api_key_status(user: User = Depends(get_current_user)):
     if not user.encrypted_api_key:
         return ApiKeyStatus(has_api_key=False)
     try:
-        key = decrypt_api_key(user.encrypted_api_key)
+        key = decrypt_api_key(user.encrypted_api_key, user.api_key_kdf_version)
         preview = f"{key[:6]}...{key[-4:]}" if len(key) > 10 else "***"
     except Exception:
         preview = None
@@ -176,8 +178,47 @@ async def delete_api_key(
     user.api_provider = None
     user.api_model = None
     user.api_custom_url = None
+    # Free of ciphertext → claim the current KDF so the next save doesn't
+    # round-trip through v1.
+    from app.core.crypto import KDF_VERSION_V2
+
+    user.api_key_kdf_version = KDF_VERSION_V2
     await db.commit()
     return {"ok": True}
+
+
+@router.post("/api-key/rotate-encryption")
+async def rotate_api_key_encryption(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Re-encrypt the user's stored BYOK key under the current KDF.
+
+    Escape hatch for the v1→v2 migration: if the bulk migrate script
+    can't decrypt a row (because JWT_SECRET_KEY was rotated before this
+    fix landed), the row stays at v1 and chat returns "decrypt failed".
+    The user can re-save their key from the UI — but if they don't have
+    the plaintext anymore, this endpoint at least lets them confirm
+    they're already on v2.  Idempotent: a v2 row stays v2.
+    """
+    if not user.encrypted_api_key:
+        raise HTTPException(status_code=404, detail="No API key configured")
+    try:
+        plaintext = decrypt_api_key(user.encrypted_api_key, user.api_key_kdf_version)
+    except Exception as exc:
+        logger.warning("Rotate-encryption decrypt failed for user %s: %s", user.id, exc)
+        # 409 rather than 500 — this is a "your stored ciphertext is no
+        # longer recoverable" state, not a server bug.  Frontend should
+        # tell the user to re-enter their key.
+        raise HTTPException(
+            status_code=409,
+            detail="Stored API key cannot be decrypted; please re-enter it.",
+        ) from None
+    cipher, kdf_ver = encrypt_api_key(plaintext)
+    user.encrypted_api_key = cipher
+    user.api_key_kdf_version = kdf_ver
+    await db.commit()
+    return {"ok": True, "kdf_version": kdf_ver}
 
 
 # ── OAuth: GitHub ────────────────────────────────────────────

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,14 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 60 * 8  # 8 hours
 
+    # BYOK API key encryption — independent of jwt_secret_key so rotating
+    # one doesn't silently destroy the other (see P0-1 audit).  Must be a
+    # base64-urlsafe 32-byte key in Fernet.generate_key() format.  In
+    # production this is fail-fast at boot; in dev a temporary key is
+    # generated on each boot, which means stored ciphertexts won't decrypt
+    # across restarts — intentional, to avoid silent dev/prod divergence.
+    api_key_encryption_key: str = os.environ.get("API_KEY_ENCRYPTION_KEY", "")
+
     # LLM (OpenAI-compatible API) — primary model
     llm_api_url: str = "https://api.openai.com/v1"
     llm_api_key: str = ""
@@ -111,8 +119,39 @@ if _fojin_env == "production":
             "FATAL: In production, JWT_SECRET_KEY must be set and at least 32 characters. "
             "Set the JWT_SECRET_KEY environment variable."
         )
-elif settings.jwt_secret_key == _DEFAULT_JWT_SECRET:
-    logger.warning(
-        "JWT_SECRET_KEY not set — using insecure default. "
-        "Set the JWT_SECRET_KEY environment variable in production!"
-    )
+    # Validate API_KEY_ENCRYPTION_KEY at boot.  Fernet construction is the
+    # canonical "is this a usable key?" check — covers length, base64
+    # alphabet, and padding in one call.
+    if not settings.api_key_encryption_key:
+        raise RuntimeError(
+            "FATAL: In production, API_KEY_ENCRYPTION_KEY must be set. "
+            "Generate one with: "
+            "python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+        )
+    try:
+        from cryptography.fernet import Fernet as _Fernet  # local import keeps tooling import paths clean
+
+        _Fernet(settings.api_key_encryption_key.encode())
+    except Exception as exc:  # pragma: no cover — exercised manually at boot
+        raise RuntimeError(
+            f"FATAL: API_KEY_ENCRYPTION_KEY is not a valid Fernet key: {exc}. "
+            "Generate one with: "
+            "python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+        ) from None
+else:
+    if settings.jwt_secret_key == _DEFAULT_JWT_SECRET:
+        logger.warning(
+            "JWT_SECRET_KEY not set — using insecure default. "
+            "Set the JWT_SECRET_KEY environment variable in production!"
+        )
+    if not settings.api_key_encryption_key:
+        # Dev fallback: ephemeral key.  Stored ciphertexts won't survive a
+        # restart, but that's preferable to silently sharing a derived key
+        # across machines (the bug we're fixing in prod).
+        from cryptography.fernet import Fernet as _Fernet
+
+        settings.api_key_encryption_key = _Fernet.generate_key().decode()
+        logger.warning(
+            "API_KEY_ENCRYPTION_KEY not set — generated an ephemeral dev key. "
+            "Stored BYOK ciphertexts will not decrypt across restarts."
+        )

--- a/backend/app/core/crypto.py
+++ b/backend/app/core/crypto.py
@@ -1,22 +1,79 @@
-"""AES encryption for user API keys (BYOK)."""
+"""Fernet encryption for user BYOK API keys, with versioned KDF support.
+
+Two key derivation versions live side-by-side during the v1→v2 migration:
+
+* ``KDF_VERSION_V1`` (legacy) — Fernet key = SHA-256(JWT_SECRET_KEY).  This
+  shares a secret with the JWT signing key, which means rotating the JWT
+  secret silently invalidates every stored API key (P0-1 audit).  Kept
+  here only as a read-side fallback while ``scripts/migrate_api_keys.py``
+  re-encrypts existing rows.
+
+* ``KDF_VERSION_V2`` (current) — Fernet key = ``API_KEY_ENCRYPTION_KEY``,
+  an independent secret managed in env.  All new writes go through v2.
+
+Callers should never decide which version to use — they pass through
+``encrypt_api_key`` (always v2) and ``decrypt_api_key(blob, version)``
+(dispatches by stored version).
+"""
 
 import base64
 import hashlib
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 
 from app.config import settings
 
+KDF_VERSION_V1 = 1
+KDF_VERSION_V2 = 2
 
-def _get_fernet() -> Fernet:
-    """Derive a Fernet key from jwt_secret_key."""
+# Default version for any user row that pre-dates the
+# ``api_key_kdf_version`` column.  Migration 0130 backfills NULL → 1.
+DEFAULT_KDF_VERSION = KDF_VERSION_V1
+
+
+def _get_v1_fernet() -> Fernet:
+    """Legacy KDF — derives from JWT secret.  Read-only after migration."""
     key = hashlib.sha256(settings.jwt_secret_key.encode()).digest()
     return Fernet(base64.urlsafe_b64encode(key))
 
 
-def encrypt_api_key(plaintext: str) -> str:
-    return _get_fernet().encrypt(plaintext.encode()).decode()
+def _get_v2_fernet() -> Fernet:
+    """Current KDF — uses the standalone ``API_KEY_ENCRYPTION_KEY``."""
+    # ``api_key_encryption_key`` is validated at boot in production and
+    # generated on-the-fly in dev, so by the time we reach here it must
+    # be a valid Fernet key.  We let any malformation surface as the
+    # native cryptography exception rather than wrapping it.
+    return Fernet(settings.api_key_encryption_key.encode())
 
 
-def decrypt_api_key(ciphertext: str) -> str:
-    return _get_fernet().decrypt(ciphertext.encode()).decode()
+def encrypt_api_key(plaintext: str) -> tuple[str, int]:
+    """Encrypt ``plaintext`` with the current KDF.
+
+    Returns ``(ciphertext, kdf_version)``.  Callers must persist *both*
+    values on the user row — the version is required to decrypt later.
+    """
+    cipher = _get_v2_fernet().encrypt(plaintext.encode()).decode()
+    return cipher, KDF_VERSION_V2
+
+
+def decrypt_api_key(ciphertext: str, version: int = DEFAULT_KDF_VERSION) -> str:
+    """Decrypt ``ciphertext`` produced by ``encrypt_api_key``.
+
+    During the migration window v2 ciphertexts may briefly arrive on
+    callers that defaulted to ``version=1`` (the column hasn't been
+    backfilled yet).  We try the requested version first and fall back
+    to the *other* version on ``InvalidToken`` so chat doesn't break
+    mid-migration.  After ``migrate_api_keys`` runs everything is v2 and
+    the fallback is a no-op.
+    """
+    if version == KDF_VERSION_V2:
+        try:
+            return _get_v2_fernet().decrypt(ciphertext.encode()).decode()
+        except InvalidToken:
+            return _get_v1_fernet().decrypt(ciphertext.encode()).decode()
+    if version == KDF_VERSION_V1:
+        try:
+            return _get_v1_fernet().decrypt(ciphertext.encode()).decode()
+        except InvalidToken:
+            return _get_v2_fernet().decrypt(ciphertext.encode()).decode()
+    raise ValueError(f"Unknown KDF version: {version!r}")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, SmallInteger, String, Text, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -26,6 +26,10 @@ class User(Base):
 
     # BYOK (Bring Your Own Key)
     encrypted_api_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Version of the KDF that produced encrypted_api_key. 1 = legacy
+    # (SHA-256 of JWT_SECRET_KEY), 2 = standalone API_KEY_ENCRYPTION_KEY.
+    # See app/core/crypto.py and migration 0130.
+    api_key_kdf_version: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="1")
     api_provider: Mapped[str | None] = mapped_column(String(50), nullable=True)
     api_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
     api_custom_url: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -441,7 +441,7 @@ def _resolve_llm_config(user: User | None) -> tuple[str, str, str, bool, str]:
     """Return (api_url, api_key, model, is_byok, provider) based on user's BYOK or platform default."""
     if user and user.encrypted_api_key:
         try:
-            key = decrypt_api_key(user.encrypted_api_key)
+            key = decrypt_api_key(user.encrypted_api_key, user.api_key_kdf_version)
             provider = user.api_provider or "openai"
             if provider == "custom":
                 url = user.api_custom_url or settings.llm_api_url
@@ -488,7 +488,7 @@ def _resolve_with_model_override(
         try:
             user_provider = user.api_provider or "openai"
             if user_provider == opt.provider:
-                key = decrypt_api_key(user.encrypted_api_key)
+                key = decrypt_api_key(user.encrypted_api_key, user.api_key_kdf_version)
                 url = PROVIDER_URLS.get(opt.provider, settings.llm_api_url)
                 return url, key, opt.model, True, opt.provider
         except Exception as exc:  # pragma: no cover — same handling as _resolve_llm_config

--- a/backend/scripts/migrate_api_keys.py
+++ b/backend/scripts/migrate_api_keys.py
@@ -98,11 +98,23 @@ async def _migrate_one(session: AsyncSession, user_id: int, v1_blob: str) -> tup
 
 
 async def _record_failure(session: AsyncSession, user_id: int, error: str) -> None:
+    """Append a failure row, but at most once per user_id per failing
+    migration window.  Codex review flagged that re-running the script
+    after a partial failure would otherwise spam the audit table; ops
+    cares about the *current* set of unmigrated users, not a per-run
+    counter.  We dedupe at insert time rather than via a unique index
+    so the column can carry distinct error messages over the lifetime
+    of the system (e.g. v1 decrypt failure today, then a different
+    error after JWT_SECRET rotation tomorrow)."""
     truncated = error[:500]
     await session.execute(
         text(
             "INSERT INTO api_key_migration_failures (user_id, error) "
-            "VALUES (:uid, :err)"
+            "SELECT :uid, :err "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM api_key_migration_failures "
+            "  WHERE user_id = :uid AND error = :err"
+            ")"
         ),
         {"uid": user_id, "err": truncated},
     )
@@ -113,6 +125,21 @@ async def run(dry_run: bool, notify_admin_on_fail: bool) -> int:
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
     )
+
+    # Hard refusal: without API_KEY_ENCRYPTION_KEY explicitly set in the
+    # process env, app/config.py's dev fallback would synthesize an
+    # ephemeral key.  Re-encrypting prod ciphertexts under a process-
+    # local random key and committing them is exactly the data-loss
+    # scenario this migration exists to prevent.  Fail loudly before we
+    # touch any rows.
+    if not os.environ.get("API_KEY_ENCRYPTION_KEY"):
+        logger.error(
+            "API_KEY_ENCRYPTION_KEY is not set in the process environment. "
+            "Refusing to run — re-encrypting under an ephemeral dev key "
+            "would corrupt every migrated row on the next restart."
+        )
+        return 2
+
     engine = create_async_engine(settings.database_url, future=True)
     Session = async_sessionmaker(engine, expire_on_commit=False)
 

--- a/backend/scripts/migrate_api_keys.py
+++ b/backend/scripts/migrate_api_keys.py
@@ -1,0 +1,189 @@
+"""One-shot v1→v2 BYOK key migration.
+
+Usage::
+
+    python -m scripts.migrate_api_keys --dry-run          # list candidates
+    python -m scripts.migrate_api_keys                    # execute
+    python -m scripts.migrate_api_keys --notify-admin-on-fail
+
+The script is intentionally **not** wired into a startup hook.  It runs
+once after deploy, prints a summary, and exits.  Re-running it after
+success is a no-op (the WHERE clause filters out v2 rows).
+
+Failure handling
+----------------
+
+A row that can't be re-encrypted (almost always: legacy v1 ciphertext
+sealed with a JWT secret that has since been rotated) is logged into
+``api_key_migration_failures`` so ops has a single place to grep.  The
+user must rotate their key from the UI — see ``POST /api/auth/api-key/
+rotate-encryption``.
+
+The ``--notify-admin-on-fail`` flag is reserved for future hookup to
+fojin's notification channel.  Today it just emits a summary line at the
+end; there's no built-in admin email path in the project yet.  TODO is
+tracked in the PR description.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+# scripts/ is run as a top-level package (``python -m scripts.X``); fix
+# sys.path so ``from app...`` resolves whether invoked from /app/backend
+# inside the container or from a checkout on the host.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+from app.core.crypto import (
+    KDF_VERSION_V1,
+    KDF_VERSION_V2,
+    _get_v1_fernet,
+    encrypt_api_key,
+)
+
+logger = logging.getLogger("migrate_api_keys")
+
+
+CANDIDATE_SQL = text(
+    "SELECT id, encrypted_api_key FROM users "
+    "WHERE api_key_kdf_version = :v AND encrypted_api_key IS NOT NULL "
+    "ORDER BY id"
+)
+
+
+async def _list_candidates(session: AsyncSession) -> list[tuple[int, str]]:
+    rows = await session.execute(CANDIDATE_SQL, {"v": KDF_VERSION_V1})
+    return [(r.id, r.encrypted_api_key) for r in rows]
+
+
+async def _migrate_one(session: AsyncSession, user_id: int, v1_blob: str) -> tuple[bool, str]:
+    """Return ``(ok, error_message)``.  Each row is its own transaction
+    so a single bad blob doesn't poison the rest."""
+    try:
+        plaintext = _get_v1_fernet().decrypt(v1_blob.encode()).decode()
+    except Exception as exc:  # InvalidToken or anything else
+        return False, f"v1 decrypt failed: {exc.__class__.__name__}: {exc}"
+
+    try:
+        new_cipher, _ = encrypt_api_key(plaintext)
+    except Exception as exc:
+        return False, f"v2 encrypt failed: {exc.__class__.__name__}: {exc}"
+
+    try:
+        await session.execute(
+            text(
+                "UPDATE users SET encrypted_api_key = :c, api_key_kdf_version = :v "
+                "WHERE id = :id AND api_key_kdf_version = :v1"
+            ),
+            {
+                "c": new_cipher,
+                "v": KDF_VERSION_V2,
+                "id": user_id,
+                "v1": KDF_VERSION_V1,
+            },
+        )
+        await session.commit()
+    except Exception as exc:
+        await session.rollback()
+        return False, f"UPDATE failed: {exc.__class__.__name__}: {exc}"
+    return True, ""
+
+
+async def _record_failure(session: AsyncSession, user_id: int, error: str) -> None:
+    truncated = error[:500]
+    await session.execute(
+        text(
+            "INSERT INTO api_key_migration_failures (user_id, error) "
+            "VALUES (:uid, :err)"
+        ),
+        {"uid": user_id, "err": truncated},
+    )
+    await session.commit()
+
+
+async def run(dry_run: bool, notify_admin_on_fail: bool) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
+    )
+    engine = create_async_engine(settings.database_url, future=True)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with Session() as session:
+        candidates = await _list_candidates(session)
+
+    if not candidates:
+        logger.info("No v1 rows to migrate — nothing to do.")
+        await engine.dispose()
+        return 0
+
+    logger.info("Found %d v1 row(s) to migrate.", len(candidates))
+    if dry_run:
+        for uid, _ in candidates:
+            logger.info("  would migrate user_id=%s", uid)
+        await engine.dispose()
+        return 0
+
+    succeeded = 0
+    failed: list[tuple[int, str]] = []
+    for uid, blob in candidates:
+        async with Session() as session:
+            ok, err = await _migrate_one(session, uid, blob)
+        if ok:
+            succeeded += 1
+            logger.info("  user_id=%s migrated v1 → v2", uid)
+        else:
+            failed.append((uid, err))
+            logger.error("  user_id=%s FAILED: %s", uid, err)
+            async with Session() as session:
+                try:
+                    await _record_failure(session, uid, err)
+                except Exception as exc:
+                    # Don't crash the whole run because the audit insert
+                    # failed — the error log above is the source of truth.
+                    logger.error("  user_id=%s failure-record insert failed: %s", uid, exc)
+
+    logger.info("=== migration summary ===")
+    logger.info("succeeded: %d", succeeded)
+    logger.info("failed:    %d", len(failed))
+    if failed and notify_admin_on_fail:
+        # Hookup to a real admin notification channel is a TODO — fojin
+        # doesn't have one yet.  Emit a clearly-tagged log line that ops
+        # can scrape.
+        logger.warning(
+            "ADMIN_NOTIFY: %d API key migration failure(s); "
+            "see api_key_migration_failures table",
+            len(failed),
+        )
+
+    await engine.dispose()
+    # Exit 0 even on partial failure — the failures are durably recorded
+    # and a non-zero exit would just confuse a single-shot deploy step.
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List rows that would be migrated; make no changes.",
+    )
+    parser.add_argument(
+        "--notify-admin-on-fail",
+        action="store_true",
+        help="Emit an ADMIN_NOTIFY log line if any rows fail (placeholder for real channel).",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(args.dry_run, args.notify_admin_on_fail)))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_api_key_rotate.py
+++ b/backend/tests/test_api_key_rotate.py
@@ -70,6 +70,13 @@ async def test_rotate_v2_to_v2_idempotent(client, monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_rotate_unauthenticated_rejected(client):
+    """Codex reviewer gap: rotate must reject unauth callers."""
+    resp = await client.post("/api/auth/api-key/rotate-encryption")
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.anyio
 async def test_rotate_409_on_undecryptable(client, monkeypatch):
     """If neither v1 nor v2 unlocks the blob, return 409 not 500."""
     monkeypatch.setattr(

--- a/backend/tests/test_api_key_rotate.py
+++ b/backend/tests/test_api_key_rotate.py
@@ -1,0 +1,92 @@
+"""POST /api/auth/api-key/rotate-encryption — user-driven re-encrypt."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.config import settings
+
+
+def _user_with_key(uid=42, encrypted=None, kdf=2):
+    u = MagicMock()
+    u.id = uid
+    u.username = "u"
+    u.email = "u@example.com"
+    u.role = "user"
+    u.is_active = True
+    u.created_at = datetime.now(UTC)
+    u.encrypted_api_key = encrypted
+    u.api_key_kdf_version = kdf
+    u.api_provider = "openai"
+    u.api_model = None
+    u.api_custom_url = None
+    return u
+
+
+@pytest.mark.anyio
+async def test_rotate_404_when_no_key(client):
+    fake_user = _user_with_key(encrypted=None)
+    from app.core.deps import get_current_user
+    from app.database import get_db as real_get_db
+    from app.main import app
+
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    app.dependency_overrides[real_get_db] = lambda: AsyncMock()
+    try:
+        resp = await client.post("/api/auth/api-key/rotate-encryption")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(real_get_db, None)
+
+
+@pytest.mark.anyio
+async def test_rotate_v2_to_v2_idempotent(client, monkeypatch):
+    """v2 row → re-encrypt under v2 → still v2."""
+    monkeypatch.setattr(
+        settings, "api_key_encryption_key", Fernet.generate_key().decode()
+    )
+    # Build a real v2 ciphertext so decrypt actually works
+    cipher = Fernet(settings.api_key_encryption_key.encode()).encrypt(b"sk-rot").decode()
+    fake_user = _user_with_key(encrypted=cipher, kdf=2)
+
+    from app.core.deps import get_current_user
+    from app.database import get_db as real_get_db
+    from app.main import app
+
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    app.dependency_overrides[real_get_db] = lambda: AsyncMock()
+    try:
+        resp = await client.post("/api/auth/api-key/rotate-encryption")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["kdf_version"] == 2
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(real_get_db, None)
+
+
+@pytest.mark.anyio
+async def test_rotate_409_on_undecryptable(client, monkeypatch):
+    """If neither v1 nor v2 unlocks the blob, return 409 not 500."""
+    monkeypatch.setattr(
+        settings, "api_key_encryption_key", Fernet.generate_key().decode()
+    )
+    monkeypatch.setattr(settings, "jwt_secret_key", "x" * 40)
+    fake_user = _user_with_key(encrypted="totally-bogus-not-a-token", kdf=2)
+
+    from app.core.deps import get_current_user
+    from app.database import get_db as real_get_db
+    from app.main import app
+
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    app.dependency_overrides[real_get_db] = lambda: AsyncMock()
+    try:
+        resp = await client.post("/api/auth/api-key/rotate-encryption")
+        assert resp.status_code == 409
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(real_get_db, None)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,6 +1,5 @@
 """Tests for JWT secret validation in production mode."""
 
-import os
 import importlib
 
 import pytest
@@ -28,13 +27,18 @@ def test_production_rejects_short_secret(monkeypatch):
 
 
 def test_production_accepts_valid_secret(monkeypatch):
-    """FOJIN_ENV=production with a 32+ char secret should not raise."""
+    """FOJIN_ENV=production with both secrets set should not raise."""
     monkeypatch.setenv("FOJIN_ENV", "production")
     monkeypatch.setenv("JWT_SECRET_KEY", "a" * 32)
+    # P0-1: API_KEY_ENCRYPTION_KEY is now also fail-fast in prod, so the
+    # "happy path" boot needs both secrets present.
+    from cryptography.fernet import Fernet
+    monkeypatch.setenv("API_KEY_ENCRYPTION_KEY", Fernet.generate_key().decode())
 
     import app.config
     importlib.reload(app.config)
     assert len(app.config.settings.jwt_secret_key) >= 32
+    assert app.config.settings.api_key_encryption_key
 
 
 def test_development_warns_on_default(monkeypatch):

--- a/backend/tests/test_crypto_versions.py
+++ b/backend/tests/test_crypto_versions.py
@@ -1,0 +1,135 @@
+"""KDF v1/v2 round-trip and cross-version contract tests.
+
+Covers app.core.crypto + the boot-time validation in app.config.  We do
+NOT exercise the production fail-fast path here (that runs once at
+import time and is covered by a manual smoke test); the focus is the
+runtime API surface that callers actually touch.
+"""
+
+import base64
+import hashlib
+import importlib
+import os
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.config import settings
+from app.core import crypto as crypto_module
+from app.core.crypto import (
+    KDF_VERSION_V1,
+    KDF_VERSION_V2,
+    decrypt_api_key,
+    encrypt_api_key,
+)
+
+
+@pytest.fixture
+def fixed_v2_key(monkeypatch):
+    """Pin a deterministic v2 key for the duration of a test."""
+    key = Fernet.generate_key().decode()
+    monkeypatch.setattr(settings, "api_key_encryption_key", key)
+    return key
+
+
+def test_v2_round_trip(fixed_v2_key):
+    cipher, version = encrypt_api_key("sk-secret-xyz")
+    assert version == KDF_VERSION_V2
+    assert decrypt_api_key(cipher, version) == "sk-secret-xyz"
+
+
+def test_v1_round_trip_via_legacy_path(monkeypatch):
+    """v1 ciphertext (sealed with the SHA-256(JWT_SECRET) KDF) decrypts."""
+    monkeypatch.setattr(settings, "jwt_secret_key", "test-jwt-secret-32-chars-long-xx")
+    legacy_key = base64.urlsafe_b64encode(
+        hashlib.sha256(settings.jwt_secret_key.encode()).digest()
+    )
+    legacy_cipher = Fernet(legacy_key).encrypt(b"sk-legacy").decode()
+
+    assert decrypt_api_key(legacy_cipher, KDF_VERSION_V1) == "sk-legacy"
+
+
+def test_v2_blob_does_not_decrypt_under_v1_key(fixed_v2_key, monkeypatch):
+    """A v2 ciphertext is not recoverable with the legacy v1 KDF alone.
+
+    We assert this by reaching past ``decrypt_api_key`` (which has a
+    cross-version fallback) directly into ``_get_v1_fernet`` so the test
+    is meaningful.
+    """
+    monkeypatch.setattr(settings, "jwt_secret_key", "test-jwt-secret-32-chars-long-xx")
+    cipher, _ = encrypt_api_key("sk-v2-only")
+    with pytest.raises(InvalidToken):
+        crypto_module._get_v1_fernet().decrypt(cipher.encode())
+
+
+def test_decrypt_dispatches_by_requested_version(fixed_v2_key, monkeypatch):
+    """If caller wrongly tags a v2 blob as v1, the fallback recovers it.
+
+    This is the migration-window safety net: a row whose
+    ``api_key_kdf_version`` is still 1 but whose ciphertext is already
+    v2 (e.g. a save that landed between the column add and the script
+    run) must still decrypt.
+    """
+    monkeypatch.setattr(settings, "jwt_secret_key", "test-jwt-secret-32-chars-long-xx")
+    cipher, _ = encrypt_api_key("sk-mismatched-tag")
+
+    assert decrypt_api_key(cipher, KDF_VERSION_V1) == "sk-mismatched-tag"
+
+
+def test_unknown_version_raises():
+    with pytest.raises(ValueError, match="Unknown KDF version"):
+        decrypt_api_key("ignored", version=99)
+
+
+def test_dev_mode_generates_ephemeral_key(monkeypatch):
+    """When API_KEY_ENCRYPTION_KEY is unset in dev, config bootstraps one."""
+    monkeypatch.setenv("FOJIN_ENV", "development")
+    monkeypatch.delenv("API_KEY_ENCRYPTION_KEY", raising=False)
+    # Reload the config module so the boot-time block runs again under
+    # the patched env. ``importlib.reload`` re-executes the module body.
+    import app.config as cfg
+
+    importlib.reload(cfg)
+    assert cfg.settings.api_key_encryption_key  # generated, non-empty
+    # And it round-trips through Fernet:
+    Fernet(cfg.settings.api_key_encryption_key.encode())
+
+
+def test_production_missing_key_fails_fast(monkeypatch):
+    """Empty API_KEY_ENCRYPTION_KEY in prod must raise at import time."""
+    monkeypatch.setenv("FOJIN_ENV", "production")
+    monkeypatch.setenv(
+        "JWT_SECRET_KEY", "x" * 40
+    )  # satisfy the JWT fail-fast so we hit our branch
+    monkeypatch.setenv("API_KEY_ENCRYPTION_KEY", "")
+
+    import app.config as cfg
+
+    with pytest.raises(RuntimeError, match="API_KEY_ENCRYPTION_KEY"):
+        importlib.reload(cfg)
+
+    # Restore module to a sane state for sibling tests in this process.
+    monkeypatch.setenv("FOJIN_ENV", "development")
+    monkeypatch.setenv("API_KEY_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    importlib.reload(cfg)
+
+
+def test_production_invalid_key_fails_fast(monkeypatch):
+    monkeypatch.setenv("FOJIN_ENV", "production")
+    monkeypatch.setenv("JWT_SECRET_KEY", "x" * 40)
+    monkeypatch.setenv("API_KEY_ENCRYPTION_KEY", "not-a-fernet-key")
+
+    import app.config as cfg
+
+    with pytest.raises(RuntimeError, match="not a valid Fernet key"):
+        importlib.reload(cfg)
+
+    monkeypatch.setenv("FOJIN_ENV", "development")
+    monkeypatch.setenv("API_KEY_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    importlib.reload(cfg)
+
+
+# Sanity: the os import isn't actually used inside test bodies above —
+# keep the linter happy without dropping it (importing config indirectly
+# can pull in env reads that future tests will want to reach for).
+_ = os.environ

--- a/backend/tests/test_llm_catalog.py
+++ b/backend/tests/test_llm_catalog.py
@@ -84,7 +84,7 @@ def test_resolve_byok_matching_provider_overrides_model(monkeypatch):
     monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
     monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
     monkeypatch.setattr(
-        chat_module, "decrypt_api_key", lambda blob: "user-moonshot-key"
+        chat_module, "decrypt_api_key", lambda blob, version=1: "user-moonshot-key"
     )
 
     user = MagicMock()


### PR DESCRIPTION
## Summary

Stops deriving the BYOK Fernet key from `JWT_SECRET_KEY`. A standalone `API_KEY_ENCRYPTION_KEY` (Fernet.generate_key() format) drives a new v2 KDF, validated fail-fast at boot in production. The legacy v1 KDF is retained as a read-only fallback for one migration cycle so existing ciphertexts decrypt while `scripts/migrate_api_keys.py` re-encrypts them in place.

References: AUDIT-REPORT.md P0-1 + CODEX-P0-1-REVIEW.md (single PR, no HKDF/per-user salt, explicit migration command, dual-read fallback, admin failure log + user-driven rotate endpoint).

### Commits

1. **`security: split BYOK encryption key from JWT_SECRET (P0-1)`** — config + `app/core/crypto.py` + model field + crypto tests.
2. **`security: wire api_key_kdf_version through callers + add migration 0130`** — alembic 0130, `api/auth.py`, `services/chat.py`, plus the rotate endpoint.
3. **`security: BYOK migration script + rotate-encryption endpoint + docs`** — `scripts/migrate_api_keys.py`, rotate-endpoint tests, `.env.example`.

### Operator runbook (post-merge)

```bash
# 1. Generate the new key
python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"

# 2. Add to /home/admin/fojin/.env as API_KEY_ENCRYPTION_KEY=...

# 3. Pull + rebuild + run migration
cd /home/admin/fojin && git pull origin master && docker compose up -d --build backend
docker exec fojin-backend python -m scripts.migrate_api_keys --dry-run
docker exec fojin-backend python -m scripts.migrate_api_keys
```

Failure rows land in `api_key_migration_failures` (audit table); affected users can call `POST /api/auth/api-key/rotate-encryption` from the UI to recover.

## Test plan

- [x] `pytest tests/` — 274 pass; 7 pre-existing failures (test_annotations_workflow / test_smoke::test_kg_entity_detail) verified present on master and unrelated to this change.
- [x] New tests in `tests/test_crypto_versions.py`, `tests/test_api_key_rotate.py`, plus `tests/test_config.py` updated.
- [x] `ruff check` clean on touched files; `bandit` no new findings.
- [ ] Post-merge: dry-run migration on prod, then live run, then verify `api_key_kdf_version=1 AND encrypted_api_key IS NOT NULL` count is 0.

## Known TODO

`--notify-admin-on-fail` currently emits an `ADMIN_NOTIFY:` log line; fojin has no built-in admin notification channel today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)