### PR TITLE
ci(security): dedupe --confidence-level flag in bandit run step

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -61,7 +61,7 @@ jobs:
         run: pip install bandit
 
       - name: Run bandit on backend
-        run: bandit -r backend/app/ --severity-level medium --confidence-level medium --confidence-level medium -f json -o bandit-report.json || true
+        run: bandit -r backend/app/ --severity-level medium --confidence-level medium -f json -o bandit-report.json || true
 
       - name: Display bandit results
         if: always()


### PR DESCRIPTION
## Summary
- 删除 `bandit -r backend/app/ ...` 命令里重复的 `--confidence-level medium` 参数（同一个 flag 写了两遍）。
- 纯清理，行为不变 — bandit 接受重复 flag 不会报错，但读起来奇怪。

## Test plan
- [x] CI Security Scan workflow 跑通