### PR TITLE
deploy: pass API_KEY_ENCRYPTION_KEY + FOJIN_ENV to backend (P0-1 follow-up)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,10 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:?Set JWT_SECRET_KEY in .env (32+ chars)}
+      # P0-1: BYOK encryption key, independent of JWT_SECRET_KEY.
+      API_KEY_ENCRYPTION_KEY: ${API_KEY_ENCRYPTION_KEY:?Set API_KEY_ENCRYPTION_KEY in .env (Fernet.generate_key() output)}
+      # Drives the production fail-fast block in app/config.py.
+      FOJIN_ENV: ${FOJIN_ENV:-production}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173,http://localhost:5174}
       LLM_API_URL: ${LLM_API_URL:-}
       LLM_API_KEY: ${LLM_API_KEY:-}


### PR DESCRIPTION
## Summary

PR #547 added the boot-time fail-fast for `API_KEY_ENCRYPTION_KEY`, but the backend service in `docker-compose.yml` never received either `API_KEY_ENCRYPTION_KEY` or `FOJIN_ENV` from the host `.env`. Codex review flagged this — without the wiring, a prod deploy would default `FOJIN_ENV=development` inside the container and synthesize an ephemeral Fernet key, then write v2 ciphertext that vanishes on restart.

Mirrors the existing `JWT_SECRET_KEY:?` hardening style so a missing key fails the compose up cold rather than silently degrading.

## Test plan

- [x] On sg-vps, `.env` already has `API_KEY_ENCRYPTION_KEY` set (added 2026-05-08 ahead of this PR).
- [ ] After merge: `docker compose up -d --build backend` on prod, verify container starts.
- [ ] Run `docker exec fojin-backend python -m scripts.migrate_api_keys --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)