### PR TITLE
chore: P2-2 npm audit fix + P2-3 dedupe response headers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -252,16 +252,10 @@ app.add_middleware(RateLimitMiddleware)
 # GZip handled by nginx — removed from backend to avoid compressing SSE streams
 
 
-class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        response: Response = await call_next(request)
-        response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "DENY"
-        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-        response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
-        response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
-        response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), payment=()"
-        return response
+# SecurityHeadersMiddleware removed in P2-3 cleanup.
+# Security headers are set exclusively in frontend/nginx.conf to avoid
+# duplicate headers on responses proxied through nginx (which the
+# pre-fix audit found arriving as e.g. two X-Frame-Options values).
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
@@ -327,7 +321,6 @@ class LastActiveMiddleware(BaseHTTPMiddleware):
         return response
 
 
-app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(LastActiveMiddleware)
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,13 +5,16 @@ server {
     index index.html;
     absolute_redirect off;
 
-    # Security headers
+    # Security headers — single source of truth.
+    # Backend SecurityHeadersMiddleware was removed in P2-3 cleanup
+    # to avoid duplicate headers on responses proxied through nginx.
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.fojin.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://analytics.fojin.app https://*.cartocdn.com https://api.maptiler.com; font-src 'self' data:; worker-src 'self' blob:;" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
 
     # Serve pre-compressed .gz files when available
     gzip_static on;
@@ -184,6 +187,7 @@ server {
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.fojin.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://analytics.fojin.app https://*.cartocdn.com https://api.maptiler.com; font-src 'self' data:; worker-src 'self' blob:;" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
     }
 
     location / {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -214,6 +214,42 @@
         "react-dom": ">=16.8.4"
       }
     },
+    "node_modules/@ant-design/graphs/node_modules/styled-components": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
+      "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "stylis": "4.3.6"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-native": ">= 0.68.0"
+      },
+      "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ant-design/icons": {
       "version": "5.6.1",
       "resolved": "https://registry.npmmirror.com/@ant-design/icons/-/icons-5.6.1.tgz",
@@ -1689,9 +1725,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmmirror.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2326,14 +2362,14 @@
       }
     },
     "node_modules/@carto/api-client": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/@carto/api-client/-/api-client-0.5.26.tgz",
-      "integrity": "sha512-dMIfVubI+4VrylazzrJQOEza+YvWEoK7fAiyqLLB3Je7yljFvklSxGA3c5LaYD3XiHhZ7PrdM3SQH84SUNrW2A==",
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/@carto/api-client/-/api-client-0.5.28.tgz",
+      "integrity": "sha512-H/bG49eh9tMKppnFcxEeaFPDUcfZAIAEig9MUVi6Tl6QVAKXEyQOj3yFfrSk2c08xsdm8ZIAARXNLxIrZvAr3A==",
       "license": "MIT",
       "dependencies": {
         "@loaders.gl/schema": "^4.3.3",
         "@types/geojson": "^7946.0.16",
-        "d3-format": "^3.1.0",
+        "d3-format": "^3.1.2",
         "d3-scale": "^4.0.2",
         "h3-js": "^4.1.0",
         "jsep": "^1.4.0",
@@ -2480,103 +2516,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@deck.gl/aggregation-layers": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.2.11.tgz",
-      "integrity": "sha512-MRFbBHtMcDkOthxXnMPm6nF08DjFDACaIQsJSyHkdWtLUTSLHsWnOTn/8QbB4ka86WyNyfJy3dibLu/m3ei2ow==",
-      "license": "MIT",
-      "dependencies": {
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/shadertools": "~9.2.6",
-        "@math.gl/core": "^4.1.0",
-        "@math.gl/web-mercator": "^4.1.0",
-        "d3-hexbin": "^0.2.1"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@deck.gl/layers": "~9.2.0",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6"
-      }
-    },
-    "node_modules/@deck.gl/arcgis": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/arcgis/-/arcgis-9.2.11.tgz",
-      "integrity": "sha512-HMGS67qgh0API5z8vEJpk6wjlYKWfWy71r9AYI4a8XubiCM1ekvLHuLDtsVNVQIdrBbT4D0CzSDwxl/pCOgslw==",
-      "license": "MIT",
-      "dependencies": {
-        "@luma.gl/constants": "~9.2.6",
-        "esri-loader": "^3.7.0"
-      },
-      "peerDependencies": {
-        "@arcgis/core": "^4.0.0",
-        "@deck.gl/core": "~9.2.0",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6",
-        "@luma.gl/webgl": "~9.2.6"
-      }
-    },
-    "node_modules/@deck.gl/carto": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-9.2.11.tgz",
-      "integrity": "sha512-2JVzsnlsQ+VTyiazpgJCS093xAV2q3g47/fkgkYrDDRuK27sISWZNgzvQ5xLCL4s/8nGa4GuMPnDIXPWasnuOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@carto/api-client": "^0.5.19",
-        "@loaders.gl/compression": "~4.3.4",
-        "@loaders.gl/gis": "~4.3.4",
-        "@loaders.gl/loader-utils": "~4.3.4",
-        "@loaders.gl/mvt": "~4.3.4",
-        "@loaders.gl/schema": "~4.3.4",
-        "@loaders.gl/tiles": "~4.3.4",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/shadertools": "~9.2.6",
-        "@math.gl/web-mercator": "^4.1.0",
-        "@types/d3-array": "^3.0.2",
-        "@types/d3-color": "^1.4.2",
-        "@types/d3-scale": "^3.0.0",
-        "cartocolor": "^5.0.2",
-        "d3-array": "^3.2.0",
-        "d3-color": "^3.1.0",
-        "d3-format": "^3.1.0",
-        "d3-scale": "^4.0.0",
-        "earcut": "^2.2.4",
-        "h3-js": "^4.1.0",
-        "moment-timezone": "^0.6.0",
-        "pbf": "^3.2.1",
-        "quadbin": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@deck.gl/aggregation-layers": "~9.2.0",
-        "@deck.gl/core": "~9.2.0",
-        "@deck.gl/extensions": "~9.2.0",
-        "@deck.gl/geo-layers": "~9.2.0",
-        "@deck.gl/layers": "~9.2.0",
-        "@loaders.gl/core": "~4.3.4",
-        "@luma.gl/core": "~9.2.6"
-      }
-    },
-    "node_modules/@deck.gl/carto/node_modules/@types/d3-color": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.5.tgz",
-      "integrity": "sha512-5sNP3DmtSnSozxcjqmzQKsDOuVJXZkceo1KJScDc1982kk/TS9mTPc6lpli1gTu1MIBF1YWutpHpjucNWcIj5g==",
-      "license": "MIT"
-    },
-    "node_modules/@deck.gl/carto/node_modules/@types/d3-scale": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.5.tgz",
-      "integrity": "sha512-YOpKj0kIEusRf7ofeJcSZQsvKbnTwpe1DUF+P2qsotqG53kEsjm7EzzliqQxMkAWdkZcHrg5rRhB4JiDOQPX+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "^2"
-      }
-    },
-    "node_modules/@deck.gl/carto/node_modules/@types/d3-time": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.4.tgz",
-      "integrity": "sha512-BTfLsxTeo7yFxI/haOOf1ZwJ6xKgQLT9dCp+EcmQv87Gox6X+oKl4mLKfO6fnWm3P22+A6DknMNEZany8ql2Rw==",
-      "license": "MIT"
-    },
     "node_modules/@deck.gl/core": {
       "version": "9.2.11",
       "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.2.11.tgz",
@@ -2607,6 +2546,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.2.11.tgz",
       "integrity": "sha512-zlpM4Bg1ifBziW1Juiii9NY5gyW2rEhyVTWnhagH/bpTCZ2E73OhnToYt1ouqmoxL6lMtIjhRXz6LPb7tJbHHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@luma.gl/constants": "~9.2.6",
         "@luma.gl/shadertools": "~9.2.6",
@@ -2652,45 +2592,6 @@
         "@luma.gl/engine": "~9.2.6"
       }
     },
-    "node_modules/@deck.gl/google-maps": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-9.2.11.tgz",
-      "integrity": "sha512-ahA+u8wkyx9vyKGekJW+Juza2jX8Yhj2+VbYQjriV4aVIJmSNiNNUqYvOwLbwhThj5HBY0jUSSQ1WixwmrBZaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/webgl": "~9.2.6",
-        "@math.gl/core": "^4.1.0",
-        "@types/google.maps": "^3.48.6"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/webgl": "~9.2.6"
-      }
-    },
-    "node_modules/@deck.gl/json": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-9.2.11.tgz",
-      "integrity": "sha512-xUc8y79kAQNqDJegDkEFWgdfE3JDaTdLtSerzwX5gR7q8mZMMZ0tcFM5IqE+mB3EoNbUgTY7m/7LnzO58XGP6g==",
-      "license": "MIT",
-      "dependencies": {
-        "jsep": "^0.3.0"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~9.2.0"
-      }
-    },
-    "node_modules/@deck.gl/json/node_modules/jsep": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
-      "integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/@deck.gl/layers": {
       "version": "9.2.11",
       "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.2.11.tgz",
@@ -2713,27 +2614,12 @@
         "@luma.gl/engine": "~9.2.6"
       }
     },
-    "node_modules/@deck.gl/mapbox": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.2.11.tgz",
-      "integrity": "sha512-5OaFZgjyA4Vq6WjHUdcEdl0Phi8dwj8hSCErej0NetW90mctdbxwMt0gSbqcvWBowwhyj2QAhH0P2FcITjKG/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@luma.gl/constants": "~9.2.6",
-        "@math.gl/web-mercator": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/core": "~9.2.6",
-        "@math.gl/web-mercator": "^4.1.0"
-      }
-    },
     "node_modules/@deck.gl/mesh-layers": {
       "version": "9.2.11",
       "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.2.11.tgz",
       "integrity": "sha512-zPB7TtnPXB3tOEoOfcOkNZo7coIq/ukIQa8HIUQLLiOE8AVSQfz3kbMmMK6rUabXlQbgSw/I/j3kFSYRHg3NGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@loaders.gl/gltf": "~4.3.4",
         "@loaders.gl/schema": "~4.3.4",
@@ -2765,6 +2651,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.2.11.tgz",
       "integrity": "sha512-90HWlQPsiRyTPWR4aYfLwnYDrJdHG2mqCzRcyMUKewWBNQLu4upB//l4ewIkUeXXCzAprjjVeRnNb7wdYj2CXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "preact": "^10.17.0"
       },
@@ -3469,7 +3356,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
       }
@@ -3479,7 +3365,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -3489,8 +3374,7 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@foliojs-fork/fontkit": {
       "version": "1.9.2",
@@ -4396,6 +4280,18 @@
         "workerize-loader": "*"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
@@ -4638,10 +4534,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+      "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
-      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4663,19 +4586,41 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmmirror.com/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^6.0.1",
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -4688,7 +4633,7 @@
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmmirror.com/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
       "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
       "dev": true,
       "license": "MIT",
@@ -5066,17 +5011,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@surma/rollup-plugin-off-main-thread": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmmirror.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
-      "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
-      "dev": true,
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "ejs": "^3.1.6",
-        "json5": "^2.2.0",
-        "magic-string": "^0.25.0",
-        "string.prototype.matchall": "^4.0.6"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -5193,6 +5134,22 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
+      "version": "3.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
+      "integrity": "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ejs": "^3.1.10",
+        "json5": "^2.2.3",
+        "magic-string": "^0.30.21",
+        "string.prototype.matchall": "^4.0.12"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@turf/boolean-clockwise": {
@@ -5323,6 +5280,18 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
     },
     "node_modules/@types/crypto-js": {
       "version": "4.2.2",
@@ -5680,9 +5649,9 @@
       "license": "MIT"
     },
     "node_modules/@types/google.maps": {
-      "version": "3.58.1",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
-      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "version": "3.64.0",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.64.0.tgz",
+      "integrity": "sha512-dN0H6tB4lgLQLovcbPXFYYOEV41TpyyJghzb5jrzjB96FZmjeOghevVdC+BMGd6YqyCqXaggyEtqRXLRjzCBZA==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -5795,7 +5764,7 @@
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
-      "resolved": "https://registry.npmmirror.com/@types/resolve/-/resolve-1.20.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
       "license": "MIT"
@@ -5812,12 +5781,6 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/stylis": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
-      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
       "license": "MIT"
     },
     "node_modules/@types/supercluster": {
@@ -6047,9 +6010,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6150,40 +6113,40 @@
       "license": "ISC"
     },
     "node_modules/@vaadin/a11y-base": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.9.13.tgz",
-      "integrity": "sha512-yHTJXKNXNPlgbvRQrLfYRATSrbDSIHrm1kvwTOXxTHuK3+Jh337FumhNu5Xl8QWBp1Z3iPahxT9Qup/vcRtwIA==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.9.14.tgz",
+      "integrity": "sha512-ropoBCS9H8sobwZneDbQaqOvOB5ZS8Mn7w9j2WMhSgclUaPIZbGOTV6er58DfaEIx0kWfLgN0Lpqu+1Fc0ssbA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.13",
+        "@vaadin/component-base": "~24.9.14",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/checkbox": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.9.13.tgz",
-      "integrity": "sha512-sGu5xuyp/E64y8hAeh+uxEKvkOG5+NpWW1zI5qfYVCBKCrLcExngcpjpj2hckW5fWsYgVJNkokhzDPk4obBGcw==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.9.14.tgz",
+      "integrity": "sha512-IRR8xNlbTy46G5hddstP1u3qpDy+GOlzQvxcdcL5Off4KtgFBuvBLHHQSQ2frolMP4sjLbeUsaagPWV/lhJ4wQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.9.13",
-        "@vaadin/component-base": "~24.9.13",
-        "@vaadin/field-base": "~24.9.13",
-        "@vaadin/vaadin-lumo-styles": "~24.9.13",
-        "@vaadin/vaadin-material-styles": "~24.9.13",
-        "@vaadin/vaadin-themable-mixin": "~24.9.13",
+        "@vaadin/a11y-base": "~24.9.14",
+        "@vaadin/component-base": "~24.9.14",
+        "@vaadin/field-base": "~24.9.14",
+        "@vaadin/vaadin-lumo-styles": "~24.9.14",
+        "@vaadin/vaadin-material-styles": "~24.9.14",
+        "@vaadin/vaadin-themable-mixin": "~24.9.14",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/component-base": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.9.13.tgz",
-      "integrity": "sha512-OvP2kIDhO8NFunZeNXnGfQZhIxDn01skl/MKRiy/w3Syj0z/XXC1SoDBk1epR85EgsoNI7R6mF5VX/DzD9L46g==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.9.14.tgz",
+      "integrity": "sha512-xTwQJaoSUhWA1xBDls8q6QkNsIlhnQRDCqt/gmLg4ixzjceajPpaobVjIoTeit9a86wwQOK0kkvPTHDM9Yku6Q==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -6195,73 +6158,73 @@
       }
     },
     "node_modules/@vaadin/field-base": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.9.13.tgz",
-      "integrity": "sha512-ad2SqqXD/U+mfX8/0FXpfEMw2j+dKCy3t1zt3O1YppyarQVXVOFgCnPavubcvGyiSMlYW8r1iwbtUpB2oQuhJQ==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.9.14.tgz",
+      "integrity": "sha512-+B2Q/Q4MzFmBfz/nFdH2RS6YYTt3JvaAgibM1bLJRihiOG2UodKy7FGik3dVcYSdEZR+jBabUNj4YwsQwuKiXw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.9.13",
-        "@vaadin/component-base": "~24.9.13",
+        "@vaadin/a11y-base": "~24.9.14",
+        "@vaadin/component-base": "~24.9.14",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/grid": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.9.13.tgz",
-      "integrity": "sha512-ePfp9IC3EE5NFsIzcNJzCWTGE3QX+pQpy7ozpkdZ1bV4yRVr5pzHW8mXie2BVltlhbXgarTPpr0WDIT39Npotw==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.9.14.tgz",
+      "integrity": "sha512-kC84mI8wZF8hVWKGIUpLWDR1HvagfySVoB9rt4RBx3sy7C+CGBnw3pHWLMMmED5soMsxuA3AWf27ut7naCudPQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.9.13",
-        "@vaadin/checkbox": "~24.9.13",
-        "@vaadin/component-base": "~24.9.13",
-        "@vaadin/lit-renderer": "~24.9.13",
-        "@vaadin/text-field": "~24.9.13",
-        "@vaadin/vaadin-lumo-styles": "~24.9.13",
-        "@vaadin/vaadin-material-styles": "~24.9.13",
-        "@vaadin/vaadin-themable-mixin": "~24.9.13",
+        "@vaadin/a11y-base": "~24.9.14",
+        "@vaadin/checkbox": "~24.9.14",
+        "@vaadin/component-base": "~24.9.14",
+        "@vaadin/lit-renderer": "~24.9.14",
+        "@vaadin/text-field": "~24.9.14",
+        "@vaadin/vaadin-lumo-styles": "~24.9.14",
+        "@vaadin/vaadin-material-styles": "~24.9.14",
+        "@vaadin/vaadin-themable-mixin": "~24.9.14",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/icon": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.9.13.tgz",
-      "integrity": "sha512-6S5e3XHURyy4WXzDVvYJl4WZPrWgJlCS3GEUMGmE1AwGwTsfE6pEqnJeKxJ9TxsIQaQYzUrjG1KAA1MyJ6RRgA==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.9.14.tgz",
+      "integrity": "sha512-o2XrPtXmVX1TFa8Sr/MelnBok9o5Eczs1W6cNMm2kaeD5O8yN5EU+G8Q71po1iBDE4Y+C86zXhcvkGvLlMrIpA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.13",
-        "@vaadin/vaadin-lumo-styles": "~24.9.13",
-        "@vaadin/vaadin-themable-mixin": "~24.9.13",
+        "@vaadin/component-base": "~24.9.14",
+        "@vaadin/vaadin-lumo-styles": "~24.9.14",
+        "@vaadin/vaadin-themable-mixin": "~24.9.14",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/input-container": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.9.13.tgz",
-      "integrity": "sha512-DBhih7er0F5sBl6snTNwVgNS4LEAeILLMHWtARJrCOhuUSlPNDG1TMQ/xKPKDJs5okys8i//9sAC+3C2xiObNg==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.9.14.tgz",
+      "integrity": "sha512-jWtpkbVOKr9MuH5Q2BnwHfzUFii3eZRBET/bxwn2gzRg4pt9KXazBJZ49SCkMYIaAqgAbkJ0vjgbC2+3OVNZYg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.13",
-        "@vaadin/vaadin-lumo-styles": "~24.9.13",
-        "@vaadin/vaadin-material-styles": "~24.9.13",
-        "@vaadin/vaadin-themable-mixin": "~24.9.13",
+        "@vaadin/component-base": "~24.9.14",
+        "@vaadin/vaadin-lumo-styles": "~24.9.14",
+        "@vaadin/vaadin-material-styles": "~24.9.14",
+        "@vaadin/vaadin-themable-mixin": "~24.9.14",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/lit-renderer": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.9.13.tgz",
-      "integrity": "sha512-NQqAdRQJdPyICBB3a5YPtcx6txgFmFNlQvs5ayOpKJrLfLsd6crcZqEd6zberN+LoThENJqh/XzNqd52QYTBgQ==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.9.14.tgz",
+      "integrity": "sha512-knpWn6+/GEJb5x/Ec7JP6JI+FAPPTKDs1XnJZ+PP+2lWo4jrW3OszG9IZK53H2KU4KrDs6iQFQ/qVzzj/71zvA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -6269,21 +6232,21 @@
       }
     },
     "node_modules/@vaadin/text-field": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.9.13.tgz",
-      "integrity": "sha512-sqm0V7t58jA0UxMzskPDO9mYqpo4xCJbUkmRgZpTiMKyxEW+oHnNRInMzcnleUg/AAP1SNJxaK29I5H+1FOLoA==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.9.14.tgz",
+      "integrity": "sha512-ve1is6xG0NopENh122ZgbN/BEffPbWcd37O+2Us4FbgUazcCm2z8AlgGNcroQo+bDDoMfsE7NjY+OfxsS5tPhA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.9.13",
-        "@vaadin/component-base": "~24.9.13",
-        "@vaadin/field-base": "~24.9.13",
-        "@vaadin/input-container": "~24.9.13",
-        "@vaadin/vaadin-lumo-styles": "~24.9.13",
-        "@vaadin/vaadin-material-styles": "~24.9.13",
-        "@vaadin/vaadin-themable-mixin": "~24.9.13",
+        "@vaadin/a11y-base": "~24.9.14",
+        "@vaadin/component-base": "~24.9.14",
+        "@vaadin/field-base": "~24.9.14",
+        "@vaadin/input-container": "~24.9.14",
+        "@vaadin/vaadin-lumo-styles": "~24.9.14",
+        "@vaadin/vaadin-material-styles": "~24.9.14",
+        "@vaadin/vaadin-themable-mixin": "~24.9.14",
         "lit": "^3.0.0"
       }
     },
@@ -6295,34 +6258,34 @@
       "peer": true
     },
     "node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.9.13.tgz",
-      "integrity": "sha512-qUqXgTFLmpHcy/hGS7nmUEdrrfynrPSv8zPJVw4PPqfCIkcWe53oXT7QNJpwp+XRrrd1CoKZzSDubSFDTT9dxQ==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.9.14.tgz",
+      "integrity": "sha512-jbvnSjvYX0mA4etq382XZ7IObfdQeoDt+v7F4cnJCJUXbGv2lYmESaOofSQnb1RBqST/5KXGk/GWIbRftCu7Qg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.13",
-        "@vaadin/icon": "~24.9.13",
-        "@vaadin/vaadin-themable-mixin": "~24.9.13"
+        "@vaadin/component-base": "~24.9.14",
+        "@vaadin/icon": "~24.9.14",
+        "@vaadin/vaadin-themable-mixin": "~24.9.14"
       }
     },
     "node_modules/@vaadin/vaadin-material-styles": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.9.13.tgz",
-      "integrity": "sha512-PVkFC9XvI5KDWVWpdR5J8ju3Q7tKz8ueSPqZYJ0ETQNPBvsveJg+4o2FJcsKg3Cdruu9puOVgV+6mkwnvPXb3w==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.9.14.tgz",
+      "integrity": "sha512-2Bl9XtNb6sGE+GpiGxqSRm/RhcU4e9oTEkzHauq8JGmBBvR/15h5CoLGPzzCRKuQpiuwrjhp3Qnz7p8KJiRaAg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.13",
-        "@vaadin/vaadin-themable-mixin": "~24.9.13"
+        "@vaadin/component-base": "~24.9.14",
+        "@vaadin/vaadin-themable-mixin": "~24.9.14"
       }
     },
     "node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.9.13",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.9.13.tgz",
-      "integrity": "sha512-FYqDaqbRjF78a6e7oSFkw5heLHO9nczAHCbr/N+3oQGI9w3hkXt2uN51ByAajDCPVau2fPNsBN7fTJgYDRHL/g==",
+      "version": "24.9.14",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.9.14.tgz",
+      "integrity": "sha512-t0igrcLaC1MeS//YUHymtGq9pjFfao4vnZTXcNrKDmi5JAozqPDPL916+Nos6/dVWVw1pcctmXdG9Z+joAxc9w==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -6481,16 +6444,6 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/@vitest/mocker/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
@@ -6532,16 +6485,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/@vitest/spy": {
@@ -6955,6 +6898,41 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
@@ -6981,9 +6959,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
@@ -7000,7 +6987,7 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
@@ -7041,14 +7028,14 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmmirror.com/async/-/async-3.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/async-function/-/async-function-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
       "license": "MIT",
@@ -7074,7 +7061,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmmirror.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
@@ -7089,14 +7076,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -7220,9 +7207,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7237,6 +7224,16 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -7313,14 +7310,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmmirror.com/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -7440,7 +7437,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -7451,6 +7447,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -7688,6 +7699,44 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmmirror.com/commander/-/commander-7.2.0.tgz",
@@ -7794,12 +7843,12 @@
       "license": "MIT"
     },
     "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -8556,7 +8605,7 @@
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
@@ -8574,7 +8623,7 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
@@ -8592,7 +8641,7 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "license": "MIT",
@@ -8648,27 +8697,27 @@
       "license": "MIT"
     },
     "node_modules/deck.gl": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-9.2.11.tgz",
-      "integrity": "sha512-oFKjJWWjEoQczfh725ypGphYGKh2sOQAFNO5/eXFlWNUZEXTTrj44ol3bmDMegL/l5qCzF4RoGWXgvLqNWphuQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-9.3.2.tgz",
+      "integrity": "sha512-+wfXSUu6sS8Ddm0edFeSNlM8LjL1/eCwxwz1muSCa0CSCQ4as/f5hSJei68ZBI3DNGsyy82uRPL3UuIYuxJQKw==",
       "license": "MIT",
       "dependencies": {
-        "@deck.gl/aggregation-layers": "9.2.11",
-        "@deck.gl/arcgis": "9.2.11",
-        "@deck.gl/carto": "9.2.11",
-        "@deck.gl/core": "9.2.11",
-        "@deck.gl/extensions": "9.2.11",
-        "@deck.gl/geo-layers": "9.2.11",
-        "@deck.gl/google-maps": "9.2.11",
-        "@deck.gl/json": "9.2.11",
-        "@deck.gl/layers": "9.2.11",
-        "@deck.gl/mapbox": "9.2.11",
-        "@deck.gl/mesh-layers": "9.2.11",
-        "@deck.gl/react": "9.2.11",
-        "@deck.gl/widgets": "9.2.11",
-        "@loaders.gl/core": "~4.3.4",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6"
+        "@deck.gl/aggregation-layers": "9.3.2",
+        "@deck.gl/arcgis": "9.3.2",
+        "@deck.gl/carto": "9.3.2",
+        "@deck.gl/core": "9.3.2",
+        "@deck.gl/extensions": "9.3.2",
+        "@deck.gl/geo-layers": "9.3.2",
+        "@deck.gl/google-maps": "9.3.2",
+        "@deck.gl/json": "9.3.2",
+        "@deck.gl/layers": "9.3.2",
+        "@deck.gl/mapbox": "9.3.2",
+        "@deck.gl/mesh-layers": "9.3.2",
+        "@deck.gl/react": "9.3.2",
+        "@deck.gl/widgets": "9.3.2",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "^9.3.3",
+        "@luma.gl/engine": "^9.3.3"
       },
       "peerDependencies": {
         "@arcgis/core": "^4.0.0",
@@ -8686,6 +8735,731 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/aggregation-layers": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.2.tgz",
+      "integrity": "sha512-aOzCmJHPYM95aFEW7s3lyFibTSP+T/fYqCP2RxHyi/IxQwROwJTDrKyn/qPw5GvzZOIgFVxlR1Qc9RY8qYRFBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@luma.gl/shadertools": "^9.3.3",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "d3-hexbin": "^0.2.1"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/arcgis": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/arcgis/-/arcgis-9.3.2.tgz",
+      "integrity": "sha512-nqqffU0ghx28uUbKRd02nr3tx1IkpkDKeqbdcSo6xFpu0RczFVcYr0mc6Xu53hqEjz8T7bBdslMxPs7QSSkqLA==",
+      "license": "MIT",
+      "dependencies": {
+        "esri-loader": "^3.7.0"
+      },
+      "peerDependencies": {
+        "@arcgis/core": "^4.0.0",
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3",
+        "@luma.gl/webgl": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/carto": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-9.3.2.tgz",
+      "integrity": "sha512-n/N6gAJyDe/OSwhCeL2Q8DvsA543hP1YO6lTotnYWZmtoSWwaBOuDTWOq9lZdA1eyGZ6GLhhI4FkZYlMjwslMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@carto/api-client": "^0.5.19",
+        "@loaders.gl/compression": "^4.4.1",
+        "@loaders.gl/gis": "^4.4.1",
+        "@loaders.gl/loader-utils": "^4.4.1",
+        "@loaders.gl/mvt": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@loaders.gl/tiles": "^4.4.1",
+        "@luma.gl/core": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@math.gl/web-mercator": "^4.1.0",
+        "@types/d3-array": "^3.0.2",
+        "@types/d3-color": "^3.1.3",
+        "@types/d3-scale": "^3.0.0",
+        "cartocolor": "^5.0.2",
+        "d3-array": "^3.2.0",
+        "d3-color": "^3.1.0",
+        "d3-format": "^3.1.0",
+        "d3-scale": "^4.0.0",
+        "earcut": "^2.2.4",
+        "h3-js": "^4.4.0",
+        "moment-timezone": "^0.6.0",
+        "pbf": "^3.2.1",
+        "quadbin": "^0.4.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/aggregation-layers": "~9.3.0",
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/extensions": "~9.3.0",
+        "@deck.gl/geo-layers": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/core": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.2.tgz",
+      "integrity": "sha512-32Va3np0Zdlz/LBNtDWCs4EkKqdHmXcbGmVp4+7i1Cpdza8y8CFmJs2VPOmSX1fwHvNCGkAZV/SFZOfDb2INsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/core": "^4.4.1",
+        "@loaders.gl/images": "^4.4.1",
+        "@luma.gl/core": "^9.3.3",
+        "@luma.gl/engine": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.3",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/sun": "^4.1.0",
+        "@math.gl/types": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "@probe.gl/env": "^4.1.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1",
+        "@types/offscreencanvas": "^2019.6.4",
+        "gl-matrix": "^3.0.0",
+        "mjolnir.js": "^3.0.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/extensions": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.3.2.tgz",
+      "integrity": "sha512-P2gPCCmGC5R6HRB3Mv3JraDnsSpvStjFFUGKxW810SXmo2eTft/5xpvliiyJeFGDjqttwo8V4Qk6oD3BNVGvRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.3",
+        "@math.gl/core": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/geo-layers": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.3.2.tgz",
+      "integrity": "sha512-3sndOyq5A3b2DMCBWFCeX9/QkBSp5MD8EUD3eu4hHfCDV4IrbJHtxE/pv60J848Yz8D5u7ftUqXf9gLWnEeBeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/3d-tiles": "^4.4.1",
+        "@loaders.gl/gis": "^4.4.1",
+        "@loaders.gl/loader-utils": "^4.4.1",
+        "@loaders.gl/mvt": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@loaders.gl/terrain": "^4.4.1",
+        "@loaders.gl/tiles": "^4.4.1",
+        "@loaders.gl/wms": "^4.4.1",
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "@types/geojson": "^7946.0.8",
+        "a5-js": "^0.7.2",
+        "h3-js": "^4.4.0",
+        "long": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/extensions": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@deck.gl/mesh-layers": "~9.3.0",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/google-maps": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-9.3.2.tgz",
+      "integrity": "sha512-oi2wbdgQns0nbqoX22WVTS7BLFuXWfdg68Iz/EjgTnmOo/a/M4Q90DzLj1s/W4fecMOy71eWRS4Ym4Zf64OqTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@luma.gl/webgl": "^9.3.3",
+        "@math.gl/core": "^4.1.0",
+        "@types/google.maps": "^3.48.6"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/webgl": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/json": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-9.3.2.tgz",
+      "integrity": "sha512-8IXRwRTs0G5TAX57JO4laKgHD+hGQsCtd3G861jb+va0sGFUH/VT6O3P+vLHoeJnHdetoRgtXSJPG82DC/oc7w==",
+      "license": "MIT",
+      "dependencies": {
+        "jsep": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/layers": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.3.2.tgz",
+      "integrity": "sha512-TeVfhQ/cQU1oTlTn16mCp7268d1uBJ6dwfgmKXThe2TzW9hql3iJaxbYTKg2phDg5YSiGmeEOpXbeBh59jyUcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/images": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@mapbox/tiny-sdf": "^2.0.5",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/polygon": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "earcut": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/mapbox": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.3.2.tgz",
+      "integrity": "sha512-+T9pJwsOXwjUxyGN6oiBMfIs28VtDIG1V1Rqz4qqn4TjjNEFFw+xO0olJIg8FO5IAqw2OtePdsrMj0tX8tHdGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/web-mercator": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@math.gl/web-mercator": "^4.1.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/mesh-layers": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.3.2.tgz",
+      "integrity": "sha512-9KeEnEx8PYalFPq/jSb1983QtjwZeuz64OfHH8I2VOB3eOhtRDxaTAaelbkVkD3E9HqlU2dD6f9huYsuv1WZfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/gltf": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3",
+        "@luma.gl/gltf": "~9.3.3",
+        "@luma.gl/shadertools": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/react": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.3.2.tgz",
+      "integrity": "sha512-XGxoyTQiQWvBHt+q5bATOHlv9INdl0xwt/IxP4eMbbE9XhLreeGTTb0CDGbk+SwDHVwQuLFp5JHZNibUt0J3fA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/widgets": "~9.3.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/widgets": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.3.2.tgz",
+      "integrity": "sha512-EdNxecpUlZHhfCSD5qpMVva7fjd48u6lDSXMxQRnT2uCGCMHBViZadkCmyK3lPwac4nylM9vRWek/NPSOqPKcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5",
+        "preact": "^10.17.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/3d-tiles": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.4.1.tgz",
+      "integrity": "sha512-837MynN5/lqVbuZcqdxFb0CMfT8v0yRlX7TUFKIBdmkS7AeRRrgcrB+XKblrkdZINUcxOs2N/YLVkwC9wLH1Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/compression": "4.4.1",
+        "@loaders.gl/crypto": "4.4.1",
+        "@loaders.gl/draco": "4.4.1",
+        "@loaders.gl/gltf": "4.4.1",
+        "@loaders.gl/images": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/math": "4.4.1",
+        "@loaders.gl/tiles": "4.4.1",
+        "@loaders.gl/zip": "4.4.1",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/geospatial": "^4.1.0",
+        "@probe.gl/log": "^4.1.1",
+        "long": "^5.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/3d-tiles/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/compression": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.4.1.tgz",
+      "integrity": "sha512-MKtGbqHBH7xRVFKyB3E9xRqRMwNW8H72OKpUBDdFwP+hQ0mjHZuud0GeYm5pP50+7o3J2PrES06kHTwT4fg7oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@types/pako": "^1.0.1",
+        "fflate": "0.7.4",
+        "pako": "1.0.11",
+        "snappyjs": "^0.6.1"
+      },
+      "optionalDependencies": {
+        "@types/brotli": "^1.3.0",
+        "brotli": "^1.3.2",
+        "lz4js": "^0.2.0",
+        "zstd-codec": "^0.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.4.1.tgz",
+      "integrity": "sha512-/s4IuvCCQUepvhjLnmePwQppGko2d1pxRS+sp7lyExU0uiqo5dVsAKaCZ2VnddBkFWgDVb/wvcZUBmv/dWcj0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/schema-utils": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@probe.gl/log": "^4.1.1"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/crypto": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.4.1.tgz",
+      "integrity": "sha512-ORhS9GSYr9uVTU4I2Taa46XBgPPG+nKErKcyDGIXov3gs0EtgMqs8nU4epuLbsJN3+du6FkQaILyGSZlTxbA7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@types/crypto-js": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/draco": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.4.1.tgz",
+      "integrity": "sha512-EcapVlkP8Pz53VKg9pYRQUzqm9jH+A+7vGE1kV8nkv63lN8/qtFzBSWMiC6IX1CwxjKJDEINU9Sh8YB1AfMwbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/schema-utils": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "draco3d": "1.5.7"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/geoarrow": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.1.tgz",
+      "integrity": "sha512-d9+AxsNpdJzilgHTFnyycoIocp4b+iEX3bbCCAEdUm/7eZbOdM7sFcgLLiGVTehtGnOUOICskjrzT27gqmzDqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/polygon": "^4.1.0",
+        "apache-arrow": ">= 17.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/gis": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.1.tgz",
+      "integrity": "sha512-M9Z9jXwye4SjlD1hAFJwE3+eZiN1lprwlSkWIo7R642kN5r3R60M9fqBD1mvCTBj96FPmbsyOm1eYKS0XCpKxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/geoarrow": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/schema-utils": "4.4.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@math.gl/polygon": "^4.1.0",
+        "pbf": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/gltf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.4.1.tgz",
+      "integrity": "sha512-9ESHEm3YoMgsQh8QS1N99uwA+cij6p6xhCmZnHX4rQnqHm0jvE5RAHlGV1D/Xjvr4PR8IiXaBn/QDl/qdGIxkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/draco": "4.4.1",
+        "@loaders.gl/images": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/textures": "4.4.1",
+        "@math.gl/core": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/images": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.4.1.tgz",
+      "integrity": "sha512-v9A4BliEKGxhLuEbh0Ke8ElUlp04KxpKIknUtXXWoEaszAMTSrHI3YhaL/JdRlHraC1VUF/sjzbSBFkKh7nxJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.1.tgz",
+      "integrity": "sha512-waosL7VtVRfXsNOXtAM3rOjZyNQD0lQBlhuB5/oY+E+lNzYNFlzgiGXiDOwBpcs7dK7kW2Vv8+KcxyIGIyXOtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/math": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.4.1.tgz",
+      "integrity": "sha512-xenAPOAUd7HDlus5V/g4LKVh1l7FpyVRSYXa+g7tBj91xzhRYgLEXSxdrGfRNAFMDOSGC1ITwCGQwlwSX4Mpxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/mvt": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.4.1.tgz",
+      "integrity": "sha512-ou1Oyec7hcpCQ2onF1FefNXVv1MwPjwUkII6IFrrRZ/f0/ei0b8yc5IVwO4gkhta/Ve/Y+mFcs/GaeQZMOEBOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/gis": "4.4.1",
+        "@loaders.gl/images": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@math.gl/polygon": "^4.1.0",
+        "@probe.gl/stats": "^4.1.1",
+        "pbf": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/schema": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.1.tgz",
+      "integrity": "sha512-s7NjEnyK6jZvJJSWj/mHq+S9mHRHVzIYtFP+C7sMf1gVCQbdkt6OSAMUWRzwPr9+whQNVWjZ9pbLsI/IPW3zvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/schema-utils": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.1.tgz",
+      "integrity": "sha512-4upip2O6MFaWzk68/lnna7P2uRj9NQ8MIk/ff3CLbciP5/9lKl1qyuzObz5JrJRYzfGB6I81vpOn6FSVQ6m6KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.1",
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/terrain": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.4.1.tgz",
+      "integrity": "sha512-cBLT+G0HefySTppxqqkMKcN5kfOfIRRx0WDPHa0VHFJw9rbnxoEDhrXvfsXfOATNFFNtcpgQUDqDqhEBp0XvZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/images": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@mapbox/martini": "^0.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/textures": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.4.1.tgz",
+      "integrity": "sha512-r1//6sO29GOHso+IvXQ3GrvXZ4cl03VWc34XcnXPn3sAV7O96uRGd5xkyx60lMYAl7Jv7qK/smT3z4Mdxdd4aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/images": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/worker-utils": "4.4.1",
+        "@math.gl/types": "^4.1.0",
+        "ktx-parse": "^0.7.0",
+        "texture-compressor": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/tiles": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.4.1.tgz",
+      "integrity": "sha512-EbF81/c1oXJocVAKR0rx+vWSOnmBBWWhM7pZpYk6oNUQAJfA99APhiRNstAJiJomAgqAxr7vfnhXHjPZg6osZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/math": "4.4.1",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/geospatial": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "@probe.gl/stats": "^4.1.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/wms": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.4.1.tgz",
+      "integrity": "sha512-sIaqyHXPuLQnkN2eebvczZYVvapkjA8EZaI8feaPxj4jZk/Hk5EuZzIbxJ4eftLotZwDHd3XzEVIs6YlFOSJ+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/images": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/xml": "4.4.1",
+        "@turf/rewind": "^5.1.5",
+        "deep-strict-equal": "^0.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.1.tgz",
+      "integrity": "sha512-ovMyIyj9dlChuHuD64Bel7Mir2UYlmLqlZ9MMzVxzTTLvaudJoNAXi6Disp0ooxwF62ZqjNXXutaSbS6UDeuIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/xml": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.4.1.tgz",
+      "integrity": "sha512-+8Dtxp0BZZj1CVUkiIlKGDLmhwsPILK9yJvc1P7tuJO9KsaQ5cywJk/b8A7lmqb2SfPkEg0xlQOK2FWIo1ATMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.1",
+        "fast-xml-parser": "^5.3.6"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@loaders.gl/zip": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.4.1.tgz",
+      "integrity": "sha512-fV7oqREEzzqYl2/b4tiM+J4qeSq6pB4gw1hHngpCtVyjVwWVtsNH2r1ly9kkv4XssIdXJxPcrX/GR0mDIwmp6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/compression": "4.4.1",
+        "@loaders.gl/crypto": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.1",
+        "jszip": "^3.1.5",
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@luma.gl/core": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.3.3.tgz",
+      "integrity": "sha512-jCFm2htvrVpcXIy85TBTF1ROgMfknKnfw2OH+Vydr41hiCFd6nqr79gM3f2uhaNkal0BghFNqF3qDioKiUWtew==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/types": "^4.1.0",
+        "@probe.gl/env": "^4.1.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1",
+        "@types/offscreencanvas": "^2019.7.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@luma.gl/engine": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.3.3.tgz",
+      "integrity": "sha512-StmMTzUcUlpKMU3wvWU48A6OQyphptD9zVGBsSkK6iHIBdtBKlOcmqRkyfvRouo8JHtlrnoJDHLVKhxorwhGAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/types": "^4.1.0",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "~9.3.0",
+        "@luma.gl/shadertools": "~9.3.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@luma.gl/gltf": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.3.3.tgz",
+      "integrity": "sha512-/wty4PHYeQelXvDJesyuMdqtAfpL1XcyEQffcEAwKwu9w7JdkygSShdUwTT1iF7no0uGKuWgq824dVC9WBBQcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/core": "~4.4.0",
+        "@loaders.gl/gltf": "~4.4.0",
+        "@loaders.gl/textures": "~4.4.0",
+        "@math.gl/core": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "~9.3.0",
+        "@luma.gl/engine": "~9.3.0",
+        "@luma.gl/shadertools": "~9.3.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@luma.gl/shadertools": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.3.3.tgz",
+      "integrity": "sha512-4ZfG4/Utix951vqyiG/JIx+Eg+GMNwOxgr/07/i0gf7bK1gJZIEQ5BxVcDw4MCQfdoVlGPGzl0cQKbdqBvaCAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/types": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "~9.3.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@luma.gl/webgl": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.3.3.tgz",
+      "integrity": "sha512-X+aavdP5o6VFHSA0es9gKZTT145jfcFbhKJt/gwJrptnKNoIW4+Y37ZEpCo1AzAnr+FQCxjgcM2kOCpoWMfSVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/types": "^4.1.0",
+        "@probe.gl/env": "^4.1.1"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "~9.3.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@types/d3-scale": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.5.tgz",
+      "integrity": "sha512-YOpKj0kIEusRf7ofeJcSZQsvKbnTwpe1DUF+P2qsotqG53kEsjm7EzzliqQxMkAWdkZcHrg5rRhB4JiDOQPX+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "^2"
+      }
+    },
+    "node_modules/deck.gl/node_modules/@types/d3-time": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.4.tgz",
+      "integrity": "sha512-BTfLsxTeo7yFxI/haOOf1ZwJ6xKgQLT9dCp+EcmQv87Gox6X+oKl4mLKfO6fnWm3P22+A6DknMNEZany8ql2Rw==",
+      "license": "MIT"
+    },
+    "node_modules/deck.gl/node_modules/a5-js": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/a5-js/-/a5-js-0.7.3.tgz",
+      "integrity": "sha512-3aoMwHmNkyuMDHS4q6GRRInpOawamen2pokIbc0MQmR9cqG0Y9+B0bZpzswwetjrSG2ckbYtShH+nKru6+3O5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gl-matrix": "^3.4.3"
+      }
+    },
+    "node_modules/deck.gl/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/deck.gl/node_modules/jsep": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
+      "integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/deck.gl/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -8742,7 +9516,7 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmmirror.com/deepmerge/-/deepmerge-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "license": "MIT",
@@ -8846,9 +9620,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8882,7 +9656,7 @@
     },
     "node_modules/ejs": {
       "version": "3.1.10",
-      "resolved": "https://registry.npmmirror.com/ejs/-/ejs-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
       "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -8946,9 +9720,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmmirror.com/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9067,7 +9841,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmmirror.com/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
       "license": "MIT",
@@ -9084,9 +9858,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
       "license": "MIT",
       "peer": true,
       "workspaces": [
@@ -9342,7 +10116,7 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
@@ -9355,6 +10129,19 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+      "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
     "node_modules/eventemitter3": {
@@ -9422,9 +10209,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -9436,6 +10223,22 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.6",
@@ -9500,7 +10303,7 @@
     },
     "node_modules/filelist": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmmirror.com/filelist/-/filelist-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
       "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -9509,9 +10312,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9520,7 +10323,7 @@
     },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-5.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
@@ -9529,6 +10332,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/find-up": {
@@ -9562,6 +10382,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatpickr": {
       "version": "4.6.13",
       "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
@@ -9570,9 +10396,9 @@
       "peer": true
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmmirror.com/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -9596,9 +10422,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -9617,7 +10443,7 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmmirror.com/for-each/-/for-each-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
@@ -9706,7 +10532,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmmirror.com/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
       "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
@@ -9736,7 +10562,7 @@
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/generator-function/-/generator-function-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true,
       "license": "MIT",
@@ -9809,7 +10635,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "license": "MIT",
@@ -9895,9 +10721,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9938,7 +10764,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "license": "MIT",
@@ -10003,7 +10829,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/has-bigints/-/has-bigints-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
@@ -10037,7 +10863,7 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/has-proto/-/has-proto-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "license": "MIT",
@@ -10251,12 +11077,12 @@
       }
     },
     "node_modules/i18next-http-backend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.2.tgz",
-      "integrity": "sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.6.tgz",
+      "integrity": "sha512-mBOqy8993jtqAoj6XaI1XeC/8/9v6EPS+681ziegrPvTB0DoaCY7PpTS0SpY56qLMoS4OI1TZEM2Zf59zNh05w==",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "4.0.0"
+        "cross-fetch": "4.1.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -10273,7 +11099,7 @@
     },
     "node_modules/idb": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmmirror.com/idb/-/idb-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "dev": true,
       "license": "ISC"
@@ -10387,7 +11213,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/internal-slot/-/internal-slot-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
@@ -10467,7 +11293,7 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmmirror.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
@@ -10491,7 +11317,7 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/is-async-function/-/is-async-function-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
       "license": "MIT",
@@ -10511,7 +11337,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/is-bigint/-/is-bigint-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "license": "MIT",
@@ -10527,7 +11353,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmmirror.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
@@ -10550,7 +11376,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmmirror.com/is-callable/-/is-callable-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
@@ -10579,7 +11405,7 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/is-data-view/-/is-data-view-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
@@ -10648,7 +11474,7 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "license": "MIT",
@@ -10673,7 +11499,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "license": "MIT",
@@ -10716,7 +11542,7 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/is-map/-/is-map-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
@@ -10729,14 +11555,14 @@
     },
     "node_modules/is-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/is-module/-/is-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "license": "MIT",
@@ -10756,7 +11582,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/is-number-object/-/is-number-object-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
@@ -10842,7 +11668,7 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/is-set/-/is-set-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
       "license": "MIT",
@@ -10855,7 +11681,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
@@ -10884,7 +11710,7 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/is-string/-/is-string-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
@@ -10901,7 +11727,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/is-symbol/-/is-symbol-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
@@ -10919,7 +11745,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmmirror.com/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
@@ -10935,7 +11761,7 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
       "license": "MIT",
@@ -10948,7 +11774,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/is-weakref/-/is-weakref-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
@@ -10964,7 +11790,7 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmmirror.com/is-weakset/-/is-weakset-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
@@ -10981,7 +11807,7 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmmirror.com/isarray/-/isarray-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
@@ -11020,7 +11846,7 @@
     },
     "node_modules/jake": {
       "version": "10.9.4",
-      "resolved": "https://registry.npmmirror.com/jake/-/jake-10.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
       "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -11203,6 +12029,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/json-buffer": {
@@ -11437,9 +12271,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -11539,13 +12379,13 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/maplibre-gl": {
@@ -12644,9 +13484,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.1.tgz",
-      "integrity": "sha512-1B9lmAhB9D9/sHaPC1N7wLFEVUoFldxOpOO96lOD1PvJ43vCd0ozDPbu0FEL3++VvawOlDkq8YD373tJmP5JHw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.2.tgz",
+      "integrity": "sha512-lDsQv8FoGdBUdf0+TjGsq2orxKuXdwFlQ6Zw6TX3xIcTwTfEpCLyKqvEauvCHJ8iu3KBV8+uPhlv70YsNGdUBQ==",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -12742,6 +13582,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12820,7 +13661,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
@@ -12859,7 +13700,7 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmmirror.com/object.assign/-/object.assign-4.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
@@ -12931,7 +13772,7 @@
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/own-keys/-/own-keys-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "license": "MIT",
@@ -13061,6 +13902,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz",
@@ -13178,9 +14034,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13238,10 +14094,13 @@
       }
     },
     "node_modules/png-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
-      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==",
-      "peer": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "peer": true,
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
     },
     "node_modules/pngjs": {
       "version": "5.0.0",
@@ -13271,7 +14130,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
@@ -13280,9 +14139,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -13424,16 +14283,19 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -13583,16 +14445,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
       "license": "ISC"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/rc-cascader": {
       "version": "3.34.0",
@@ -14414,7 +15266,7 @@
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmmirror.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "license": "MIT",
@@ -14728,15 +15580,15 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmmirror.com/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -14747,30 +15599,9 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "license": "MIT",
@@ -14787,7 +15618,7 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
@@ -14925,13 +15756,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmmirror.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-blocking": {
@@ -14974,7 +15805,7 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/set-proto/-/set-proto-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
       "license": "MIT",
@@ -15039,7 +15870,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
@@ -15058,14 +15889,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15076,7 +15907,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
@@ -15095,7 +15926,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
@@ -15144,7 +15975,7 @@
     },
     "node_modules/smob": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmmirror.com/smob/-/smob-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
       "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
       "dev": true,
       "license": "MIT",
@@ -15218,6 +16049,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -15241,14 +16073,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmmirror.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
@@ -15329,7 +16153,7 @@
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "license": "MIT",
@@ -15385,7 +16209,7 @@
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
-      "resolved": "https://registry.npmmirror.com/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
       "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "license": "MIT",
@@ -15413,7 +16237,7 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmmirror.com/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
       "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
@@ -15435,7 +16259,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmmirror.com/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
       "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
@@ -15454,7 +16278,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmmirror.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "license": "MIT",
@@ -15594,73 +16418,6 @@
         "inline-style-parser": "0.2.7"
       }
     },
-    "node_modules/styled-components": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.12.tgz",
-      "integrity": "sha512-hFR6xsVkVYbsdcUlzPYFvFfoc6o2KlV0VvgRIQwSYMtdThM7SCxnjX9efh/cWce2kTq16I/Kl3xM98xiLptsXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/is-prop-valid": "1.4.0",
-        "@emotion/unitless": "0.10.0",
-        "@types/stylis": "4.2.7",
-        "css-to-react-native": "3.2.0",
-        "csstype": "3.2.3",
-        "postcss": "8.4.49",
-        "shallowequal": "1.1.0",
-        "stylis": "4.3.6",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/styled-components/node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmmirror.com/stylis/-/stylis-4.3.6.tgz",
@@ -15680,7 +16437,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15728,6 +16484,19 @@
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
@@ -16066,7 +16835,7 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
@@ -16081,7 +16850,7 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "license": "MIT",
@@ -16101,7 +16870,7 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "license": "MIT",
@@ -16123,7 +16892,7 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmmirror.com/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
       "license": "MIT",
@@ -16195,9 +16964,18 @@
       "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
       "license": "MIT"
     },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
@@ -16542,9 +17320,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmmirror.com/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16729,16 +17507,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -16911,7 +17679,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
@@ -16931,7 +17699,7 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "license": "MIT",
@@ -16959,7 +17727,7 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/which-collection/-/which-collection-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
       "license": "MIT",
@@ -16984,7 +17752,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
-      "resolved": "https://registry.npmmirror.com/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "dev": true,
       "license": "MIT",
@@ -17031,31 +17799,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/workbox-background-sync": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-background-sync/-/workbox-background-sync-7.4.0.tgz",
-      "integrity": "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
+      "integrity": "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-broadcast-update": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-broadcast-update/-/workbox-broadcast-update-7.4.0.tgz",
-      "integrity": "sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz",
+      "integrity": "sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-build": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-build/-/workbox-build-7.4.0.tgz",
-      "integrity": "sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.1.tgz",
+      "integrity": "sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17063,39 +17840,39 @@
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.11.0",
         "@babel/runtime": "^7.11.2",
-        "@rollup/plugin-babel": "^5.2.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^2.4.1",
-        "@rollup/plugin-terser": "^0.4.3",
-        "@surma/rollup-plugin-off-main-thread": "^2.2.3",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@rollup/plugin-terser": "^1.0.0",
+        "@trickfilm400/rollup-plugin-off-main-thread": "^3.0.0-pre1",
         "ajv": "^8.6.0",
         "common-tags": "^1.8.0",
+        "eta": "^4.5.1",
         "fast-json-stable-stringify": "^2.1.0",
         "fs-extra": "^9.0.1",
         "glob": "^11.0.1",
-        "lodash": "^4.17.20",
         "pretty-bytes": "^5.3.0",
-        "rollup": "^2.79.2",
+        "rollup": "^4.53.3",
         "source-map": "^0.8.0-beta.0",
         "stringify-object": "^3.3.0",
         "strip-comments": "^2.0.1",
         "tempy": "^0.6.0",
         "upath": "^1.2.0",
-        "workbox-background-sync": "7.4.0",
-        "workbox-broadcast-update": "7.4.0",
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-google-analytics": "7.4.0",
-        "workbox-navigation-preload": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-range-requests": "7.4.0",
-        "workbox-recipes": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0",
-        "workbox-streams": "7.4.0",
-        "workbox-sw": "7.4.0",
-        "workbox-window": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-broadcast-update": "7.4.1",
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-google-analytics": "7.4.1",
+        "workbox-navigation-preload": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-range-requests": "7.4.1",
+        "workbox-recipes": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1",
+        "workbox-streams": "7.4.1",
+        "workbox-sw": "7.4.1",
+        "workbox-window": "7.4.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -17119,69 +17896,6 @@
         "ajv": ">=8"
       }
     },
-    "node_modules/workbox-build/node_modules/@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/plugin-replace": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmmirror.com/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
-      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.18.0.tgz",
@@ -17199,32 +17913,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/workbox-build/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/workbox-build/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/workbox-build/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/workbox-build/node_modules/pretty-bytes": {
       "version": "5.6.0",
@@ -17239,157 +17933,141 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/workbox-build/node_modules/rollup": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-2.80.0.tgz",
-      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/workbox-cacheable-response": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-cacheable-response/-/workbox-cacheable-response-7.4.0.tgz",
-      "integrity": "sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz",
+      "integrity": "sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-core/-/workbox-core-7.4.0.tgz",
-      "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
+      "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-expiration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-expiration/-/workbox-expiration-7.4.0.tgz",
-      "integrity": "sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.1.tgz",
+      "integrity": "sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-google-analytics": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-google-analytics/-/workbox-google-analytics-7.4.0.tgz",
-      "integrity": "sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz",
+      "integrity": "sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-background-sync": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-navigation-preload": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-navigation-preload/-/workbox-navigation-preload-7.4.0.tgz",
-      "integrity": "sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz",
+      "integrity": "sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-precaching": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-precaching/-/workbox-precaching-7.4.0.tgz",
-      "integrity": "sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.1.tgz",
+      "integrity": "sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-range-requests": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-range-requests/-/workbox-range-requests-7.4.0.tgz",
-      "integrity": "sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz",
+      "integrity": "sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-recipes": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-recipes/-/workbox-recipes-7.4.0.tgz",
-      "integrity": "sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.1.tgz",
+      "integrity": "sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-routing": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-routing/-/workbox-routing-7.4.0.tgz",
-      "integrity": "sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.1.tgz",
+      "integrity": "sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-strategies": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-strategies/-/workbox-strategies-7.4.0.tgz",
-      "integrity": "sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.1.tgz",
+      "integrity": "sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-streams": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-streams/-/workbox-streams-7.4.0.tgz",
-      "integrity": "sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.1.tgz",
+      "integrity": "sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1"
       }
     },
     "node_modules/workbox-sw": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-sw/-/workbox-sw-7.4.0.tgz",
-      "integrity": "sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.1.tgz",
+      "integrity": "sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-window": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmmirror.com/workbox-window/-/workbox-window-7.4.0.tgz",
-      "integrity": "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.1.tgz",
+      "integrity": "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workerize-loader": {
@@ -17427,6 +18105,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {


### PR DESCRIPTION
## Summary

Two small, independent hardening items from `AUDIT-REPORT.md`:

### P2-2 — npm prod vulnerabilities
`npm audit fix` (compatible only). Resolves the high-severity RCE chain:
- **lodash** 4.17.x template injection RCE (CVSS 8.1, GHSA-r5fr-rjxr-66jc)
- **serialize-javascript** RegExp.flags RCE (CVSS 8.1, GHSA-5c6j-r48x-rmvq)
- **flatted** prototype pollution (GHSA-rf6f-7fwh-wjgh)

Prod-only audit count: **14 → 4** (3 high → 0 high). Remaining 4 moderate are the `deck.gl 9 → @loaders.gl/wms → @loaders.gl/xml → fast-xml-parser` chain — would need a deck.gl major bump, deferred.

### P2-3 — duplicate security response headers
`curl -D-` against fojin.app showed `X-Frame-Options`, `X-Content-Type-Options`, `Strict-Transport-Security`, `Referrer-Policy`, `Permissions-Policy` each arriving twice on responses proxied through nginx — both backend SecurityHeadersMiddleware and nginx were setting them.

Fix: **nginx is the single source of truth.** Added `X-Permitted-Cross-Domain-Policies` to nginx (was unique to backend before). Removed `SecurityHeadersMiddleware` from backend.

## Test plan
- [x] `npm run build` clean, bundle size unchanged
- [x] `bash -n` on entrypoint, no shell syntax issues (no entrypoint touched)
- [x] No backend tests reference SecurityHeadersMiddleware (grep confirmed)
- [x] CI: bandit / ruff / smoke / frontend audit / secrets / GitGuardian
- [ ] Post-deploy: `curl -D- https://fojin.app/api/health | grep -i x-frame` → expect single occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)