### PR TITLE
feat: unified search backend + enhanced autocomplete (PR-Y)

### DIFF
--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -2,10 +2,13 @@ import asyncio
 import time
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.elasticsearch import get_es
 from app.database import get_db
+from app.models.dictionary import DictionaryEntry
+from app.models.hot_question import HotQuestion
 from app.schemas.text import CrossLanguageSearchResponse, SearchResponse, SemanticSearchResponse
 from app.services.search import (
     get_aggregations,
@@ -48,13 +51,74 @@ async def search(
 @router.get("/search/suggest")
 async def search_suggest(
     q: str = Query(..., min_length=1, max_length=200, description="搜索建议关键词"),
+    db: AsyncSession = Depends(get_db),
 ):
-    """Return search suggestions (autocomplete) based on input.
+    """Return autocomplete suggestions across multiple sources.
 
-    根据输入返回搜索建议（自动补全）。"""
+    Sources merged in priority order:
+    1. ES title prefix matches (existing behavior — sutra titles & translators)
+    2. Dictionary headword exact + prefix matches (300k+ unique headwords —
+       captures terminology queries like "苦谛" / "般若")
+    3. hot_questions display_text substring matches (200 curated prompts —
+       steers users toward known-answerable questions)
+
+    Each source has its own quota; the response returns up to ~10
+    deduplicated suggestions total. All three lookups run in parallel.
+
+    根据输入返回搜索建议（自动补全），整合经文标题、辞典词头与精选问题。"""
     es = get_es()
-    suggestions = await get_suggestions(es, q)
-    return {"suggestions": suggestions}
+
+    async def _dict_prefix() -> list[str]:
+        try:
+            stmt = (
+                select(DictionaryEntry.headword)
+                .where(DictionaryEntry.headword.ilike(f"{q}%"))
+                .group_by(DictionaryEntry.headword)
+                .order_by(func.length(DictionaryEntry.headword), DictionaryEntry.headword)
+                .limit(5)
+            )
+            rows = await db.execute(stmt)
+            return [r[0] for r in rows.all() if r[0]]
+        except Exception:
+            return []
+
+    async def _hot_q_match() -> list[str]:
+        try:
+            stmt = (
+                select(HotQuestion.display_text)
+                .where(HotQuestion.is_active.is_(True))
+                .where(HotQuestion.display_text.ilike(f"%{q}%"))
+                .order_by(HotQuestion.sort_order.asc())
+                .limit(3)
+            )
+            rows = await db.execute(stmt)
+            return [r[0] for r in rows.all() if r[0]]
+        except Exception:
+            return []
+
+    es_suggestions, dict_suggestions, hot_suggestions = await asyncio.gather(
+        get_suggestions(es, q),
+        _dict_prefix(),
+        _hot_q_match(),
+        return_exceptions=False,
+    )
+
+    seen: set[str] = set()
+    merged: list[str] = []
+    # Order: dict (most specific) > es titles > hot questions.
+    # Users searching "苦" want the dictionary entry first, not a sutra
+    # whose title begins with 苦.
+    for source_list in (dict_suggestions, es_suggestions, hot_suggestions):
+        for s in source_list:
+            if s and s not in seen:
+                seen.add(s)
+                merged.append(s)
+            if len(merged) >= 10:
+                break
+        if len(merged) >= 10:
+            break
+
+    return {"suggestions": merged}
 
 
 @router.get("/search/cross-language", response_model=CrossLanguageSearchResponse)

--- a/backend/app/api/search_unified.py
+++ b/backend/app/api/search_unified.py
@@ -1,0 +1,183 @@
+"""Unified search endpoint that fans out to all search backends in parallel.
+
+Why this exists:
+- /search returns metadata hits, /search/content returns body hits,
+  /search/semantic returns RAG vector hits, /api/dictionary/search/grouped
+  returns dictionary hits. Frontend currently runs them as separate React
+  Query hooks per tab, forcing the user to choose "which kind of search"
+  before seeing results.
+- Real users (per Umami: /search PV 3,585/mo, #2 entry) just type a
+  word — they don't know whether they want catalog vs content vs semantic.
+- This endpoint runs all four in parallel and returns a sectioned response.
+  The frontend can render a single unified result page or fall back to
+  the per-backend tabs for advanced users.
+
+Concurrency safety:
+- Each backend has its own retry/timeout. We use asyncio.gather with
+  return_exceptions so a single backend failure doesn't sink the whole
+  response — the failed section just comes back empty with an
+  ``error`` field set.
+- Total wall time ≈ max of the slowest backend, not sum.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import case, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.core.elasticsearch import get_es
+from app.database import get_db
+from app.models.dictionary import DictionaryEntry
+from app.models.hot_question import HotQuestion
+from app.services.search import (
+    search_content,
+    search_semantic,
+    search_texts,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["search"])
+
+_DICT_SECTION_LIMIT = 5
+_HOT_Q_SECTION_LIMIT = 4
+
+
+async def _dict_top_hits(db: AsyncSession, q: str) -> list[dict]:
+    """Top-N exact + prefix dictionary hits for the unified result.
+
+    Mirrors the /api/dictionary/search prioritization but caps tighter
+    since this is a teaser, not a full results page.
+    """
+    relevance = case(
+        (DictionaryEntry.headword == q, 3),
+        (DictionaryEntry.headword.ilike(f"{q}%"), 2),
+        else_=1,
+    )
+    stmt = (
+        select(DictionaryEntry)
+        .options(joinedload(DictionaryEntry.source))
+        .where(or_(DictionaryEntry.headword == q, DictionaryEntry.headword.ilike(f"{q}%")))
+        .order_by(relevance.desc(), func.length(DictionaryEntry.headword), DictionaryEntry.headword)
+        .limit(_DICT_SECTION_LIMIT)
+    )
+    rows = await db.execute(stmt)
+    out = []
+    for e in rows.unique().scalars().all():
+        out.append(
+            {
+                "id": e.id,
+                "headword": e.headword,
+                "reading": e.reading,
+                "definition": (e.definition or "")[:200],
+                "source": e.source.name_zh if e.source else None,
+                "url": f"/dict/{e.headword}",
+            }
+        )
+    return out
+
+
+async def _hot_question_hits(db: AsyncSession, q: str) -> list[dict]:
+    """Pre-curated hot_questions matching the query as substring.
+
+    These are 200 hand-edited prompts that already exist in the system —
+    surfacing them in unified results steers the 77 empty chat sessions /
+    493 single-turn sessions toward a starting point.
+    """
+    stmt = (
+        select(HotQuestion)
+        .where(HotQuestion.is_active.is_(True))
+        .where(HotQuestion.display_text.ilike(f"%{q}%"))
+        .order_by(HotQuestion.sort_order.asc())
+        .limit(_HOT_Q_SECTION_LIMIT)
+    )
+    rows = await db.execute(stmt)
+    out = []
+    for h in rows.scalars().all():
+        out.append(
+            {
+                "slug": h.slug,
+                "category": h.category,
+                "text": h.display_text,
+                "url": f"/chat?q={h.display_text}",
+            }
+        )
+    return out
+
+
+@router.get("/search/unified")
+async def search_unified(
+    q: str = Query(..., min_length=1, max_length=200, description="Unified search query"),
+    sources: str | None = Query(None, description="Comma-separated source codes filter"),
+    lang: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+):
+    """Run all search backends in parallel and return sectioned results.
+
+    Returns:
+        {
+            "query": str,
+            "sections": {
+                "dictionary": [...]    # top-5 dict hits with /dict/ links
+                "hot_questions": [...] # top-4 curated prompts
+                "catalog": {...}       # SearchResponse — top-10 metadata hits
+                "content": {...}       # ContentSearchResponse — top-5 body hits
+                "semantic": {...}      # SemanticSearchResponse — top-5 vector hits
+            },
+            "errors": { section_name: error_string, ... }
+        }
+    """
+    es = get_es()
+
+    catalog_coro = search_texts(es, q, page=1, size=10, sources=sources, lang=lang, db=db)
+    content_coro = search_content(es, q, page=1, size=5, sources=sources, lang=lang)
+    semantic_coro = search_semantic(db, q, size=5, lang=lang, sources=sources)
+    dict_coro = _dict_top_hits(db, q)
+    hot_coro = _hot_question_hits(db, q)
+
+    catalog_r, content_r, semantic_r, dict_r, hot_r = await asyncio.gather(
+        catalog_coro,
+        content_coro,
+        semantic_coro,
+        dict_coro,
+        hot_coro,
+        return_exceptions=True,
+    )
+
+    sections: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+
+    def _attach(name: str, result: Any, on_ok=lambda r: r):
+        if isinstance(result, Exception):
+            logger.warning("unified search section %s failed: %s", name, result)
+            errors[name] = str(result)
+            sections[name] = None
+        else:
+            sections[name] = on_ok(result)
+
+    _attach(
+        "catalog",
+        catalog_r,
+        on_ok=lambda r: {
+            "total": r.total,
+            "results": [hit.model_dump() for hit in r.results],
+        },
+    )
+    _attach("content", content_r)
+    _attach(
+        "semantic",
+        semantic_r,
+        on_ok=lambda r: {
+            "total": r.total,
+            "results": [hit.model_dump() for hit in r.results],
+        },
+    )
+    _attach("dictionary", dict_r)
+    _attach("hot_questions", hot_r)
+
+    return {"query": q, "sections": sections, "errors": errors}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,7 @@ from app.api import (
     relations,
     rss,
     search,
+    search_unified,
     seo,
     seo_persons,
     share,
@@ -338,6 +339,7 @@ async def fojin_error_handler(request: Request, exc: FoJinError):
 # Phase 1 routers
 app.include_router(auth.router, prefix="/api")
 app.include_router(search.router, prefix="/api")
+app.include_router(search_unified.router, prefix="/api")
 app.include_router(texts.router, prefix="/api")
 app.include_router(bookmarks.router, prefix="/api")
 app.include_router(history.router, prefix="/api")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -435,6 +435,41 @@ export async function getSearchSuggestions(q: string): Promise<string[]> {
   return data.suggestions;
 }
 
+export interface UnifiedSearchSection {
+  dictionary?: Array<{
+    id: number;
+    headword: string;
+    reading?: string | null;
+    definition: string;
+    source?: string | null;
+    url: string;
+  }> | null;
+  hot_questions?: Array<{
+    slug: string;
+    category: string;
+    text: string;
+    url: string;
+  }> | null;
+  catalog?: { total: number; results: SearchHit[] } | null;
+  content?: unknown;
+  semantic?: { total: number; results: SemanticSearchHit[] } | null;
+}
+
+export interface UnifiedSearchResponse {
+  query: string;
+  sections: UnifiedSearchSection;
+  errors: Record<string, string>;
+}
+
+export async function searchUnified(params: {
+  q: string;
+  sources?: string;
+  lang?: string;
+}): Promise<UnifiedSearchResponse> {
+  const { data } = await api.get<UnifiedSearchResponse>("/search/unified", { params, timeout: 30000 });
+  return data;
+}
+
 export async function getTextDetail(id: number): Promise<TextDetail> {
   const { data } = await api.get<TextDetail>(`/texts/${id}`);
   return data;


### PR DESCRIPTION
## 背景

/search 是 fojin.app 第 2 大入口（PV 3,585/月）。但当前 UX 让用户先选 tab（catalog / content / cross-language / semantic / dictionary）再看结果。同时 chat 数据显示：77 空会话 + 493 一问就走（66%），说明用户**不知道从哪里问起**。

## 实现

### 1. 新 endpoint `/api/search/unified`

并发跑全部搜索后端 + 词典 + hot_questions，返回 sectioned 响应：

\`\`\`json
{
  "query": "苦谛",
  "sections": {
    "dictionary": [{"headword": "苦谛", "definition": "...", "url": "/dict/苦谛"}],
    "hot_questions": [{"text": "苦谛与缘起的关系", "url": "/chat?q=..."}],
    "catalog": {"total": 12, "results": [...]},
    "content": {...},
    "semantic": {"total": 5, "results": [...]}
  },
  "errors": {}
}
\`\`\`

- `asyncio.gather(return_exceptions=True)` — 单个后端失败不拖整体
- 总耗时 ≈ 最慢后端，不是各后端之和

### 2. 增强 `/api/search/suggest`

并发查 3 源：
- ES title prefix（原有）
- DictionaryEntry headword prefix（300k+ 词头）
- hot_questions display_text 子串匹配（200 curated）

合并去重，词典优先（用户搜"苦"应先看到"苦谛"词典条目，不是某部经的标题）。

### 3. 前端

只加 client helper `searchUnified()`，**未改 SearchPage UI**——保持向后兼容，让下一个 PR 单独做 UX 重构。

## 预期效果

- autocomplete 命中率显著提升（词典 + 热问加入）
- 空会话率（77 / 884 = 8.7%）下降
- 一问就走率（493 / 807 = 61%）下降——用户在搜索时已经看到 hot_questions 引导

## 与 PR-X 关系

PR-X 提供 `/dict/{headword}` SSR 落地页；PR-Y 在 unified 搜索结果中链接到这些页面。两者互补，但相互独立可单独 ship。

🤖 Generated with [Claude Code](https://claude.com/claude-code)