### PR TITLE
fix: simplified→traditional dict redirect + concurrent session in unified

### DIFF
--- a/backend/app/api/search_unified.py
+++ b/backend/app/api/search_unified.py
@@ -32,7 +32,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.elasticsearch import get_es
-from app.database import get_db
+from app.database import async_session, get_db
 from app.models.dictionary import DictionaryEntry
 from app.models.hot_question import HotQuestion
 from app.services.search import (
@@ -48,27 +48,33 @@ _DICT_SECTION_LIMIT = 5
 _HOT_Q_SECTION_LIMIT = 4
 
 
-async def _dict_top_hits(db: AsyncSession, q: str) -> list[dict]:
+async def _dict_top_hits(q: str) -> list[dict]:
     """Top-N exact + prefix dictionary hits for the unified result.
 
     Mirrors the /api/dictionary/search prioritization but caps tighter
-    since this is a teaser, not a full results page.
+    since this is a teaser, not a full results page. Uses its own session
+    so it can run concurrently with other DB-using sections in
+    asyncio.gather (a single AsyncSession does not allow concurrent
+    operations).
     """
     relevance = case(
         (DictionaryEntry.headword == q, 3),
         (DictionaryEntry.headword.ilike(f"{q}%"), 2),
         else_=1,
     )
-    stmt = (
-        select(DictionaryEntry)
-        .options(joinedload(DictionaryEntry.source))
-        .where(or_(DictionaryEntry.headword == q, DictionaryEntry.headword.ilike(f"{q}%")))
-        .order_by(relevance.desc(), func.length(DictionaryEntry.headword), DictionaryEntry.headword)
-        .limit(_DICT_SECTION_LIMIT)
-    )
-    rows = await db.execute(stmt)
+    async with async_session() as db:
+        stmt = (
+            select(DictionaryEntry)
+            .options(joinedload(DictionaryEntry.source))
+            .where(or_(DictionaryEntry.headword == q, DictionaryEntry.headword.ilike(f"{q}%")))
+            .order_by(relevance.desc(), func.length(DictionaryEntry.headword), DictionaryEntry.headword)
+            .limit(_DICT_SECTION_LIMIT)
+        )
+        rows = await db.execute(stmt)
+        entries = list(rows.unique().scalars().all())
+
     out = []
-    for e in rows.unique().scalars().all():
+    for e in entries:
         out.append(
             {
                 "id": e.id,
@@ -82,23 +88,27 @@ async def _dict_top_hits(db: AsyncSession, q: str) -> list[dict]:
     return out
 
 
-async def _hot_question_hits(db: AsyncSession, q: str) -> list[dict]:
+async def _hot_question_hits(q: str) -> list[dict]:
     """Pre-curated hot_questions matching the query as substring.
 
     These are 200 hand-edited prompts that already exist in the system —
     surfacing them in unified results steers the 77 empty chat sessions /
-    493 single-turn sessions toward a starting point.
+    493 single-turn sessions toward a starting point. Independent session
+    for asyncio.gather concurrency safety.
     """
-    stmt = (
-        select(HotQuestion)
-        .where(HotQuestion.is_active.is_(True))
-        .where(HotQuestion.display_text.ilike(f"%{q}%"))
-        .order_by(HotQuestion.sort_order.asc())
-        .limit(_HOT_Q_SECTION_LIMIT)
-    )
-    rows = await db.execute(stmt)
+    async with async_session() as db:
+        stmt = (
+            select(HotQuestion)
+            .where(HotQuestion.is_active.is_(True))
+            .where(HotQuestion.display_text.ilike(f"%{q}%"))
+            .order_by(HotQuestion.sort_order.asc())
+            .limit(_HOT_Q_SECTION_LIMIT)
+        )
+        rows = await db.execute(stmt)
+        questions = list(rows.scalars().all())
+
     out = []
-    for h in rows.scalars().all():
+    for h in questions:
         out.append(
             {
                 "slug": h.slug,
@@ -134,11 +144,14 @@ async def search_unified(
     """
     es = get_es()
 
+    # search_semantic uses the request-scoped session; catalog/content use ES.
+    # dict + hot_q each open their own session for concurrency safety
+    # (a single AsyncSession can't service two concurrent execute() calls).
     catalog_coro = search_texts(es, q, page=1, size=10, sources=sources, lang=lang, db=db)
     content_coro = search_content(es, q, page=1, size=5, sources=sources, lang=lang)
     semantic_coro = search_semantic(db, q, size=5, lang=lang, sources=sources)
-    dict_coro = _dict_top_hits(db, q)
-    hot_coro = _hot_question_hits(db, q)
+    dict_coro = _dict_top_hits(q)
+    hot_coro = _hot_question_hits(q)
 
     catalog_r, content_r, semantic_r, dict_r, hot_r = await asyncio.gather(
         catalog_coro,

--- a/backend/app/api/seo_dict.py
+++ b/backend/app/api/seo_dict.py
@@ -27,8 +27,9 @@ import logging
 from urllib.parse import unquote
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import HTMLResponse
-from sqlalchemy import func, select
+from fastapi.responses import HTMLResponse, RedirectResponse
+from opencc import OpenCC
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -36,6 +37,12 @@ from app.api.seo import _escape_meta_value
 from app.database import get_db
 from app.models.dictionary import DictionaryEntry
 from app.models.text import BuddhistText, TextContent
+
+# Dictionary entries are stored in traditional Chinese (CBETA / DDB / FGS
+# convention). Users typing simplified Chinese in the URL must be matched
+# against the traditional form; dictionary.py uses the same pattern.
+_s2t = OpenCC("s2t")
+_t2s = OpenCC("t2s")
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["seo"])
@@ -254,10 +261,29 @@ async def dict_seo_html(headword: str, request: Request, db: AsyncSession = Depe
     if not headword or len(headword) > _MAX_HEADWORD_LEN:
         raise HTTPException(status_code=404, detail="invalid headword")
 
+    # Try simplified, traditional, and original variant — dictionary entries
+    # are stored in traditional Chinese, but Google / users may arrive with
+    # the simplified form. Dedupe to a single SQL roundtrip.
+    variants = list({headword, _s2t.convert(headword), _t2s.convert(headword)})
+    canonical_headword = headword
+    if len(variants) > 1:
+        # Probe which variant actually exists; prefer traditional (CBETA convention).
+        probe = await db.execute(
+            select(DictionaryEntry.headword)
+            .where(DictionaryEntry.headword.in_(variants))
+            .limit(1)
+        )
+        found = probe.scalar_one_or_none()
+        if found and found != headword:
+            # Redirect simplified → canonical traditional URL so we don't
+            # split SEO juice across simplified + traditional duplicates.
+            return RedirectResponse(url=f"/dict/{found}", status_code=301)
+        canonical_headword = found or headword
+
     stmt = (
         select(DictionaryEntry)
         .options(joinedload(DictionaryEntry.source))
-        .where(DictionaryEntry.headword == headword)
+        .where(or_(*[DictionaryEntry.headword == v for v in variants]))
         .limit(50)
     )
     rows = await db.execute(stmt)
@@ -266,7 +292,8 @@ async def dict_seo_html(headword: str, request: Request, db: AsyncSession = Depe
         raise HTTPException(status_code=404, detail="headword not found")
 
     base_url = str(request.base_url).rstrip("/")
-    canonical = f"{base_url}/dict/{headword}"
+    canonical = f"{base_url}/dict/{canonical_headword}"
+    headword = canonical_headword
 
     try:
         related = await _fetch_reverse_index(db, headword)


### PR DESCRIPTION
Follow-up to #552 + #553 — two bugs caught in production verification:

## 1. /dict/苦谛 returned 404
Dictionary entries are stored in traditional Chinese; URL had simplified.
seo_dict.py now uses OpenCC s2t/t2s to expand variants. Simplified URLs
get a 301 to the canonical traditional form (avoids SEO duplicate juice).

## 2. /api/search/unified hot_questions failed with concurrent SQL session
asyncio.gather() with a single request-scoped AsyncSession fails because
SQLAlchemy 2.x async sessions don't allow concurrent execute() calls.
Fix: _dict_top_hits and _hot_question_hits each open their own
async_session() context.

## Verification (post-deploy)
- /dict/般若 — entries returned
- /dict/苦谛 → 301 → /dict/苦諦
- /api/search/unified?q=金刚经 — all 5 sections populated, errors={}

🤖 Generated with [Claude Code](https://claude.com/claude-code)