### PR TITLE
feat(search): CBETA ID 直跳经文页

### DIFF
--- a/backend/app/api/texts.py
+++ b/backend/app/api/texts.py
@@ -1,6 +1,7 @@
+import re
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,9 +14,13 @@ from app.models.text import BuddhistText
 from app.models.user import ReadingHistory, User
 from app.schemas.text import JuanContentResponse, JuanLanguagesResponse, JuanListResponse, TextResponseBase
 from app.services.content import get_juan_content, get_juan_languages, get_juan_list
-from app.services.text import get_text_by_id, get_text_count
+from app.services.text import get_text_by_id, get_text_count, get_text_id_by_cbeta
 
 router = APIRouter(tags=["texts"])
+
+# CBETA-style identifier: prefix letter (T/X/J/B/P/C) + 1-4 digits + optional lowercase suffix.
+# 例：T0278、X0235a、J1510b。Web search 直跳走这个正则即可。
+_CBETA_ID_RE = re.compile(r"^[TXJBPC]\d{1,4}[a-z]?$")
 
 
 @router.get("/texts/lookup-cbeta")
@@ -33,6 +38,33 @@ async def lookup_cbeta_ids(
         select(BuddhistText.cbeta_id, BuddhistText.id).where(BuddhistText.cbeta_id.in_(cbeta_ids))
     )
     return dict(result.all())
+
+
+class CbetaRedirectResponse(BaseModel):
+    text_id: int
+    cbeta_id: str
+    redirect_to: str
+
+
+@router.get("/cbeta/{cbeta_id}", response_model=CbetaRedirectResponse)
+async def resolve_cbeta_id(
+    cbeta_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Resolve a CBETA ID (e.g. ``T0278``) to the canonical ``/texts/{id}`` URL.
+
+    用户在搜索栏输入 CBETA 编号时直跳经文页，跳过结果列表。"""
+    cbeta_id = cbeta_id.strip().upper()
+    if not _CBETA_ID_RE.match(cbeta_id):
+        raise HTTPException(status_code=404, detail="Invalid CBETA ID format")
+    text_id = await get_text_id_by_cbeta(db, cbeta_id)
+    if text_id is None:
+        raise HTTPException(status_code=404, detail=f"CBETA ID {cbeta_id} not found")
+    return CbetaRedirectResponse(
+        text_id=text_id,
+        cbeta_id=cbeta_id,
+        redirect_to=f"/texts/{text_id}",
+    )
 
 
 class SimilarPassageItem(BaseModel):

--- a/backend/app/services/text.py
+++ b/backend/app/services/text.py
@@ -11,6 +11,20 @@ async def get_text_by_id(session: AsyncSession, text_id: int) -> BuddhistText | 
     return result.scalar_one_or_none()
 
 
+async def get_text_id_by_cbeta(session: AsyncSession, cbeta_id: str) -> int | None:
+    """Resolve a CBETA ID (e.g. ``T0278``) to the lowest internal text id.
+
+    cbeta_id 在 buddhist_texts 上为 unique，但若未来同一编号跨数据源出现，
+    取 id 最小那条以保持可预测的跳转目标。"""
+    result = await session.execute(
+        select(BuddhistText.id)
+        .where(BuddhistText.cbeta_id == cbeta_id)
+        .order_by(BuddhistText.id.asc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def get_text_count(session: AsyncSession) -> int:
     result = await session.execute(select(func.count(BuddhistText.id)))
     return result.scalar() or 0

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -435,6 +435,30 @@ export async function getSearchSuggestions(q: string): Promise<string[]> {
   return data.suggestions;
 }
 
+export interface CbetaRedirect {
+  text_id: number;
+  cbeta_id: string;
+  redirect_to: string;
+}
+
+/**
+ * Resolve a CBETA ID (e.g. "T0278") to a canonical /texts/{id} URL.
+ * Returns null on 404 / non-CBETA input — callers should silently fall back
+ * to the regular search results path.
+ *
+ * 用户在搜索栏输入 CBETA 编号时直跳经文页。
+ */
+export async function getCbetaRedirect(cbetaId: string): Promise<CbetaRedirect | null> {
+  try {
+    const { data } = await api.get<CbetaRedirect>(
+      `/cbeta/${encodeURIComponent(cbetaId)}`,
+    );
+    return data;
+  } catch {
+    return null;
+  }
+}
+
 export interface UnifiedSearchSection {
   dictionary?: Array<{
     id: number;
@@ -451,7 +475,7 @@ export interface UnifiedSearchSection {
     url: string;
   }> | null;
   catalog?: { total: number; results: SearchHit[] } | null;
-  content?: unknown;
+  content?: { total: number; total_juans?: number; results: ContentSearchHit[] } | null;
   semantic?: { total: number; results: SemanticSearchHit[] } | null;
 }
 

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from "react";
-import { useSearchParams, Link } from "react-router-dom";
+import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
@@ -9,7 +9,7 @@ import {
 import {
   SearchOutlined, VerticalAlignTopOutlined, CloseOutlined,
 } from "@ant-design/icons";
-import { searchTexts, searchContent, searchDictionary, searchCrossLanguage, searchSemantic, getSources, getSearchSuggestions, searchDictionaryGrouped } from "../api/client";
+import { searchTexts, searchContent, searchDictionary, searchCrossLanguage, searchSemantic, getSources, getSearchSuggestions, searchDictionaryGrouped, getCbetaRedirect } from "../api/client";
 import type { DictGroupedSearchResponse } from "../api/client";
 import { hasDirectSearchUrl } from "../utils/sourceUrls";
 import { addSearchHistory, getSearchHistory, type SearchHistoryItem } from "../utils/history";
@@ -17,9 +17,14 @@ import { ResultCard, ExternalCard, DictCard, ContentCard, CrossLangCard, Semanti
 import "../styles/search.css";
 import "../styles/sources.css";
 
+// CBETA-style identifier: prefix letter (T/X/J/B/P/C) + 1-4 digits + optional lowercase suffix.
+// 例：T0278、X0235a、J1510b。命中即直跳 /texts/{id}，跳过结果列表。
+const CBETA_ID_RE = /^[TXJBPC]\d{1,4}[a-z]?$/i;
+
 export default function SearchPage() {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   // Derive state from URL — these are the source of truth
   const query = searchParams.get("q") ?? "";
@@ -62,6 +67,24 @@ export default function SearchPage() {
   useEffect(() => {
     setAcInput(query);
   }, [query]);
+
+  // CBETA ID 直跳：用户输入 T0278 / X0235a 等时，命中即跳 /texts/{id}，
+  // 跳过结果列表。404/非 CBETA 静默 fallback 到常规搜索。
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed || !CBETA_ID_RE.test(trimmed)) return;
+    let cancelled = false;
+    (async () => {
+      const result = await getCbetaRedirect(trimmed.toUpperCase());
+      if (cancelled || !result) return;
+      // Umami: track CBETA shortcut hits — power-user signal.
+      if (typeof umami !== "undefined") {
+        umami.track("cbeta-shortcut", { cbeta_id: result.cbeta_id });
+      }
+      navigate(result.redirect_to, { replace: true });
+    })();
+    return () => { cancelled = true; };
+  }, [query, navigate]);
 
   const langFilter = searchParams.get("lang") || "";
   const dictLang = searchParams.get("dict_lang") || "";


### PR DESCRIPTION
## 背景

Umami 30 天数据显示 CBETA 编号直搜是 power user 真实行为：
- `T0278` 40 次/月、`T0235` 等其它编号亦有命中
- 配合 `金刚经`(906)/`心经`(303) 等关键词查询

输入编号的用户已经知道想读哪部经，现在却被先丢进结果列表再点一次链接。

## 改动

### Backend
- `GET /api/cbeta/{cbeta_id}` → `{text_id, cbeta_id, redirect_to}`
- 正则 `^[TXJBPC]\d{1,4}[a-z]?$`（覆盖 T/X/J/B/P/C 大正藏-嘉兴等系列 + 可选小写后缀如 `T0236a`）
- 同一 `cbeta_id` 若未来出现重复，按 `id ASC LIMIT 1` 返回最早收录的那条
- 404 / 不合法编号走静默路径，前端 fallback 常规搜索

### Frontend
- `getCbetaRedirect(q)` helper（仿 `getSearchSuggestions` 写法），404 静默
- `SearchPage` 顶部 `useEffect` 检测 query 命中正则，命中即 `navigate(redirect_to, { replace: true })`
- 命中时触发 Umami 事件 `cbeta-shortcut`，方便后续验证 power user 行为是否被加速

## 不影响

- 非 CBETA 编号查询（金刚经/心经/Diamond Sutra）走原搜索路径
- nginx / SPA 路由不动
- search/search_unified 后端 / SearchPage 的 tabs 区域不动（与并行 unified UI PR 隔离）

## Test plan
- [ ] `/search?q=T0278` 应直跳 `/texts/{id}`
- [ ] `/search?q=t0278`（小写）也应触发跳转（前端正则带 `i` flag，后端 `.upper()` 归一）
- [ ] `/search?q=X0001a` 等带后缀 ID 命中
- [ ] `/search?q=T9999`（不存在的 CBETA）显示常规搜索结果（404 静默）
- [ ] `/search?q=金刚经` 行为不变
- [ ] Umami 后台能看到 `cbeta-shortcut` 事件计数

🤖 Generated with [Claude Code](https://claude.com/claude-code)