### PR TITLE
feat(search): unified "全部" tab as default landing

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -451,7 +451,7 @@ export interface UnifiedSearchSection {
     url: string;
   }> | null;
   catalog?: { total: number; results: SearchHit[] } | null;
-  content?: unknown;
+  content?: { total: number; total_juans?: number; results: ContentSearchHit[] } | null;
   semantic?: { total: number; results: SemanticSearchHit[] } | null;
 }
 

--- a/frontend/src/components/search/UnifiedResults.tsx
+++ b/frontend/src/components/search/UnifiedResults.tsx
@@ -1,0 +1,178 @@
+import { Link } from "react-router-dom";
+import { Empty } from "antd";
+import type { UnifiedSearchResponse } from "../../api/client";
+import ResultCard from "./ResultCard";
+import ContentCard from "./ContentCard";
+import SemanticCard from "./SemanticCard";
+
+interface Props {
+  data: UnifiedSearchResponse;
+}
+
+/**
+ * Unified search results — sectioned overview combining dictionary entries,
+ * catalog hits, hot Q&A, and content/semantic snippets in a single view.
+ *
+ * Sections render in importance order; empty sections are hidden.
+ * Used by SearchPage's "全部 / All" tab (default landing tab).
+ */
+export default function UnifiedResults({ data }: Props) {
+  const sections = data.sections;
+
+  const dictionary = sections.dictionary ?? [];
+  const hotQuestions = sections.hot_questions ?? [];
+  const catalogResults = sections.catalog?.results ?? [];
+  const contentResults = sections.content?.results ?? [];
+  const semanticResults = sections.semantic?.results ?? [];
+
+  // Cross-display content + semantic, dedup by text_id
+  const seenTextIds = new Set<number | string>();
+  const mergedSnippets: Array<
+    | { kind: "content"; hit: (typeof contentResults)[number]; key: string }
+    | { kind: "semantic"; hit: (typeof semanticResults)[number]; key: string }
+  > = [];
+  for (const hit of contentResults.slice(0, 3)) {
+    if (seenTextIds.has(hit.text_id)) continue;
+    seenTextIds.add(hit.text_id);
+    mergedSnippets.push({ kind: "content", hit, key: `c-${hit.text_id}` });
+  }
+  for (const hit of semanticResults.slice(0, 3)) {
+    if (seenTextIds.has(hit.text_id)) continue;
+    seenTextIds.add(hit.text_id);
+    mergedSnippets.push({ kind: "semantic", hit, key: `s-${hit.text_id}-${hit.juan_num}` });
+  }
+
+  const hasAny =
+    dictionary.length > 0 ||
+    catalogResults.length > 0 ||
+    hotQuestions.length > 0 ||
+    mergedSnippets.length > 0;
+
+  if (!hasAny) {
+    return (
+      <div style={{ marginTop: 32 }}>
+        <Empty description={`未找到「${data.query}」的相关结果`} />
+      </div>
+    );
+  }
+
+  const sectionTitleStyle: React.CSSProperties = {
+    margin: "24px 0 12px",
+    fontSize: 15,
+    fontWeight: 600,
+    color: "#5b4a32",
+    borderBottom: "1px solid #e8e0d4",
+    paddingBottom: 6,
+  };
+
+  return (
+    <div className="s-unified">
+      {/* 词典释义 */}
+      {dictionary.length > 0 && (
+        <section className="s-unified-section">
+          <h3 style={sectionTitleStyle}>{"🔤"} 词典释义</h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            {dictionary.map((entry) => (
+              <Link
+                key={entry.id}
+                to={`/dict/${encodeURIComponent(entry.headword)}`}
+                style={{
+                  display: "block",
+                  padding: "10px 14px",
+                  background: "var(--fj-sand-light, #faf7f2)",
+                  border: "1px solid #e8e0d4",
+                  borderRadius: 6,
+                  color: "inherit",
+                  textDecoration: "none",
+                }}
+              >
+                <div style={{ fontSize: 15, fontWeight: 600, color: "#3d2f1a" }}>
+                  {entry.headword}
+                  {entry.reading && (
+                    <span style={{ fontSize: 13, color: "#9a8e7a", fontWeight: 400, marginLeft: 8 }}>
+                      [{entry.reading}]
+                    </span>
+                  )}
+                </div>
+                <div style={{ fontSize: 13, color: "#5b4a32", marginTop: 4, lineHeight: 1.6 }}>
+                  {entry.definition.length > 200
+                    ? entry.definition.slice(0, 200) + "…"
+                    : entry.definition}
+                </div>
+                {entry.source && (
+                  <div style={{ fontSize: 12, color: "#9a8e7a", marginTop: 4 }}>
+                    出处：{entry.source}
+                  </div>
+                )}
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* 经文标题 */}
+      {catalogResults.length > 0 && (
+        <section className="s-unified-section">
+          <h3 style={sectionTitleStyle}>{"📖"} 经文标题</h3>
+          {catalogResults.slice(0, 5).map((hit, i) => (
+            <ResultCard key={hit.id} hit={hit} rank={i + 1} />
+          ))}
+        </section>
+      )}
+
+      {/* 相关问答 */}
+      {hotQuestions.length > 0 && (
+        <section className="s-unified-section">
+          <h3 style={sectionTitleStyle}>{"💡"} 相关问答</h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {hotQuestions.map((q) => (
+              <Link
+                key={q.slug}
+                to={q.url.startsWith("/") ? q.url : `/${q.url}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "10px 14px",
+                  background: "#fff",
+                  border: "1px solid #e8e0d4",
+                  borderRadius: 6,
+                  color: "inherit",
+                  textDecoration: "none",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "#9a8e7a",
+                    background: "var(--fj-sand-light, #faf7f2)",
+                    padding: "2px 8px",
+                    borderRadius: 4,
+                    flexShrink: 0,
+                  }}
+                >
+                  {q.category}
+                </span>
+                <span style={{ fontSize: 14, color: "#3d2f1a" }}>{q.text}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* 经文内文片段 */}
+      {mergedSnippets.length > 0 && (
+        <section className="s-unified-section">
+          <h3 style={sectionTitleStyle}>{"🔍"} 经文内文片段</h3>
+          {mergedSnippets.map((item, i) =>
+            item.kind === "content" ? (
+              <ContentCard key={item.key} hit={item.hit} rank={i + 1} />
+            ) : (
+              <SemanticCard key={item.key} hit={item.hit} rank={i + 1} />
+            )
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/search/index.ts
+++ b/frontend/src/components/search/index.ts
@@ -4,3 +4,4 @@ export { default as DictCard } from "./DictCard";
 export { default as ContentCard } from "./ContentCard";
 export { default as CrossLangCard } from "./CrossLangCard";
 export { default as SemanticCard } from "./SemanticCard";
+export { default as UnifiedResults } from "./UnifiedResults";

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -9,11 +9,11 @@ import {
 import {
   SearchOutlined, VerticalAlignTopOutlined, CloseOutlined,
 } from "@ant-design/icons";
-import { searchTexts, searchContent, searchDictionary, searchCrossLanguage, searchSemantic, getSources, getSearchSuggestions, searchDictionaryGrouped } from "../api/client";
+import { searchTexts, searchContent, searchDictionary, searchCrossLanguage, searchSemantic, searchUnified, getSources, getSearchSuggestions, searchDictionaryGrouped } from "../api/client";
 import type { DictGroupedSearchResponse } from "../api/client";
 import { hasDirectSearchUrl } from "../utils/sourceUrls";
 import { addSearchHistory, getSearchHistory, type SearchHistoryItem } from "../utils/history";
-import { ResultCard, ExternalCard, DictCard, ContentCard, CrossLangCard, SemanticCard } from "../components/search";
+import { ResultCard, ExternalCard, DictCard, ContentCard, CrossLangCard, SemanticCard, UnifiedResults } from "../components/search";
 import "../styles/search.css";
 import "../styles/sources.css";
 
@@ -21,9 +21,11 @@ export default function SearchPage() {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Derive state from URL — these are the source of truth
+  // Derive state from URL — these are the source of truth.
+  // Default tab is "all" (unified overview); legacy aliases still resolve to
+  // their canonical tab so old links keep working.
   const query = searchParams.get("q") ?? "";
-  const rawTab = searchParams.get("tab") ?? "catalog";
+  const rawTab = searchParams.get("tab") ?? "all";
   const tab = rawTab === "crosslang" ? "catalog" : rawTab === "semantic" ? "content" : rawTab === "dictionary" ? "catalog" : rawTab;
   const selectedSources = searchParams.get("sources") ?? "";
 
@@ -118,6 +120,15 @@ export default function SearchPage() {
     queryKey: ["searchSemantic", query, selectedSources, langFilter, dynasty, category],
     queryFn: () => searchSemantic({ q: query, size: 20, dynasty, category, lang: langFilter || undefined, sources: selectedSources || undefined }),
     enabled: query.length > 0 && tab === "content",
+  });
+
+  // Unified search powers the default "全部 / All" tab — single round trip
+  // to /search/unified returns sectioned results (dictionary, hot_questions,
+  // catalog, content, semantic) so the user no longer has to pick a tab.
+  const { data: unifiedData, isLoading: unifiedLoading, isError: unifiedError, refetch: refetchUnified } = useQuery({
+    queryKey: ["searchUnified", query, selectedSources, langFilter],
+    queryFn: () => searchUnified({ q: query, sources: selectedSources || undefined, lang: langFilter || undefined }),
+    enabled: query.length > 0 && tab === "all",
   });
 
   // Dictionary knowledge card (parallel, non-blocking)
@@ -302,13 +313,16 @@ export default function SearchPage() {
           activeKey={tab}
           onChange={(k) => { setPage(1); updateUrl({ tab: k }); }}
           items={[
+            { key: "all", label: "全部" },
             { key: "catalog", label: "搜经典" },
             { key: "content", label: "搜经文" },
           ]}
           size="small"
         />
         <div className="s-mode-hint">
-          {tab === "catalog"
+          {tab === "all"
+            ? "一站式综合检索：词典释义、经文标题、相关问答、内文片段一次呈现"
+            : tab === "catalog"
             ? "按经名、译者、编号检索，自动匹配所有语种标题与翻译版本"
             : tab === "content"
             ? "AI 语义理解 + 关键词精确匹配，在 34.7 万段经文中检索"
@@ -369,6 +383,45 @@ export default function SearchPage() {
 
           {/* 主内容 */}
           <main className="s-main">
+            {tab === "all" ? (
+              <>
+                {unifiedLoading && (
+                  <div style={{ marginTop: 16 }}>
+                    {Array.from({ length: 4 }).map((_, i) => (
+                      <div className="s-card" key={`skel-all-${i}`}>
+                        <div className="s-card-body">
+                          <Skeleton.Input active size="small" style={{ width: 200, height: 18, marginBottom: 8 }} />
+                          <Skeleton active paragraph={{ rows: 2 }} title={false} />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {!unifiedLoading && unifiedError && (
+                  <Result
+                    status="error"
+                    title="搜索失败"
+                    subTitle="搜索服务暂时不可用，请稍后重试。"
+                    extra={<Button type="primary" onClick={() => refetchUnified()}>重试</Button>}
+                  />
+                )}
+                {!unifiedLoading && !unifiedError && unifiedData && (
+                  <UnifiedResults data={unifiedData} />
+                )}
+                {/* 外部数据源结果 */}
+                {!unifiedLoading && !unifiedError && query.length > 0 && filteredExtSources.length > 0 && (
+                  <>
+                    <div className="s-ext-divider">
+                      以下 {extTotal} 个外部数据源可继续搜索「{query}」
+                    </div>
+                    {filteredExtSources.map((s, i) => (
+                      <ExternalCard key={s.code} source={s} query={query} rank={i + 1} />
+                    ))}
+                  </>
+                )}
+              </>
+            ) : (
+            <>
             <div className="s-result-header">
               <span className="s-result-count">
                 {tab === "dictionary"
@@ -590,6 +643,8 @@ export default function SearchPage() {
                     rank={i + 1} />
                 ))}
               </>
+            )}
+            </>
             )}
           </main>
         </div>


### PR DESCRIPTION
## Summary

接入 PR #553 后端的 `/api/search/unified` 端点，给 `/search` 页加默认 tab **"全部"**，一次请求拿到 dictionary / hot_questions / catalog / content / semantic 五段结果，sectioned 渲染。用户不再需要在 4 个 tab 之间切换猜哪个。

- 新组件 `<UnifiedResults>` 按 importance 渲染 4 个 section：
  - 🔤 词典释义（dictionary，点击跳 `/dict/{headword}`）
  - 📖 经文标题（catalog 前 5 条，复用 `ResultCard`）
  - 💡 相关问答（hot_questions，点击跳 `/chat?q=...`）
  - 🔍 经文内文片段（content 前 3 + semantic 前 3，by text_id 去重）
- 默认 tab `?tab` 不指定时进入 `all`
- 现有 `catalog` / `content` tab 完全保留，"all" 是叠加不是替换
- legacy `?tab=crosslang|semantic|dictionary` 继续工作
- 顺手把 `UnifiedSearchSection.content` 从 `unknown` 收紧为 `{ total; total_juans?; results: ContentSearchHit[] } | null`

## 背景

`/search` PV 3,585/月（站内 #2 入口），原先用户每次输入跑 3-4 个并发查询，看到 catalog/content/dictionary/external 4 个 tab 不知道选哪个。统一 tab 一次返回，降低 tab 选择困惑。

## Test plan

- [ ] `/search?q=般若` 默认进 "全部" tab，4 个 section 都显示
- [ ] 点击词典条目 → `/dict/{headword}`
- [ ] 点击相关问答 → `/chat?q=...`
- [ ] 切到 "搜经典" tab 行为完全不变
- [ ] 切到 "搜经文" tab 行为完全不变
- [ ] `?tab=catalog` 老链接直接进入 "搜经典"
- [ ] `?tab=dictionary` 老链接静默 fallback 到 "搜经典"（保持原行为）
- [ ] 空搜索词不触发请求
- [ ] tsc --noEmit 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)