### PR TITLE
feat(chat): 模型下拉只保留每家最新旗舰

### DIFF
--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -17,7 +17,7 @@ class ChatRequest(BaseModel):
     # the LLM for the matching hot-question prompt template, keeping the
     # natural display_text in history/RAG.
     hot_question_id: int | None = None
-    # Per-message model override — id from llm_catalog.CATALOG (e.g. "deepseek:v4-flash").
+    # Per-message model override — id from llm_catalog.CATALOG (e.g. "deepseek:v4-pro").
     # Unknown ids fall back gracefully so stale localStorage doesn't break chat.
     model_id: str | None = None
     # File attachments uploaded via POST /chat/attachments. The service

--- a/backend/app/services/llm_catalog.py
+++ b/backend/app/services/llm_catalog.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class ModelOption:
-    id: str           # stable key sent from frontend (e.g. "deepseek:v4-flash")
+    id: str           # stable key sent from frontend (e.g. "deepseek:v4-pro")
     provider: str     # matches PROVIDER_URLS keys in chat.py
     model: str        # actual API model id
     label: str        # display name for dropdown
@@ -22,23 +22,18 @@ class ModelOption:
 
 
 # Order matters — first entry is the default when no localStorage value exists.
+# 每个模型商只保留最新的一个旗舰模型。
 CATALOG: list[ModelOption] = [
-    ModelOption("deepseek:v4-flash", "deepseek", "deepseek-v4-flash",
-                "DeepSeek V4 Flash", "经济快速，日常问答", False),
     ModelOption("deepseek:v4-pro", "deepseek", "deepseek-v4-pro",
                 "DeepSeek V4 Pro", "旗舰模型，复杂推理", False),
     ModelOption("dashscope:qwen3.6-plus", "dashscope", "qwen3.6-plus",
                 "通义千问 Qwen3.6 Plus", "阿里最新文本旗舰", False),
-    ModelOption("dashscope:qwen3-vl-flash", "dashscope", "qwen3-vl-flash-2026-01-22",
-                "通义千问 Qwen3-VL Flash", "支持图片识别（PR-C 启用）", True),
     ModelOption("moonshot:kimi-k2.6", "moonshot", "kimi-k2.6",
-                "Kimi K2.6", "Moonshot 原生多模态，支持图片", True),
+                "Kimi K2.6", "Moonshot 最新旗舰", False),
     ModelOption("zhipu:glm-5.1", "zhipu", "glm-5.1",
                 "智谱 GLM-5.1", "744B 参数，编码与推理强", False),
-    ModelOption("zhipu:glm-4.6v", "zhipu", "glm-4.6v",
-                "智谱 GLM-4.6V", "智谱视觉模型，支持图片", True),
 ]
 
 CATALOG_BY_ID = {opt.id: opt for opt in CATALOG}
 
-DEFAULT_MODEL_ID = "deepseek:v4-flash"
+DEFAULT_MODEL_ID = "deepseek:v4-pro"

--- a/backend/tests/test_llm_catalog.py
+++ b/backend/tests/test_llm_catalog.py
@@ -40,7 +40,7 @@ def test_resolve_with_no_model_id_falls_back_to_default(monkeypatch):
     """No model_id → behave exactly like _resolve_llm_config(user)."""
     monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
     monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
-    monkeypatch.setattr(chat_module.settings, "llm_model", "deepseek-v4-flash")
+    monkeypatch.setattr(chat_module.settings, "llm_model", "deepseek-v4-pro")
 
     assert _resolve_with_model_override(None, None) == _resolve_llm_config(None)
 
@@ -49,7 +49,7 @@ def test_resolve_with_unknown_model_id_falls_back_gracefully(monkeypatch):
     """Stale localStorage id must not 400 — fall back to default."""
     monkeypatch.setattr(chat_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
     monkeypatch.setattr(chat_module.settings, "llm_api_key", "platform-key")
-    monkeypatch.setattr(chat_module.settings, "llm_model", "deepseek-v4-flash")
+    monkeypatch.setattr(chat_module.settings, "llm_model", "deepseek-v4-pro")
 
     result = _resolve_with_model_override(None, "vendor:nonsense-model")
     assert result == _resolve_llm_config(None)
@@ -114,10 +114,10 @@ def test_resolve_byok_provider_mismatch_falls_to_platform(monkeypatch):
     user.api_provider = "moonshot"
 
     url, key, model, is_byok, provider = _resolve_with_model_override(
-        user, "deepseek:v4-flash"
+        user, "deepseek:v4-pro"
     )
     assert url == PROVIDER_URLS["deepseek"]
     assert key == "platform-key"
-    assert model == "deepseek-v4-flash"
+    assert model == "deepseek-v4-pro"
     assert is_byok is False
     assert provider == "deepseek"

--- a/frontend/src/components/ChatModelSelector.tsx
+++ b/frontend/src/components/ChatModelSelector.tsx
@@ -24,9 +24,9 @@ interface ChatModelSelectorProps {
 
 const FALLBACK_OPTIONS: ChatModelOption[] = [
   {
-    id: "deepseek:v4-flash",
+    id: "deepseek:v4-pro",
     provider: "deepseek",
-    label: "DeepSeek V4 Flash",
+    label: "DeepSeek V4 Pro",
     description: "默认模型",
     vision: false,
     available: true,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -259,8 +259,8 @@ export default function ChatPage() {
   const [input, setInput] = useState("");
   const [masterId, setMasterId] = useState<string | null>(null);
   const [modelId, setModelId] = useState<string>(() => {
-    if (typeof window === "undefined") return "deepseek:v4-flash";
-    return window.localStorage.getItem("fojin.chat.modelId") || "deepseek:v4-flash";
+    if (typeof window === "undefined") return "deepseek:v4-pro";
+    return window.localStorage.getItem("fojin.chat.modelId") || "deepseek:v4-pro";
   });
   const handleModelChange = useCallback((id: string) => {
     setModelId(id);
@@ -700,7 +700,7 @@ export default function ChatPage() {
       // pick the platform default for whatever LLM_API_URL is configured —
       // important for non-deepseek deployments where forcing a deepseek
       // catalog id would otherwise raise.
-      modelId: modelId === "deepseek:v4-flash" ? null : modelId,
+      modelId: modelId === "deepseek:v4-pro" ? null : modelId,
       attachmentIds: attachmentIdsForSend.length ? attachmentIdsForSend : null,
     });
   }, [sending, sessionId, masterId, modelId, user, attachments, refetchSessions, refetchQuota, queryClient]);


### PR DESCRIPTION
## Summary
- AI 问答模型下拉简化为每家一个最新旗舰：DeepSeek V4 Pro / Qwen3.6 Plus / Kimi K2.6 / GLM-5.1
- 默认模型从 deepseek:v4-flash 改为 deepseek:v4-pro
- 移除 vision 变体（qwen3-vl-flash、glm-4.6v）；PR-C 尚未启用，BYOK 仍可自填

## Test plan
- [x] backend/tests/test_llm_catalog.py 9 passed
- [x] ChatModelSelector 已有 stale-id 自动回填逻辑（111–114 行），旧 localStorage 值会平滑迁移
- [ ] 部署后访问 fojin.app/chat 验证下拉只显示 4 项

🤖 Generated with [Claude Code](https://claude.com/claude-code)