### PR TITLE
fix(xml-parser): 提取 <item>，修复章疏/科文类典籍正文丢失

### DIFF
--- a/backend/app/core/xml_parser.py
+++ b/backend/app/core/xml_parser.py
@@ -27,6 +27,7 @@ CONTENT_TAGS = {
     f"{{{TEI_NS}}}p",
     f"{{{TEI_NS}}}l",       # verse line
     f"{{{TEI_NS}}}head",
+    f"{{{TEI_NS}}}item",    # list entries — catalog/科文 texts (T2178-2182, X "科" series) are entirely <list><item>
 }
 
 # Elements to skip entirely (including their children)

--- a/backend/tests/test_xml_parser.py
+++ b/backend/tests/test_xml_parser.py
@@ -1,0 +1,71 @@
+"""Tests for CBETA TEI XML parser, especially catalog-style texts."""
+
+from app.core.xml_parser import parse_tei_xml
+
+
+CATALOG_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:cb="http://www.cbeta.org/ns/1.0">
+<teiHeader><fileDesc><titleStmt><title>Test catalog</title></titleStmt>
+<publicationStmt><p>x</p></publicationStmt>
+<sourceDesc><bibl>x</bibl></sourceDesc></fileDesc></teiHeader>
+<text><body>
+<milestone n="1" unit="juan"/>
+<cb:div type="other">
+<byline cb:type="author">延曆寺玄日大法師奉　聖王勅錄上</byline>
+<list rend="no-marker">
+<item><title>法華玄義十卷</title><note place="inline">天台智者大師說</note></item>
+<item><title>法華玄義釋籤十卷</title><note place="inline">荊谿湛然大師述</note></item>
+<item><title>法華玄義科文一卷</title><note place="inline">湛然述</note></item>
+</list>
+<p>百八十一部六百四十二卷。</p>
+</cb:div>
+</body></text></TEI>
+"""
+
+
+PARAGRAPH_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:cb="http://www.cbeta.org/ns/1.0">
+<teiHeader><fileDesc><titleStmt><title>x</title></titleStmt>
+<publicationStmt><p>x</p></publicationStmt>
+<sourceDesc><bibl>x</bibl></sourceDesc></fileDesc></teiHeader>
+<text><body>
+<milestone n="1" unit="juan"/>
+<p>如是我聞。一時佛在舍衛國。</p>
+<p>祇樹給孤獨園。與大比丘眾。</p>
+</body></text></TEI>
+"""
+
+
+def _write(tmp_path, xml: str):
+    p = tmp_path / "t.xml"
+    p.write_text(xml, encoding="utf-8")
+    return p
+
+
+def test_catalog_items_are_extracted(tmp_path):
+    """Catalog-style texts (T2178, X "科" series) use <list>/<item>/<title>.
+    Parser must extract those titles, not just byline + trailing <p>.
+    """
+    juans = parse_tei_xml(_write(tmp_path, CATALOG_XML))
+    assert len(juans) == 1
+    content = juans[0]["content"]
+    assert "法華玄義十卷" in content
+    assert "法華玄義釋籤十卷" in content
+    assert "法華玄義科文一卷" in content
+    assert "延曆寺玄日大法師奉" in content  # byline still works
+    assert "百八十一部六百四十二卷" in content  # trailing <p> still works
+    # <note> inside <item> stays in SKIP_TAGS — the fix relies on this contract.
+    assert "天台智者大師說" not in content
+    assert "荊谿湛然大師述" not in content
+    # Pre-fix: char_count was 32 (byline + trailing <p> only).
+    # After fix: 3 titles add ~22 chars on top.
+    assert juans[0]["char_count"] >= 48
+
+
+def test_paragraphs_still_extracted(tmp_path):
+    """Regression guard: regular <p> text still works."""
+    juans = parse_tei_xml(_write(tmp_path, PARAGRAPH_XML))
+    assert len(juans) == 1
+    content = juans[0]["content"]
+    assert "如是我聞" in content
+    assert "祇樹給孤獨園" in content


### PR DESCRIPTION
## 问题

线上 fojin.app/texts/8320/read《天台宗章疏》(T2178) 显示空白，只剩 32 字 byline + 结尾一句。

## 根因

CBETA 章疏/科文类典籍正文几乎全由 \`<list><item><title>条目</title><note>作者</note></item></list>\` 组成（T2178 1507 个 \`<lb>\` / 65 个 \`<item>\`，X0290 740 个 \`<item>\` / 168 个 \`<list>\`、只 4 个 \`<p>\`）。

原 \`xml_parser.CONTENT_TAGS = {p, l, head}\` 不识别 \`<item>\`：

- T2178: 32 字（byline + 结尾 \`<p>\`）
- T2181: 35 字
- X0290: 8 字

## 影响范围

\`has_content=true AND content_char_count<100\` 共 51 部。其中章疏五兄弟 T2178-2182、卍续藏 X 系列科文（X0290/X0463/X0349/X0644/X0993/...）几乎全部受影响。

陀罗尼短经（T1316/T1328/T1329/T1382）、Toh 藏译目录条目可能本就如此，需单独核对。

## 修复

\`CONTENT_TAGS\` 加入 \`<item>\`。\`<list>\` 走原 fallback 递归即可。

\`<note>\` 仍在 SKIP_TAGS（保持现状，目录条目暂时丢失作者注，后续可按 cb:type 区分）。

## 验证

- 单元测试：\`tests/test_xml_parser.py\` (catalog + paragraph 回归)
- 真实 T2178 XML 解析：32 → 1141 字

## 部署后

在 prod 上对受影响典籍批量 re-import：

\`\`\`sql
SELECT cbeta_id FROM buddhist_texts
WHERE has_content=true AND content_char_count<100
ORDER BY content_char_count;
\`\`\`

挑出章疏/科文类（排除 Toh/陀罗尼短经），用 \`import_content.py --work <ID>\` 重导，并 sync ES。

## Test plan

- [ ] CI pytest 通过
- [ ] 部署到 prod 后 re-import T2178 验证 fojin.app/texts/8320/read 正常显示目录条目
- [ ] 批量 re-import 章疏/科文清单 + ES sync