### PR TITLE
feat(admin): add admin audit log + fix daily-active-users metric

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -17,7 +17,7 @@ from app.models import (  # noqa: F401
     KGEntity, KGRelation, IIIFManifest,
     TextEmbedding, ChatSession, ChatMessage,
     Annotation, AnnotationReview,
-    DictionaryEntry,
+    DictionaryEntry, AdminAuditLog,
 )
 
 config = context.config

--- a/backend/alembic/versions/0135_add_admin_audit_log.py
+++ b/backend/alembic/versions/0135_add_admin_audit_log.py
@@ -1,0 +1,67 @@
+"""Add admin_audit_log table.
+
+Records every state-changing admin action so role changes and account
+bans/unbans are attributable. Until now ``PATCH /admin/users/{id}`` mutated
+a user's role / is_active with no trace of who did it or when — a hard gap
+for a user-management backend.
+
+Why columns:
+
+- ``actor_id`` nullable + ON DELETE SET NULL: the audit row must outlive the
+  admin account; if that admin is ever deleted we keep the trail and only
+  drop the link (same rationale as chat_attachments.user_id).
+- ``target_type`` / ``target_id``: generic so the log can later cover
+  non-user targets (sources, annotations) without a schema change.
+- ``detail`` JSON: carries the before→after diff, e.g.
+  {"role": {"from": "user", "to": "reviewer"}}.
+
+Append-only: application code only ever INSERTs. Indexes mirror the read
+patterns — by actor and by created_at (the audit view is time-ordered).
+
+Revision ID: 0135
+Revises: 0134
+Create Date: 2026-05-15
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0135"
+down_revision = "0134"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admin_audit_log",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "actor_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("action", sa.String(50), nullable=False),
+        sa.Column("target_type", sa.String(30), nullable=False),
+        sa.Column("target_id", sa.Integer(), nullable=True),
+        sa.Column("detail", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_admin_audit_log_actor_id", "admin_audit_log", ["actor_id"]
+    )
+    op.create_index(
+        "ix_admin_audit_log_created_at", "admin_audit_log", ["created_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_admin_audit_log_created_at", table_name="admin_audit_log")
+    op.drop_index("ix_admin_audit_log_actor_id", table_name="admin_audit_log")
+    op.drop_table("admin_audit_log")

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.role_guard import require_role
@@ -6,13 +7,21 @@ from app.database import get_db
 from app.models.user import User
 from app.schemas.admin import (
     AdminAnnotationListResponse,
+    AdminAuditLogListResponse,
     AdminOverview,
     AdminTrends,
     AdminUserItem,
     AdminUserListResponse,
     AdminUserUpdate,
 )
-from app.services.admin_service import get_overview, get_trends, list_annotations_for_review, list_users
+from app.services.admin_service import (
+    get_overview,
+    get_trends,
+    list_annotations_for_review,
+    list_audit_log,
+    list_users,
+    record_audit,
+)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -64,16 +73,28 @@ async def update_user(
             detail="不能修改自己的角色或状态",
         )
 
-    from sqlalchemy import select
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="用户不存在")
 
-    if payload.role is not None:
+    changes: dict = {}
+    if payload.role is not None and payload.role != user.role:
+        changes["role"] = {"from": user.role, "to": payload.role}
         user.role = payload.role
-    if payload.is_active is not None:
+    if payload.is_active is not None and payload.is_active != user.is_active:
+        changes["is_active"] = {"from": user.is_active, "to": payload.is_active}
         user.is_active = payload.is_active
+
+    if changes:
+        record_audit(
+            db,
+            actor_id=current_user.id,
+            action="update_user",
+            target_type="user",
+            target_id=user.id,
+            detail=changes,
+        )
     await db.commit()
     await db.refresh(user)
     return user
@@ -88,4 +109,16 @@ async def annotation_list(
     db: AsyncSession = Depends(get_db),
 ):
     total, items = await list_annotations_for_review(db, page, size, status)
+    return {"total": total, "page": page, "size": size, "items": items}
+
+
+@router.get("/audit-log", response_model=AdminAuditLogListResponse)
+async def audit_log_list(
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    action: str | None = Query(None),
+    _user=Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+):
+    total, items = await list_audit_log(db, page, size, action)
     return {"total": total, "page": page, "size": size, "items": items}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.annotation import Annotation, AnnotationReview
+from app.models.audit import AdminAuditLog
 from app.models.chat import ChatAttachment, ChatMessage, ChatSession, TextEmbedding
 from app.models.dictionary import DictionaryEntry
 from app.models.feed import AcademicFeed, SourceUpdate
@@ -12,6 +13,7 @@ from app.models.user import Bookmark, ReadingHistory, User
 
 __all__ = [
     "AcademicFeed",
+    "AdminAuditLog",
     "Annotation",
     "AnnotationReview",
     "Bookmark",

--- a/backend/app/models/audit.py
+++ b/backend/app/models/audit.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class AdminAuditLog(Base):
+    """One row per state-changing admin action.
+
+    Append-only: application code never updates or deletes rows. ``actor_id``
+    is SET NULL on user deletion so the trail survives even if the admin
+    account is later removed.
+    """
+
+    __tablename__ = "admin_audit_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    actor_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    action: Mapped[str] = mapped_column(String(50))
+    target_type: Mapped[str] = mapped_column(String(30))
+    target_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    detail: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -73,3 +73,21 @@ class AdminAnnotationListResponse(BaseModel):
     page: int
     size: int
     items: list[AdminAnnotationItem]
+
+
+class AdminAuditLogItem(BaseModel):
+    id: int
+    actor_id: int | None
+    actor_username: str | None
+    action: str
+    target_type: str
+    target_id: int | None
+    detail: dict | None
+    created_at: datetime
+
+
+class AdminAuditLogListResponse(BaseModel):
+    total: int
+    page: int
+    size: int
+    items: list[AdminAuditLogItem]

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -7,10 +7,16 @@ from sqlalchemy import Date, and_, case, cast, distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.annotation import Annotation
+from app.models.audit import AdminAuditLog
 from app.models.chat import ChatMessage, ChatSession
 from app.models.source import SourceSuggestion
 from app.models.user import ReadingHistory, User
-from app.schemas.admin import AdminAnnotationItem, AdminOverview, DailyCount
+from app.schemas.admin import (
+    AdminAnnotationItem,
+    AdminAuditLogItem,
+    AdminOverview,
+    DailyCount,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -173,13 +179,27 @@ async def _daily_counts(
 async def _daily_active_users(
     db: AsyncSession, since: datetime, date_grid: list[date]
 ) -> list[DailyCount]:
-    """Active users = distinct users who sent chat messages OR read texts each day."""
-    chat_day = _local_day(ChatSession.created_at)
+    """Active users = distinct users who sent a chat message OR read a text each day.
+
+    Chat activity keys off ``ChatMessage.created_at`` (joined to ChatSession for
+    the owner), NOT ``ChatSession.created_at``. A user replying inside a session
+    opened on an earlier day is active on the day they send the message — keying
+    off session creation would miss every follow-up turn in an existing session.
+    Only ``role='user'`` messages count, since an assistant reply is not the
+    user doing something.
+    """
+    chat_day = _local_day(ChatMessage.created_at)
     read_day = _local_day(ReadingHistory.last_read_at)
 
     chat_q = (
         select(chat_day.label("day"), ChatSession.user_id.label("uid"))
-        .where(ChatSession.created_at >= since, ChatSession.user_id.is_not(None))
+        .select_from(ChatMessage)
+        .join(ChatSession, ChatMessage.session_id == ChatSession.id)
+        .where(
+            ChatMessage.created_at >= since,
+            ChatMessage.role == "user",
+            ChatSession.user_id.is_not(None),
+        )
     )
     read_q = (
         select(read_day.label("day"), ReadingHistory.user_id.label("uid"))
@@ -257,4 +277,69 @@ async def list_annotations_for_review(
             status=ann.status,
             created_at=ann.created_at,
         ))
+    return total, items
+
+
+def record_audit(
+    db: AsyncSession,
+    actor_id: int | None,
+    action: str,
+    target_type: str,
+    target_id: int | None = None,
+    detail: dict | None = None,
+) -> None:
+    """Stage an audit-log row in the caller's transaction.
+
+    Deliberately does NOT commit: the caller commits the audited mutation and
+    this row together, so a change can never land without its trail (and a
+    failed audit insert rolls the mutation back).
+    """
+    db.add(
+        AdminAuditLog(
+            actor_id=actor_id,
+            action=action,
+            target_type=target_type,
+            target_id=target_id,
+            detail=detail,
+        )
+    )
+
+
+async def list_audit_log(
+    db: AsyncSession,
+    page: int = 1,
+    size: int = 20,
+    action: str | None = None,
+) -> tuple[int, list[AdminAuditLogItem]]:
+    base = select(AdminAuditLog, User.username).outerjoin(
+        User, AdminAuditLog.actor_id == User.id
+    )
+    count_base = select(func.count()).select_from(AdminAuditLog)
+
+    if action:
+        base = base.where(AdminAuditLog.action == action)
+        count_base = count_base.where(AdminAuditLog.action == action)
+
+    total = (await db.execute(count_base)).scalar_one()
+
+    query = (
+        base.order_by(AdminAuditLog.created_at.desc())
+        .offset((page - 1) * size)
+        .limit(size)
+    )
+    result = await db.execute(query)
+
+    items = [
+        AdminAuditLogItem(
+            id=row.id,
+            actor_id=row.actor_id,
+            actor_username=username,
+            action=row.action,
+            target_type=row.target_type,
+            target_id=row.target_id,
+            detail=row.detail,
+            created_at=row.created_at,
+        )
+        for row, username in result.all()
+    ]
     return total, items

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -72,3 +72,24 @@ async def test_annotations_list_requires_admin(client):
     """GET /admin/annotations without auth returns 401."""
     resp = await client.get("/api/admin/annotations")
     assert resp.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+async def test_audit_log_requires_admin(client):
+    """GET /admin/audit-log without auth returns 401."""
+    resp = await client.get("/api/admin/audit-log")
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+async def test_audit_log_non_admin(client):
+    """GET /admin/audit-log as regular user returns 403."""
+    fake_user = _fake_user(role="user")
+    from app.main import app
+    from app.core.deps import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    try:
+        resp = await client.get("/api/admin/audit-log")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)


### PR DESCRIPTION
## Summary

修复用户管理后台的两个准确性/问责缺口。

### 1. 管理操作审计日志
`PATCH /admin/users/{id}` 此前能改用户角色、封禁/解封，但**完全没有记录谁、何时、对谁做了什么**——用户管理后台缺审计日志是硬伤。

- 新增 append-only 表 `admin_audit_log`（migration 0135），含 actor / action / target / before→after diff
- `record_audit()` 把审计行**暂存在调用方的事务里**（自身不 commit），与被审计的变更同一事务提交——变更绝不会无痕落地，审计失败则变更一并回滚
- `update_user` 接线：仅在字段**实际变化**时写审计行（无操作 PATCH 不写）
- 新增 `GET /admin/audit-log`，分页 + 按 action 过滤

### 2. 「活跃用户」口径修正
`_daily_active_users` 此前用 `ChatSession.created_at` 判定聊天活跃——用户在**几天前建的旧会话**里继续提问，不算当天活跃。改为按 `ChatMessage.created_at`（join ChatSession 取归属用户）判定，且只算 `role='user'` 消息（AI 回复不算用户行为）。

## 实现说明

- migration `0135` revises `0134`；离线 SQL 渲染通过（CREATE TABLE + 2 索引）
- `AdminAuditLog` 模型已注册到 `models/__init__.py` 与 `alembic/env.py`
- `actor_id` FK `ON DELETE SET NULL`——审计行须比管理员账号存活更久
- 已过独立代码审核（Ready to merge: Yes，无 Critical/Important）

## 注意

- 「活跃用户」历史曲线的聊天侧数字会有轻微不连续——这是修正生效的预期结果，非缺陷。
- 本 PR 为后端切片：审计数据已捕获且可经 API 查询。后台前端的「审计日志」查看页可作为后续 PR。

## Test plan

- [x] 7 个 admin 测试通过（含 2 个新增的 audit-log 权限守卫测试）
- [x] alembic 链完整性 + 离线 SQL 渲染
- [x] app import 检查（路由 `/admin/audit-log` 注册成功）
- [x] 独立代码审核
- [ ] 部署后冒烟：改一次用户角色 → `GET /admin/audit-log` 应出现对应记录

🤖 Generated with [Claude Code](https://claude.com/claude-code)