### PR TITLE
feat(admin): cache /stats/trends; extend audit log to suggestion review

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -43,7 +43,10 @@ async def stats_trends(
     _user=Depends(require_role("admin")),
     db: AsyncSession = Depends(get_db),
 ):
-    return AdminTrends(**(await get_trends(db, days)))
+    from app.main import app
+
+    redis = getattr(app.state, "redis", None)
+    return AdminTrends(**(await get_trends(db, days, redis)))
 
 
 @router.get("/users", response_model=AdminUserListResponse)

--- a/backend/app/api/source_suggestions.py
+++ b/backend/app/api/source_suggestions.py
@@ -13,6 +13,7 @@ from app.database import get_db
 from app.models.notification import Notification
 from app.models.source import DataSource, SourceSuggestion
 from app.models.user import User
+from app.services.admin_service import record_audit
 
 router = APIRouter(prefix="/source-suggestions", tags=["source-suggestions"])
 
@@ -103,7 +104,7 @@ async def list_source_suggestions(
 @router.delete("/{suggestion_id}", status_code=204)
 async def delete_source_suggestion(
     suggestion_id: int,
-    _user=Depends(require_role("admin")),
+    current_user: User = Depends(require_role("admin")),
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(
@@ -112,6 +113,14 @@ async def delete_source_suggestion(
     suggestion = result.scalar_one_or_none()
     if not suggestion:
         raise SuggestionNotFoundError()
+    record_audit(
+        db,
+        actor_id=current_user.id,
+        action="delete_suggestion",
+        target_type="source_suggestion",
+        target_id=suggestion.id,
+        detail={"name": suggestion.name, "url": suggestion.url},
+    )
     await db.delete(suggestion)
     await db.commit()
 
@@ -120,7 +129,7 @@ async def delete_source_suggestion(
 async def update_suggestion_status(
     suggestion_id: int,
     payload: StatusUpdate,
-    _user=Depends(require_role("admin")),
+    current_user: User = Depends(require_role("admin")),
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(
@@ -136,6 +145,16 @@ async def update_suggestion_status(
     # Auto-create DataSource when accepted
     if payload.status == "accepted" and old_status != "accepted":
         await _create_data_source(db, suggestion)
+
+    if payload.status != old_status:
+        record_audit(
+            db,
+            actor_id=current_user.id,
+            action="update_suggestion",
+            target_type="source_suggestion",
+            target_id=suggestion.id,
+            detail={"status": {"from": old_status, "to": payload.status}},
+        )
 
     # Notify the submitting user if they exist
     if suggestion.user_id and payload.status in ("accepted", "rejected"):

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -21,6 +21,7 @@ from app.schemas.admin import (
 logger = logging.getLogger(__name__)
 
 OVERVIEW_CACHE_KEY = "admin:stats:overview"
+TRENDS_CACHE_KEY_PREFIX = "admin:stats:trends:"  # full key appends the days window
 OVERVIEW_CACHE_TTL = 300  # 5 minutes
 
 # Server, ops team, and end users all live in CST. created_at columns are stored
@@ -129,7 +130,12 @@ async def _cache_set(redis, key: str, value: dict, ttl: int = OVERVIEW_CACHE_TTL
         logger.debug("Cache set error for key=%s", key)
 
 
-async def get_trends(db: AsyncSession, days: int = 30) -> dict:
+async def get_trends(db: AsyncSession, days: int = 30, redis=None) -> dict:
+    cache_key = f"{TRENDS_CACHE_KEY_PREFIX}{days}"
+    cached = await _cache_get(redis, cache_key)
+    if cached is not None:
+        return cached
+
     today = _local_today()
     since = today - timedelta(days=days - 1)
     since_dt = _local_midnight_utc(since)
@@ -139,11 +145,15 @@ async def get_trends(db: AsyncSession, days: int = 30) -> dict:
     messages = await _daily_counts(db, ChatMessage, ChatMessage.created_at, since_dt, date_grid)
     active_users = await _daily_active_users(db, since_dt, date_grid)
 
-    return {
-        "registrations": registrations,
-        "messages": messages,
-        "active_users": active_users,
+    # Stored as plain dicts so the Redis JSON round-trip is lossless;
+    # AdminTrends(**result) coerces them back into DailyCount either way.
+    result = {
+        "registrations": [d.model_dump() for d in registrations],
+        "messages": [d.model_dump() for d in messages],
+        "active_users": [d.model_dump() for d in active_users],
     }
+    await _cache_set(redis, cache_key, result)
+    return result
 
 
 def _fill_missing_days(rows: dict[date, int], date_grid: list[date]) -> list[DailyCount]:


### PR DESCRIPTION
## Summary

后台优化清单的两个后续小改进，主题一致——补全后台的性能与可观测性。

### 1. `/admin/stats/trends` 加缓存
`get_overview` 早有 5 分钟 Redis 缓存，但更重的 `get_trends`（3 个按日计数查询 + 一个 union 算活跃用户，窗口最大 365 天）每次开后台都全量重算。现按 `admin:stats:trends:{days}` 缓存，TTL 同为 300s。趋势数据以纯 dict 返回，JSON 往返无损，`AdminTrends(**result)` 在命中/未命中两条路径都成立。

### 2. 审计日志延伸到建议审核
migration 0135 建了 `admin_audit_log`，但只有 `update_user` 写入。采纳/拒绝/删除数据源建议同样是改状态的管理操作——现在 `update_suggestion_status` 和 `delete_source_suggestion` 也调 `record_audit`，审计覆盖所有管理变更，不只用户编辑。

## 实现说明

- 缓存逻辑完全对齐 `get_overview`（同 `_cache_get`/`_cache_set` 辅助、同 TTL、`redis is None` 优雅降级）
- per-`days` 缓存键，1–365 窗口无碰撞
- `record_audit` 暂存在调用方事务内——审计行与变更原子提交
- `update_suggestion_status` 仅在状态实际变化时写审计行
- 已过独立代码审核（Ready to merge: Yes，无 Critical/Important）

## 说明（澄清前次的误判）

我此前提到「pending_suggestions 有数字没处理入口」是**错的**——建议审核的完整 API（列表/采纳/拒绝/删除）一直在独立 router `/source-suggestions` 下，功能齐全。本 PR 只是给它补审计，不是补功能。

## Test plan

- [x] 7 个 admin 测试通过
- [x] app import 检查（`get_trends` 新签名、路由完整）
- [x] 独立代码审核
- [ ] 部署后冒烟：连开两次 `/admin/stats/trends` 第二次走缓存；审一条建议后 `/admin/audit-log` 出现记录

🤖 Generated with [Claude Code](https://claude.com/claude-code)