### PR TITLE
feat(admin): readable trend charts + audit log viewer page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -16,6 +16,7 @@
   "nav.admin_suggestions": "Suggestions",
   "nav.admin_annotations": "Annotations",
   "nav.admin_feedbacks": "Feedbacks",
+  "nav.admin_audit_log": "Audit Log",
   "nav.drawer_title": "Navigation",
   "nav.skip_to_content": "Skip to main content",
   "nav.open_menu": "Open navigation menu",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -16,6 +16,7 @@
   "nav.admin_suggestions": "源建議",
   "nav.admin_annotations": "標註稽核",
   "nav.admin_feedbacks": "使用者反饋",
+  "nav.admin_audit_log": "稽核日誌",
   "nav.drawer_title": "導航",
   "nav.skip_to_content": "跳至主要內容",
   "nav.open_menu": "開啟導航選單",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -16,6 +16,7 @@
   "nav.admin_suggestions": "源建议",
   "nav.admin_annotations": "标注审核",
   "nav.admin_feedbacks": "用户反馈",
+  "nav.admin_audit_log": "审计日志",
   "nav.drawer_title": "导航",
   "nav.skip_to_content": "跳至主要内容",
   "nav.open_menu": "打开导航菜单",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ const AdminDashboardPage = lazy(() => import("./pages/AdminDashboardPage"));
 const AdminUsersPage = lazy(() => import("./pages/AdminUsersPage"));
 const AdminAnnotationsPage = lazy(() => import("./pages/AdminAnnotationsPage"));
 const AdminFeedbacksPage = lazy(() => import("./pages/AdminFeedbacksPage"));
+const AdminAuditLogPage = lazy(() => import("./pages/AdminAuditLogPage"));
 const NotFoundPage = lazy(() => import("./pages/NotFoundPage"));
 const TimelinePage = lazy(() => import("./pages/TimelinePage"));
 const DashboardPage = lazy(() => import("./pages/DashboardPage"));
@@ -82,6 +83,7 @@ function App() {
               <Route path="/admin/suggestions" element={<AdminSuggestionsPage />} />
               <Route path="/admin/annotations" element={<AdminAnnotationsPage />} />
               <Route path="/admin/feedbacks" element={<AdminFeedbacksPage />} />
+              <Route path="/admin/audit-log" element={<AdminAuditLogPage />} />
             </Route>
             <Route path="/parallel/:textId" element={<ParallelReaderPage />} />
             <Route path="/kg" element={<RouteErrorBoundary><KnowledgeGraphPage /></RouteErrorBoundary>} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1070,6 +1070,26 @@ export async function getAdminAnnotations(params: {
   return data;
 }
 
+export interface AdminAuditLogItem {
+  id: number;
+  actor_id: number | null;
+  actor_username: string | null;
+  action: string;
+  target_type: string;
+  target_id: number | null;
+  detail: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export async function getAdminAuditLog(params: {
+  page?: number;
+  size?: number;
+  action?: string;
+}): Promise<PaginatedResponse<AdminAuditLogItem>> {
+  const { data } = await api.get<PaginatedResponse<AdminAuditLogItem>>("/admin/audit-log", { params });
+  return data;
+}
+
 // --- Similar Passages ---
 
 export interface SimilarPassageItem {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -95,6 +95,7 @@ export default function Layout() {
               { label: t("nav.admin_suggestions"), path: "/admin/suggestions" },
               { label: t("nav.admin_annotations"), path: "/admin/annotations" },
               { label: t("nav.admin_feedbacks"), path: "/admin/feedbacks" },
+              { label: t("nav.admin_audit_log"), path: "/admin/audit-log" },
             ],
           },
         ]

--- a/frontend/src/pages/AdminAuditLogPage.tsx
+++ b/frontend/src/pages/AdminAuditLogPage.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState, useCallback } from "react";
+import { Table, Tag, Select, Typography, message } from "antd";
+import { Helmet } from "react-helmet-async";
+import { getAdminAuditLog, type AdminAuditLogItem } from "../api/client";
+
+const actionLabel: Record<string, string> = {
+  update_user: "用户变更",
+  update_suggestion: "建议审核",
+  delete_suggestion: "删除建议",
+};
+
+const actionColor: Record<string, string> = {
+  update_user: "blue",
+  update_suggestion: "green",
+  delete_suggestion: "red",
+};
+
+const fieldLabel: Record<string, string> = {
+  role: "角色",
+  is_active: "账号状态",
+  status: "状态",
+  name: "名称",
+  url: "链接",
+};
+
+function renderValue(v: unknown): string {
+  if (v === true) return "启用";
+  if (v === false) return "停用";
+  if (v === null || v === undefined) return "—";
+  return String(v);
+}
+
+function renderDetail(detail: Record<string, unknown> | null) {
+  if (!detail || Object.keys(detail).length === 0) return <span style={{ color: "#999" }}>—</span>;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {Object.entries(detail).map(([key, value]) => {
+        const label = fieldLabel[key] || key;
+        if (value && typeof value === "object" && "from" in value && "to" in value) {
+          const diff = value as { from: unknown; to: unknown };
+          return (
+            <span key={key} style={{ fontSize: 13 }}>
+              {label}：<span style={{ color: "#999" }}>{renderValue(diff.from)}</span>
+              {" → "}
+              <span style={{ color: "#1677ff" }}>{renderValue(diff.to)}</span>
+            </span>
+          );
+        }
+        return (
+          <span key={key} style={{ fontSize: 13 }}>
+            {label}：{renderValue(value)}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function AdminAuditLogPage() {
+  const [items, setItems] = useState<AdminAuditLogItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [actionFilter, setActionFilter] = useState<string | undefined>(undefined);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getAdminAuditLog({ page, size: 20, action: actionFilter });
+      setItems(res.items);
+      setTotal(res.total);
+    } catch {
+      message.error("加载审计日志失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [page, actionFilter]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const columns = [
+    {
+      title: "时间",
+      dataIndex: "created_at",
+      width: 170,
+      render: (t: string) => new Date(t).toLocaleString("zh-CN", { hour12: false }),
+    },
+    {
+      title: "操作人",
+      dataIndex: "actor_username",
+      width: 130,
+      render: (name: string | null) => name || <span style={{ color: "#999" }}>已删除用户</span>,
+    },
+    {
+      title: "动作",
+      dataIndex: "action",
+      width: 110,
+      render: (a: string) => <Tag color={actionColor[a]}>{actionLabel[a] || a}</Tag>,
+    },
+    {
+      title: "对象",
+      width: 150,
+      render: (_: unknown, record: AdminAuditLogItem) =>
+        record.target_id != null ? `${record.target_type} #${record.target_id}` : record.target_type,
+    },
+    {
+      title: "变更详情",
+      dataIndex: "detail",
+      render: (detail: Record<string, unknown> | null) => renderDetail(detail),
+    },
+  ];
+
+  return (
+    <>
+      <Helmet>
+        <title>审计日志 - 佛津</title>
+      </Helmet>
+      <div style={{ maxWidth: 1200, margin: "0 auto" }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 16,
+          }}
+        >
+          <Typography.Title level={4} style={{ margin: 0 }}>
+            审计日志
+          </Typography.Title>
+          <Select
+            style={{ width: 160 }}
+            placeholder="筛选动作"
+            allowClear
+            value={actionFilter}
+            onChange={(v) => {
+              setActionFilter(v);
+              setPage(1);
+            }}
+            options={[
+              { value: "update_user", label: "用户变更" },
+              { value: "update_suggestion", label: "建议审核" },
+              { value: "delete_suggestion", label: "删除建议" },
+            ]}
+          />
+        </div>
+        <Table
+          rowKey="id"
+          columns={columns}
+          dataSource={items}
+          loading={loading}
+          pagination={{
+            current: page,
+            total,
+            pageSize: 20,
+            onChange: setPage,
+            showTotal: (t) => `共 ${t} 条`,
+          }}
+          size="middle"
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -81,7 +81,6 @@ function MiniTrend({ title, data, color }: { title: string; data: DailyCount[]; 
         smooth
         height={200}
         style={{ stroke: color }}
-        axis={{ x: { labelAutoHide: true, labelAutoRotate: false } }}
       />
     </div>
   );

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -19,6 +19,7 @@ import {
   getAdminOverview,
   getAdminTrends,
   type AdminOverview,
+  type DailyCount,
 } from "../api/client";
 import { getPlatformActivity } from "../api/feed";
 
@@ -65,6 +66,27 @@ function PendingCard({ overview }: { overview: AdminOverview }) {
   );
 }
 
+function MiniTrend({ title, data, color }: { title: string; data: DailyCount[]; color: string }) {
+  const peak = data.reduce((m, d) => Math.max(m, d.count), 0);
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4 }}>
+        <Text type="secondary" style={{ fontSize: 13 }}>{title}</Text>
+        <Text type="secondary" style={{ fontSize: 12 }}>峰值 {peak}</Text>
+      </div>
+      <Line
+        data={data}
+        xField="date"
+        yField="count"
+        smooth
+        height={200}
+        style={{ stroke: color }}
+        axis={{ x: { labelAutoHide: true, labelAutoRotate: false } }}
+      />
+    </div>
+  );
+}
+
 export default function AdminDashboardPage() {
   const overviewQuery = useQuery({
     queryKey: ["adminOverview"],
@@ -96,24 +118,6 @@ export default function AdminDashboardPage() {
 
   const overview = overviewQuery.data!;
   const trends = trendsQuery.data!;
-
-  const chartData = [
-    ...trends.registrations.map((d) => ({ ...d, type: "新注册" })),
-    ...trends.messages.map((d) => ({ ...d, type: "消息数" })),
-    ...trends.active_users.map((d) => ({ ...d, type: "活跃用户" })),
-  ];
-
-  const lineConfig = {
-    data: chartData,
-    xField: "date",
-    yField: "count",
-    colorField: "type",
-    smooth: true,
-    height: 360,
-    axis: {
-      x: { labelAutoRotate: false },
-    },
-  };
 
   const lastUpdated = overview.last_updated
     ? new Date(overview.last_updated).toLocaleString("zh-CN", { hour12: false })
@@ -181,7 +185,19 @@ export default function AdminDashboardPage() {
           style={{ marginTop: 16 }}
           extra={<Text type="secondary" style={{ fontSize: 12 }}>更新于 {lastUpdated}</Text>}
         >
-          <Line {...lineConfig} />
+          {/* Three separately-scaled charts: a shared Y axis would squash
+              新注册/消息数 (single digits) against 活跃用户 (hundreds). */}
+          <Row gutter={[16, 16]}>
+            <Col xs={24} md={8}>
+              <MiniTrend title="新注册" data={trends.registrations} color="#1677ff" />
+            </Col>
+            <Col xs={24} md={8}>
+              <MiniTrend title="消息数" data={trends.messages} color="#fa8c16" />
+            </Col>
+            <Col xs={24} md={8}>
+              <MiniTrend title="活跃用户" data={trends.active_users} color="#13c2c2" />
+            </Col>
+          </Row>
         </Card>
 
         <PlatformActivityCard />


### PR DESCRIPTION
## Summary

后台优化清单的两个前端项——把前面做的后端工作在 UI 上呈现出来。

### 1. 趋势图可读性
「最近 30 天趋势」原来把 新注册 / 消息数 / 活跃用户 三条线画在**同一个 Y 轴**——活跃用户在几十到几百量级，另外两条只有个位数，结果后两条几乎贴地看不出趋势（用户截图里就是这个问题）。改为 **3 个独立缩放的小图**（small multiples），每个按自身数据自动缩放并显示峰值。

### 2. 审计日志查看页
新增 `/admin/audit-log` 页面，把 migration 0135 建的 `admin_audit_log` 表在 UI 上呈现——此前审计数据只采集、可经 API 查但后台看不到。表格显示 时间 / 操作人 / 动作 / 对象，并内联渲染 before→after 变更详情，可按动作筛选。已接入路由、后台导航菜单、zh/zh-Hant/en 三语。

## 实现说明

- 趋势图弃用 DualAxes（v2 的 children API 版本敏感），选 small multiples——`<Line>` 组件已验证可用，零新 API 风险
- 审计页完全沿用 `AdminAnnotationsPage` 的模式（分页、loading、Table）
- `renderDetail` 覆盖后端所有 detail 形态（role/is_active/status 的 from→to、name/url、null）
- 已过独立前端代码审核（Ready to merge: Yes，无 Critical/Important）；审核指出的无效 axis 配置已在后续 commit 移除

## 验证

- `tsc --noEmit` 通过
- `npm run build` 成功
- 注：未做浏览器实测（admin 页在 admin 角色守卫后，需登录态）。建议合并部署后在 fojin.app/admin 用你的管理员账号实看一眼三个小图与审计页。

## Test plan

- [x] TypeScript 类型检查
- [x] 生产 build
- [x] 独立前端代码审核
- [ ] 部署后：fojin.app/admin 看趋势图 3 小图渲染正常；改一次用户角色后 `/admin/audit-log` 出现记录

🤖 Generated with [Claude Code](https://claude.com/claude-code)