### PR TITLE
feat(sources): data-source health monitoring cron + UI badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Data-source health monitoring. `scripts/health_check_sources.py` probes every active source's `base_url` and records a `health_status` verdict (`ok` / `degraded` / `cert_invalid` / `unreachable` / `moved`) plus `health_checked_at`. The Sources page now shows a warning badge on cards whose source has moved, is unreachable, has an invalid TLS certificate, or returns HTTP errors — healthy sources stay unbadged. Designed to run from cron; busts the sources-list cache on completion so the UI reflects new verdicts within one TTL. Builds on the `health_status` column added in migration 0132.
+
 ### Changed
 - Default DeepSeek model alias `deepseek-chat` → `deepseek-v4-flash` (legacy ID still works as alias). Production `LLM_MODEL` upgraded to `deepseek-v4-pro` to leverage 75% promotional pricing through 2026-05-31; revisit before promo ends to avoid 4× cost increase.
 - Updated `build_alignments.py` price table with `deepseek-v4-flash` ($0.28/1M output) and `deepseek-v4-pro` ($0.87/1M output, promo).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- Data-source health monitoring. `scripts/health_check_sources.py` probes every active source's `base_url` and records a `health_status` verdict (`ok` / `degraded` / `cert_invalid` / `unreachable` / `moved`) plus `health_checked_at`. The Sources page now shows a warning badge on cards whose source has moved, is unreachable, has an invalid TLS certificate, or returns HTTP errors — healthy sources stay unbadged. Designed to run from cron; busts the sources-list cache on completion so the UI reflects new verdicts within one TTL. Builds on the `health_status` column added in migration 0132.
+- Data-source health monitoring. `scripts/health_check_sources.py` probes every active source's `base_url` and records a `health_status` verdict (`ok` / `degraded` / `cert_invalid` / `unreachable` / `moved`) plus `health_checked_at`. The Sources page now shows a warning badge on cards whose source has moved, is unreachable, has an invalid TLS certificate, or returns HTTP errors — healthy sources stay unbadged. Redirects are followed by hand with a per-hop public-IP check so a hijacked source URL cannot turn the cron into an SSRF against internal services. Designed to run from cron; busts the sources-list cache after writing so a stale verdict survives at most one cache TTL. Builds on the `health_status` column added in migration 0132.
 
 ### Changed
 - Default DeepSeek model alias `deepseek-chat` → `deepseek-v4-flash` (legacy ID still works as alias). Production `LLM_MODEL` upgraded to `deepseek-v4-pro` to leverage 75% promotional pricing through 2026-05-31; revisit before promo ends to avoid 4× cost increase.

--- a/backend/app/services/source_health.py
+++ b/backend/app/services/source_health.py
@@ -1,0 +1,82 @@
+"""Health-state classification for external data sources.
+
+外部数据源的健康状态分类逻辑。
+
+`health_status` (column on ``data_sources``) is the cron-updated reachability
+signal, independent of ``is_active`` (which is editorial removal). This module
+holds the pure classification logic so it can be unit-tested without network
+or DB; the probing/IO lives in ``scripts/health_check_sources.py``.
+
+Valid statuses: ok | degraded | cert_invalid | unreachable | moved
+"""
+
+from urllib.parse import urlsplit
+
+# Probe error kinds the caller may report. Anything that is not a clean HTTP
+# response with a status code falls into one of these.
+SSL_ERROR = "ssl"
+
+VALID_STATUSES = frozenset({"ok", "degraded", "cert_invalid", "unreachable", "moved"})
+
+
+def _registrable_host(url: str | None) -> str:
+    """Return a normalised host for same-site comparison.
+
+    Lower-cased, leading ``www.`` stripped. Returns ``""`` when the URL has no
+    host (so two host-less URLs never compare equal to a real host)."""
+    if not url:
+        return ""
+    host = (urlsplit(url).hostname or "").lower()
+    return host[4:] if host.startswith("www.") else host
+
+
+def _is_moved(requested_url: str, final_url: str | None) -> bool:
+    """True when a redirect landed on a different registrable host.
+
+    Path-only redirects, http→https upgrades and www-prefix changes are *not*
+    moves — sites reorganise constantly and those are not actionable."""
+    if not final_url:
+        return False
+    src = _registrable_host(requested_url)
+    dst = _registrable_host(final_url)
+    return bool(src) and bool(dst) and src != dst
+
+
+def classify_health(
+    *,
+    error: str | None,
+    status_code: int | None,
+    requested_url: str,
+    final_url: str | None,
+) -> str:
+    """Map a single probe outcome to a ``health_status`` value.
+
+    Args:
+        error: ``None`` for a clean HTTP response; otherwise the probe error
+            kind — ``"ssl"`` for a certificate failure, or any other token
+            (``"timeout"``, ``"connect"``, ``"redirect_loop"``, ``"other"``)
+            for an unreachable host.
+        status_code: final HTTP status, or ``None`` when ``error`` is set.
+        requested_url: the URL the probe started from.
+        final_url: the URL after following redirects, or ``None``.
+
+    Returns:
+        One of :data:`VALID_STATUSES`.
+    """
+    if error == SSL_ERROR:
+        return "cert_invalid"
+    if error is not None:
+        return "unreachable"
+
+    # A cross-domain redirect is the most actionable editorial signal — surface
+    # it even if the new domain itself answered with an error status.
+    if _is_moved(requested_url, final_url):
+        return "moved"
+
+    if status_code is None:
+        return "unreachable"
+    if status_code >= 500:
+        return "unreachable"
+    if status_code >= 400:
+        return "degraded"
+    return "ok"

--- a/backend/app/services/source_health.py
+++ b/backend/app/services/source_health.py
@@ -10,6 +10,8 @@ or DB; the probing/IO lives in ``scripts/health_check_sources.py``.
 Valid statuses: ok | degraded | cert_invalid | unreachable | moved
 """
 
+import ipaddress
+import socket
 from urllib.parse import urlsplit
 
 # Probe error kinds the caller may report. Anything that is not a clean HTTP
@@ -17,6 +19,42 @@ from urllib.parse import urlsplit
 SSL_ERROR = "ssl"
 
 VALID_STATUSES = frozenset({"ok", "degraded", "cert_invalid", "unreachable", "moved"})
+
+
+def _ip_is_blocked(ip: str) -> bool:
+    """True for any non-public address: private, loopback, link-local, etc.
+
+    Unparseable input is treated as blocked (fail closed)."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return True
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_reserved
+        or addr.is_unspecified
+    )
+
+
+def host_is_public(host: str | None) -> bool:
+    """True only when *every* address ``host`` resolves to is publicly routable.
+
+    The health-check cron follows redirects from admin-editable source URLs on a
+    VPS with internal network reach; without this guard a hijacked source could
+    redirect the probe at ``169.254.169.254`` (cloud metadata) or an RFC1918
+    host — an SSRF. A residual DNS-rebinding window remains between this check
+    and httpx's own connect-time resolution; acceptable for a cron over curated
+    academic sites, but noted deliberately."""
+    if not host:
+        return False
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except (socket.gaierror, UnicodeError, OSError):
+        return False
+    return bool(infos) and all(not _ip_is_blocked(info[4][0]) for info in infos)
 
 
 def _registrable_host(url: str | None) -> str:

--- a/backend/scripts/health_check_sources.py
+++ b/backend/scripts/health_check_sources.py
@@ -3,8 +3,12 @@
 巡检所有活跃数据源的可达性，将结果写入 data_sources.health_status /
 health_checked_at，并失效 sources 列表缓存。
 
-Designed to run from cron (see docs/deployment / VPS crontab). Independent of
-``is_active``: a source can be reachable-but-deprecated, or down-but-kept.
+Designed to run from cron on the deployment host. Independent of ``is_active``:
+a source can be reachable-but-deprecated, or down-but-kept.
+
+Redirects are followed manually with a per-hop public-IP check (see
+``host_is_public``) so a hijacked source URL cannot turn the probe into an
+SSRF against internal services.
 
 Usage:
     cd backend
@@ -17,6 +21,7 @@ import asyncio
 import os
 import sys
 import warnings
+from urllib.parse import urlsplit
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -28,10 +33,16 @@ from sqlalchemy.orm import sessionmaker
 
 from app.api.sources import SOURCES_LIST_CACHE_KEY
 from app.config import settings
-from app.services.source_health import SSL_ERROR, classify_health
+from app.services.source_health import (
+    SSL_ERROR,
+    VALID_STATUSES,
+    classify_health,
+    host_is_public,
+)
 
 TIMEOUT = 15  # seconds per request
 CONCURRENCY = 10  # max concurrent probes — be gentle on small academic sites
+MAX_REDIRECTS = 5  # redirect hops to follow before giving up
 USER_AGENT = "Mozilla/5.0 (compatible; FoJin-HealthCheck/1.0; +https://fojin.app)"
 
 
@@ -52,22 +63,51 @@ def _error_kind(exc: Exception) -> str:
 
 
 async def probe(client: httpx.AsyncClient, code: str, url: str | None) -> dict:
-    """Probe one source and return {code, status} where status is a health_status."""
+    """Probe one source and return {code, status} where status is a health_status.
+
+    Redirects are followed by hand (``follow_redirects=False``) so every hop's
+    host can be vetted with :func:`host_is_public` before a request is sent —
+    this is what stops a redirect chain from reaching internal services."""
     if not url or url == "None":
         # No URL to probe — leave it as-is rather than inventing a verdict.
         return {"code": code, "status": None, "detail": "no base_url"}
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https") or not parts.hostname:
+        # A malformed base_url is a config error, not a reachability verdict.
+        return {"code": code, "status": None, "detail": f"bad base_url: {url[:80]}"}
+
+    current = url
     try:
-        resp = await client.get(url, follow_redirects=True, timeout=TIMEOUT)
+        for _ in range(MAX_REDIRECTS + 1):
+            host = urlsplit(current).hostname
+            if not host_is_public(host):
+                # Internal / unresolvable target — refuse to probe it. From an
+                # editor's view the source is effectively unreachable.
+                return {
+                    "code": code,
+                    "status": "unreachable",
+                    "detail": f"blocked or unresolvable host: {host}",
+                }
+            resp = await client.get(current, follow_redirects=False, timeout=TIMEOUT)
+            if resp.is_redirect and "location" in resp.headers:
+                current = str(httpx.URL(current).join(resp.headers["location"]))
+                continue
+            status = classify_health(
+                error=None,
+                status_code=resp.status_code,
+                requested_url=url,
+                final_url=current,
+            )
+            detail = f"HTTP {resp.status_code}"
+            if current != url:
+                detail += f" -> {current}"
+            return {"code": code, "status": status, "detail": detail}
+
+        # Redirect budget exhausted.
         status = classify_health(
-            error=None,
-            status_code=resp.status_code,
-            requested_url=url,
-            final_url=str(resp.url),
+            error="redirect_loop", status_code=None, requested_url=url, final_url=None
         )
-        detail = f"HTTP {resp.status_code}"
-        if str(resp.url) != url:
-            detail += f" -> {resp.url}"
-        return {"code": code, "status": status, "detail": detail}
+        return {"code": code, "status": status, "detail": f"redirect_loop: >{MAX_REDIRECTS} hops"}
     except Exception as exc:  # every probe failure maps to a health verdict
         kind = _error_kind(exc)
         status = classify_health(error=kind, status_code=None, requested_url=url, final_url=None)
@@ -106,6 +146,13 @@ async def main(dry_run: bool) -> None:
     verdicts = [r for r in results if r["status"] is not None]
     skipped = [r for r in results if r["status"] is None]
 
+    # Guard against a logic regression writing an unknown token: classify_health
+    # only ever returns VALID_STATUSES, but a bad value would land silently in
+    # the DB (the frontend badge lookup fails open to "no badge").
+    bad = [r for r in verdicts if r["status"] not in VALID_STATUSES]
+    if bad:
+        raise SystemExit(f"ABORT: classifier produced invalid status(es): {bad}")
+
     # ---- write back ----
     changed = 0
     if not dry_run:
@@ -121,13 +168,18 @@ async def main(dry_run: bool) -> None:
                 )
                 changed += res.rowcount or 0
             await session.commit()
+        if changed != len(verdicts):
+            # A source deactivated between the SELECT and the UPDATE drops out.
+            print(f"NOTE: {len(verdicts) - changed} verdict(s) not written (source deactivated?).")
 
     await engine.dispose()
 
     # ---- bust the sources list cache so the UI badge reflects new verdicts ----
+    # delete() runs after commit() so a concurrent reader can only ever
+    # re-cache fresh data; only .delete() is used, so no decode_responses.
     if not dry_run and verdicts:
         try:
-            redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+            redis_client = aioredis.from_url(settings.redis_url)
             await redis_client.delete(SOURCES_LIST_CACHE_KEY)
             await redis_client.aclose()
             print(f"Invalidated cache key '{SOURCES_LIST_CACHE_KEY}'.")

--- a/backend/scripts/health_check_sources.py
+++ b/backend/scripts/health_check_sources.py
@@ -1,0 +1,167 @@
+"""Probe every active data source and persist its health_status.
+
+巡检所有活跃数据源的可达性，将结果写入 data_sources.health_status /
+health_checked_at，并失效 sources 列表缓存。
+
+Designed to run from cron (see docs/deployment / VPS crontab). Independent of
+``is_active``: a source can be reachable-but-deprecated, or down-but-kept.
+
+Usage:
+    cd backend
+    python scripts/health_check_sources.py            # probe + write
+    python scripts/health_check_sources.py --dry-run   # probe + report only
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+import warnings
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import httpx
+import redis.asyncio as aioredis
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.sources import SOURCES_LIST_CACHE_KEY
+from app.config import settings
+from app.services.source_health import SSL_ERROR, classify_health
+
+TIMEOUT = 15  # seconds per request
+CONCURRENCY = 10  # max concurrent probes — be gentle on small academic sites
+USER_AGENT = "Mozilla/5.0 (compatible; FoJin-HealthCheck/1.0; +https://fojin.app)"
+
+
+def _error_kind(exc: Exception) -> str:
+    """Map an httpx exception to a source_health error token."""
+    if isinstance(exc, httpx.TooManyRedirects):
+        return "redirect_loop"
+    if isinstance(exc, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(exc, httpx.ConnectError):
+        # httpx has no dedicated SSL exception; certificate failures surface as
+        # ConnectError with an SSL-flavoured message.
+        msg = str(exc).lower()
+        if "ssl" in msg or "certificate" in msg or "tls" in msg:
+            return SSL_ERROR
+        return "connect"
+    return "other"
+
+
+async def probe(client: httpx.AsyncClient, code: str, url: str | None) -> dict:
+    """Probe one source and return {code, status} where status is a health_status."""
+    if not url or url == "None":
+        # No URL to probe — leave it as-is rather than inventing a verdict.
+        return {"code": code, "status": None, "detail": "no base_url"}
+    try:
+        resp = await client.get(url, follow_redirects=True, timeout=TIMEOUT)
+        status = classify_health(
+            error=None,
+            status_code=resp.status_code,
+            requested_url=url,
+            final_url=str(resp.url),
+        )
+        detail = f"HTTP {resp.status_code}"
+        if str(resp.url) != url:
+            detail += f" -> {resp.url}"
+        return {"code": code, "status": status, "detail": detail}
+    except Exception as exc:  # every probe failure maps to a health verdict
+        kind = _error_kind(exc)
+        status = classify_health(error=kind, status_code=None, requested_url=url, final_url=None)
+        return {"code": code, "status": status, "detail": f"{kind}: {str(exc)[:120]}"}
+
+
+async def main(dry_run: bool) -> None:
+    engine = create_async_engine(settings.database_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        rows = (
+            await session.execute(
+                text(
+                    "SELECT code, base_url FROM data_sources "
+                    "WHERE is_active = true ORDER BY code"
+                )
+            )
+        ).fetchall()
+
+    print(
+        f"Health-checking {len(rows)} active sources "
+        f"(concurrency={CONCURRENCY}, timeout={TIMEOUT}s, dry_run={dry_run})...\n"
+    )
+
+    semaphore = asyncio.Semaphore(CONCURRENCY)
+    # verify=True is intentional — detecting cert_invalid is a goal of this job.
+    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, verify=True) as client:
+
+        async def bounded(code: str, url: str | None) -> dict:
+            async with semaphore:
+                return await probe(client, code, url)
+
+        results = await asyncio.gather(*(bounded(r[0], r[1]) for r in rows))
+
+    verdicts = [r for r in results if r["status"] is not None]
+    skipped = [r for r in results if r["status"] is None]
+
+    # ---- write back ----
+    changed = 0
+    if not dry_run:
+        async with async_session() as session:
+            for r in verdicts:
+                res = await session.execute(
+                    text(
+                        "UPDATE data_sources "
+                        "SET health_status = :s, health_checked_at = now() "
+                        "WHERE code = :c AND is_active = true"
+                    ),
+                    {"s": r["status"], "c": r["code"]},
+                )
+                changed += res.rowcount or 0
+            await session.commit()
+
+    await engine.dispose()
+
+    # ---- bust the sources list cache so the UI badge reflects new verdicts ----
+    if not dry_run and verdicts:
+        try:
+            redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+            await redis_client.delete(SOURCES_LIST_CACHE_KEY)
+            await redis_client.aclose()
+            print(f"Invalidated cache key '{SOURCES_LIST_CACHE_KEY}'.")
+        except Exception as exc:  # cache bust is best-effort
+            print(f"WARNING: could not invalidate sources cache: {exc}")
+
+    # ---- report ----
+    by_status: dict[str, list[dict]] = {}
+    for r in verdicts:
+        by_status.setdefault(r["status"], []).append(r)
+
+    for status in ("moved", "cert_invalid", "unreachable", "degraded", "ok"):
+        bucket = by_status.get(status, [])
+        if not bucket:
+            continue
+        print(f"{'=' * 70}\n{status.upper()} ({len(bucket)})\n{'=' * 70}")
+        for r in sorted(bucket, key=lambda x: x["code"]):
+            print(f"  {r['code']:36s} {r['detail']}")
+        print()
+
+    if skipped:
+        print(f"SKIPPED — no base_url ({len(skipped)}): {', '.join(s['code'] for s in skipped)}\n")
+
+    problems = sum(len(by_status.get(s, [])) for s in ("moved", "cert_invalid", "unreachable", "degraded"))
+    print(
+        f"SUMMARY: {len(verdicts)} probed, {len(by_status.get('ok', []))} ok, "
+        f"{problems} need attention, {len(skipped)} skipped. "
+        f"{'(dry-run, nothing written)' if dry_run else f'{changed} rows updated.'}"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Probe data-source health and persist verdicts.")
+    parser.add_argument("--dry-run", action="store_true", help="probe and report without writing")
+    args = parser.parse_args()
+    warnings.filterwarnings("ignore", message="Unverified HTTPS request")
+    asyncio.run(main(args.dry_run))

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -1,0 +1,99 @@
+"""Unit tests for data-source health classification.
+
+数据源健康状态分类的单元测试。Pure logic, no DB / network."""
+
+import pytest
+
+from app.services.source_health import classify_health
+
+HOME = "https://example.org/"
+
+
+def test_plain_2xx_same_site_is_ok():
+    assert classify_health(error=None, status_code=200, requested_url=HOME, final_url=HOME) == "ok"
+
+
+def test_redirect_within_same_host_is_ok():
+    # Sites reorganise paths; a path-only redirect is not a "move".
+    assert (
+        classify_health(
+            error=None, status_code=200, requested_url=HOME, final_url="https://example.org/welcome"
+        )
+        == "ok"
+    )
+
+
+def test_http_to_https_upgrade_is_ok():
+    assert (
+        classify_health(
+            error=None, status_code=200, requested_url="http://example.org/", final_url=HOME
+        )
+        == "ok"
+    )
+
+
+def test_www_prefix_difference_is_ok():
+    assert (
+        classify_health(
+            error=None, status_code=200, requested_url=HOME, final_url="https://www.example.org/"
+        )
+        == "ok"
+    )
+
+
+def test_redirect_to_different_domain_is_moved():
+    assert (
+        classify_health(
+            error=None, status_code=200, requested_url=HOME, final_url="https://newsite.com/"
+        )
+        == "moved"
+    )
+
+
+def test_4xx_is_degraded():
+    for code in (403, 404, 410):
+        assert (
+            classify_health(error=None, status_code=code, requested_url=HOME, final_url=HOME)
+            == "degraded"
+        )
+
+
+def test_5xx_is_unreachable():
+    for code in (500, 502, 503):
+        assert (
+            classify_health(error=None, status_code=code, requested_url=HOME, final_url=HOME)
+            == "unreachable"
+        )
+
+
+def test_ssl_error_is_cert_invalid():
+    assert (
+        classify_health(error="ssl", status_code=None, requested_url=HOME, final_url=None)
+        == "cert_invalid"
+    )
+
+
+def test_timeout_and_connect_errors_are_unreachable():
+    for err in ("timeout", "connect", "redirect_loop", "other"):
+        assert (
+            classify_health(error=err, status_code=None, requested_url=HOME, final_url=None)
+            == "unreachable"
+        )
+
+
+def test_moved_classification_ignores_error_status_codes():
+    # A cross-domain redirect that lands on a 404 is still primarily "moved":
+    # the domain change is the more actionable signal for an editor.
+    assert (
+        classify_health(
+            error=None, status_code=404, requested_url=HOME, final_url="https://newsite.com/gone"
+        )
+        == "moved"
+    )
+
+
+@pytest.mark.parametrize("status", [200, 301, 302, 399])
+def test_2xx_3xx_range_treated_as_reachable(status):
+    assert classify_health(
+        error=None, status_code=status, requested_url=HOME, final_url=HOME
+    ) == "ok"

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from app.services.source_health import classify_health
+from app.services.source_health import _ip_is_blocked, classify_health, host_is_public
 
 HOME = "https://example.org/"
 
@@ -97,3 +97,51 @@ def test_2xx_3xx_range_treated_as_reachable(status):
     assert classify_health(
         error=None, status_code=status, requested_url=HOME, final_url=HOME
     ) == "ok"
+
+
+def test_no_final_url_with_2xx_is_ok():
+    # A clean status with no final_url (no redirect observed) is not a "move".
+    assert classify_health(error=None, status_code=200, requested_url=HOME, final_url=None) == "ok"
+
+
+# ---- SSRF guard: IP / host classification ----
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "10.0.0.1",  # private
+        "192.168.1.1",  # private
+        "172.16.0.1",  # private
+        "127.0.0.1",  # loopback
+        "169.254.169.254",  # link-local (cloud metadata)
+        "0.0.0.0",  # unspecified
+        "224.0.0.1",  # multicast
+        "::1",  # IPv6 loopback
+        "fe80::1",  # IPv6 link-local
+        "not-an-ip",  # unparseable -> fail closed
+    ],
+)
+def test_ip_is_blocked_rejects_non_public(ip):
+    assert _ip_is_blocked(ip) is True
+
+
+@pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "2001:4860:4860::8888"])
+def test_ip_is_blocked_allows_public(ip):
+    assert _ip_is_blocked(ip) is False
+
+
+def test_host_is_public_rejects_loopback_and_metadata():
+    # IP literals resolve through getaddrinfo without a DNS lookup.
+    assert host_is_public("127.0.0.1") is False
+    assert host_is_public("169.254.169.254") is False
+    assert host_is_public("localhost") is False
+
+
+def test_host_is_public_allows_public_ip_literal():
+    assert host_is_public("8.8.8.8") is True
+
+
+def test_host_is_public_rejects_empty():
+    assert host_is_public(None) is False
+    assert host_is_public("") is False

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -268,6 +268,9 @@ export interface DataSource {
   supports_api: boolean;
   sort_order: number;
   is_active: boolean;
+  /** Cron-updated reachability signal; independent of is_active. */
+  health_status: "ok" | "degraded" | "cert_invalid" | "unreachable" | "moved";
+  health_checked_at: string | null;
   distributions: SourceDistribution[];
 }
 

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -6,6 +6,7 @@ import {
   LinkOutlined,
   ReadOutlined,
   SearchOutlined,
+  WarningOutlined,
 } from "@ant-design/icons";
 import type { DataSource } from "../../api/client";
 import { buildSearchUrl, getLangName } from "../../utils/sourceUrls";
@@ -15,6 +16,34 @@ interface SourceCardProps {
   source: DataSource;
   searchQuery: string;
 }
+
+// Cron-updated reachability verdicts worth surfacing to readers. "ok" shows
+// nothing — only problems get a badge, to keep healthy cards uncluttered.
+const HEALTH_BADGE: Record<
+  Exclude<DataSource["health_status"], "ok">,
+  { label: string; color: string; tip: string }
+> = {
+  degraded: {
+    label: "访问受限",
+    color: "gold",
+    tip: "原站可达，但目标页面返回错误（如 403/404）。链接可能已失效，建议核对后再访问。",
+  },
+  cert_invalid: {
+    label: "证书异常",
+    color: "orange",
+    tip: "原站 HTTPS 证书校验失败，浏览器访问时可能弹出安全警告。",
+  },
+  unreachable: {
+    label: "暂无法访问",
+    color: "red",
+    tip: "最近一次巡检时原站连接超时或被拒绝，可能为临时故障。",
+  },
+  moved: {
+    label: "站点已迁移",
+    color: "volcano",
+    tip: "原站已重定向到其他域名，原链接可能已迁移。",
+  },
+};
 
 export default function SourceCard({ source: s, searchQuery }: SourceCardProps) {
   const langs = [
@@ -38,6 +67,12 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
   // misleading users. If a source lacks a template, the button is hidden.
   const searchUrl = searchQuery ? buildSearchUrl(s.code, searchQuery) : null;
 
+  const health =
+    s.health_status && s.health_status !== "ok" ? HEALTH_BADGE[s.health_status] : null;
+  const healthCheckedAt = s.health_checked_at
+    ? new Date(s.health_checked_at).toLocaleDateString("zh-CN")
+    : null;
+
   return (
     <div className="source-card">
       <div className="source-card-top">
@@ -49,6 +84,17 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
           {s.name_en && <span className="source-card-name-en">{s.name_en}</span>}
         </div>
         <div className="source-card-badges">
+          {health && (
+            <Tooltip
+              title={
+                healthCheckedAt ? `${health.tip}（最近巡检：${healthCheckedAt}）` : health.tip
+              }
+            >
+              <Tag color={health.color} className="source-card-badge">
+                <WarningOutlined /> {health.label}
+              </Tag>
+            </Tooltip>
+          )}
           {s.has_local_fulltext && (
             <Tooltip title="正文已入库 FoJin 数据库，可在站内直接阅读、引用与全文检索">
               <Tag color="green" className="source-card-badge">


### PR DESCRIPTION
## What

P1 of source-health monitoring. Migration 0132 added `data_sources.health_status` / `health_checked_at` and even pointed at a cron in its column comment — but nothing ever wrote them, and `audit_sources.py` only printed results. This wires it up end to end.

## Changes

- **`app/services/source_health.py`** — pure `classify_health()` mapping a probe outcome to `ok|degraded|cert_invalid|unreachable|moved`. Cross-domain redirects → `moved`; path-only / `www` / `http→https` are *not* moves. Plus `host_is_public()` — the SSRF guard.
- **`scripts/health_check_sources.py`** — cron script: probes every active source's `base_url` (`verify=True`, so cert failures surface), persists the verdict + `health_checked_at`, busts the `sources:list:v2` cache. `--dry-run` supported.
- **Sources page** — `SourceCard` shows a warning badge (with tooltip + last-checked date) for non-`ok` sources; healthy cards stay unbadged.

## Security

The cron runs on the VPS with internal network reach and probes admin-editable URLs. Redirects are followed **by hand** with a per-hop `host_is_public()` check (getaddrinfo + reject private/loopback/link-local/multicast/reserved) so a hijacked source URL can't redirect the probe at `169.254.169.254` or an RFC1918 host. Residual DNS-rebinding window is documented in-code.

## Tests

31 unit tests for the classification + SSRF-guard logic — pure functions, no DB/network. `_ip_is_blocked` / `host_is_public` verified against private/loopback/metadata IPs and public IP literals.

```
31 passed in 0.03s
```

Backend full suite: 14 pre-existing failures in `test_annotations_workflow.py` + `test_smoke.py::test_kg_entity_detail` exist on `master` too — unrelated to this change. Frontend `tsc -b` clean.

## Follow-up

The crontab entry is added on the deployment host (not in-repo, consistent with other FoJin cron jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)