### PR TITLE
feat(sources): record health_detail so a moved verdict is actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Data-source health monitoring. `scripts/health_check_sources.py` probes every active source's `base_url` and records a `health_status` verdict (`ok` / `degraded` / `cert_invalid` / `unreachable` / `moved`) plus `health_checked_at`. The Sources page now shows a warning badge on cards whose source has moved, is unreachable, has an invalid TLS certificate, or returns HTTP errors — healthy sources stay unbadged. Redirects are followed by hand with a per-hop public-IP check so a hijacked source URL cannot turn the cron into an SSRF against internal services. Designed to run from cron; busts the sources-list cache after writing so a stale verdict survives at most one cache TTL. Builds on the `health_status` column added in migration 0132.
+- `data_sources.health_detail` (migration 0136) — the health check now records actionable context for the latest probe: the redirect target for a `moved` source, the failure reason otherwise. A `moved` source's badge tooltip surfaces where it relocated to, so the verdict can be acted on instead of just observed.
 
 ### Changed
 - Default DeepSeek model alias `deepseek-chat` → `deepseek-v4-flash` (legacy ID still works as alias). Production `LLM_MODEL` upgraded to `deepseek-v4-pro` to leverage 75% promotional pricing through 2026-05-31; revisit before promo ends to avoid 4× cost increase.

--- a/backend/alembic/versions/0136_add_source_health_detail.py
+++ b/backend/alembic/versions/0136_add_source_health_detail.py
@@ -1,0 +1,51 @@
+"""Add data_sources.health_detail.
+
+P1 of source-health left the health-check cron writing only a one-word verdict
+(``health_status``). A ``moved`` source therefore showed a badge with no record
+of *where* it moved — the redirect target lived in console logs and nowhere
+else, so the verdict could not be acted on.
+
+``health_detail`` carries the actionable context for the latest probe:
+
+  - moved        -> the redirect target URL
+  - cert_invalid -> the TLS failure reason
+  - unreachable  -> the failure reason (timeout / connect / DNS / HTTP 5xx)
+  - degraded     -> the HTTP status line
+  - ok           -> NULL (no detail)
+
+Nullable, no default: existing rows simply have no detail until the next cron
+pass. Set by ``scripts/health_check_sources.py`` alongside ``health_status``.
+
+Revision ID: 0136
+Revises: 0135
+Create Date: 2026-05-16
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0136"
+down_revision = "0135"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            "ALTER TABLE data_sources "
+            "ADD COLUMN IF NOT EXISTS health_detail VARCHAR(500)"
+        )
+    )
+    op.execute(
+        text(
+            "COMMENT ON COLUMN data_sources.health_detail IS "
+            "'Actionable context for the latest health probe — redirect target "
+            "for moved, failure reason otherwise, NULL when ok. "
+            "Set by scripts/health_check_sources.py.'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(text("ALTER TABLE data_sources DROP COLUMN IF EXISTS health_detail"))

--- a/backend/app/api/sources.py
+++ b/backend/app/api/sources.py
@@ -24,7 +24,7 @@ from app.services.source import (
 
 router = APIRouter(prefix="/sources", tags=["sources"])
 
-SOURCES_LIST_CACHE_KEY = "sources:list:v2"  # v2: + health_status/health_checked_at (0132)
+SOURCES_LIST_CACHE_KEY = "sources:list:v3"  # v3: + health_detail (0136)
 SOURCES_LIST_CACHE_TTL = 1800  # 30 min; data only changes on manual admin edits
 
 _sources_list_adapter = TypeAdapter(list[DataSourceResponse])

--- a/backend/app/models/source.py
+++ b/backend/app/models/source.py
@@ -32,6 +32,9 @@ class DataSource(Base):
     # removal; health_status is the cron-updated reachability signal.
     health_status: Mapped[str] = mapped_column(String(20), server_default="ok")
     health_checked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # Actionable context for the latest probe: redirect target for moved,
+    # failure reason otherwise, NULL when ok.
+    health_detail: Mapped[str | None] = mapped_column(String(500))
     # embedding column is vector(1024), managed via raw SQL; not mapped here
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/app/schemas/source.py
+++ b/backend/app/schemas/source.py
@@ -47,6 +47,7 @@ class DataSourceResponse(BaseModel):
     is_active: bool = True
     health_status: str = "ok"
     health_checked_at: datetime | None = None
+    health_detail: str | None = None
     created_at: datetime
     distributions: list[SourceDistributionResponse] = Field(default_factory=list)
 

--- a/backend/scripts/health_check_sources.py
+++ b/backend/scripts/health_check_sources.py
@@ -62,32 +62,36 @@ def _error_kind(exc: Exception) -> str:
     return "other"
 
 
+def _verdict(code: str, status: str | None, detail: str | None) -> dict:
+    """A probe result. ``detail`` is the storage-ready health_detail value:
+    the redirect target for ``moved``, the failure reason otherwise, ``None``
+    for ``ok`` (and for skipped probes, where ``status`` is also ``None``)."""
+    return {"code": code, "status": status, "detail": detail}
+
+
 async def probe(client: httpx.AsyncClient, code: str, url: str | None) -> dict:
-    """Probe one source and return {code, status} where status is a health_status.
+    """Probe one source into a {code, status, detail} verdict.
 
     Redirects are followed by hand (``follow_redirects=False``) so every hop's
     host can be vetted with :func:`host_is_public` before a request is sent —
     this is what stops a redirect chain from reaching internal services."""
     if not url or url == "None":
         # No URL to probe — leave it as-is rather than inventing a verdict.
-        return {"code": code, "status": None, "detail": "no base_url"}
+        return _verdict(code, None, "no base_url")
     parts = urlsplit(url)
     if parts.scheme not in ("http", "https") or not parts.hostname:
         # A malformed base_url is a config error, not a reachability verdict.
-        return {"code": code, "status": None, "detail": f"bad base_url: {url[:80]}"}
+        return _verdict(code, None, f"bad base_url: {url[:80]}")
 
     current = url
     try:
         for _ in range(MAX_REDIRECTS + 1):
             host = urlsplit(current).hostname
             if not host_is_public(host):
-                # Internal / unresolvable target — refuse to probe it. From an
-                # editor's view the source is effectively unreachable.
-                return {
-                    "code": code,
-                    "status": "unreachable",
-                    "detail": f"blocked or unresolvable host: {host}",
-                }
+                # Host does not resolve, or resolves to a non-public address —
+                # refuse to probe it. From an editor's view the source is
+                # effectively unreachable.
+                return _verdict(code, "unreachable", f"unresolvable or non-public host: {host}")
             resp = await client.get(current, follow_redirects=False, timeout=TIMEOUT)
             if resp.is_redirect and "location" in resp.headers:
                 current = str(httpx.URL(current).join(resp.headers["location"]))
@@ -98,20 +102,24 @@ async def probe(client: httpx.AsyncClient, code: str, url: str | None) -> dict:
                 requested_url=url,
                 final_url=current,
             )
-            detail = f"HTTP {resp.status_code}"
-            if current != url:
-                detail += f" -> {current}"
-            return {"code": code, "status": status, "detail": detail}
+            if status == "ok":
+                detail = None
+            elif status == "moved":
+                # The redirect target — the one piece of actionable context.
+                detail = current
+            else:
+                detail = f"HTTP {resp.status_code}"
+            return _verdict(code, status, detail)
 
         # Redirect budget exhausted.
         status = classify_health(
             error="redirect_loop", status_code=None, requested_url=url, final_url=None
         )
-        return {"code": code, "status": status, "detail": f"redirect_loop: >{MAX_REDIRECTS} hops"}
+        return _verdict(code, status, f"exceeded {MAX_REDIRECTS} redirect hops")
     except Exception as exc:  # every probe failure maps to a health verdict
         kind = _error_kind(exc)
         status = classify_health(error=kind, status_code=None, requested_url=url, final_url=None)
-        return {"code": code, "status": status, "detail": f"{kind}: {str(exc)[:120]}"}
+        return _verdict(code, status, f"{kind}: {str(exc)[:160]}")
 
 
 async def main(dry_run: bool) -> None:
@@ -161,10 +169,11 @@ async def main(dry_run: bool) -> None:
                 res = await session.execute(
                     text(
                         "UPDATE data_sources "
-                        "SET health_status = :s, health_checked_at = now() "
+                        "SET health_status = :s, health_checked_at = now(), "
+                        "    health_detail = :d "
                         "WHERE code = :c AND is_active = true"
                     ),
-                    {"s": r["status"], "c": r["code"]},
+                    {"s": r["status"], "d": r["detail"], "c": r["code"]},
                 )
                 changed += res.rowcount or 0
             await session.commit()
@@ -197,7 +206,7 @@ async def main(dry_run: bool) -> None:
             continue
         print(f"{'=' * 70}\n{status.upper()} ({len(bucket)})\n{'=' * 70}")
         for r in sorted(bucket, key=lambda x: x["code"]):
-            print(f"  {r['code']:36s} {r['detail']}")
+            print(f"  {r['code']:36s} {r['detail'] or ''}")
         print()
 
     if skipped:

--- a/backend/scripts/health_check_sources.py
+++ b/backend/scripts/health_check_sources.py
@@ -62,10 +62,20 @@ def _error_kind(exc: Exception) -> str:
     return "other"
 
 
+# data_sources.health_detail is VARCHAR(500); Postgres errors (not truncates)
+# on an over-long value, which would abort the whole write transaction. Cap
+# every detail at the boundary so one pathological redirect URL can't do that.
+HEALTH_DETAIL_MAXLEN = 500
+
+
 def _verdict(code: str, status: str | None, detail: str | None) -> dict:
     """A probe result. ``detail`` is the storage-ready health_detail value:
     the redirect target for ``moved``, the failure reason otherwise, ``None``
-    for ``ok`` (and for skipped probes, where ``status`` is also ``None``)."""
+    for ``ok`` (and for skipped probes, where ``status`` is also ``None``).
+
+    ``detail`` is hard-capped to the column width — see HEALTH_DETAIL_MAXLEN."""
+    if detail is not None and len(detail) > HEALTH_DETAIL_MAXLEN:
+        detail = detail[: HEALTH_DETAIL_MAXLEN - 1] + "…"
     return {"code": code, "status": status, "detail": detail}
 
 
@@ -106,6 +116,9 @@ async def probe(client: httpx.AsyncClient, code: str, url: str | None) -> dict:
                 detail = None
             elif status == "moved":
                 # The redirect target — the one piece of actionable context.
+                # Stored and shown as plain text only; if it is ever turned
+                # into an href, the scheme must be sanitised first (a source
+                # could redirect to a javascript: / data: Location).
                 detail = current
             else:
                 detail = f"HTTP {resp.status_code}"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -271,6 +271,8 @@ export interface DataSource {
   /** Cron-updated reachability signal; independent of is_active. */
   health_status: "ok" | "degraded" | "cert_invalid" | "unreachable" | "moved";
   health_checked_at: string | null;
+  /** Latest-probe context: redirect target for `moved`, failure reason otherwise, null when ok. */
+  health_detail: string | null;
   distributions: SourceDistribution[];
 }
 

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -72,6 +72,19 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
   const healthCheckedAt = s.health_checked_at
     ? new Date(s.health_checked_at).toLocaleDateString("zh-CN")
     : null;
+  // For a moved source, health_detail is the redirect target — the one piece
+  // of actionable context worth surfacing in the badge tooltip.
+  const healthTooltip = health
+    ? [
+        health.tip,
+        s.health_status === "moved" && s.health_detail
+          ? `现重定向至：${s.health_detail}`
+          : null,
+        healthCheckedAt ? `最近巡检：${healthCheckedAt}` : null,
+      ]
+        .filter(Boolean)
+        .join("\n")
+    : null;
 
   return (
     <div className="source-card">
@@ -85,11 +98,7 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
         </div>
         <div className="source-card-badges">
           {health && (
-            <Tooltip
-              title={
-                healthCheckedAt ? `${health.tip}（最近巡检：${healthCheckedAt}）` : health.tip
-              }
-            >
+            <Tooltip title={<span style={{ whiteSpace: "pre-line" }}>{healthTooltip}</span>}>
               <Tag color={health.color} className="source-card-badge">
                 <WarningOutlined /> {health.label}
               </Tag>


### PR DESCRIPTION
## What

Follow-up to #567. The health check wrote only a one-word verdict — a `moved` source got a badge but the redirect target (where it moved *to*) lived only in ephemeral console logs. The verdict could be observed but not acted on. This closes the loop.

First health-check run flagged **13 moved sources** (84000 → 84000.co, suttaworld → vob.uk.com, va-museum → vam.ac.uk, …) — exactly the case this PR makes usable.

## Changes

- **migration 0136** — `data_sources.health_detail VARCHAR(500)`, nullable. Chains `0135`; up/down idempotent.
- **`health_check_sources.py`** — each probe yields a storage-ready `detail`: redirect target for `moved`, failure reason for errors, `NULL` for `ok`. Written alongside `health_status`. Capped at the column width in `_verdict()` so an over-long redirect URL can't abort the write transaction. Also reworded the host-rejection message (`blocked or unresolvable` → `unresolvable or non-public host` — pure DNS failures aren't "blocked").
- **model / schema / API** — expose `health_detail`; sources-list cache key `v2` → `v3`.
- **`SourceCard`** — a `moved` source's badge tooltip now shows `现重定向至 <url>`.

## Security

`health_detail` for a `moved` source stores a URL derived from an external `Location` header. It is rendered **as escaped text only** (React string child, never an `href` / `dangerouslySetInnerHTML`) — no XSS, no clickable hijacked link. Noted in-code that the scheme must be sanitised before this is ever turned into a link. The per-hop SSRF guard from #567 is untouched.

## Tests

Backend 411 passed (14 pre-existing failures in `test_annotations_workflow.py` + `test_smoke.py::test_kg_entity_detail` exist on `master` too). Frontend `tsc -b` clean. `_verdict` cap verified. Reviewed via independent code-review agent — flagged the VARCHAR truncation bug, fixed before push.

## Deploy note

After deploy, the stale `sources:list:v2` Redis key self-expires within its 30-min TTL (or `redis-cli del sources:list:v2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)