### PR TITLE
feat(sources): reactivate 佛书网 / 学点佛 / 无忧索引 (migration 0141)

### DIFF
--- a/backend/alembic/versions/0141_reactivate_three_chinese_sources.py
+++ b/backend/alembic/versions/0141_reactivate_three_chinese_sources.py
@@ -1,0 +1,47 @@
+"""Reactivate three Chinese sources confirmed back after a temporary outage.
+
+Migration 0138 retired four sources whose homepages were unconfigured-host
+placeholders ("Site is created successfully!"). Three of them —
+shu-fo (佛书网), xuefo (学点佛), 51shu (无忧索引) — were only temporarily
+down; the site owner has confirmed they are back with real content, so they
+return to the public catalog.
+
+The fourth from 0138, gandhari-scrolls (ebmp.org), stays retired — its domain
+was sold off, a permanent loss.
+
+health_status is deliberately left at 'cert_invalid': all three sites
+currently serve an expired TLS certificate (verified 2026-05-17). is_active
+flips them back into the catalog; the health badge keeps honestly flagging
+the cert until it is renewed. is_active and health_status are independent by
+design (see migration 0132).
+
+Revision ID: 0141
+Revises: 0140
+Create Date: 2026-05-17
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0141"
+down_revision = "0140"
+branch_labels = None
+depends_on = None
+
+RESTORED_SOURCES = ("shu-fo", "xuefo", "51shu")
+
+
+def _set_active(active: bool) -> None:
+    # RESTORED_SOURCES are fixed ASCII slugs — safe to inline, and an inline
+    # IN-list renders under `alembic --sql` offline mode (a bound list does not).
+    codes = ", ".join(f"'{c}'" for c in RESTORED_SOURCES)
+    value = "true" if active else "false"
+    op.execute(text(f"UPDATE data_sources SET is_active = {value} WHERE code IN ({codes})"))
+
+
+def upgrade() -> None:
+    _set_active(True)
+
+
+def downgrade() -> None:
+    _set_active(False)


### PR DESCRIPTION
## Summary

恢复三个**暂时下架、现已确认恢复**的中文数据源。

migration `0138` 此前一次性下架了 4 个首页为「未配置主机占位页」的源。其中三个——`shu-fo`(佛书网)、`xuefo`(学点佛)、`51shu`(无忧索引)——只是**暂时下架**，站点所有者已确认恢复了真实内容，本 migration 将它们 `is_active=true` 重新放回目录。

`gandhari-scrolls`（0138 的第 4 个，ebmp.org）**不恢复**——其域名已被出售，是永久性失效。

## 说明

- `health_status` 保留 `cert_invalid`：刚才（2026-05-17）实测三站**服务器在线但 TLS 证书过期**。按 fojin 设计（migration 0132），`is_active`（编辑性上架/下架）与 `health_status`（健康状态）相互独立——本 PR 把三站放回目录，健康徽章会如实标记证书问题，直到站点续期证书。
- migration 仅一条 `UPDATE ... SET is_active=true WHERE code IN (...)`，codes 为固定常量。

## Test plan

- [x] Python 语法 + alembic 链（0141 revises 0140，无重复 revision）
- [x] 离线 SQL 渲染通过
- [ ] 部署后：`/api/sources` 数量 +3，三站出现在 fojin.app/sources（带健康徽章）

🤖 Generated with [Claude Code](https://claude.com/claude-code)