### PR TITLE
feat(home): add 佛教地理 feature card to homepage

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -82,6 +82,8 @@
   "home.feature_collections_desc": "Browse curated Buddhist text collections by theme",
   "home.feature_dict_title": "Buddhist Dictionary",
   "home.feature_dict_desc": "Multilingual Buddhist terminology lookup and definitions",
+  "home.feature_geo_title": "Buddhist Geography",
+  "home.feature_geo_desc": "Map exploration of Buddhist figures, monasteries and places",
   "home.trust": "All data sourced from publicly available academic resources worldwide, synced regularly with automatic deduplication",
   "home.trust_link": "About our sources →",
   "footer.copyright": "FoJin © 2026 — Global Buddhist Classics Digital Resource Platform",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -82,6 +82,8 @@
   "home.feature_collections_desc": "按主題瀏覽精選佛教典籍",
   "home.feature_dict_title": "佛學辭典",
   "home.feature_dict_desc": "多語種佛學術語查詢與釋義",
+  "home.feature_geo_title": "佛教地理",
+  "home.feature_geo_desc": "佛教人物、寺院與地點的地理分佈探索",
   "home.trust": "資料來源均為全球學術機構公開資源，定期同步，自動去重",
   "home.trust_link": "瞭解資料來源 →",
   "footer.copyright": "佛津 FoJin © 2026 — 全球佛教古籍數字資源聚合平臺",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -82,6 +82,8 @@
   "home.feature_collections_desc": "按主题浏览精选佛教典籍",
   "home.feature_dict_title": "佛学辞典",
   "home.feature_dict_desc": "多语种佛学术语查询与释义",
+  "home.feature_geo_title": "佛教地理",
+  "home.feature_geo_desc": "佛教人物、寺院与地点的地理分布探索",
   "home.trust": "数据来源均为全球学术机构公开资源，定期同步，自动去重",
   "home.trust_link": "了解数据来源 →",
   "footer.copyright": "佛津 FoJin © 2026 — 全球佛教古籍数字资源聚合平台",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -11,6 +11,7 @@ import {
   RobotOutlined,
   BookOutlined,
   FileTextOutlined,
+  GlobalOutlined,
 } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { InfoCircleOutlined, CloseOutlined } from "@ant-design/icons";
@@ -177,6 +178,11 @@ export default function HomePage() {
             <ApartmentOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_kg_title")}</div>
             <div className="home-feature-desc">{t("home.feature_kg_desc")}</div>
+          </div>
+          <div className="home-feature-card" onClick={() => navigate("/map")}>
+            <GlobalOutlined className="home-feature-icon" />
+            <div className="home-feature-title">{t("home.feature_geo_title")}</div>
+            <div className="home-feature-desc">{t("home.feature_geo_desc")}</div>
           </div>
           <div className="home-feature-card" onClick={() => navigate("/collections")}>
             <BookOutlined className="home-feature-icon" />

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -546,9 +546,9 @@
 /* ---------- 功能导航卡片 ---------- */
 .home-features {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: 16px;
-  max-width: 900px;
+  max-width: 1080px;
   margin: 32px auto 0;
 }
 


### PR DESCRIPTION
## Summary

首页特性卡片区原本只有 5 张（数据源 / AI问答 / 佛学辞典 / 知识图谱 / 经典专题），漏了「佛教地理」——尽管它是站点顶层导航板块之一。本 PR 补上这张卡片，**位置在「知识图谱」之后、「经典专题」之前**，使首页卡片顺序与站点导航一致：

`数据源 → AI问答 → 佛学辞典 → 知识图谱 → 佛教地理 → 经典专题`

## 改动

- `HomePage.tsx`：在 kg 卡片与 collections 卡片之间插入 geo 卡片（`GlobalOutlined` 图标，跳转 `/map`，与导航栏 `nav.geo` 一致）
- `home.css`：`.home-features` 网格 5 列 → 6 列，`max-width` 900→1080px 保持卡片宽度不缩水；平板/手机断点本就是 2 列网格，6 张卡片自然换行
- 三语新增 `home.feature_geo_title` / `home.feature_geo_desc`

## Test plan

- [x] `tsc --noEmit` 通过
- [x] `npm run build` 成功
- [ ] 部署后 fojin.app 首页：确认 6 张卡片一行排列、佛教地理在第 5 位

🤖 Generated with [Claude Code](https://claude.com/claude-code)