### PR TITLE
fix(admin): revert trend chart to single combined 3-curve view

### DIFF
--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -19,7 +19,6 @@ import {
   getAdminOverview,
   getAdminTrends,
   type AdminOverview,
-  type DailyCount,
 } from "../api/client";
 import { getPlatformActivity } from "../api/feed";
 
@@ -66,26 +65,6 @@ function PendingCard({ overview }: { overview: AdminOverview }) {
   );
 }
 
-function MiniTrend({ title, data, color }: { title: string; data: DailyCount[]; color: string }) {
-  const peak = data.reduce((m, d) => Math.max(m, d.count), 0);
-  return (
-    <div>
-      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4 }}>
-        <Text type="secondary" style={{ fontSize: 13 }}>{title}</Text>
-        <Text type="secondary" style={{ fontSize: 12 }}>峰值 {peak}</Text>
-      </div>
-      <Line
-        data={data}
-        xField="date"
-        yField="count"
-        smooth
-        height={200}
-        style={{ stroke: color }}
-      />
-    </div>
-  );
-}
-
 export default function AdminDashboardPage() {
   const overviewQuery = useQuery({
     queryKey: ["adminOverview"],
@@ -117,6 +96,24 @@ export default function AdminDashboardPage() {
 
   const overview = overviewQuery.data!;
   const trends = trendsQuery.data!;
+
+  const chartData = [
+    ...trends.registrations.map((d) => ({ ...d, type: "新注册" })),
+    ...trends.messages.map((d) => ({ ...d, type: "消息数" })),
+    ...trends.active_users.map((d) => ({ ...d, type: "活跃用户" })),
+  ];
+
+  const lineConfig = {
+    data: chartData,
+    xField: "date",
+    yField: "count",
+    colorField: "type",
+    smooth: true,
+    height: 360,
+    axis: {
+      x: { labelAutoRotate: false },
+    },
+  };
 
   const lastUpdated = overview.last_updated
     ? new Date(overview.last_updated).toLocaleString("zh-CN", { hour12: false })
@@ -184,19 +181,7 @@ export default function AdminDashboardPage() {
           style={{ marginTop: 16 }}
           extra={<Text type="secondary" style={{ fontSize: 12 }}>更新于 {lastUpdated}</Text>}
         >
-          {/* Three separately-scaled charts: a shared Y axis would squash
-              新注册/消息数 (single digits) against 活跃用户 (hundreds). */}
-          <Row gutter={[16, 16]}>
-            <Col xs={24} md={8}>
-              <MiniTrend title="新注册" data={trends.registrations} color="#1677ff" />
-            </Col>
-            <Col xs={24} md={8}>
-              <MiniTrend title="消息数" data={trends.messages} color="#fa8c16" />
-            </Col>
-            <Col xs={24} md={8}>
-              <MiniTrend title="活跃用户" data={trends.active_users} color="#13c2c2" />
-            </Col>
-          </Row>
+          <Line {...lineConfig} />
         </Card>
 
         <PlatformActivityCard />


### PR DESCRIPTION
## Summary

PR #566 把「最近 30 天趋势」图拆成三个独立缩放的小图。用户实际查看后反馈：**原来的单图三曲线更直观清晰**——三条曲线叠在一张图上读起来更直接，且全尺寸图（height 360）的字体比拆分后的小图更大更清楚。

按用户偏好还原为原来的单个 `<Line>`（`colorField="type"`，三曲线叠加）。PR #566 的审计日志查看页不受影响。

## Test plan

- [x] `tsc --noEmit` 通过
- [x] `npm run build` 成功
- [ ] 部署后 fojin.app/admin 确认趋势图恢复为单图三曲线

🤖 Generated with [Claude Code](https://claude.com/claude-code)