### PR TITLE
fix(sources): set supports_api / supports_iiif on new sources (migration 0142)

### DIFF
--- a/backend/alembic/versions/0142_set_capability_flags_for_new_sources.py
+++ b/backend/alembic/versions/0142_set_capability_flags_for_new_sources.py
@@ -1,0 +1,75 @@
+"""Set supports_api / supports_iiif on sources added in 0133, 0134, 0141.
+
+Those three migrations inserted 39 sources but reused the 0132 column set,
+which omits supports_api / supports_iiif — so every new source defaulted to
+false on both. The /sources page capability badges (影像 / API) are computed
+live from these flags, so the counts under-reported the new museum, API and
+manuscript-imaging sources.
+
+Verified each candidate against its live site (REST API docs, IIIF manifests,
+high-res scan delivery). supports_iiif follows fojin's broad definition:
+"IIIF service OR high-resolution scanned imagery".
+
+  supports_api  (5): the five museum open-data APIs — Met, Cleveland, Harvard,
+                     Smithsonian, V&A — all ship documented machine-readable
+                     REST/JSON APIs.
+  supports_iiif (11): the five above (all serve IIIF or high-res imagery) plus
+                     rubin-museum, utsbm-tokyo, tmpv-vienna, femc-khmer,
+                     sac-manuscripts, eap791-lanten (manuscript/art scans).
+
+Left false (no evidence found): asianart-sf, ngmcp-hamburg,
+indica-buddhica-repo, webuddhist, tidl.
+
+Revision ID: 0142
+Revises: 0141
+Create Date: 2026-05-17
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0142"
+down_revision = "0141"
+branch_labels = None
+depends_on = None
+
+API_SOURCES = (
+    "met-openaccess",
+    "cleveland-art-api",
+    "harvard-art-api",
+    "si-asian-art-oa",
+    "va-museum",
+)
+
+IIIF_SOURCES = (
+    "met-openaccess",
+    "cleveland-art-api",
+    "harvard-art-api",
+    "si-asian-art-oa",
+    "va-museum",
+    "rubin-museum",
+    "utsbm-tokyo",
+    "tmpv-vienna",
+    "femc-khmer",
+    "sac-manuscripts",
+    "eap791-lanten",
+)
+
+
+def _set_flag(column: str, codes: tuple[str, ...], value: bool) -> None:
+    # codes are fixed ASCII slugs — safe to inline; an inline IN-list also
+    # renders under `alembic --sql` offline mode (a bound list does not).
+    in_list = ", ".join(f"'{c}'" for c in codes)
+    op.execute(
+        text(f"UPDATE data_sources SET {column} = {str(value).lower()} WHERE code IN ({in_list})")
+    )
+
+
+def upgrade() -> None:
+    _set_flag("supports_api", API_SOURCES, True)
+    _set_flag("supports_iiif", IIIF_SOURCES, True)
+
+
+def downgrade() -> None:
+    _set_flag("supports_api", API_SOURCES, False)
+    _set_flag("supports_iiif", IIIF_SOURCES, False)


### PR DESCRIPTION
## Summary

核查 fojin.app/sources 页面能力徽章（影像 / API 等）后发现的底层数据修正。

**结论先说**：徽章数字是从 `/api/sources` **实时计算**的（`SourcesPage.tsx` 的 `counters` useMemo），不是写死的——徽章逻辑本身无需改动。

**问题**：migration 0133/0134/0141 录入的 39 个新源沿用了 0132 的列集，**漏设 `supports_api` / `supports_iiif`**，全部默认 false。导致「影像」「API」徽章计数漏掉了新增的博物馆、API、写本影像类数据源。

## 核查与修正

逐个对照站点实情核实（REST API 文档、IIIF manifest、高清扫描影像交付）：

- **`supports_api = true`（5）**：met-openaccess、cleveland-art-api、harvard-art-api、si-asian-art-oa、va-museum —— 五大博物馆开放数据 API，均有文档化的机读 REST/JSON 接口
- **`supports_iiif = true`（11）**：上述 5 个 + rubin-museum、utsbm-tokyo、tmpv-vienna、femc-khmer、sac-manuscripts、eap791-lanten —— 提供 IIIF 或高清扫描影像（写本/艺术品）

保持 false（查无证据）：asianart-sf、ngmcp-hamburg、indica-buddhica-repo、webuddhist、tidl

## Test plan

- [x] 模型确认含 `supports_iiif` / `supports_api` 列
- [x] alembic 链（0142 revises 0141，无重复 revision）+ 离线 SQL 渲染通过
- [ ] 部署后清 Redis 缓存，fojin.app/sources 影像/API 徽章计数应相应增加

🤖 Generated with [Claude Code](https://claude.com/claude-code)