### PR TITLE
fix(chat): align AI Q&A citations to the quoted passage

### DIFF
--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -134,50 +134,51 @@ def _normalise(s: str) -> str:
     return s.lower()
 
 
-def _find_source(
+def _find_sources(
     sources: Iterable[ChatSource], title: str, juan: int | None
-) -> ChatSource | None:
-    """Locate the source whose ``title_zh`` and ``juan_num`` match.
+) -> list[ChatSource]:
+    """All retrieved chunks (and parallels) whose title/juan match the cite.
 
-    Falls back to title-only match (any juan) when the user-supplied
-    juan can't be found — the verifier's job is to check the quote
-    against *some* legitimate retrieval of that text, and the LLM
-    occasionally cites the right text with a slightly off fascicle
-    number that the citation guard already corrected.
+    RAG returns several chunks per text, and the quoted sentence is often
+    not in the first-iterated one — so the verifier must check the quote
+    against the *whole* candidate set, not a single hit. Returning the first
+    match (as the earlier ``_find_source`` did) false-flagged a legitimate
+    quote whenever it landed in a non-first retrieved chunk of the cited juan.
+
+    Exact (title + juan) matches are returned when juan is given; if none
+    match the juan, falls back to every title match (any juan) — the
+    citation guard occasionally corrects a slightly-off fascicle number.
     """
-    title_match: ChatSource | None = None
-    parallel_title_match: ChatSource | None = None
+    exact: list[ChatSource] = []
+    title_only: list[ChatSource] = []
     for s in sources:
         if s.title_zh == title:
             if juan is not None and s.juan_num == juan:
-                return s
-            if title_match is None:
-                title_match = s
+                exact.append(s)
+            else:
+                title_only.append(s)
         # Always check parallels — a Pali / Tibetan parallel arrives
         # via alignment_pairs as a child of an unrelated lzh source,
         # so the parent's title_zh is never the parallel's title.
         for p in s.parallel_chunks:
             if p.title != title:
                 continue
+            # Adapt the parallel chunk into a ChatSource-shaped carrier
+            # so the substring test reads its chunk_text.
+            carrier = ChatSource(
+                text_id=p.text_id,
+                juan_num=p.juan_num,
+                chunk_index=p.chunk_index,
+                chunk_text=p.chunk_text,
+                score=1.0,
+                title_zh=p.title,
+                lang=p.lang,
+            )
             if juan is None or p.juan_num == juan:
-                # Adapt the parallel chunk into a ChatSource-shaped
-                # carrier so the substring test reads its chunk_text.
-                return ChatSource(
-                    text_id=p.text_id,
-                    juan_num=p.juan_num,
-                    chunk_index=p.chunk_index,
-                    chunk_text=p.chunk_text,
-                    score=1.0,
-                    title_zh=p.title,
-                    lang=p.lang,
-                )
-            if parallel_title_match is None:
-                parallel_title_match = ChatSource(
-                    text_id=p.text_id, juan_num=p.juan_num,
-                    chunk_index=p.chunk_index, chunk_text=p.chunk_text,
-                    score=1.0, title_zh=p.title, lang=p.lang,
-                )
-    return title_match or parallel_title_match
+                exact.append(carrier)
+            else:
+                title_only.append(carrier)
+    return exact or title_only
 
 
 def verify_quoted_content(
@@ -207,8 +208,8 @@ def verify_quoted_content(
         if len(quote) < MIN_QUOTE_CHARS:
             continue
 
-        source = _find_source(sources, title, juan)
-        if source is None:
+        candidates = _find_sources(sources, title, juan)
+        if not candidates:
             mutations.append(
                 QuoteMutation(
                     quote=quote, title=title, juan=juan,
@@ -220,9 +221,13 @@ def verify_quoted_content(
             )
             continue
 
+        # Pass if the quote is a substring of ANY retrieved chunk for the
+        # cited text — a multi-chunk retrieval scatters the passage across
+        # several chunks of the same juan.
         normalised_quote = _normalise(quote)
-        normalised_source = _normalise(source.chunk_text)
-        if normalised_quote not in normalised_source:
+        if not any(
+            normalised_quote in _normalise(c.chunk_text) for c in candidates
+        ):
             mutations.append(
                 QuoteMutation(
                     quote=quote, title=title, juan=juan,

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -160,6 +160,21 @@ def test_parallel_chunk_quotes_are_checkable():
     assert muts == []
 
 
+def test_quote_in_non_first_retrieved_chunk_passes():
+    """RAG returns several chunks per juan. A quote living in a later
+    chunk must still verify — the verifier checks every candidate chunk,
+    not just the first-iterated one. Before the multi-chunk fix this
+    false-flagged a perfectly legitimate quote."""
+    answer = "经中说「以五事交擾，渾濁真性，故名惡世」【《阿彌陀經疏鈔》第4卷】。"
+    sources = [
+        _src(12379, "阿彌陀經疏鈔", 4, "卷四前段……与引文无关的高分内容……"),
+        _src(12379, "阿彌陀經疏鈔", 4, "……以五事交擾，渾濁真性，故名惡世……"),
+    ]
+    out, muts = verify_quoted_content(answer, sources)
+    assert muts == []
+    assert "⚠️" not in out
+
+
 def test_multiple_failing_quotes_all_annotated():
     """Two fabricated quotes in one answer must both be marked, and
     the markers must not interfere with each other (right-to-left

--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -1,15 +1,19 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 import { Button, Spin, Alert, Tabs } from "antd";
 import { BookOutlined, ArrowRightOutlined, CloseOutlined, GlobalOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { getChunkContext, getChunkAlignment, type ChunkContextItem, type ParallelPair } from "../api/client";
+import { findQuoteSpan } from "../utils/citationMatch";
 
 export interface CitationTarget {
   textId: number;
   juanNum: number;
   chunkIndex: number;
   titleZh: string;
+  /** The quoted passage, when the citation came from a 「…」 quote — lets the
+   *  drawer highlight the exact sentence inside the cited chunk. */
+  quote?: string;
 }
 
 // Map ISO language codes from alignment_pairs to display labels + font classes.
@@ -121,6 +125,47 @@ function groupByCenter(chunks: ChunkContextItem[]): CitationBlock[] {
     }
   }
   return out;
+}
+
+/**
+ * Render the 汉文 passage blocks. The center (cited) block gets the quoted
+ * sentence wrapped in <mark> and scrolled into view, so a citation lands on
+ * the exact passage rather than a ~500-char chunk the reader must scan.
+ */
+function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?: string }) {
+  const markRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    markRef.current?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, [chunks, quote]);
+
+  return (
+    <div
+      style={{
+        fontFamily: '"Noto Serif SC", "Source Han Serif", serif',
+        fontSize: 15,
+        lineHeight: 1.9,
+        color: "var(--fj-ink)",
+      }}
+    >
+      {groupByCenter(chunks).map((b) => {
+        const cls = `chat-citation-chunk${b.isCenter ? " chat-citation-chunk-center" : ""}`;
+        const span = b.isCenter && quote ? findQuoteSpan(b.text, quote) : null;
+        if (!span) {
+          return <div key={b.key} className={cls}>{b.text}</div>;
+        }
+        return (
+          <div key={b.key} className={cls}>
+            {b.text.slice(0, span[0])}
+            <mark className="chat-citation-quote-mark" ref={markRef}>
+              {b.text.slice(span[0], span[1])}
+            </mark>
+            {b.text.slice(span[1])}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 /**
@@ -252,23 +297,7 @@ export default function CitationDrawer({ target, onClose }: Props) {
                           … 前文（本卷第 {data.chunks[0]?.chunk_index ?? 0} 段之前）
                         </div>
                       )}
-                      <div
-                        style={{
-                          fontFamily: '"Noto Serif SC", "Source Han Serif", serif',
-                          fontSize: 15,
-                          lineHeight: 1.9,
-                          color: "var(--fj-ink)",
-                        }}
-                      >
-                        {groupByCenter(dedupedChunks).map((b) => (
-                          <div
-                            key={b.key}
-                            className={`chat-citation-chunk${b.isCenter ? " chat-citation-chunk-center" : ""}`}
-                          >
-                            {b.text}
-                          </div>
-                        ))}
-                      </div>
+                      <CitationBlocks chunks={dedupedChunks} quote={target?.quote} />
                       {data.has_more_after && (
                         <div className="chat-citation-boundary-hint">
                           … 后文（本卷第 {data.chunks[data.chunks.length - 1]?.chunk_index ?? 0} 段之后）
@@ -313,23 +342,7 @@ export default function CitationDrawer({ target, onClose }: Props) {
                     … 前文（本卷第 {data.chunks[0]?.chunk_index ?? 0} 段之前）
                   </div>
                 )}
-                <div
-                  style={{
-                    fontFamily: '"Noto Serif SC", "Source Han Serif", serif',
-                    fontSize: 15,
-                    lineHeight: 1.9,
-                    color: "var(--fj-ink)",
-                  }}
-                >
-                  {groupByCenter(dedupedChunks).map((b) => (
-                    <div
-                      key={b.key}
-                      className={`chat-citation-chunk${b.isCenter ? " chat-citation-chunk-center" : ""}`}
-                    >
-                      {b.text}
-                    </div>
-                  ))}
-                </div>
+                <CitationBlocks chunks={dedupedChunks} quote={target?.quote} />
                 {data.has_more_after && (
                   <div className="chat-citation-boundary-hint">
                     … 后文（本卷第 {data.chunks[data.chunks.length - 1]?.chunk_index ?? 0} 段之后）

--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -148,6 +148,8 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
         color: "var(--fj-ink)",
       }}
     >
+      {/* groupByCenter collapses the contiguous center chunks into exactly
+          one center block, so markRef binds to a single element. */}
       {groupByCenter(chunks).map((b) => {
         const cls = `chat-citation-chunk${b.isCenter ? " chat-citation-chunk-center" : ""}`;
         const span = b.isCenter && quote ? findQuoteSpan(b.text, quote) : null;

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -6,7 +6,11 @@ import { Input, Button, message, Alert, Tooltip, Modal, Select, Tag, Spin } from
 import Markdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import * as OpenCC from "opencc-js";
+import {
+  toSimplified,
+  extractPrecedingQuote,
+  pickSourceForQuote,
+} from "../utils/citationMatch";
 import {
   SendOutlined,
   RobotOutlined,
@@ -94,15 +98,6 @@ function parseFollowUps(content: string): { cleanContent: string; suggestions: s
 
 const CITATION_URL_SCHEME = "fojin-citation";
 
-// CBETA stores sutra titles in traditional Chinese; LLM answers come back in
-// simplified Chinese whenever the user's question was simplified. Normalizing
-// both sides to simplified via opencc-js lets injectCitationLinks actually
-// find matches in the RAG source map.
-const _t2s = OpenCC.Converter({ from: "tw", to: "cn" });
-const toSimplified = (s: string): string => {
-  try { return _t2s(s); } catch { return s; }
-};
-
 // rehype-sanitize's defaultSchema strips any <a href> whose protocol is not
 // in its allowlist (http, https, mailto, tel, …). We add our custom citation
 // scheme so the citation-drawer machinery below can intercept it instead of
@@ -145,50 +140,65 @@ const chatUrlTransform = (url: string): string => {
 function injectCitationLinks(content: string, sources: ChatSource[] | null): string {
   if (!sources || sources.length === 0) return content;
 
-  // Key on the simplified form so titles coming back from CBETA in
-  // traditional characters can be matched against simplified-Chinese
-  // answer text. Multiple traditional sources that collapse to the same
-  // simplified key keep the highest-scoring one.
+  // Two indexes over the RAG sources, both keyed on the simplified title so
+  // traditional CBETA titles match simplified answer text:
+  //   titleMap     — the single highest-scored chunk per title (fallback)
+  //   titleSources — every retrieved chunk per title, for quote-aware pick
   const titleMap = new Map<string, ChatSource>();
+  const titleSources = new Map<string, ChatSource[]>();
   for (const s of sources) {
     if (!s.title_zh || s.text_id <= 0) continue;
     const key = toSimplified(s.title_zh);
     const existing = titleMap.get(key);
-    if (!existing || s.score > existing.score) {
-      titleMap.set(key, s);
-    }
+    if (!existing || s.score > existing.score) titleMap.set(key, s);
+    const list = titleSources.get(key);
+    if (list) list.push(s);
+    else titleSources.set(key, [s]);
   }
   if (titleMap.size === 0) return content;
 
-  const buildUrl = (source: ChatSource, title: string, juan: number): string => {
+  // Build the citation URL. When a quote is known and a retrieved chunk
+  // actually contains it, anchor the citation to THAT chunk — otherwise the
+  // drawer opens whichever chunk merely scored highest, which usually does
+  // not hold the quoted sentence. The quote rides along in the URL so the
+  // drawer can highlight the exact passage.
+  const buildUrl = (
+    fallback: ChatSource,
+    simplifiedTitle: string,
+    juanHint: number | null,
+    quote: string | null,
+  ): string => {
+    const candidates = titleSources.get(simplifiedTitle) ?? [];
+    const picked = pickSourceForQuote(candidates, quote);
+    const source = picked ?? fallback;
     const chunkIdx = source.chunk_index ?? -1;
-    return `${CITATION_URL_SCHEME}://${source.text_id}/${juan}/${chunkIdx}/${encodeURIComponent(title)}`;
+    const juan = picked ? picked.juan_num : (juanHint ?? source.juan_num);
+    const tail = quote ? `/${encodeURIComponent(quote)}` : "";
+    return `${CITATION_URL_SCHEME}://${source.text_id}/${juan}/${chunkIdx}/${encodeURIComponent(simplifiedTitle)}${tail}`;
   };
 
-  // Pass 1 — explicit 【《title》…】 markers. Previously the tail was locked to
-  // "第(\d+)卷", which dropped perfectly-valid variants like "卷上" or
-  // "第十八愿" on the floor. Now we accept any qualifier up to the close
-  // bracket and only parse a juan number out of it when we can.
+  // Pass 1 — explicit 【《title》…】 markers. The replace callback receives the
+  // marker's offset in the original string; the text just before it carries
+  // the passage the LLM is attributing.
   let withExplicit = content.replace(
     /【《([^》]+)》([^】]*)】/g,
-    (_match, rawTitle: string, tail: string) => {
+    (_match, rawTitle: string, tail: string, offset: number, full: string) => {
       const title = rawTitle.trim();
       const simplifiedTitle = toSimplified(title);
       const source = titleMap.get(simplifiedTitle);
       if (!source) return _match;
       const juanMatch = tail.match(/第(\d+)卷/);
-      const juan = juanMatch ? parseInt(juanMatch[1], 10) : source.juan_num;
-      const url = buildUrl(source, simplifiedTitle, juan);
-      const labelTail = tail ? tail : "";
-      return `[【《${title}》${labelTail}】](${url})`;
+      const juanHint = juanMatch ? parseInt(juanMatch[1], 10) : null;
+      const quote = extractPrecedingQuote(full.slice(0, offset));
+      const url = buildUrl(source, simplifiedTitle, juanHint, quote);
+      return `[【《${title}》${tail}】](${url})`;
     },
   );
 
   // Pass 2 — bare 《title》 in prose. Split on any markdown links already in
   // the content (the ones pass 1 just produced, plus any pre-existing links)
-  // so we only process plaintext segments. Split with a capture group: JS
-  // interleaves the matches into the output array, so odd indices are the
-  // preserved link strings and even indices are plaintext we can rewrite.
+  // so we only process plaintext segments. No quote is bound to a bare
+  // mention, so the chunk stays the top-scored one.
   const parts = withExplicit.split(/(\[[^\]]*\]\([^)]*\))/g);
   withExplicit = parts
     .map((part, i) => {
@@ -198,7 +208,7 @@ function injectCitationLinks(content: string, sources: ChatSource[] | null): str
         const simplifiedTitle = toSimplified(title);
         const source = titleMap.get(simplifiedTitle);
         if (!source) return bareMatch;
-        const url = buildUrl(source, simplifiedTitle, source.juan_num);
+        const url = buildUrl(source, simplifiedTitle, null, null);
         return `[《${title}》](${url})`;
       });
     })
@@ -212,6 +222,7 @@ interface ParsedCitation {
   juanNum: number;
   chunkIndex: number;
   titleZh: string;
+  quote?: string;
 }
 
 function parseCitationHref(href: string): ParsedCitation | null {
@@ -223,10 +234,13 @@ function parseCitationHref(href: string): ParsedCitation | null {
   const juanNum = parseInt(parts[1], 10);
   const chunkIndex = parseInt(parts[2], 10);
   const titleZh = parts[3] ? decodeURIComponent(parts[3]) : "";
+  // Segment 5 (optional) carries the quoted passage so the drawer can
+  // highlight it. Absent on legacy links built before quote-aware citations.
+  const quote = parts[4] ? decodeURIComponent(parts[4]) : undefined;
   if (!Number.isFinite(textId) || !Number.isFinite(juanNum) || !Number.isFinite(chunkIndex)) {
     return null;
   }
-  return { textId, juanNum, chunkIndex, titleZh };
+  return { textId, juanNum, chunkIndex, titleZh, quote };
 }
 
 function groupSessionsByDate(sessions: ChatSessionItem[]): { label: string; items: ChatSessionItem[] }[] {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -388,6 +388,18 @@ em {
   background: rgba(255, 220, 90, 0.15);
 }
 
+/* The exact quoted sentence inside the cited chunk — distinct from the
+   chunk-level tint so the reader's eye lands on the sentence itself. */
+.chat-citation-quote-mark {
+  background: rgba(255, 196, 0, 0.5);
+  border-radius: 2px;
+  padding: 1px 1px;
+  color: inherit;
+  font-weight: 600;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
 /* Mobile: stack the panel below the chat column instead of side-by-side.
    The divider hides; the parent flex container should switch direction to
    column via an additional class applied when the panel is open (handled

--- a/frontend/src/utils/citationMatch.test.ts
+++ b/frontend/src/utils/citationMatch.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeForMatch,
+  extractPrecedingQuote,
+  pickSourceForQuote,
+  findQuoteSpan,
+} from "./citationMatch";
+import type { ChatSource } from "../api/client";
+
+function src(partial: Partial<ChatSource>): ChatSource {
+  return {
+    text_id: 1 as ChatSource["text_id"],
+    juan_num: 1,
+    chunk_index: 0,
+    chunk_text: "",
+    score: 0,
+    title_zh: "测试",
+    ...partial,
+  } as ChatSource;
+}
+
+describe("normalizeForMatch", () => {
+  it("folds 繁→简 and strips punctuation", () => {
+    // 繁: 以五事交擾，渾濁真性  简(input): 以五事交扰，浑浊真性
+    expect(normalizeForMatch("以五事交擾，渾濁真性")).toBe(
+      normalizeForMatch("以五事交扰，浑浊真性"),
+    );
+  });
+});
+
+describe("extractPrecedingQuote", () => {
+  it("pulls a 「」 quote sitting before a marker", () => {
+    const before = "蓮池大師說「以五事交扰，浑浊真性，故名恶世」";
+    expect(extractPrecedingQuote(before)).toBe("以五事交扰，浑浊真性，故名恶世");
+  });
+  it("pulls a curly-quote passage with a short gap before the marker", () => {
+    const before = '答案中提到“以五事交扰，浑浊真性”，可见';
+    expect(extractPrecedingQuote(before)).toBe("以五事交扰，浑浊真性");
+  });
+  it("returns null when there is no nearby quote", () => {
+    expect(extractPrecedingQuote("这一段没有任何引号内容")).toBeNull();
+  });
+});
+
+describe("pickSourceForQuote", () => {
+  const candidates = [
+    src({ chunk_index: 12, score: 0.9, chunk_text: "前略……不相干的高分内容……" }),
+    src({ chunk_index: 50, score: 0.4, chunk_text: "……以五事交擾，渾濁真性，故名惡世……" }),
+  ];
+
+  it("picks the chunk containing the quote, not the top-scored one", () => {
+    const picked = pickSourceForQuote(candidates, "以五事交扰，浑浊真性，故名恶世");
+    expect(picked?.chunk_index).toBe(50);
+  });
+
+  it("returns null when no chunk contains the quote", () => {
+    expect(pickSourceForQuote(candidates, "完全不存在的另一句话内容")).toBeNull();
+  });
+
+  it("returns null for an empty quote", () => {
+    expect(pickSourceForQuote(candidates, null)).toBeNull();
+  });
+});
+
+describe("findQuoteSpan", () => {
+  it("locates a simplified quote inside traditional source text", () => {
+    const hay = "如經所言，以五事交擾，渾濁真性，故名惡世，眾生難度。";
+    const span = findQuoteSpan(hay, "以五事交扰，浑浊真性，故名恶世");
+    expect(span).not.toBeNull();
+    expect(hay.slice(span![0], span![1])).toBe("以五事交擾，渾濁真性，故名惡世");
+  });
+
+  it("tolerates punctuation differences between quote and source", () => {
+    const hay = "以五事交擾渾濁真性故名惡世"; // source has no commas
+    const span = findQuoteSpan(hay, "以五事交扰，浑浊真性，故名恶世");
+    expect(span).not.toBeNull();
+    expect(hay.slice(span![0], span![1])).toBe("以五事交擾渾濁真性故名惡世");
+  });
+
+  it("returns null when the quote is absent", () => {
+    expect(findQuoteSpan("一段无关的原文", "以五事交扰，浑浊真性")).toBeNull();
+  });
+});

--- a/frontend/src/utils/citationMatch.ts
+++ b/frontend/src/utils/citationMatch.ts
@@ -30,10 +30,12 @@ export function toSimplified(s: string): string {
 // Punctuation + whitespace stripped before substring tests so a dropped or
 // swapped comma does not break matching. Mirrors the backend quote verifier's
 // _STRIP_PUNCT_RE. `g` flag — only use with .replace(), not .test().
+// \u3000 is the ideographic (full-width) space — written as an escape so
+// ESLint's no-irregular-whitespace does not trip on a literal in source.
 const PUNCT_GLOBAL =
-  /[\s,.!?;:"'()[\]\-_~`<>*，。！？、；：「」『』“”‘’《》〈〉…—（）【】·•～　]/g;
+  /[\s,.!?;:"'()[\]\-_~`<>*，。！？、；：「」『』“”‘’《》〈〉…—（）【】·•～\u3000]/g;
 const PUNCT_ONE =
-  /[\s,.!?;:"'()[\]\-_~`<>*，。！？、；：「」『』“”‘’《》〈〉…—（）【】·•～　]/;
+  /[\s,.!?;:"'()[\]\-_~`<>*，。！？、；：「」『』“”‘’《》〈〉…—（）【】·•～\u3000]/;
 
 /** Fold 繁→简, strip punctuation/whitespace, lowercase — for tolerant matching. */
 export function normalizeForMatch(s: string): string {

--- a/frontend/src/utils/citationMatch.ts
+++ b/frontend/src/utils/citationMatch.ts
@@ -1,0 +1,111 @@
+/**
+ * Quote-aware citation matching.
+ *
+ * The RAG pipeline retrieves several chunks per cited text. The old citation
+ * wiring keyed a citation to the *highest-scored* chunk for a title, which is
+ * rarely the chunk that actually holds the sentence the LLM quoted — so
+ * clicking a citation opened a passage that did not contain the quote.
+ *
+ * These helpers locate the chunk whose text genuinely contains the quoted
+ * passage, and (for the drawer) the quote's span inside that text so it can
+ * be highlighted. CBETA stores traditional Chinese while LLM answers are
+ * usually simplified, so every comparison folds 繁→简 first. That fold is
+ * 1 char → 1 char, which preserves string indices — findQuoteSpan depends on
+ * that to map a match on the folded text back onto the original.
+ */
+import * as OpenCC from "opencc-js";
+
+import type { ChatSource } from "../api/client";
+
+const _t2s = OpenCC.Converter({ from: "tw", to: "cn" });
+
+export function toSimplified(s: string): string {
+  try {
+    return _t2s(s);
+  } catch {
+    return s;
+  }
+}
+
+// Punctuation + whitespace stripped before substring tests so a dropped or
+// swapped comma does not break matching. Mirrors the backend quote verifier's
+// _STRIP_PUNCT_RE. `g` flag — only use with .replace(), not .test().
+const PUNCT_GLOBAL =
+  /[\s,.!?;:"'()[\]\-_~`<>*，。！？、；：「」『』“”‘’《》〈〉…—（）【】·•～　]/g;
+const PUNCT_ONE =
+  /[\s,.!?;:"'()[\]\-_~`<>*，。！？、；：「」『』“”‘’《》〈〉…—（）【】·•～　]/;
+
+/** Fold 繁→简, strip punctuation/whitespace, lowercase — for tolerant matching. */
+export function normalizeForMatch(s: string): string {
+  return toSimplified(s).replace(PUNCT_GLOBAL, "").toLowerCase();
+}
+
+// A 「…」/『…』/“…”/‘…’/"…" pair sitting within ~80 chars before a citation
+// marker — the passage the LLM is attributing. Mirrors the backend verifier's
+// _QUOTE_CITATION_RE lookback window.
+const PRECEDING_QUOTE_RE =
+  /[「『“‘"]([^「『“‘"」』”’]{6,400})[」』”’"][^【】「『“‘"」』”’]{0,80}$/;
+
+/** Pull the quoted passage that sits just before a citation marker, if any. */
+export function extractPrecedingQuote(textBefore: string): string | null {
+  const m = textBefore.slice(-520).match(PRECEDING_QUOTE_RE);
+  return m ? m[1].trim() : null;
+}
+
+/**
+ * Among the retrieved chunks for a cited title, pick the one whose text
+ * actually contains the quoted passage. Returns null when no chunk does
+ * (genuine hallucination, or a quote spanning a chunk boundary) — callers
+ * fall back to the top-scored chunk.
+ */
+export function pickSourceForQuote(
+  candidates: ChatSource[],
+  quote: string | null,
+): ChatSource | null {
+  if (!quote) return null;
+  const nq = normalizeForMatch(quote);
+  if (nq.length < 6) return null;
+  let best: ChatSource | null = null;
+  for (const s of candidates) {
+    if (s.chunk_index == null) continue;
+    if (normalizeForMatch(s.chunk_text).includes(nq)) {
+      if (!best || s.score > best.score) best = s;
+    }
+  }
+  return best;
+}
+
+/**
+ * Locate the quoted passage inside a rendered chunk so the drawer can <mark>
+ * it. Returns [start, end) indices into the original `haystack`, or null.
+ *
+ * Folds both sides 繁→简 (index-preserving) for a direct substring hit; if
+ * punctuation differs between the LLM quote and the CBETA text, retries on a
+ * punctuation-stripped projection and maps the hit back to original indices.
+ */
+export function findQuoteSpan(
+  haystack: string,
+  quote: string,
+): [number, number] | null {
+  const hs = toSimplified(haystack);
+  const qs = toSimplified(quote).trim();
+  if (qs.length < 4) return null;
+
+  const direct = hs.indexOf(qs);
+  if (direct >= 0) return [direct, direct + qs.length];
+
+  // Punctuation-tolerant pass: strip punct from both, match, map back.
+  const qStripped = qs.replace(PUNCT_GLOBAL, "");
+  if (qStripped.length < 4) return null;
+  const map: number[] = [];
+  let stripped = "";
+  for (let i = 0; i < hs.length; i++) {
+    if (!PUNCT_ONE.test(hs[i])) {
+      map.push(i);
+      stripped += hs[i];
+    }
+  }
+  const sIdx = stripped.indexOf(qStripped);
+  if (sIdx < 0) return null;
+  return [map[sIdx], map[sIdx + qStripped.length - 1] + 1];
+}


### PR DESCRIPTION
## 问题

AI 问答里点击引文（如《阿彌陀經疏鈔》第4卷），右侧栏显示一大段文字，但**根本找不到答案引用的那句话**（用户反馈："以五事交扰，浑浊真性，故名恶世" 这句在打开的段落里找不到）。

## 根因（已用生产数据验证）

引文链接里的 chunk 取的是「该书名 RAG 检索得分最高的 chunk」，**不是「包含引文那句话的 chunk」**。整条流水线从没有一步定位引文落在哪个检索 chunk。实测该引文实际在《阿彌陀經疏鈔》卷4 的第 50 段，但链接指向的是得分最高的另一段 → 抽屉打开的窗口不含引文。

## 修复（句级精准对齐）

- **新增 `utils/citationMatch.ts`**：繁→简容错的工具函数——`extractPrecedingQuote`（取 `【《X》第N卷】` 标记前的 `「…」` 引文）、`pickSourceForQuote`（在检索 chunk 里找含引文的那个）、`findQuoteSpan`（在文本里定位引文的字符区间用于高亮）。配 10 个 vitest 用例。
- **`injectCitationLinks`**：现在索引每个书名的全部检索 chunk，把引文锚定到**含引文那句话的 chunk**（得分最高的 chunk 仅作回退）。引文随 URL 传递。
- **`CitationDrawer`**：新 `CitationBlocks` 组件把引文那句话用 `<mark>` 高亮并滚动定位——真正"精准到句"。
- **后端 `quote_verifier`**：`_find_source` 原来只查第一个书名+卷号匹配的 chunk，引文落在后面的检索 chunk 会被误标 `⚠️`。改为 `_find_sources` 检查全部候选 chunk。

## Test plan

- [x] `citationMatch.test.ts` 10 例（含"选含引文的 chunk 而非最高分 chunk"复现用例）
- [x] `test_quote_verifier.py` 37 例（新增"引文落在非首个检索 chunk"用例）
- [x] `tsc --noEmit` + `npm run build` + 后端 36 引文测试通过
- [x] 独立代码审核（Ready to merge，无 Critical/Important）
- [ ] 部署后用原问题复测：点击引文 → 右侧栏高亮并定位到引文那句话

🤖 Generated with [Claude Code](https://claude.com/claude-code)