### PR TITLE
fix(chat): highlight citation quotes that straddle a chunk boundary

### DIFF
--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -4,7 +4,7 @@ import { BookOutlined, ArrowRightOutlined, CloseOutlined, GlobalOutlined } from 
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { getChunkContext, getChunkAlignment, type ChunkContextItem, type ParallelPair } from "../api/client";
-import { findQuoteSpan } from "../utils/citationMatch";
+import { mapQuoteToBlocks } from "../utils/citationMatch";
 
 export interface CitationTarget {
   textId: number;
@@ -128,9 +128,12 @@ function groupByCenter(chunks: ChunkContextItem[]): CitationBlock[] {
 }
 
 /**
- * Render the 汉文 passage blocks. The center (cited) block gets the quoted
- * sentence wrapped in <mark> and scrolled into view, so a citation lands on
- * the exact passage rather than a ~500-char chunk the reader must scan.
+ * Render the 汉文 passage blocks with the quoted sentence wrapped in <mark>
+ * and scrolled into view, so a citation lands on the exact passage rather
+ * than a ~500-char chunk the reader must scan. The quote is matched across
+ * the whole passage — chunks overlap by 50 chars, so a boundary-spanning
+ * sentence is split across the leading-context and center blocks and must
+ * be highlighted in both halves.
  */
 function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?: string }) {
   const markRef = useRef<HTMLElement | null>(null);
@@ -138,6 +141,11 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
   useEffect(() => {
     markRef.current?.scrollIntoView({ block: "center", behavior: "smooth" });
   }, [chunks, quote]);
+
+  const blocks = groupByCenter(chunks);
+  const blockSpans = mapQuoteToBlocks(blocks.map((b) => b.text), quote);
+  // The first highlighted block carries markRef — that is where we scroll to.
+  const firstHighlighted = blockSpans.findIndex((s) => s !== null);
 
   return (
     <div
@@ -148,18 +156,19 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
         color: "var(--fj-ink)",
       }}
     >
-      {/* groupByCenter collapses the contiguous center chunks into exactly
-          one center block, so markRef binds to a single element. */}
-      {groupByCenter(chunks).map((b) => {
+      {blocks.map((b, i) => {
         const cls = `chat-citation-chunk${b.isCenter ? " chat-citation-chunk-center" : ""}`;
-        const span = b.isCenter && quote ? findQuoteSpan(b.text, quote) : null;
+        const span = blockSpans[i];
         if (!span) {
           return <div key={b.key} className={cls}>{b.text}</div>;
         }
         return (
           <div key={b.key} className={cls}>
             {b.text.slice(0, span[0])}
-            <mark className="chat-citation-quote-mark" ref={markRef}>
+            <mark
+              className="chat-citation-quote-mark"
+              ref={i === firstHighlighted ? markRef : undefined}
+            >
               {b.text.slice(span[0], span[1])}
             </mark>
             {b.text.slice(span[1])}

--- a/frontend/src/utils/citationMatch.test.ts
+++ b/frontend/src/utils/citationMatch.test.ts
@@ -4,6 +4,7 @@ import {
   extractPrecedingQuote,
   pickSourceForQuote,
   findQuoteSpan,
+  mapQuoteToBlocks,
 } from "./citationMatch";
 import type { ChatSource } from "../api/client";
 
@@ -79,5 +80,36 @@ describe("findQuoteSpan", () => {
 
   it("returns null when the quote is absent", () => {
     expect(findQuoteSpan("一段无关的原文", "以五事交扰，浑浊真性")).toBeNull();
+  });
+});
+
+describe("mapQuoteToBlocks", () => {
+  it("highlights a quote contained within one block", () => {
+    const blocks = ["前文……", "如经云：以五事交擾，渾濁真性，故名惡世……", "后文"];
+    const spans = mapQuoteToBlocks(blocks, "以五事交扰，浑浊真性，故名恶世");
+    expect(spans[0]).toBeNull();
+    expect(spans[2]).toBeNull();
+    expect(spans[1]).not.toBeNull();
+    const [s, e] = spans[1]!;
+    expect(blocks[1].slice(s, e)).toBe("以五事交擾，渾濁真性，故名惡世");
+  });
+
+  it("highlights a quote straddling two blocks (chunk-boundary case)", () => {
+    // The de-overlap splits a boundary-spanning sentence: head in the
+    // leading block, tail in the center block.
+    const blocks = ["……前文以五事交擾，渾濁真", "性，故名惡世；無五濁者……"];
+    const spans = mapQuoteToBlocks(blocks, "以五事交扰，浑浊真性，故名恶世");
+    expect(spans[0]).not.toBeNull();
+    expect(spans[1]).not.toBeNull();
+    expect(blocks[0].slice(spans[0]![0], spans[0]![1])).toBe("以五事交擾，渾濁真");
+    expect(blocks[1].slice(spans[1]![0], spans[1]![1])).toBe("性，故名惡世");
+  });
+
+  it("returns all-null when the quote is absent", () => {
+    expect(mapQuoteToBlocks(["甲段", "乙段"], "不存在的句子内容")).toEqual([null, null]);
+  });
+
+  it("returns all-null when no quote is given", () => {
+    expect(mapQuoteToBlocks(["甲段", "乙段"], undefined)).toEqual([null, null]);
   });
 });

--- a/frontend/src/utils/citationMatch.ts
+++ b/frontend/src/utils/citationMatch.ts
@@ -111,3 +111,33 @@ export function findQuoteSpan(
   if (sIdx < 0) return null;
   return [map[sIdx], map[sIdx + qStripped.length - 1] + 1];
 }
+
+/**
+ * Locate the quote across a sequence of rendered blocks and return, per block,
+ * the [start, end) slice to highlight (or null).
+ *
+ * The citation drawer splits the passage into leading-context / center /
+ * trailing blocks, and chunks overlap by 50 chars — so a sentence sitting on
+ * a chunk boundary ends up straddling two blocks after de-overlap. Searching
+ * the concatenated text and mapping the hit back per block highlights the
+ * whole sentence even when it crosses a block boundary.
+ */
+export function mapQuoteToBlocks(
+  blockTexts: string[],
+  quote: string | undefined,
+): ([number, number] | null)[] {
+  const result: ([number, number] | null)[] = blockTexts.map(() => null);
+  if (!quote) return result;
+  const span = findQuoteSpan(blockTexts.join(""), quote);
+  if (!span) return result;
+  let offset = 0;
+  for (let i = 0; i < blockTexts.length; i++) {
+    const blockStart = offset;
+    const blockEnd = offset + blockTexts[i].length;
+    offset = blockEnd;
+    const s = Math.max(span[0], blockStart);
+    const e = Math.min(span[1], blockEnd);
+    if (s < e) result[i] = [s - blockStart, e - blockStart];
+  }
+  return result;
+}


### PR DESCRIPTION
## 问题

上一个引文对齐修复（PR #577）做了句级高亮，但**只在中央块内搜索引文**。RAG 的 chunk 之间有 50 字重叠，`dedupeOverlap` 去重后，一句正好落在 chunk 边界上的引文会被**裂成两块**——句首在前文块、句尾在中央块。

实测：引文「以五事交擾，渾濁真性，故名惡世」句首「以五事交擾，渾濁真」在前文块末尾、句尾「性，故名惡世」在中央块开头，`findQuoteSpan` 在中央块单独搜索两半都搜不到 → 没有高亮。

## 修复

新增 `mapQuoteToBlocks`：在**拼接后的整段文本**里定位引文，再把命中区间映射回每个块的 `[start,end)`。`<mark>` 因此能跨块——引文经过的每个块都高亮自己那一段，`markRef`（滚动锚点）绑在第一个高亮块。

## Test plan

- [x] `citationMatch.test.ts` 新增 4 个 `mapQuoteToBlocks` 用例（含跨块裂开的复现用例），共 14 例通过
- [x] `tsc` + `eslint` + `npm run build` 通过
- [ ] 部署后浏览器复测：点击跨边界引文 → 句首句尾两段都高亮

🤖 Generated with [Claude Code](https://claude.com/claude-code)