### PR TITLE
fix(chat): stop false ⚠️ on faithful simplified-Chinese quotes

### DIFF
--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -47,9 +47,17 @@ import unicodedata
 from collections.abc import Iterable
 from dataclasses import dataclass
 
+from opencc import OpenCC
+
 from app.schemas.chat import ChatSource
 
 logger = logging.getLogger(__name__)
+
+# 繁→简 fold for the substring test. The user asks in 简体 and the LLM
+# answers — and quotes — in 简体, while CBETA stores 繁体. Rendering a quote
+# in the reader's script is localisation, not a fidelity loss, so a script
+# mismatch must not by itself fail verification.
+_t2s = OpenCC("t2s")
 
 
 # Minimum length of a quoted segment we'll subject to verification.
@@ -120,16 +128,15 @@ def _normalise(s: str) -> str:
 
     Goals:
       1. NFKC fold so half/full-width forms compare equal
-      2. Strip every punctuation and whitespace character so that an
+      2. 繁→简 fold so a simplified-Chinese quote matches a traditional
+         CBETA source — without this every quote in a 简体 answer of a
+         繁体 source false-fails, drowning the answer in ⚠️ notices
+      3. Strip every punctuation and whitespace character so that an
          LLM that drops a comma doesn't false-positive
-      3. Lowercase (no effect on CJK but covers stray Latin)
-
-    What this does *not* do: 简→繁 conversion. The cited source is
-    already traditional (CBETA stores 繁 only); if the LLM emits 简
-    inside its own quote it deserves to fail verification — quoting
-    a canonical text in 简 isn't preserving the citation either.
+      4. Lowercase (no effect on CJK but covers stray Latin)
     """
     s = unicodedata.normalize("NFKC", s)
+    s = _t2s.convert(s)
     s = _STRIP_PUNCT_RE.sub("", s)
     return s.lower()
 
@@ -148,11 +155,16 @@ def _find_sources(
     Exact (title + juan) matches are returned when juan is given; if none
     match the juan, falls back to every title match (any juan) — the
     citation guard occasionally corrects a slightly-off fascicle number.
+
+    Title comparison is 繁→简 folded: the LLM may write the title in 简体
+    while CBETA stores it in 繁体, and an exact ``==`` would then miss the
+    source and false-flag the quote as having no matching source.
     """
+    target_title = _t2s.convert(title)
     exact: list[ChatSource] = []
     title_only: list[ChatSource] = []
     for s in sources:
-        if s.title_zh == title:
+        if s.title_zh and _t2s.convert(s.title_zh) == target_title:
             if juan is not None and s.juan_num == juan:
                 exact.append(s)
             else:
@@ -161,7 +173,7 @@ def _find_sources(
         # via alignment_pairs as a child of an unrelated lzh source,
         # so the parent's title_zh is never the parallel's title.
         for p in s.parallel_chunks:
-            if p.title != title:
+            if not p.title or _t2s.convert(p.title) != target_title:
                 continue
             # Adapt the parallel chunk into a ChatSource-shaped carrier
             # so the substring test reads its chunk_text.

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -175,6 +175,19 @@ def test_quote_in_non_first_retrieved_chunk_passes():
     assert "⚠️" not in out
 
 
+def test_simplified_answer_quote_verifies_against_traditional_source():
+    """The user asks in 简体; the LLM answers and cites in 简体; CBETA stores
+    繁体. A faithful simplified rendering of the traditional original must
+    verify — script localisation is not a fidelity loss, and before the
+    繁→简 fold every such quote drowned the answer in false ⚠️ notices."""
+    answer = "经云「一切诸行皆是无常，是名第一」【《瑜伽师地论》第46卷】。"
+    # CBETA-style source: traditional title AND traditional chunk text.
+    src = _src(7, "瑜伽師地論", 46, "如彼頌言「一切諸行皆是無常，是名第一」唱拕南。")
+    out, muts = verify_quoted_content(answer, [src])
+    assert muts == []
+    assert "⚠️" not in out
+
+
 def test_multiple_failing_quotes_all_annotated():
     """Two fabricated quotes in one answer must both be marked, and
     the markers must not interfere with each other (right-to-left


### PR DESCRIPTION
## 问题

AI 问答的引文后大量出现 `[⚠️ 引文未在该卷原文中验证到，请谨慎引用]`（用户反馈截图，一条回答里 3 处）。这些警告让读者对输出失去信心。

## 根因

后端 quote 验证器对 `「引文」【《X》第N卷】` 做子串校验，校验不过就标 ⚠️。它的 `_normalise` **故意不做简↔繁转换**——docstring 还专门论证"简体引文校验失败是正确行为"。

但实际相反：**用户用简体提问 → LLM 用简体回答、简体引用 → CBETA 原文是繁体**。简体引文拿去繁体原文里子串匹配**永远匹配不到** → 正常简体回答里几乎每条引文都被误标 ⚠️。这个警告**绝大多数是误报**，而满屏误报恰恰摧毁了学术工具最需要的可信度。

简繁只是书写形式的本地化，不是文本失真。

## 修复

- `_normalise` 在子串校验前折叠繁→简（opencc t2s）——简体引文与繁体原文不再因书写形式不匹配
- `_find_sources` 的书名比较也折叠繁→简——简体引用的书名仍能匹配到繁体 CBETA 源

验证器对**真正无法验证**的引文（真实幻觉 / 大幅改写）仍会标 ⚠️——这种诚实信号保留（学术工具不能让伪造经文静默蒙混；验证器 docstring 记录过真实的生产幻觉案例）。修复后 ⚠️ 只在真正可疑时出现，忠实引文一律静默通过。

## Test plan

- [x] `test_quote_verifier.py` 新增"简体回答引文校验繁体源"用例（书名与正文都繁体，引文简体）；19+15=34 个引文测试通过
- [x] 后端语法检查通过
- [ ] 部署后复测：正常简体问答的引文不再批量出现 ⚠️

🤖 Generated with [Claude Code](https://claude.com/claude-code)