### PR TITLE
fix(search): cap the 词典释义 section in the unified overview

### DIFF
--- a/frontend/src/components/search/UnifiedResults.tsx
+++ b/frontend/src/components/search/UnifiedResults.tsx
@@ -67,12 +67,14 @@ export default function UnifiedResults({ data }: Props) {
 
   return (
     <div className="s-unified">
-      {/* 词典释义 */}
+      {/* 词典释义 — overview shows only the first 2 entries; the full set
+          (often a dozen dictionaries for a common term) lives on the
+          dedicated dictionary page so it doesn't push the text results down. */}
       {dictionary.length > 0 && (
         <section className="s-unified-section">
           <h3 style={sectionTitleStyle}>{"🔤"} 词典释义</h3>
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-            {dictionary.map((entry) => (
+            {dictionary.slice(0, 2).map((entry) => (
               <Link
                 key={entry.id}
                 to={`/dict/${encodeURIComponent(entry.headword)}`}
@@ -95,8 +97,8 @@ export default function UnifiedResults({ data }: Props) {
                   )}
                 </div>
                 <div style={{ fontSize: 13, color: "#5b4a32", marginTop: 4, lineHeight: 1.6 }}>
-                  {entry.definition.length > 200
-                    ? entry.definition.slice(0, 200) + "…"
+                  {entry.definition.length > 140
+                    ? entry.definition.slice(0, 140) + "…"
                     : entry.definition}
                 </div>
                 {entry.source && (
@@ -107,6 +109,14 @@ export default function UnifiedResults({ data }: Props) {
               </Link>
             ))}
           </div>
+          {dictionary.length > 2 && (
+            <Link
+              to={`/dictionary?q=${encodeURIComponent(data.query)}`}
+              style={{ display: "inline-block", marginTop: 8, fontSize: 13, color: "var(--fj-accent)" }}
+            >
+              查看全部 {dictionary.length} 条词典释义 →
+            </Link>
+          )}
         </section>
       )}
 


### PR DESCRIPTION
## 问题

搜索「天台宗」（`/search?q=天台宗`，默认"全部"标签），顶部的**词典释义**区块太长——把真正的经文结果挤到了屏幕下方。

## 根因

"全部"概览的词典释义区 `dictionary.map(...)` 渲染**全部**词典条目。像「天台宗」这种常见词有十几部辞典各收一条、每条约 200 字，光这一个区块就占满了整屏。概览里其他区块都已限量（经文标题 `slice(0,5)`、内文片段 `slice(0,3)`），唯独词典区没限。

## 修复

词典释义区只显示**前 2 条**（截断到 140 字，与辞典知识卡一致），超过 2 条时加「查看全部 N 条词典释义 →」链接跳到 `/dictionary` 页看完整列表。

## Test plan

- [x] `tsc` + `eslint` + `npm run build` 通过
- [ ] 部署后 `/search?q=天台宗`：词典释义区只剩 2 条 + 查看全部链接，经文结果上移

🤖 Generated with [Claude Code](https://claude.com/claude-code)