### PR TITLE
fix(search): unify 词典释义 → 辞典释义 wording

### DIFF
--- a/frontend/src/components/search/UnifiedResults.tsx
+++ b/frontend/src/components/search/UnifiedResults.tsx
@@ -67,12 +67,12 @@ export default function UnifiedResults({ data }: Props) {
 
   return (
     <div className="s-unified">
-      {/* 词典释义 — overview shows only the first 2 entries; the full set
+      {/* 辞典释义 — overview shows only the first 2 entries; the full set
           (often a dozen dictionaries for a common term) lives on the
           dedicated dictionary page so it doesn't push the text results down. */}
       {dictionary.length > 0 && (
         <section className="s-unified-section">
-          <h3 style={sectionTitleStyle}>{"🔤"} 词典释义</h3>
+          <h3 style={sectionTitleStyle}>{"🔤"} 辞典释义</h3>
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
             {dictionary.slice(0, 2).map((entry) => (
               <Link
@@ -114,7 +114,7 @@ export default function UnifiedResults({ data }: Props) {
               to={`/dictionary?q=${encodeURIComponent(data.query)}`}
               style={{ display: "inline-block", marginTop: 8, fontSize: 13, color: "var(--fj-accent)" }}
             >
-              查看全部 {dictionary.length} 条词典释义 →
+              查看全部 {dictionary.length} 条辞典释义 →
             </Link>
           )}
         </section>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -344,7 +344,7 @@ export default function SearchPage() {
         />
         <div className="s-mode-hint">
           {tab === "all"
-            ? "一站式综合检索：词典释义、经文标题、相关问答、内文片段一次呈现"
+            ? "一站式综合检索：辞典释义、经文标题、相关问答、内文片段一次呈现"
             : tab === "catalog"
             ? "按经名、译者、编号检索，自动匹配所有语种标题与翻译版本"
             : tab === "content"


### PR DESCRIPTION
## Summary

「全部」搜索概览页用「**词**典释义」，而搜经典/搜经文标签的辞典卡、导航菜单（佛学辞典）都用「**辞**典」。站内「辞典」用 24 次、「词典」7 次——「辞典」是统一用词。

把「全部」概览的区块标题、「查看全部」链接、页面副标题里的「词典」统一改为「辞典」。

区块标题颜色不变（4 个概览标题维持统一深棕色）。

## Test plan

- [x] `tsc` + `npm run build` 通过
- [ ] 部署后 `/search?q=天台宗`：标题显示「辞典释义」，与其他标签一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)