### PR TITLE
feat(kg): wave 1 — shareable URLs, curated entry points, degree-ranked search

### DIFF
--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -63,10 +63,12 @@ async def get_kg_entity(entity_id: int, db: AsyncSession = Depends(get_db)):
     if not entity:
         raise KGEntityNotFoundError(entity_id=entity_id)
     relations = await get_entity_relations(db, entity_id)
-    return KGEntityDetailResponse(
-        **KGEntityResponse.model_validate(entity).model_dump(),
-        relations=relations,
-    )
+    # relation_count isn't set on the detail path (search_entities computes
+    # it via a degree subquery); derive it from the relations we just
+    # fetched so the field isn't a misleading 0.
+    base = KGEntityResponse.model_validate(entity).model_dump()
+    base["relation_count"] = len(relations)
+    return KGEntityDetailResponse(**base, relations=relations)
 
 
 @router.get("/entities/{entity_id}/graph", response_model=KGGraphResponse)

--- a/backend/app/schemas/knowledge_graph.py
+++ b/backend/app/schemas/knowledge_graph.py
@@ -13,6 +13,10 @@ class KGEntityResponse(BaseModel):
     properties: dict | None = None
     text_id: int | None = None
     external_ids: dict | None = None
+    # Number of KG relations touching this entity. Populated by
+    # search_entities (used for degree-ranked results + UI badge);
+    # defaults to 0 for endpoints that don't compute it.
+    relation_count: int = 0
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -80,8 +80,10 @@ async def search_entities(
     total_result = await session.execute(count_stmt)
     total = total_result.scalar() or 0
 
-    # Relevance sorting: exact > prefix > contains; person/school before text
-    # Use first variant (original query) for matching
+    # Relevance sorting: exact > prefix > contains; within the same
+    # relevance tier, the most-connected entity (highest graph degree)
+    # wins so an ambiguous name resolves to its richest node; type and
+    # id are final tiebreaks.
     relevance = case(
         (KGEntity.name_zh == q, 0),
         (KGEntity.name_zh.startswith(q), 1),
@@ -93,9 +95,33 @@ async def search_entities(
         (KGEntity.entity_type == "dynasty", 2),
         else_=3,
     )
-    stmt = stmt.order_by(relevance, type_priority, KGEntity.id).offset(offset).limit(limit)
+    # Degree = number of KG relations touching the entity (as subject or
+    # object). Used both as a sort key and surfaced to the UI as
+    # `relation_count` so a result can show "N 条关系".
+    degree_col = (
+        select(func.count(KGRelation.id))
+        .where(
+            or_(
+                KGRelation.subject_id == KGEntity.id,
+                KGRelation.object_id == KGEntity.id,
+            )
+        )
+        .correlate(KGEntity)
+        .scalar_subquery()
+        .label("degree")
+    )
+    stmt = (
+        stmt.add_columns(degree_col)
+        .order_by(relevance, degree_col.desc(), type_priority, KGEntity.id)
+        .offset(offset)
+        .limit(limit)
+    )
     result = await session.execute(stmt)
-    return list(result.scalars().all()), total
+    entities: list[KGEntity] = []
+    for ent, degree in result.all():
+        ent.relation_count = int(degree or 0)
+        entities.append(ent)
+    return entities, total
 
 
 async def get_entity(session: AsyncSession, entity_id: int) -> KGEntity | None:

--- a/backend/tests/test_kg.py
+++ b/backend/tests/test_kg.py
@@ -32,6 +32,7 @@ def _make_entity(id, entity_type, name_zh, **kwargs):
     obj.properties = kwargs.get("properties")
     obj.text_id = kwargs.get("text_id")
     obj.external_ids = kwargs.get("external_ids")
+    obj.relation_count = kwargs.get("relation_count", 0)
     return obj
 
 
@@ -198,3 +199,23 @@ async def test_entity_detail_includes_relations(kg_client):
         assert len(data["relations"]) == 1
         assert data["relations"][0]["predicate"] == "member_of_school"
         assert data["relations"][0]["target_name"] == "華嚴宗"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: 搜索结果透出 relation_count（图度数），供前端排序徽章使用
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_search_results_expose_relation_count(kg_client):
+    with patch(f"{_KG_API}.search_entities") as m:
+        m.return_value = (
+            [
+                _make_entity(1, "person", "玄奘", relation_count=42),
+                _make_entity(2, "person", "玄奘三藏", relation_count=0),
+            ],
+            2,
+        )
+        resp = await kg_client.get("/api/kg/entities", params={"q": "玄奘"})
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert results[0]["relation_count"] == 42
+        assert results[1]["relation_count"] == 0

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -321,6 +321,8 @@ export interface KGEntity {
   properties: Record<string, any> | null;
   text_id: TextId | null;
   external_ids: Record<string, string> | null;
+  /** KG relation count — populated by search results, used for the degree badge. */
+  relation_count?: number;
 }
 
 export interface EntityRelationItem {

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -329,7 +329,16 @@ export default function KnowledgeGraphPage() {
       <div className="kg-curated">
         <div
           className="kg-curated-head"
+          role="button"
+          tabIndex={0}
+          aria-expanded={curatedOpen}
           onClick={() => setCuratedOpen((o) => !o)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setCuratedOpen((o) => !o);
+            }
+          }}
         >
           <CompassOutlined />
           <span className="kg-curated-title">推荐探索</span>

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -1,7 +1,15 @@
 import { useState, useMemo, useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Input, Select, Spin, Empty, Slider, Checkbox, Alert, Tooltip } from "antd";
-import { ApartmentOutlined, SearchOutlined, BarChartOutlined } from "@ant-design/icons";
+import {
+  ApartmentOutlined,
+  SearchOutlined,
+  BarChartOutlined,
+  CompassOutlined,
+  DownOutlined,
+  RightOutlined,
+} from "@ant-design/icons";
 import ForceGraph, {
   TYPE_COLORS,
   TYPE_LABELS,
@@ -40,6 +48,21 @@ const ALL_PREDICATES = [
 
 const ALL_PREDICATE_VALUES = ALL_PREDICATES.map((p) => p.value);
 
+// One-line plain-language gloss for each relation type — surfaced as a
+// tooltip on the filter checkboxes so terms like 「异译」「平行文本」
+// don't gate casual users out of the graph.
+const PREDICATE_DESC: Record<string, string> = {
+  translated: "某人翻译了某部典籍",
+  teacher_of: "师徒之间的传法承继关系",
+  member_of_school: "人物所归属的宗派",
+  cites: "一部典籍引用了另一部典籍",
+  commentary_on: "对某部典籍的注释或疏解",
+  active_in: "人物活跃的朝代或地域",
+  alt_translation: "同一原典的不同译本（异译）",
+  parallel_text: "跨语言或跨藏经对应的平行文本",
+  associated_with: "其它相关联系",
+};
+
 const TYPE_LABEL_MAP: Record<string, string> = {
   person: "人物",
   text: "典籍",
@@ -50,15 +73,78 @@ const TYPE_LABEL_MAP: Record<string, string> = {
   dynasty: "朝代",
 };
 
+// Curated entry points for the "推荐探索" strip. Every name below was
+// verified against the production /kg/entities API to resolve to at
+// least one related entity, so a chip never lands on an empty graph.
+const CURATED_GROUPS: { title: string; items: { label: string; type: string }[] }[] = [
+  {
+    title: "高僧大德",
+    items: [
+      { label: "玄奘", type: "person" },
+      { label: "鸠摩罗什", type: "person" },
+      { label: "不空", type: "person" },
+      { label: "义净", type: "person" },
+      { label: "法显", type: "person" },
+      { label: "龙树", type: "person" },
+      { label: "世亲", type: "person" },
+      { label: "无著", type: "person" },
+      { label: "法藏", type: "person" },
+      { label: "惠能", type: "person" },
+      { label: "智顗", type: "person" },
+      { label: "道宣", type: "person" },
+    ],
+  },
+  {
+    title: "八大宗派",
+    items: [
+      { label: "天台宗", type: "school" },
+      { label: "华严宗", type: "school" },
+      { label: "法相宗", type: "school" },
+      { label: "三论宗", type: "school" },
+      { label: "律宗", type: "school" },
+      { label: "净土宗", type: "school" },
+      { label: "禅宗", type: "school" },
+      { label: "密宗", type: "school" },
+    ],
+  },
+  {
+    title: "核心概念",
+    items: [
+      { label: "缘起", type: "concept" },
+      { label: "佛性", type: "concept" },
+      { label: "般若", type: "concept" },
+      { label: "涅槃", type: "concept" },
+      { label: "中观", type: "concept" },
+    ],
+  },
+];
+
 export default function KnowledgeGraphPage() {
-  const [query, setQuery] = useState("玄奘");
-  const [entityType, setEntityType] = useState("");
-  const [selectedEntityId, setSelectedEntityId] = useState<number | null>(null);
   const isMobile = typeof window !== "undefined" && window.innerWidth <= 768;
-  const [graphDepth, setGraphDepth] = useState(isMobile ? 1 : 2);
-  const [selectedPredicates, setSelectedPredicates] =
-    useState<string[]>(ALL_PREDICATE_VALUES);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Initialise all view state from the URL once, so a shared/bookmarked
+  // /kg?q=…&id=…&depth=…&rels=… link restores the exact same view.
+  const [query, setQuery] = useState(() => searchParams.get("q") || "玄奘");
+  const [entityType, setEntityType] = useState(() => searchParams.get("type") || "");
+  const [selectedEntityId, setSelectedEntityId] = useState<number | null>(() => {
+    const id = searchParams.get("id");
+    return id && /^\d+$/.test(id) ? Number(id) : null;
+  });
+  const [graphDepth, setGraphDepth] = useState(() => {
+    const d = Number(searchParams.get("depth"));
+    return d >= 1 && d <= 4 ? d : isMobile ? 1 : 2;
+  });
+  const [selectedPredicates, setSelectedPredicates] = useState<string[]>(() => {
+    const rels = searchParams.get("rels");
+    if (rels) {
+      const parsed = rels.split(",").filter((r) => ALL_PREDICATE_VALUES.includes(r));
+      if (parsed.length) return parsed;
+    }
+    return ALL_PREDICATE_VALUES;
+  });
   const [showStats, setShowStats] = useState(false);
+  const [curatedOpen, setCuratedOpen] = useState(!isMobile);
 
   const { data: kgStats } = useQuery({
     queryKey: ["kg-stats"],
@@ -66,8 +152,22 @@ export default function KnowledgeGraphPage() {
     staleTime: 60_000,
   });
 
-  // 标记是否需要自动选中下一次搜索结果
-  const autoSelectRef = useRef(true);
+  // 标记是否需要自动选中下一次搜索结果。初始为 true，除非 URL 已指定 id。
+  const autoSelectRef = useRef(!searchParams.get("id"));
+
+  // Mirror view state back into the URL (replace, so it doesn't spam
+  // history). Only non-default values are written to keep links clean.
+  useEffect(() => {
+    const next = new URLSearchParams();
+    if (query) next.set("q", query);
+    if (entityType) next.set("type", entityType);
+    if (selectedEntityId != null) next.set("id", String(selectedEntityId));
+    if (graphDepth !== (isMobile ? 1 : 2)) next.set("depth", String(graphDepth));
+    if (selectedPredicates.length !== ALL_PREDICATE_VALUES.length) {
+      next.set("rels", selectedPredicates.join(","));
+    }
+    setSearchParams(next, { replace: true });
+  }, [query, entityType, selectedEntityId, graphDepth, selectedPredicates, isMobile, setSearchParams]);
 
   const { data: searchResults, isLoading: searching } = useQuery({
     queryKey: ["kg-search", query, entityType],
@@ -108,6 +208,14 @@ export default function KnowledgeGraphPage() {
 
   const handleGraphNodeClick = (node: { id: number }) => {
     setSelectedEntityId(node.id);
+  };
+
+  // 点击「推荐探索」入口：相当于一次带类型过滤的搜索
+  const handleCurated = (label: string, type: string) => {
+    setQuery(label);
+    setEntityType(type);
+    setSelectedEntityId(null);
+    autoSelectRef.current = true;
   };
 
   const entityHasRelations = graphData && graphData.links.length > 0;
@@ -207,10 +315,46 @@ export default function KnowledgeGraphPage() {
             onChange={(vals) => setSelectedPredicates(vals as string[])}
             options={ALL_PREDICATES.map((p) => ({
               value: p.value,
-              label: p.label,
+              label: (
+                <Tooltip title={PREDICATE_DESC[p.value]}>
+                  <span>{p.label}</span>
+                </Tooltip>
+              ),
             }))}
           />
         </div>
+      </div>
+
+      {/* 推荐探索 — curated entry points so a new user doesn't face a blank search box */}
+      <div className="kg-curated">
+        <div
+          className="kg-curated-head"
+          onClick={() => setCuratedOpen((o) => !o)}
+        >
+          <CompassOutlined />
+          <span className="kg-curated-title">推荐探索</span>
+          {curatedOpen ? <DownOutlined /> : <RightOutlined />}
+        </div>
+        {curatedOpen && (
+          <div className="kg-curated-body">
+            {CURATED_GROUPS.map((g) => (
+              <div key={g.title} className="kg-curated-group">
+                <span className="kg-curated-group-title">{g.title}</span>
+                <div className="kg-curated-chips">
+                  {g.items.map((item) => (
+                    <button
+                      key={item.label}
+                      className={`kg-chip${query === item.label ? " active" : ""}`}
+                      onClick={() => handleCurated(item.label, item.type)}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Three-column layout */}
@@ -260,6 +404,11 @@ export default function KnowledgeGraphPage() {
                       >
                         {TYPE_LABEL_MAP[entity.entity_type] || entity.entity_type}
                       </span>
+                      {entity.relation_count != null && entity.relation_count > 0 && (
+                        <span className="kg-result-degree">
+                          {entity.relation_count} 关系
+                        </span>
+                      )}
                     </div>
                   </div>
                 ))

--- a/frontend/src/styles/kg.css
+++ b/frontend/src/styles/kg.css
@@ -174,6 +174,97 @@
   border-color: var(--fj-accent);
 }
 
+/* ---------- 推荐探索 ---------- */
+.kg-curated {
+  background: #faf8f4;
+  border: 1px solid var(--fj-border);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.kg-curated-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  cursor: pointer;
+  user-select: none;
+  color: var(--fj-ink-muted);
+}
+.kg-curated-head:hover { color: var(--fj-ink); }
+.kg-curated-head .anticon { font-size: 12px; }
+
+.kg-curated-title {
+  font-family: "Noto Serif SC", serif;
+  font-size: 13px;
+  font-weight: 600;
+  margin-right: auto;
+}
+
+.kg-curated-body {
+  padding: 4px 14px 12px;
+}
+
+.kg-curated-group {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 5px 0;
+}
+
+.kg-curated-group-title {
+  font-family: "Noto Serif SC", serif;
+  font-size: 12px;
+  color: var(--fj-ink-muted);
+  flex-shrink: 0;
+  width: 56px;
+}
+
+.kg-curated-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.kg-chip {
+  font-family: "Noto Serif SC", serif;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 3px 11px;
+  border-radius: 12px;
+  border: 1px solid var(--fj-border);
+  background: #fff;
+  color: var(--fj-ink-light);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.kg-chip:hover {
+  border-color: var(--fj-gold);
+  color: var(--fj-ink);
+}
+.kg-chip.active {
+  background: var(--fj-gold);
+  border-color: var(--fj-gold);
+  color: #fff;
+}
+
+@media (max-width: 768px) {
+  .kg-curated-group {
+    flex-direction: column;
+    gap: 4px;
+  }
+  .kg-curated-group-title { width: auto; }
+}
+
+/* 关系度数徽章 */
+.kg-result-degree {
+  font-size: 10px;
+  line-height: 18px;
+  color: #9a8e7a;
+  white-space: nowrap;
+}
+
 /* ---------- 三栏布局 ---------- */
 .kg-layout {
   display: flex;


### PR DESCRIPTION
## 知识图谱优化 · 第一波(上手与发现性)

针对 `/kg` 页面"功能完整但不会引导用户"的问题,本波聚焦**低成本高回报**的四项改进。

### 改动
1. **状态进 URL** — 搜索词 / 类型 / 选中实体 / 深度 / 关系筛选全部同步到 query string(`useSearchParams`,`replace` 模式不污染历史)。一张图谱视图现在**可收藏、可分享、刷新不丢**。
2. **「推荐探索」入口** — 在工具栏下新增可折叠的策展面板:高僧大德 / 八大宗派 / 核心概念。新用户落地即有去处,不必面对空搜索框。所有入口名称已逐一对生产 API 校验,保证点进去不是空图谱。
3. **搜索结果按图度数排序** — `search_entities` 在同一相关性档内按关系数量(degree)排序,同名实体解析到"最有料"的节点;度数透出为 `relation_count`,结果项显示「N 关系」徽章。
4. **关系类型 Tooltip** — 筛选勾选框加一句话白话解释(「异译」「平行文本」等术语不再劝退非专业用户)。

### 验证
- 后端 `tests/test_kg.py` 7 项通过(新增 relation_count 透传测试)。
- 前端 `tsc --noEmit` 通过,ESLint 无新增 error。
- 已过代码评审:无 P0;两项 P2(detail 端点 relation_count、面板键盘可达性)已在本 PR 修复。

后续第二波(边方向/节点缩放/移动端 Tab/渐进展开)、第三波(路径查询/关系出处/跨模块跳转)将分别提 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)