### PR TITLE
feat(kg): wave 3 — relation provenance + cross-module links

### DIFF
--- a/frontend/src/components/EntityCard.tsx
+++ b/frontend/src/components/EntityCard.tsx
@@ -1,6 +1,7 @@
-import { Typography, Button, Divider } from "antd";
+import { Typography, Button, Divider, Tooltip } from "antd";
 import {
   BookOutlined,
+  ReadOutlined,
   ArrowRightOutlined,
   ArrowLeftOutlined,
 } from "@ant-design/icons";
@@ -52,6 +53,27 @@ const PROPERTY_LABELS: Record<string, string> = {
   year_start: "生年",
   year_end: "卒年",
 };
+
+/* Relation-source provenance labels. A relation's `source` records where
+   the assertion came from — an authoritative catalogue, auto-extracted
+   metadata, or hand-seeded data. Surfacing it lets a scholar judge how
+   much to trust an edge instead of taking every relation at face value. */
+const SOURCE_LABELS: Record<string, string> = {
+  dila_catalog: "DILA 规范目录",
+  dila: "DILA 规范库",
+  "auto:cbeta_metadata": "CBETA 元数据",
+  "seed:lineage": "师承谱系（人工校订）",
+  "seed:person_place": "人物地理（人工校订）",
+  "seed:school_affiliation": "宗派归属（人工校订）",
+};
+
+function prettifySource(source: string): string {
+  if (SOURCE_LABELS[source]) return SOURCE_LABELS[source];
+  if (source.startsWith("seed:")) return "人工校订";
+  if (source.startsWith("auto:")) return "自动提取";
+  if (source.startsWith("dila")) return "DILA 规范库";
+  return source;
+}
 
 interface Entity {
   id: number;
@@ -119,7 +141,8 @@ export default function EntityCard({ entity, onEntityClick }: EntityCardProps) {
         </Typography.Paragraph>
       )}
 
-      {/* Link to text */}
+      {/* Cross-module jumps: read the linked text, or look the term up
+          in the Buddhist dictionary — so the graph isn't a dead end. */}
       {entity.text_id && (
         <Button
           type="link"
@@ -129,6 +152,19 @@ export default function EntityCard({ entity, onEntityClick }: EntityCardProps) {
           onClick={() => navigate(`/texts/${entity.text_id}`)}
         >
           查看关联经文
+        </Button>
+      )}
+      {entity.entity_type === "concept" && (
+        <Button
+          type="link"
+          size="small"
+          icon={<ReadOutlined />}
+          style={{ padding: 0, marginBottom: 10, color: "#8b2500", fontSize: 12 }}
+          onClick={() =>
+            navigate(`/dict/${encodeURIComponent(entity.name_zh)}`)
+          }
+        >
+          查辞典释义
         </Button>
       )}
 
@@ -298,6 +334,20 @@ export default function EntityCard({ entity, onEntityClick }: EntityCardProps) {
                         {targetMeta.label}
                       </span>
                       <span>{rel.target_name}</span>
+                      {rel.source && (
+                        <Tooltip title={`关系出处：${rel.source}`}>
+                          <span
+                            style={{
+                              fontSize: 10,
+                              color: "#b3a98f",
+                              marginLeft: "auto",
+                              flexShrink: 0,
+                            }}
+                          >
+                            据 {prettifySource(rel.source)}
+                          </span>
+                        </Tooltip>
+                      )}
                     </div>
                   );
                 })}


### PR DESCRIPTION
## 知识图谱优化 · 第三波(学术深度)

承接 #583 / #584,本波聚焦实体详情面板的学术可用性。

### 改动(`EntityCard.tsx`)
1. **关系出处** — 每条关系现在显示来源(`source`):「DILA 规范目录」「CBETA 元数据」「师承谱系(人工校订)」等。学者可据此判断一条边的可信度,而不是把所有关系都当作既定事实。原始 source 代码悬停可见。
2. **概念→辞典跨模块跳转** — 概念类实体新增「查辞典释义」按钮,跳转 `/dict/{词条}`,让图谱连出到辞典而不是走到死胡同(典籍类实体的「查看关联经文」已有)。

### 说明 / 后续
原分析第三波还含三项**重量级**改动,建议各自独立推进,不塞进本 PR:
- **路径查询**(两实体间最短关系路径)— 需新增后端 BFS 端点 + 新 UI。
- **渐进展开**(折叠默认 + 点击展开)— 需改图谱数据获取模型。
- **移动端 Tab 布局 / 时间轴** — 独立前端工作。

本波只做数据已就绪、零后端改动、纯增量的两项,当天可上线。

### 验证
- `tsc --noEmit` 通过;ESLint 0 error。
- 关系 source 取值已对生产 API 核验(dila_catalog / auto:cbeta_metadata / seed:* 等)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)