### PR TITLE
feat(kg): 渐进展开 — 邻域按需展开

### DIFF
--- a/frontend/src/components/ForceGraph.tsx
+++ b/frontend/src/components/ForceGraph.tsx
@@ -382,9 +382,21 @@ export default function ForceGraph({
         hideTooltip();
       })
       .on("click", (_event: any, d: any) => {
-        if (onNodeClick) onNodeClick(d);
+        // Debounce: wait 250 ms so a double-click can cancel before we
+        // treat this as a single-click re-root.  The timer is stored on
+        // the node datum itself so each node has its own pending timer.
+        if (d._clickTimer != null) return; // already waiting — this is the 2nd click of a dblclick, ignore
+        d._clickTimer = window.setTimeout(() => {
+          d._clickTimer = null;
+          if (onNodeClick) onNodeClick(d);
+        }, 250);
       })
       .on("dblclick", (event: any, d: any) => {
+        // Cancel the pending single-click timer so onNodeClick is NOT called.
+        if (d._clickTimer != null) {
+          clearTimeout(d._clickTimer);
+          d._clickTimer = null;
+        }
         // Prevent the zoom double-click handler from triggering on the node.
         event.stopPropagation();
         if (onNodeExpand) onNodeExpand(d);

--- a/frontend/src/components/ForceGraph.tsx
+++ b/frontend/src/components/ForceGraph.tsx
@@ -28,6 +28,10 @@ interface ForceGraphProps {
   width?: number;
   height?: number;
   onNodeClick?: (node: GraphNode) => void;
+  /** Called when the user double-clicks a node to progressively expand it. */
+  onNodeExpand?: (node: GraphNode) => void;
+  /** Set of node ids that have already been expanded (depth-1 fetched). */
+  expandedNodeIds?: Set<number>;
 }
 
 /* ── 古典配色 ── */
@@ -83,6 +87,8 @@ export default function ForceGraph({
   width: propWidth,
   height = 600,
   onNodeClick,
+  onNodeExpand,
+  expandedNodeIds,
 }: ForceGraphProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -276,6 +282,22 @@ export default function ForceGraph({
           }) as any
       );
 
+    // ── Expand ring: a faint outer circle on nodes that haven't yet been
+    // depth-1 expanded.  Gives the user a cue that double-clicking will
+    // reveal more connections without cluttering the layout.
+    node
+      .append("circle")
+      .attr("class", "expand-ring")
+      .attr("r", (d: any) => nodeRadius(d) + 5)
+      .attr("fill", "none")
+      .attr("stroke", (d: any) =>
+        expandedNodeIds?.has(d.id) ? "none" : (TYPE_COLORS[d.entity_type] || "#888")
+      )
+      .attr("stroke-width", 1.5)
+      .attr("stroke-opacity", (d: any) => (expandedNodeIds?.has(d.id) ? 0 : 0.35))
+      .attr("stroke-dasharray", "3 3")
+      .attr("pointer-events", "none");
+
     // Node circle with subtle shadow — radius scaled by degree
     node
       .append("circle")
@@ -341,10 +363,13 @@ export default function ForceGraph({
             return sid === d.id || tid === d.id ? 2.5 : 0.5;
           });
 
-        // Tooltip
+        // Tooltip — include expand hint if node hasn't been expanded yet
         const typeLabel = TYPE_LABELS[d.entity_type] || d.entity_type;
         let html = `<strong>${escapeHtml(d.name)}</strong> <span style="color:#9a8e7a">${escapeHtml(typeLabel)}</span>`;
         if (d.description) html += `<br><span style="color:#7a6e5c;font-size:11px">${escapeHtml(d.description)}</span>`;
+        if (onNodeExpand && !expandedNodeIds?.has(d.id)) {
+          html += `<br><span style="color:#b08d57;font-size:10px">双击展开邻域</span>`;
+        }
         showTooltip(html, event.offsetX, event.offsetY);
       })
       .on("mouseout", function () {
@@ -358,6 +383,11 @@ export default function ForceGraph({
       })
       .on("click", (_event: any, d: any) => {
         if (onNodeClick) onNodeClick(d);
+      })
+      .on("dblclick", (event: any, d: any) => {
+        // Prevent the zoom double-click handler from triggering on the node.
+        event.stopPropagation();
+        if (onNodeExpand) onNodeExpand(d);
       });
 
     // Trim a link to the node boundaries so it starts/ends at the
@@ -428,7 +458,7 @@ export default function ForceGraph({
     return () => {
       simulation.stop();
     };
-  }, [nodes, links, width, height, onNodeClick, showTooltip, hideTooltip]);
+  }, [nodes, links, width, height, onNodeClick, onNodeExpand, expandedNodeIds, showTooltip, hideTooltip]);
 
   return (
     <div ref={containerRef} style={{ width: "100%", position: "relative" }} role="img" aria-label="知识图谱可视化">

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Input, Select, Spin, Empty, Slider, Checkbox, Alert, Tooltip, Segmented } from "antd";
 import {
   ApartmentOutlined,
@@ -23,7 +23,7 @@ import EntityCard from "../components/EntityCard";
 import KGTimeline from "../components/kg/KGTimeline";
 import KGPathQuery from "../components/kg/KGPathQuery";
 import { searchKGEntities, getKGEntity, getKGEntityGraph, getKGStats, getKGTimeline } from "../api/client";
-import type { KGEntity } from "../api/client";
+import type { KGEntity, KGGraphNode, KGGraphLink } from "../api/client";
 import "../styles/kg.css";
 
 const { Search } = Input;
@@ -127,6 +127,36 @@ const CURATED_GROUPS: { title: string; items: { label: string; type: string }[] 
 // 移动端 Tab 三选项
 type MobileTab = "search" | "graph" | "detail";
 
+// ── Graph merge helpers ──────────────────────────────────────────────────────
+// Merge a freshly-fetched subgraph into the accumulated display set.
+// Nodes are deduped by id; links are deduped by source+target+predicate.
+function mergeGraphData(
+  base: { nodes: KGGraphNode[]; links: KGGraphLink[] },
+  incoming: { nodes: KGGraphNode[]; links: KGGraphLink[] },
+): { nodes: KGGraphNode[]; links: KGGraphLink[] } {
+  const nodeMap = new Map<number, KGGraphNode>(base.nodes.map((n) => [n.id as number, n]));
+  for (const n of incoming.nodes) {
+    if (!nodeMap.has(n.id as number)) nodeMap.set(n.id as number, n);
+  }
+
+  // Link key: smaller-id first so undirected duplicates also collapse.
+  const linkKey = (l: KGGraphLink) => {
+    const s = l.source as number;
+    const t = l.target as number;
+    return `${Math.min(s, t)}_${Math.max(s, t)}_${l.predicate}`;
+  };
+  const linkMap = new Map<string, KGGraphLink>(base.links.map((l) => [linkKey(l), l]));
+  for (const l of incoming.links) {
+    const k = linkKey(l);
+    if (!linkMap.has(k)) linkMap.set(k, l);
+  }
+
+  return {
+    nodes: [...nodeMap.values()],
+    links: [...linkMap.values()],
+  };
+}
+
 export default function KnowledgeGraphPage() {
   // 响应式 isMobile：监听 resize，避免旋转/窗口变化后失效
   const [isMobile, setIsMobile] = useState(
@@ -168,6 +198,22 @@ export default function KnowledgeGraphPage() {
   const [showStats, setShowStats] = useState(false);
   const [showTimeline, setShowTimeline] = useState(false);
   const [curatedOpen, setCuratedOpen] = useState(!isMobile);
+
+  // ── Progressive expand state ──────────────────────────────────────────────
+  // The graph displayed is an *accumulated* union of the initial fetch plus any
+  // depth-1 expansions triggered by the user.  Reset whenever the root entity,
+  // depth slider, or predicate filter changes.
+  const [accumulatedGraph, setAccumulatedGraph] = useState<{
+    nodes: KGGraphNode[];
+    links: KGGraphLink[];
+    truncated: boolean;
+  } | null>(null);
+
+  // Track which node ids have already been depth-1 fetched so we can draw
+  // the expand-ring affordance on unexpanded nodes.
+  const [expandedNodeIds, setExpandedNodeIds] = useState<Set<number>>(new Set());
+
+  const queryClient = useQueryClient();
 
   const { data: kgStats } = useQuery({
     queryKey: ["kg-stats"],
@@ -226,6 +272,66 @@ export default function KnowledgeGraphPage() {
     enabled: !!selectedEntityId,
   });
 
+  // Reset accumulated graph whenever the root query changes — entity, depth, or
+  // predicate filter. Seed immediately from the initial fetch result so the
+  // graph renders as soon as data arrives.
+  useEffect(() => {
+    if (graphData) {
+      setAccumulatedGraph({
+        nodes: graphData.nodes,
+        links: graphData.links,
+        truncated: graphData.truncated,
+      });
+      // Mark the root entity as expanded (initial fetch already covers its neighbourhood)
+      setExpandedNodeIds(selectedEntityId != null ? new Set([selectedEntityId]) : new Set());
+    } else {
+      setAccumulatedGraph(null);
+      setExpandedNodeIds(new Set());
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graphData]);
+
+  // When the root entity / depth / predicates change, clear stale accumulated data
+  // immediately (don't wait for the new fetch) so the graph never shows old data.
+  const prevRootRef = useRef<string>("");
+  useEffect(() => {
+    const key = `${selectedEntityId}_${graphDepth}_${selectedPredicates.join(",")}`;
+    if (key !== prevRootRef.current) {
+      prevRootRef.current = key;
+      setAccumulatedGraph(null);
+      setExpandedNodeIds(new Set());
+    }
+  }, [selectedEntityId, graphDepth, selectedPredicates]);
+
+  // ── Expand handler ─────────────────────────────────────────────────────────
+  // Fetches the depth-1 neighbourhood of a node and merges it into the
+  // accumulated display graph.  Uses queryClient.fetchQuery so the result is
+  // cached and avoids re-fetching if the same node is double-clicked again.
+  const handleNodeExpand = useCallback(
+    async (node: { id: number }) => {
+      if (expandedNodeIds.has(node.id)) return; // already expanded
+
+      try {
+        const incoming = await queryClient.fetchQuery({
+          queryKey: ["kg-graph-expand", node.id, selectedPredicates],
+          queryFn: () => getKGEntityGraph(node.id, 1, 80, selectedPredicates),
+          staleTime: 5 * 60_000,
+        });
+
+        setAccumulatedGraph((prev) => {
+          if (!prev) return prev;
+          const merged = mergeGraphData(prev, incoming);
+          return { ...merged, truncated: prev.truncated || incoming.truncated };
+        });
+
+        setExpandedNodeIds((prev) => new Set([...prev, node.id]));
+      } catch {
+        // Silent fail — if the network request errors the graph stays as-is
+      }
+    },
+    [expandedNodeIds, selectedPredicates, queryClient],
+  );
+
   const handleSearch = (value: string) => {
     setQuery(value.trim());
     setSelectedEntityId(null);
@@ -254,16 +360,20 @@ export default function KnowledgeGraphPage() {
     if (isMobile) setMobileTab("search");
   };
 
-  const entityHasRelations = graphData && graphData.links.length > 0;
+  // Use accumulated graph for display; fall back to raw query result while the
+  // first effect hasn't run yet (avoids a blank frame on initial load).
+  const displayGraph = accumulatedGraph ?? graphData ?? null;
+
+  const entityHasRelations = displayGraph && displayGraph.links.length > 0;
 
   // Compute used types/predicates for legend
   const usedNodeTypes = useMemo(
-    () => [...new Set((graphData?.nodes || []).map((n) => n.entity_type))],
-    [graphData]
+    () => [...new Set((displayGraph?.nodes || []).map((n) => n.entity_type))],
+    [displayGraph]
   );
   const usedPredicates = useMemo(
-    () => [...new Set((graphData?.links || []).map((l) => l.predicate))],
-    [graphData]
+    () => [...new Set((displayGraph?.links || []).map((l) => l.predicate))],
+    [displayGraph]
   );
 
   // Graph height: fill viewport; on mobile use a shorter but still usable height
@@ -562,27 +672,29 @@ export default function KnowledgeGraphPage() {
                   )}
                 </Empty>
               </div>
-            ) : graphData?.nodes.length ? (
+            ) : displayGraph?.nodes.length ? (
               <div className="kg-graph-container">
-                {graphData.truncated && (
+                {displayGraph.truncated && (
                   <div className="kg-truncated-bar">
                     <Alert
                       type="warning"
                       showIcon
                       message={
                         isMobile
-                          ? `节点过多（${graphData.nodes.length}），请减小深度`
-                          : `图谱节点超出（${graphData.nodes.length} 节点 / ${graphData.links.length} 边），可减小深度或过滤关系类型`
+                          ? `节点过多（${displayGraph.nodes.length}），请减小深度或按需展开`
+                          : `图谱节点超出（${displayGraph.nodes.length} 节点 / ${displayGraph.links.length} 边），可减小深度、过滤关系类型，或双击节点按需展开`
                       }
                       closable
                     />
                   </div>
                 )}
                 <ForceGraph
-                  nodes={graphData.nodes}
-                  links={graphData.links}
+                  nodes={displayGraph.nodes}
+                  links={displayGraph.links}
                   height={graphHeight}
                   onNodeClick={handleGraphNodeClick}
+                  onNodeExpand={handleNodeExpand}
+                  expandedNodeIds={expandedNodeIds}
                 />
                 {/* HTML Legend */}
                 <div className="kg-legend">

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -213,6 +213,10 @@ export default function KnowledgeGraphPage() {
   // the expand-ring affordance on unexpanded nodes.
   const [expandedNodeIds, setExpandedNodeIds] = useState<Set<number>>(new Set());
 
+  // Ref mirror of expandedNodeIds — kept in sync after every setState so
+  // handleNodeExpand can read the latest value without being recreated.
+  const expandedNodeIdsRef = useRef<Set<number>>(new Set());
+
   const queryClient = useQueryClient();
 
   const { data: kgStats } = useQuery({
@@ -272,49 +276,68 @@ export default function KnowledgeGraphPage() {
     enabled: !!selectedEntityId,
   });
 
-  // Reset accumulated graph whenever the root query changes — entity, depth, or
-  // predicate filter. Seed immediately from the initial fetch result so the
-  // graph renders as soon as data arrives.
+  // Single coherent effect: manages both clearing on root-key change and
+  // seeding from graphData.  Tracks the "current root key" so we only seed
+  // accumulatedGraph when graphData actually belongs to the active query —
+  // this eliminates the two-effect race where the clear ran, then the old
+  // graphData seeded stale data for one render before the refetch finished.
+  const prevRootRef = useRef<string>("");
+  // The root key that graphData currently corresponds to (react-query's
+  // queryKey is [entity, depth, predicates], so we build the same key here).
   useEffect(() => {
-    if (graphData) {
+    const key = `${selectedEntityId}_${graphDepth}_${selectedPredicates.join(",")}`;
+    const rootChanged = key !== prevRootRef.current;
+
+    if (rootChanged) {
+      // Root changed: immediately wipe accumulated state.
+      prevRootRef.current = key;
+      setAccumulatedGraph(null);
+      const empty = new Set<number>();
+      setExpandedNodeIds(empty);
+      expandedNodeIdsRef.current = empty;
+    }
+
+    // Seed from graphData only when it matches the *current* root key.
+    // If the root just changed above, graphData is still from the old query
+    // (react-query hasn't refetched yet) — we must not seed from it.
+    if (!rootChanged && graphData) {
       setAccumulatedGraph({
         nodes: graphData.nodes,
         links: graphData.links,
         truncated: graphData.truncated,
       });
-      // Mark the root entity as expanded (initial fetch already covers its neighbourhood)
-      setExpandedNodeIds(selectedEntityId != null ? new Set([selectedEntityId]) : new Set());
-    } else {
-      setAccumulatedGraph(null);
-      setExpandedNodeIds(new Set());
+      // Mark the root entity as expanded (initial fetch covers its neighbourhood)
+      const seeded = selectedEntityId != null ? new Set([selectedEntityId]) : new Set<number>();
+      setExpandedNodeIds(seeded);
+      expandedNodeIdsRef.current = seeded;
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [graphData]);
-
-  // When the root entity / depth / predicates change, clear stale accumulated data
-  // immediately (don't wait for the new fetch) so the graph never shows old data.
-  const prevRootRef = useRef<string>("");
-  useEffect(() => {
-    const key = `${selectedEntityId}_${graphDepth}_${selectedPredicates.join(",")}`;
-    if (key !== prevRootRef.current) {
-      prevRootRef.current = key;
-      setAccumulatedGraph(null);
-      setExpandedNodeIds(new Set());
-    }
-  }, [selectedEntityId, graphDepth, selectedPredicates]);
+  }, [selectedEntityId, graphDepth, selectedPredicates, graphData]);
 
   // ── Expand handler ─────────────────────────────────────────────────────────
   // Fetches the depth-1 neighbourhood of a node and merges it into the
   // accumulated display graph.  Uses queryClient.fetchQuery so the result is
   // cached and avoids re-fetching if the same node is double-clicked again.
+  //
+  // P2: reads expandedNodeIds from a ref (not the state) so this callback
+  // is never recreated on each expand — stable identity prevents the d3
+  // simulation from re-initialising on every expand.
+  //
+  // selectedPredicates is captured via a ref for the same reason: the
+  // callback identity must not change when predicates change between expands.
+  const selectedPredicatesRef = useRef<string[]>(selectedPredicates);
+  useEffect(() => {
+    selectedPredicatesRef.current = selectedPredicates;
+  }, [selectedPredicates]);
+
   const handleNodeExpand = useCallback(
     async (node: { id: number }) => {
-      if (expandedNodeIds.has(node.id)) return; // already expanded
+      if (expandedNodeIdsRef.current.has(node.id)) return; // already expanded
 
+      const predicates = selectedPredicatesRef.current;
       try {
         const incoming = await queryClient.fetchQuery({
-          queryKey: ["kg-graph-expand", node.id, selectedPredicates],
-          queryFn: () => getKGEntityGraph(node.id, 1, 80, selectedPredicates),
+          queryKey: ["kg-graph-expand", node.id, predicates],
+          queryFn: () => getKGEntityGraph(node.id, 1, 80, predicates),
           staleTime: 5 * 60_000,
         });
 
@@ -324,12 +347,17 @@ export default function KnowledgeGraphPage() {
           return { ...merged, truncated: prev.truncated || incoming.truncated };
         });
 
-        setExpandedNodeIds((prev) => new Set([...prev, node.id]));
+        setExpandedNodeIds((prev) => {
+          const next = new Set([...prev, node.id]);
+          expandedNodeIdsRef.current = next;
+          return next;
+        });
       } catch {
         // Silent fail — if the network request errors the graph stays as-is
       }
     },
-    [expandedNodeIds, selectedPredicates, queryClient],
+    // queryClient is stable; refs are stable — no deps that would cause churn
+    [queryClient],
   );
 
   const handleSearch = (value: string) => {


### PR DESCRIPTION
## 功能说明

知识图谱「渐进展开」：初始渲染根实体的 depth-N 子图，用户可双击任意节点按需拉取其 depth-1 邻域并合并进当前视图，避免大枢纽节点一次性触发 150 节点上限截断。

## 主要变更

**`frontend/src/components/ForceGraph.tsx`**
- 新增可选 prop `onNodeExpand?: (node) => void` 和 `expandedNodeIds?: Set<number>`
- `dblclick` 事件触发 `onNodeExpand`（`stopPropagation` 防止 d3-zoom 缩放干扰）
- 每个**未展开**节点绘制同色虚线外环（`stroke-dasharray: 3 3`，透明度 0.35），展开后环消失
- hover tooltip 对未展开节点附加「双击展开邻域」提示（金色小字，与古典配色一致）
- 单击选中、拖拽、缩放、高亮等既有交互**不受影响**

**`frontend/src/pages/KnowledgeGraphPage.tsx`**
- 引入 `accumulatedGraph` 状态（`{ nodes, links, truncated }`）作为实际渲染数据
- 引入 `expandedNodeIds: Set<number>` 追踪已展开节点
- `graphData`（初始查询）到达后种入累积集合；entity / depth / predicates 三者任一变化立即清空并重置
- `handleNodeExpand` 通过 `queryClient.fetchQuery` 拉取 depth-1 子图（结果 5 分钟缓存，重复双击不重发请求），调用 `mergeGraphData` 按 id / source+target+predicate 去重合并
- 截断警告文案更新为提示用户「双击节点按需展开」
- 图例、legend、usedNodeTypes/usedPredicates 均改用 `displayGraph`（= `accumulatedGraph ?? graphData`）

## 测试建议

1. 选择「玄奘」或「龙树」等高连接度实体，确认初始图正常渲染
2. 双击图内一个非根节点 → 验证新邻域节点/边合并进图，虚线环消失
3. 重复双击同一节点 → 不再发起网络请求（React Query 缓存命中）
4. 切换深度滑块或取消某关系类型 → 图重置，所有虚线环重新出现
5. 单击节点仍跳转实体详情，拖拽/缩放不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)