### PR TITLE
feat(kg): 时间轴视图

### DIFF
--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -18,6 +18,8 @@ from app.schemas.knowledge_graph import (
     KGGraphResponse,
     KGLineageArcsResponse,
     KGSearchResponse,
+    KGTimelineEntity,
+    KGTimelineResponse,
 )
 from app.services.knowledge_graph import (
     get_entity,
@@ -27,6 +29,7 @@ from app.services.knowledge_graph import (
     get_kg_stats,
     get_lineage_arcs,
     get_text_entities,
+    get_timeline_entities,
     search_entities,
 )
 
@@ -96,6 +99,25 @@ async def kg_stats(db: AsyncSession = Depends(get_db)):
 
     获取知识图谱统计信息（各类型实体与关系数量）。"""
     return await get_kg_stats(db)
+
+
+@router.get("/timeline", response_model=KGTimelineResponse)
+async def get_kg_timeline(
+    entity_type: str | None = Query(
+        None,
+        description="Filter by entity type (e.g. 'person', 'dynasty'). Omit for all temporal entities.",
+    ),
+    limit: int = Query(500, le=2000),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get knowledge graph entities with temporal data for timeline display.
+
+    返回携带有效起始年份的知识图谱实体，用于时间轴可视化。BCE年份以负整数表示。"""
+    entities, total = await get_timeline_entities(db, entity_type, limit)
+    return KGTimelineResponse(
+        entities=[KGTimelineEntity(**e) for e in entities],
+        total=total,
+    )
 
 
 @router.get("/geo", response_model=KGGeoResponse)

--- a/backend/app/schemas/knowledge_graph.py
+++ b/backend/app/schemas/knowledge_graph.py
@@ -110,3 +110,16 @@ class KGLineageArc(BaseModel):
 class KGLineageArcsResponse(BaseModel):
     arcs: list[KGLineageArc]
     total: int
+
+
+class KGTimelineEntity(BaseModel):
+    id: int
+    name_zh: str
+    entity_type: str
+    year_start: int
+    year_end: int | None = None
+
+
+class KGTimelineResponse(BaseModel):
+    entities: list[KGTimelineEntity]
+    total: int

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -429,6 +429,66 @@ async def get_geo_entities(
     return entities, total
 
 
+async def get_timeline_entities(
+    session: AsyncSession,
+    entity_type: str | None = None,
+    limit: int = 500,
+) -> tuple[list[dict], int]:
+    """Get entities with usable temporal data (numeric year_start required).
+
+    返回具有有效起始年份的实体列表，支持朝代和人物类型；BCE年份以负整数表示。"""
+    # Allow filtering by a single entity_type; if absent, return both person
+    # and dynasty rows (the two types most likely to carry year data).
+    if entity_type:
+        type_condition = "e.entity_type = :entity_type"
+        params: dict = {"entity_type": entity_type, "limit": limit}
+    else:
+        type_condition = "e.entity_type IN ('person', 'dynasty')"
+        params = {"limit": limit}
+
+    sql = text(
+        f"""
+        SELECT
+            e.id,
+            e.name_zh,
+            e.entity_type,
+            (e.properties->>'year_start')::int AS year_start,
+            (e.properties->>'year_end')::int   AS year_end
+        FROM kg_entities e
+        WHERE {type_condition}
+          AND (e.properties->>'year_start') ~ '^-?[0-9]+$'
+          AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
+        ORDER BY (e.properties->>'year_start')::int ASC
+        LIMIT :limit
+        """  # nosec B608 - type_condition is a hardcoded clause, not user input
+    )
+    result = await session.execute(sql, params)
+    rows = result.fetchall()
+
+    count_sql = text(
+        f"""
+        SELECT COUNT(*) FROM kg_entities e
+        WHERE {type_condition}
+          AND (e.properties->>'year_start') ~ '^-?[0-9]+$'
+          AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
+        """  # nosec B608
+    )
+    count_result = await session.execute(count_sql, params)
+    total = count_result.scalar() or 0
+
+    entities = [
+        {
+            "id": row[0],
+            "name_zh": row[1],
+            "entity_type": row[2],
+            "year_start": row[3],
+            "year_end": row[4],
+        }
+        for row in rows
+    ]
+    return entities, total
+
+
 async def get_lineage_arcs(
     session: AsyncSession,
     school: str | None = None,

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -446,6 +446,11 @@ async def get_timeline_entities(
         type_condition = "e.entity_type IN ('person', 'dynasty')"
         params = {"limit": limit}
 
+    # Year regex is length-bounded ('{1,6}'): a plain '[0-9]+' would let a
+    # 20-digit string pass the filter and then overflow int4 in the cast,
+    # crashing the endpoint. year_end is cast through a CASE because it has
+    # no WHERE filter of its own — a row with a valid year_start but a
+    # garbage year_end must yield NULL, not an error.
     sql = text(
         f"""
         SELECT
@@ -453,10 +458,14 @@ async def get_timeline_entities(
             e.name_zh,
             e.entity_type,
             (e.properties->>'year_start')::int AS year_start,
-            (e.properties->>'year_end')::int   AS year_end
+            CASE
+                WHEN (e.properties->>'year_end') ~ '^-?[0-9]{{1,6}}$'
+                THEN (e.properties->>'year_end')::int
+                ELSE NULL
+            END AS year_end
         FROM kg_entities e
         WHERE {type_condition}
-          AND (e.properties->>'year_start') ~ '^-?[0-9]+$'
+          AND (e.properties->>'year_start') ~ '^-?[0-9]{{1,6}}$'
           AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
         ORDER BY (e.properties->>'year_start')::int ASC
         LIMIT :limit
@@ -469,7 +478,7 @@ async def get_timeline_entities(
         f"""
         SELECT COUNT(*) FROM kg_entities e
         WHERE {type_condition}
-          AND (e.properties->>'year_start') ~ '^-?[0-9]+$'
+          AND (e.properties->>'year_start') ~ '^-?[0-9]{{1,6}}$'
           AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
         """  # nosec B608
     )

--- a/backend/tests/test_kg.py
+++ b/backend/tests/test_kg.py
@@ -202,6 +202,87 @@ async def test_entity_detail_includes_relations(kg_client):
 
 
 # ---------------------------------------------------------------------------
+# Test 8: 时间轴端点返回实体列表及 total
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_timeline_returns_entities(kg_client):
+    timeline_entities = [
+        {"id": 4, "name_zh": "玄奘", "entity_type": "person",
+         "year_start": 602, "year_end": 664},
+        {"id": 6, "name_zh": "法显", "entity_type": "person",
+         "year_start": 337, "year_end": 422},
+    ]
+    with patch(f"{_KG_API}.get_timeline_entities") as m:
+        m.return_value = (timeline_entities, 2)
+        resp = await kg_client.get("/api/kg/timeline")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert len(data["entities"]) == 2
+        assert data["entities"][0]["name_zh"] == "玄奘"
+        assert data["entities"][0]["year_start"] == 602
+        assert data["entities"][0]["year_end"] == 664
+
+
+# ---------------------------------------------------------------------------
+# Test 9: 时间轴端点支持 entity_type 过滤
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_timeline_entity_type_filter(kg_client):
+    dynasty_entity = [
+        {"id": 10, "name_zh": "唐朝", "entity_type": "dynasty",
+         "year_start": 618, "year_end": 907},
+    ]
+    with patch(f"{_KG_API}.get_timeline_entities") as m:
+        m.return_value = (dynasty_entity, 1)
+        resp = await kg_client.get("/api/kg/timeline", params={"entity_type": "dynasty"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["entities"][0]["entity_type"] == "dynasty"
+        # Verify service was called with the filter
+        m.assert_called_once()
+        call_kwargs = m.call_args
+        assert call_kwargs[0][1] == "dynasty" or call_kwargs[1].get("entity_type") == "dynasty"
+
+
+# ---------------------------------------------------------------------------
+# Test 10: 时间轴端点正确处理 BCE（负数）年份
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_timeline_bce_years(kg_client):
+    bce_entity = [
+        {"id": 20, "name_zh": "龙树", "entity_type": "person",
+         "year_start": -150, "year_end": -70},
+    ]
+    with patch(f"{_KG_API}.get_timeline_entities") as m:
+        m.return_value = (bce_entity, 1)
+        resp = await kg_client.get("/api/kg/timeline")
+        assert resp.status_code == 200
+        entities = resp.json()["entities"]
+        assert entities[0]["year_start"] == -150
+        assert entities[0]["year_end"] == -70
+
+
+# ---------------------------------------------------------------------------
+# Test 11: 时间轴端点处理 year_end 为空的实体
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_timeline_missing_year_end(kg_client):
+    partial_entity = [
+        {"id": 30, "name_zh": "某法师", "entity_type": "person",
+         "year_start": 800, "year_end": None},
+    ]
+    with patch(f"{_KG_API}.get_timeline_entities") as m:
+        m.return_value = (partial_entity, 1)
+        resp = await kg_client.get("/api/kg/timeline")
+        assert resp.status_code == 200
+        entities = resp.json()["entities"]
+        assert entities[0]["year_start"] == 800
+        assert entities[0]["year_end"] is None
+
+
+# ---------------------------------------------------------------------------
 # Test 7: 搜索结果透出 relation_count（图度数），供前端排序徽章使用
 # ---------------------------------------------------------------------------
 @pytest.mark.anyio

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -730,6 +730,27 @@ export async function getKGLineageArcs(params?: {
   return data;
 }
 
+export interface KGTimelineEntity {
+  id: number;
+  name_zh: string;
+  entity_type: string;
+  year_start: number;
+  year_end: number | null;
+}
+
+export interface KGTimelineResponse {
+  entities: KGTimelineEntity[];
+  total: number;
+}
+
+export async function getKGTimeline(params?: {
+  entity_type?: string;
+  limit?: number;
+}): Promise<KGTimelineResponse> {
+  const { data } = await api.get<KGTimelineResponse>("/kg/timeline", { params });
+  return data;
+}
+
 // Dictionary
 export interface DictEntry {
   id: DictEntryId;

--- a/frontend/src/components/kg/KGTimeline.tsx
+++ b/frontend/src/components/kg/KGTimeline.tsx
@@ -1,0 +1,287 @@
+/**
+ * KGTimeline — 知识图谱实体时间轴视图
+ *
+ * 将携带 year_start（及可选 year_end）的实体渲染在水平时间轴上。
+ * - person / dynasty 各自以 TYPE_COLORS 配色区分。
+ * - BCE 年份以负整数表示，坐标轴正确处理跨零点跨度。
+ * - 单点实体（无 year_end）显示为圆点；有时段的显示为短横条。
+ * - 点击实体调用 onEntityClick(id)。
+ */
+
+import { useMemo, useRef, useState, useEffect } from "react";
+import { Spin, Empty, Tooltip } from "antd";
+import { TYPE_COLORS } from "../ForceGraph";
+import type { KGTimelineEntity } from "../../api/client";
+
+interface KGTimelineProps {
+  entities: KGTimelineEntity[];
+  loading?: boolean;
+  onEntityClick: (id: number) => void;
+  selectedEntityId?: number | null;
+}
+
+// 年份格式化：负数显示为 BCE，正数直接显示
+function formatYear(year: number): string {
+  if (year < 0) return `公元前 ${Math.abs(year)}`;
+  return `公元 ${year}`;
+}
+
+// 每个 entity_type 在时间轴上的垂直分组序号（影响 y 偏移，用于错排防重叠）
+const TYPE_ROW: Record<string, number> = {
+  dynasty: 0,
+  person: 1,
+};
+
+const ROW_HEIGHT = 28;   // px per entity-type row
+const POINT_R = 5;       // 单点圆半径
+const BAR_H = 10;        // 时段横条高度
+const MIN_BAR_W = 4;     // 最小横条宽度（避免过细不可点）
+const AXIS_H = 28;       // 坐标轴高度（底部）
+const PADDING = { top: 8, right: 24, bottom: AXIS_H, left: 24 };
+
+export default function KGTimeline({
+  entities,
+  loading,
+  onEntityClick,
+  selectedEntityId,
+}: KGTimelineProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(800);
+
+  // 响应容器宽度
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w && w > 0) setWidth(w);
+    });
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  const { domain, rowGroups, svgHeight } = useMemo(() => {
+    if (!entities.length) {
+      return { domain: [-100, 2000] as [number, number], rowGroups: {}, svgHeight: 80 };
+    }
+
+    const allYears = entities.flatMap((e) =>
+      e.year_end != null ? [e.year_start, e.year_end] : [e.year_start]
+    );
+    const minY = Math.min(...allYears);
+    const maxY = Math.max(...allYears);
+    // 留出边距
+    const pad = Math.max((maxY - minY) * 0.02, 30);
+    const domain: [number, number] = [minY - pad, maxY + pad];
+
+    // 按 entity_type 分组
+    const rowGroups: Record<string, KGTimelineEntity[]> = {};
+    for (const e of entities) {
+      (rowGroups[e.entity_type] ??= []).push(e);
+    }
+
+    const numRows = Object.keys(rowGroups).length;
+    const svgHeight = PADDING.top + numRows * ROW_HEIGHT + PADDING.bottom + 8;
+
+    return { domain, rowGroups, svgHeight };
+  }, [entities]);
+
+  // 线性映射 year → x
+  const chartW = width - PADDING.left - PADDING.right;
+  const scaleX = (year: number) => {
+    const ratio = (year - domain[0]) / (domain[1] - domain[0]);
+    return PADDING.left + ratio * chartW;
+  };
+
+  // 坐标轴刻度（最多 10 个）
+  const ticks = useMemo(() => {
+    const span = domain[1] - domain[0];
+    const rough = span / 8;
+    const magnitude = Math.pow(10, Math.floor(Math.log10(rough)));
+    const candidates = [1, 2, 5, 10].map((m) => m * magnitude);
+    const step = candidates.find((c) => span / c <= 10) ?? magnitude * 10;
+    const start = Math.ceil(domain[0] / step) * step;
+    const result: number[] = [];
+    for (let y = start; y <= domain[1]; y += step) result.push(y);
+    return result;
+  }, [domain]);
+
+  // 按类型排序的 row 列表（dynasty 排在上方）
+  const sortedTypes = Object.keys(rowGroups).sort(
+    (a, b) => (TYPE_ROW[a] ?? 99) - (TYPE_ROW[b] ?? 99)
+  );
+
+  if (loading) {
+    return (
+      <div className="kg-timeline-loading">
+        <Spin />
+      </div>
+    );
+  }
+
+  if (!entities.length) {
+    return (
+      <div className="kg-timeline-empty">
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="暂无时间数据"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="kg-timeline-wrap" ref={containerRef}>
+      <svg
+        width={width}
+        height={svgHeight}
+        className="kg-timeline-svg"
+        aria-label="知识图谱时间轴"
+      >
+        {/* ── 坐标轴底线 ── */}
+        <line
+          x1={PADDING.left}
+          y1={svgHeight - PADDING.bottom}
+          x2={width - PADDING.right}
+          y2={svgHeight - PADDING.bottom}
+          stroke="#c8bfb0"
+          strokeWidth={1}
+        />
+
+        {/* ── 刻度 ── */}
+        {ticks.map((y) => {
+          const x = scaleX(y);
+          return (
+            <g key={y}>
+              <line
+                x1={x} y1={svgHeight - PADDING.bottom}
+                x2={x} y2={svgHeight - PADDING.bottom + 5}
+                stroke="#c8bfb0"
+                strokeWidth={1}
+              />
+              <text
+                x={x}
+                y={svgHeight - PADDING.bottom + 16}
+                textAnchor="middle"
+                fontSize={10}
+                fill="#9a8e7a"
+                fontFamily="'Noto Serif SC', serif"
+              >
+                {y < 0 ? `前${Math.abs(y)}` : y}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* ── 各类型行 ── */}
+        {sortedTypes.map((etype, rowIdx) => {
+          const color = TYPE_COLORS[etype] ?? "#888";
+          const rowY = PADDING.top + rowIdx * ROW_HEIGHT + ROW_HEIGHT / 2;
+          const rowEntities = rowGroups[etype];
+
+          return (
+            <g key={etype}>
+              {/* 行背景网格线 */}
+              <line
+                x1={PADDING.left}
+                y1={rowY}
+                x2={width - PADDING.right}
+                y2={rowY}
+                stroke="#f0ebe3"
+                strokeWidth={1}
+              />
+
+              {/* 实体 */}
+              {rowEntities.map((e) => {
+                const x1 = scaleX(e.year_start);
+                const isSelected = e.id === selectedEntityId;
+
+                if (e.year_end != null && e.year_end !== e.year_start) {
+                  // 时段横条
+                  const x2 = scaleX(e.year_end);
+                  const barW = Math.max(x2 - x1, MIN_BAR_W);
+                  return (
+                    <Tooltip
+                      key={e.id}
+                      title={`${e.name_zh}（${formatYear(e.year_start)} — ${formatYear(e.year_end)}）`}
+                      placement="top"
+                    >
+                      <rect
+                        x={x1}
+                        y={rowY - BAR_H / 2}
+                        width={barW}
+                        height={BAR_H}
+                        rx={3}
+                        ry={3}
+                        fill={color}
+                        fillOpacity={isSelected ? 1 : 0.72}
+                        stroke={isSelected ? "#fff" : "none"}
+                        strokeWidth={isSelected ? 1.5 : 0}
+                        style={{ cursor: "pointer" }}
+                        onClick={() => onEntityClick(e.id)}
+                        tabIndex={0}
+                        role="button"
+                        aria-label={e.name_zh}
+                        onKeyDown={(ev) => {
+                          if (ev.key === "Enter" || ev.key === " ") {
+                            ev.preventDefault();
+                            onEntityClick(e.id);
+                          }
+                        }}
+                      />
+                    </Tooltip>
+                  );
+                }
+
+                // 单点
+                return (
+                  <Tooltip
+                    key={e.id}
+                    title={`${e.name_zh}（${formatYear(e.year_start)}）`}
+                    placement="top"
+                  >
+                    <circle
+                      cx={x1}
+                      cy={rowY}
+                      r={isSelected ? POINT_R + 2 : POINT_R}
+                      fill={color}
+                      fillOpacity={isSelected ? 1 : 0.78}
+                      stroke={isSelected ? "#fff" : "rgba(0,0,0,0.12)"}
+                      strokeWidth={isSelected ? 2 : 1}
+                      style={{ cursor: "pointer" }}
+                      onClick={() => onEntityClick(e.id)}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={e.name_zh}
+                      onKeyDown={(ev) => {
+                        if (ev.key === "Enter" || ev.key === " ") {
+                          ev.preventDefault();
+                          onEntityClick(e.id);
+                        }
+                      }}
+                    />
+                  </Tooltip>
+                );
+              })}
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* ── 图例 ── */}
+      <div className="kg-timeline-legend">
+        {sortedTypes.map((etype) => (
+          <span key={etype} className="kg-timeline-legend-item">
+            <span
+              className="kg-timeline-legend-swatch"
+              style={{ background: TYPE_COLORS[etype] ?? "#888" }}
+            />
+            {etype === "person" ? "人物" : etype === "dynasty" ? "朝代" : etype}
+            <span className="kg-timeline-legend-count">
+              {rowGroups[etype].length}
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -11,6 +11,7 @@ import {
   RightOutlined,
   UnorderedListOutlined,
   ProfileOutlined,
+  FieldTimeOutlined,
 } from "@ant-design/icons";
 import ForceGraph, {
   TYPE_COLORS,
@@ -19,7 +20,8 @@ import ForceGraph, {
   PREDICATE_COLORS,
 } from "../components/ForceGraph";
 import EntityCard from "../components/EntityCard";
-import { searchKGEntities, getKGEntity, getKGEntityGraph, getKGStats } from "../api/client";
+import KGTimeline from "../components/kg/KGTimeline";
+import { searchKGEntities, getKGEntity, getKGEntityGraph, getKGStats, getKGTimeline } from "../api/client";
 import type { KGEntity } from "../api/client";
 import "../styles/kg.css";
 
@@ -163,12 +165,20 @@ export default function KnowledgeGraphPage() {
     return ALL_PREDICATE_VALUES;
   });
   const [showStats, setShowStats] = useState(false);
+  const [showTimeline, setShowTimeline] = useState(false);
   const [curatedOpen, setCuratedOpen] = useState(!isMobile);
 
   const { data: kgStats } = useQuery({
     queryKey: ["kg-stats"],
     queryFn: getKGStats,
     staleTime: 60_000,
+  });
+
+  const { data: timelineData, isLoading: timelineLoading } = useQuery({
+    queryKey: ["kg-timeline"],
+    queryFn: () => getKGTimeline({ limit: 1000 }),
+    staleTime: 300_000,
+    enabled: showTimeline,
   });
 
   // 标记是否需要自动选中下一次搜索结果。初始为 true，除非 URL 已指定 id。
@@ -279,7 +289,37 @@ export default function KnowledgeGraphPage() {
             </span>
           </Tooltip>
         )}
+        <Tooltip title="时间轴视图">
+          <span
+            className={`kg-timeline-toggle${showTimeline ? " active" : ""}`}
+            onClick={() => setShowTimeline((v) => !v)}
+          >
+            <FieldTimeOutlined />
+            <span>时间轴</span>
+          </span>
+        </Tooltip>
       </div>
+      {showTimeline && (
+        <div className="kg-timeline-panel">
+          <div className="kg-timeline-header">
+            <span className="kg-timeline-title">
+              <FieldTimeOutlined style={{ marginRight: 6 }} />
+              历史时间轴
+            </span>
+            <span style={{ fontSize: 11, color: "#9a8e7a" }}>
+              点击实体可查看详情
+            </span>
+          </div>
+          <div className="kg-timeline-body">
+            <KGTimeline
+              entities={timelineData?.entities ?? []}
+              loading={timelineLoading}
+              selectedEntityId={selectedEntityId}
+              onEntityClick={(id) => setSelectedEntityId(id)}
+            />
+          </div>
+        </div>
+      )}
       {showStats && kgStats && (
         <div className="kg-stats-panel">
           <div className="kg-stats-group">

--- a/frontend/src/styles/kg.css
+++ b/frontend/src/styles/kg.css
@@ -523,6 +523,95 @@
   font-size: 12px;
 }
 
+/* ---------- 时间轴面板 ---------- */
+.kg-timeline-panel {
+  background: #fff;
+  border: 1px solid var(--fj-border);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.kg-timeline-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--fj-bg-alt);
+  background: #faf8f4;
+}
+
+.kg-timeline-title {
+  font-family: "Noto Serif SC", serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fj-ink);
+  letter-spacing: 1px;
+}
+
+.kg-timeline-body {
+  padding: 8px 0 4px;
+  overflow-x: auto;
+}
+
+.kg-timeline-wrap {
+  min-width: 480px;
+}
+
+.kg-timeline-svg {
+  display: block;
+  overflow: visible;
+}
+
+.kg-timeline-loading,
+.kg-timeline-empty {
+  padding: 32px 16px;
+  text-align: center;
+}
+
+.kg-timeline-legend {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 4px 24px 8px;
+  flex-wrap: wrap;
+}
+
+.kg-timeline-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--fj-ink-muted);
+  font-family: "Noto Serif SC", serif;
+}
+
+.kg-timeline-legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  opacity: 0.82;
+}
+
+.kg-timeline-legend-count {
+  color: #9a8e7a;
+  margin-left: 1px;
+}
+
+/* 时间轴切换按钮（紧靠统计按钮右侧） */
+.kg-timeline-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 10px;
+  cursor: pointer;
+  color: #9a8e7a;
+  font-size: 13px;
+  transition: color 0.2s;
+}
+.kg-timeline-toggle:hover { color: var(--fj-ink); }
+.kg-timeline-toggle.active { color: var(--fj-accent); }
+
 /* ---------- 响应式 ---------- */
 @media (max-width: 1200px) {
   .kg-detail-panel {


### PR DESCRIPTION
## 功能概述

为知识图谱新增「时间轴视图」，将携带历史年份数据的实体（人物、朝代）渲染在水平时间轴上，支持直观浏览佛教历史脉络。

## 变更内容

### Backend
- **`GET /kg/timeline`** 新端点：返回 `person` / `dynasty` 实体中携带有效 `year_start` 的行，支持 `entity_type` 过滤和 `limit`（最大 2000）
- `get_timeline_entities()` 服务函数：SQL 使用正则 `'^-?[0-9]+$'` 过滤，BCE 年份以负整数保留（如龙树 -150 ~ -70）；跳过缺失或非数字的行
- 新增 `KGTimelineEntity` / `KGTimelineResponse` Pydantic 模型
- `backend/tests/test_kg.py` 新增 4 个 mock-at-API-layer 测试，覆盖：基本返回、`entity_type` 过滤、BCE 负年份、`year_end=null`

### Frontend
- **`KGTimeline.tsx`** 新组件（`frontend/src/components/kg/`）：
  - SVG 渲染，`ResizeObserver` 自适应容器宽度
  - `dynasty` 和 `person` 分行排列（朝代在上）
  - 有 `year_end` → 横条；仅 `year_start` → 圆点
  - 使用 ForceGraph 同款 `TYPE_COLORS` 配色（古典水墨）
  - 点击/键盘回车触发 `onEntityClick(id)`，与主图谱联动
- `client.ts`：新增 `KGTimelineEntity`、`KGTimelineResponse` TS 接口及 `getKGTimeline()`
- `KnowledgeGraphPage.tsx`：`.kg-header` 新增「时间轴」切换按钮（`FieldTimeOutlined`），数据懒加载（`enabled: showTimeline`）；编辑局限在 header 区和统计面板之后，**不影响其他 Wave4 PR 的改动区域**
- `kg.css`：新增 `.kg-timeline-*` 系列样式，风格与现有水墨主题一致

## BCE 年份处理说明

- SQL 过滤：`(e.properties->>'year_start') ~ '^-?[0-9]+$'`，负整数合法通过
- 前端：`formatYear(year)` 函数对负值显示「公元前 N」，坐标轴也正确标注「前N」
- 跨零点（BCE→CE）的时间轴 domain 自动计算，含 2% 边距

## 验证

- `pytest tests/test_kg.py -q`：11 passed
- `npx tsc --noEmit`：0 errors
- `npx eslint <changed files>`：0 errors（1 pre-existing `any` warning in client.ts）

## 测试计划

- [ ] 点击「时间轴」按钮，面板展开并加载实体
- [ ] 时段实体（如「唐朝」618~907）显示为横条，单点实体显示为圆点
- [ ] 点击实体，右侧详情面板更新为该实体
- [ ] BCE 实体（如龙树）坐标轴左侧正确显示
- [ ] 移动端：时间轴容器横向滚动，不破坏三栏布局

🤖 Generated with [Claude Code](https://claude.com/claude-code)