### PR TITLE
feat(kg): SPA 交互式人物页 /person/:id

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ const LoginPage = lazy(() => import("./pages/LoginPage"));
 const ProfilePage = lazy(() => import("./pages/ProfilePage"));
 const ParallelReaderPage = lazy(() => import("./pages/ParallelReaderPage"));
 const KnowledgeGraphPage = lazy(() => import("./pages/KnowledgeGraphPage"));
+const PersonPage = lazy(() => import("./pages/PersonPage"));
 const ChatPage = lazy(() => import("./pages/ChatPage"));
 const DictionaryPage = lazy(() => import("./pages/DictionaryPage"));
 const SutraLandingPage = lazy(() => import("./pages/SutraLandingPage"));
@@ -87,6 +88,7 @@ function App() {
             </Route>
             <Route path="/parallel/:textId" element={<ParallelReaderPage />} />
             <Route path="/kg" element={<RouteErrorBoundary><KnowledgeGraphPage /></RouteErrorBoundary>} />
+            <Route path="/person/:id" element={<RouteErrorBoundary><PersonPage /></RouteErrorBoundary>} />
             <Route path="/exports" element={<ExportsPage />} />
             <Route path="/timeline" element={<TimelinePage />} />
             <Route path="/dashboard" element={<DashboardPage />} />

--- a/frontend/src/components/EntityCard.tsx
+++ b/frontend/src/components/EntityCard.tsx
@@ -4,6 +4,7 @@ import {
   ReadOutlined,
   ArrowRightOutlined,
   ArrowLeftOutlined,
+  UserOutlined,
 } from "@ant-design/icons";
 import { useNavigate } from "react-router-dom";
 import type { EntityRelationItem } from "../api/client";
@@ -165,6 +166,17 @@ export default function EntityCard({ entity, onEntityClick }: EntityCardProps) {
           }
         >
           查辞典释义
+        </Button>
+      )}
+      {entity.entity_type === "person" && (
+        <Button
+          type="link"
+          size="small"
+          icon={<UserOutlined />}
+          style={{ padding: 0, marginBottom: 10, color: "#8b2500", fontSize: 12 }}
+          onClick={() => navigate(`/person/${entity.id}`)}
+        >
+          人物主页
         </Button>
       )}
 

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -1,0 +1,367 @@
+/**
+ * PersonPage — SPA 交互式人物页 /person/:id
+ *
+ * 读取 /api/kg/entities/{id}（已含 relations[]），展示人物档案。
+ * 路由：/person/:id（注意是单数，避免与后端 /persons/:id SEO 页冲突）
+ */
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Spin,
+  Typography,
+  Button,
+  Divider,
+  Tooltip,
+  Empty,
+} from "antd";
+import {
+  ApartmentOutlined,
+  LinkOutlined,
+  ArrowLeftOutlined,
+  ArrowRightOutlined,
+  UserOutlined,
+} from "@ant-design/icons";
+import { getKGEntity } from "../api/client";
+import type { EntityRelationItem } from "../api/client";
+import "../styles/person.css";
+
+// ── 属性提取（与 seo_persons.py 逻辑对等） ─────────────────────────
+
+function personDisplayDates(props: Record<string, unknown> | null | undefined): string {
+  if (!props || typeof props !== "object") return "";
+  const birth = (props["birth_year"] as string | undefined) || (props["birth"] as string | undefined);
+  const death = (props["death_year"] as string | undefined) || (props["death"] as string | undefined);
+  if (birth && death) return `（${birth}–${death}）`;
+  if (birth) return `（${birth}–）`;
+  if (death) return `（–${death}）`;
+  return "";
+}
+
+function personDynasty(props: Record<string, unknown> | null | undefined): string {
+  if (!props || typeof props !== "object") return "";
+  return ((props["dynasty"] as string | undefined) || (props["era"] as string | undefined) || "").trim();
+}
+
+function personNationality(props: Record<string, unknown> | null | undefined): string {
+  if (!props || typeof props !== "object") return "";
+  return (
+    (props["nationality"] as string | undefined) ||
+    (props["country"] as string | undefined) ||
+    ""
+  ).trim();
+}
+
+function personSchool(props: Record<string, unknown> | null | undefined): string {
+  if (!props || typeof props !== "object") return "";
+  return ((props["school"] as string | undefined) || (props["tradition"] as string | undefined) || "").trim();
+}
+
+// ── 关系分组与标签 ──────────────────────────────────────────────────
+
+const PREDICATE_LABELS: Record<string, string> = {
+  translated: "翻译",
+  active_in: "所处",
+  alt_translation: "异译",
+  parallel_text: "平行文本",
+  member_of_school: "属于宗派",
+  teacher_of: "师承",
+  cites: "引用",
+  commentary_on: "注疏",
+  associated_with: "相关",
+};
+
+// 按展示优先级排列
+const PREDICATE_ORDER = [
+  "teacher_of",
+  "translated",
+  "commentary_on",
+  "active_in",
+  "member_of_school",
+  "associated_with",
+  "cites",
+  "alt_translation",
+  "parallel_text",
+];
+
+const TYPE_LABELS: Record<string, { label: string; className: string }> = {
+  person:    { label: "人物", className: "kg-type-tag kg-type-tag--person" },
+  text:      { label: "典籍", className: "kg-type-tag kg-type-tag--text" },
+  monastery: { label: "寺院", className: "kg-type-tag kg-type-tag--monastery" },
+  school:    { label: "宗派", className: "kg-type-tag kg-type-tag--school" },
+  place:     { label: "地点", className: "kg-type-tag kg-type-tag--place" },
+  concept:   { label: "概念", className: "kg-type-tag kg-type-tag--concept" },
+  dynasty:   { label: "朝代", className: "kg-type-tag kg-type-tag--dynasty" },
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  dila_catalog: "DILA 规范目录",
+  dila: "DILA 规范库",
+  "auto:cbeta_metadata": "CBETA 元数据",
+  "seed:lineage": "师承谱系（人工校订）",
+  "seed:person_place": "人物地理（人工校订）",
+  "seed:school_affiliation": "宗派归属（人工校订）",
+};
+
+function prettifySource(source: string): string {
+  if (SOURCE_LABELS[source]) return SOURCE_LABELS[source];
+  if (source.startsWith("seed:")) return "人工校订";
+  if (source.startsWith("auto:")) return "自动提取";
+  if (source.startsWith("dila")) return "DILA 规范库";
+  return source;
+}
+
+/** 根据目标实体类型决定链接路径 */
+function targetLink(rel: EntityRelationItem): string {
+  if (rel.target_type === "text") return `/texts/${rel.target_id}`;
+  if (rel.target_type === "person") return `/person/${rel.target_id}`;
+  return `/kg?id=${rel.target_id}`;
+}
+
+// ── 主组件 ─────────────────────────────────────────────────────────
+
+export default function PersonPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const { data: entity, isLoading, isError } = useQuery({
+    queryKey: ["kgEntity", id],
+    queryFn: () => getKGEntity(Number(id)),
+    enabled: !!id,
+    retry: 1,
+  });
+
+  // ── 加载中 ──
+  if (isLoading) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  // ── 未找到 / 非人物 ──
+  if (isError || !entity || entity.entity_type !== "person") {
+    return (
+      <div className="person-page">
+        <Empty
+          description={
+            <span style={{ fontFamily: '"Noto Serif SC", serif', color: "#7a6e5c" }}>
+              未找到该人物
+            </span>
+          }
+          style={{ padding: "80px 0" }}
+        />
+        <div style={{ textAlign: "center" }}>
+          <Button onClick={() => navigate("/kg")}>返回知识图谱</Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── 属性提取 ──
+  const props = entity.properties as Record<string, unknown> | null;
+  const dates = personDisplayDates(props);
+  const dynasty = personDynasty(props);
+  const nationality = personNationality(props);
+  const school = personSchool(props);
+  const wikidataQid = entity.external_ids?.["wikidata"];
+
+  // ── 关系分组 ──
+  const relationsByPredicate: Record<string, EntityRelationItem[]> = {};
+  for (const rel of entity.relations ?? []) {
+    if (!relationsByPredicate[rel.predicate]) {
+      relationsByPredicate[rel.predicate] = [];
+    }
+    relationsByPredicate[rel.predicate].push(rel);
+  }
+
+  // 按优先级排序 predicate key 列表
+  const sortedPredicates = [
+    ...PREDICATE_ORDER.filter((p) => p in relationsByPredicate),
+    ...Object.keys(relationsByPredicate).filter((p) => !PREDICATE_ORDER.includes(p)),
+  ];
+
+  const metaBits = [dynasty, nationality, school].filter(Boolean);
+
+  return (
+    <div className="person-page">
+      {/* ── 面包屑 ── */}
+      <nav className="person-breadcrumb">
+        <span
+          className="person-breadcrumb-link"
+          onClick={() => navigate("/")}
+        >
+          首页
+        </span>
+        <span className="person-breadcrumb-sep">›</span>
+        <span
+          className="person-breadcrumb-link"
+          onClick={() => navigate("/kg")}
+        >
+          知识图谱
+        </span>
+        <span className="person-breadcrumb-sep">›</span>
+        <span className="person-breadcrumb-current">{entity.name_zh}</span>
+      </nav>
+
+      {/* ── 主卡片 ── */}
+      <div className="person-card">
+        {/* 标题行 */}
+        <div className="person-header">
+          <div className="person-title-row">
+            <h1 className="person-name">
+              {entity.name_zh}
+              {dates && <span className="person-dates">{dates}</span>}
+            </h1>
+            <span className="kg-type-tag kg-type-tag--person">人物</span>
+          </div>
+
+          {/* 元信息徽章行 */}
+          {metaBits.length > 0 && (
+            <div className="person-meta">
+              {metaBits.map((bit, i) => (
+                <span key={i} className="person-meta-chip">{bit}</span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* 多语言名称 */}
+        {(entity.name_sa || entity.name_pi || entity.name_bo || entity.name_en) && (
+          <div className="person-altnames">
+            {entity.name_sa && (
+              <div className="person-altname-row">
+                <span className="person-altname-lang">梵文</span>
+                <span className="person-altname-val">{entity.name_sa}</span>
+              </div>
+            )}
+            {entity.name_pi && (
+              <div className="person-altname-row">
+                <span className="person-altname-lang">巴利</span>
+                <span className="person-altname-val">{entity.name_pi}</span>
+              </div>
+            )}
+            {entity.name_bo && (
+              <div className="person-altname-row">
+                <span className="person-altname-lang">藏文</span>
+                <span className="person-altname-val">{entity.name_bo}</span>
+              </div>
+            )}
+            {entity.name_en && (
+              <div className="person-altname-row">
+                <span className="person-altname-lang">英文</span>
+                <span className="person-altname-val">{entity.name_en}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 简介 */}
+        {entity.description && (
+          <Typography.Paragraph className="person-description">
+            {entity.description}
+          </Typography.Paragraph>
+        )}
+
+        {/* 外部链接 */}
+        {wikidataQid && (
+          <div className="person-extlinks">
+            <a
+              href={`https://www.wikidata.org/wiki/${wikidataQid}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="person-extlink"
+            >
+              <LinkOutlined style={{ marginRight: 4 }} />
+              Wikidata {wikidataQid}
+            </a>
+          </div>
+        )}
+
+        {/* 在知识图谱中查看 */}
+        <div className="person-kg-link">
+          <Button
+            icon={<ApartmentOutlined />}
+            onClick={() => navigate(`/kg?id=${entity.id}`)}
+            className="person-kg-btn"
+          >
+            在知识图谱中查看
+          </Button>
+        </div>
+      </div>
+
+      {/* ── 关系面板 ── */}
+      {sortedPredicates.length > 0 && (
+        <div className="person-card person-relations-card">
+          <h2 className="person-section-title">关系网络</h2>
+          {sortedPredicates.map((predicate) => {
+            const rels = relationsByPredicate[predicate];
+            return (
+              <div key={predicate} className="person-rel-group">
+                <div className="person-rel-group-head">
+                  <span className="person-rel-label">
+                    {PREDICATE_LABELS[predicate] || predicate}
+                  </span>
+                  <span className="person-rel-count">{rels.length}</span>
+                </div>
+                <div className="person-rel-items">
+                  {rels.map((rel) => {
+                    const tMeta = TYPE_LABELS[rel.target_type] || {
+                      label: rel.target_type,
+                      className: "kg-type-tag",
+                    };
+                    return (
+                      <Link
+                        key={`${rel.predicate}-${rel.target_id}-${rel.direction}`}
+                        to={targetLink(rel)}
+                        className="person-rel-item"
+                      >
+                        {rel.direction === "outgoing" ? (
+                          <ArrowRightOutlined className="person-rel-arrow" />
+                        ) : (
+                          <ArrowLeftOutlined className="person-rel-arrow" />
+                        )}
+                        <span
+                          className={tMeta.className}
+                          style={{ fontSize: 9, lineHeight: "16px", padding: "0 4px" }}
+                        >
+                          {tMeta.label}
+                        </span>
+                        <span className="person-rel-name">{rel.target_name}</span>
+                        {rel.source && (
+                          <Tooltip title={`关系出处：${rel.source}`}>
+                            <span className="person-rel-source">
+                              据 {prettifySource(rel.source)}
+                            </span>
+                          </Tooltip>
+                        )}
+                      </Link>
+                    );
+                  })}
+                </div>
+                <Divider className="person-rel-divider" />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 无关系时提示 */}
+      {sortedPredicates.length === 0 && (
+        <div className="person-card">
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={
+              <span style={{ color: "#9a8e7a", fontFamily: '"Noto Serif SC", serif' }}>
+                暂无关系数据
+              </span>
+            }
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Explicit named export for use in EntityCard navigation
+export { UserOutlined };

--- a/frontend/src/styles/person.css
+++ b/frontend/src/styles/person.css
@@ -1,0 +1,284 @@
+/* ========================================
+   PersonPage — 古典水墨风格 人物档案页
+   ======================================== */
+
+/* 复用 kg.css 中的 kg-type-tag 样式，无需重复声明 */
+@import "./kg.css";
+
+/* ---------- 页面容器 ---------- */
+.person-page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px 16px 48px;
+}
+
+/* ---------- 面包屑 ---------- */
+.person-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #9a8e7a;
+  margin-bottom: 18px;
+  font-family: "Noto Serif SC", serif;
+}
+
+.person-breadcrumb-link {
+  color: #9a8e7a;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.person-breadcrumb-link:hover { color: #8b2500; }
+
+.person-breadcrumb-sep { color: #d9d0c1; }
+
+.person-breadcrumb-current {
+  color: #5c4f3d;
+  font-weight: 500;
+}
+
+/* ---------- 通用卡片 ---------- */
+.person-card {
+  background: #fff;
+  border: 1px solid #e8e0d0;
+  border-radius: 10px;
+  padding: 24px 28px;
+  margin-bottom: 16px;
+  box-shadow: 0 1px 4px rgba(43, 35, 24, 0.06);
+}
+
+/* ---------- 标题区 ---------- */
+.person-header {
+  margin-bottom: 16px;
+}
+
+.person-title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.person-name {
+  font-family: "Noto Serif SC", serif;
+  font-size: 26px;
+  font-weight: 700;
+  color: #2b2318;
+  margin: 0;
+  letter-spacing: 2px;
+  line-height: 1.3;
+}
+
+.person-dates {
+  font-size: 16px;
+  font-weight: 400;
+  color: #7a6e5c;
+  margin-left: 4px;
+  letter-spacing: 0;
+}
+
+/* ---------- 元信息徽章 ---------- */
+.person-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.person-meta-chip {
+  font-family: "Noto Serif SC", serif;
+  font-size: 12px;
+  background: #faf6ef;
+  border: 1px solid #e8e0d0;
+  border-radius: 12px;
+  padding: 2px 10px;
+  color: #7a6e5c;
+}
+
+/* ---------- 多语言名称 ---------- */
+.person-altnames {
+  background: #faf8f5;
+  border: 1px solid #f0ebe2;
+  border-radius: 6px;
+  padding: 10px 14px;
+  margin-bottom: 14px;
+}
+
+.person-altname-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+  font-size: 13px;
+  color: #5c4f3d;
+}
+.person-altname-row:last-child { margin-bottom: 0; }
+
+.person-altname-lang {
+  color: #9a8e7a;
+  font-size: 11px;
+  width: 36px;
+  flex-shrink: 0;
+}
+
+.person-altname-val {
+  color: #3a2e1c;
+  font-style: italic;
+}
+
+/* ---------- 简介 ---------- */
+.person-description {
+  color: #5c4f3d !important;
+  font-size: 14px !important;
+  line-height: 1.8 !important;
+  margin-bottom: 14px !important;
+}
+
+/* ---------- 外部链接 ---------- */
+.person-extlinks {
+  margin-bottom: 14px;
+}
+
+.person-extlink {
+  font-size: 12px;
+  color: #8b2500;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: color 0.15s;
+}
+.person-extlink:hover { color: #5c1800; text-decoration: underline; }
+
+/* ---------- 知识图谱跳转按钮 ---------- */
+.person-kg-link {
+  margin-top: 4px;
+}
+
+.person-kg-btn {
+  font-family: "Noto Serif SC", serif;
+  font-size: 13px;
+  border-color: #d9d0c1;
+  color: #5c4f3d;
+  background: #faf8f5;
+  border-radius: 6px;
+  transition: all 0.15s;
+}
+.person-kg-btn:hover {
+  border-color: #b5a890 !important;
+  color: #2b2318 !important;
+  background: #f5f0e8 !important;
+}
+
+/* ---------- 关系网络面板 ---------- */
+.person-relations-card {}
+
+.person-section-title {
+  font-family: "Noto Serif SC", serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: #2b2318;
+  margin: 0 0 16px;
+  letter-spacing: 1px;
+}
+
+.person-rel-group {
+  margin-bottom: 6px;
+}
+
+.person-rel-group-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.person-rel-label {
+  font-family: "Noto Serif SC", serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: #5c4f3d;
+}
+
+.person-rel-count {
+  font-size: 10px;
+  background: #f0ebe2;
+  border-radius: 8px;
+  padding: 0 6px;
+  color: #7a6e5c;
+  line-height: 18px;
+}
+
+.person-rel-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: 4px;
+}
+
+.person-rel-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  text-decoration: none;
+  color: #5c4f3d;
+  font-size: 13px;
+  transition: background 0.12s, color 0.12s;
+}
+.person-rel-item:hover {
+  background: #faf6ef;
+  color: #8b2500;
+}
+
+.person-rel-arrow {
+  color: #d9d0c1;
+  font-size: 9px;
+  flex-shrink: 0;
+}
+
+.person-rel-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.person-rel-source {
+  font-size: 11px;
+  color: #b3a98f;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.person-rel-divider {
+  margin: 12px 0 10px !important;
+  border-color: #f0ebe2 !important;
+}
+.person-rel-group:last-child .person-rel-divider {
+  display: none;
+}
+
+/* ---------- 响应式 ---------- */
+@media (max-width: 768px) {
+  .person-page {
+    padding: 14px 10px 40px;
+  }
+
+  .person-card {
+    padding: 16px 16px;
+    border-radius: 8px;
+  }
+
+  .person-name {
+    font-size: 21px;
+  }
+
+  .person-dates {
+    font-size: 14px;
+  }
+
+  .person-rel-source {
+    display: none;
+  }
+}


### PR DESCRIPTION
## 变更摘要

- 新增 `frontend/src/pages/PersonPage.tsx`：通过 `getKGEntity()` 渲染人物档案，包含多语言名称、生卒年/朝代/籍贯/宗派、关系网络（分组可点击跳转）、Wikidata 外链、"在知识图谱中查看"按钮
- 新增 `frontend/src/styles/person.css`：古典水墨风格样式，与 `kg.css` 共享 type-tag 系统
- 更新 `frontend/src/App.tsx`：懒加载 `PersonPage`，路由 `/person/:id`（单数），用 `RouteErrorBoundary` 包裹，与后端 `/persons/:id` SEO 路由无冲突
- 更新 `frontend/src/components/EntityCard.tsx`：对 `entity_type === 'person'` 实体增加"人物主页"按钮，导航到 `/person/{id}`

## 关键设计决策

- **路由路径**：`/person/:id`（单数）以避免与 `backend/app/api/seo_persons.py` 的 `/persons/:id` 路由冲突
- **属性提取**：`personDisplayDates` / `personDynasty` / `personNationality` 与 `seo_persons.py` 辅助函数逻辑对等
- **关系跳转**：`text` 目标 → `/texts/{id}`；`person` 目标 → `/person/{id}`；其它 → `/kg?id={id}`
- **关系排序**：`teacher_of → translated → commentary_on → active_in → member_of_school → ...` 优先展示最具语义价值的谱系关系

## 测试计划

- [ ] `npx tsc --noEmit` 通过（已验证：0 错误）
- [ ] `npx eslint` 0 错误（已验证；1 pre-existing `any` 警告在 EntityCard 非新增代码中）
- [ ] 访问 `/person/1`（任意人物 ID）渲染正常
- [ ] 访问 `/person/99999999`（不存在 ID）显示"未找到该人物"
- [ ] 访问 `/person/某非人物ID`（entity_type ≠ person）显示"未找到该人物"
- [ ] EntityCard 中人物实体显示"人物主页"按钮，点击跳转 `/person/{id}`
- [ ] 关系行中 person 类型跳转 `/person/*`，text 类型跳转 `/texts/*`，其它跳转 `/kg?id=*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)