### PR TITLE
fix(infra): raise postgres mem_limit 1g → 3g

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ services:
     container_name: fojin-postgres
     restart: always
     logging: *default-logging
-    mem_limit: 1g
+    # 1g chronically OOM-killed backends (155 cgroup OOMs in the dmesg
+    # buffer, all task=postgres) → full crash-recovery cycles dropping
+    # every connection. Raised to 3g; host has the headroom.
+    mem_limit: 3g
     cpus: 1.0
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-fojin}


### PR DESCRIPTION
## 确认后的修复:postgres 容器内存上限过紧

### 核查结论
- `docker inspect fojin-postgres` → `MemLimit=1073741824`(1 GiB),`OOMKilled=true`。
- dmesg 共 **155 次 oom-killer 事件,全部 `task=postgres`**,`constraint=CONSTRAINT_MEMCG`(撞的是容器自身 cgroup 上限)。
- 按天递增:5/14 43 次、5/17 27 次、**5/18 49 次**。
- postgres 日志证实影响:每次 `server process ... terminated by signal 9` → `all server processes terminated; reinitializing` —— **整库崩溃恢复,所有连接断开**。

### 修复
`docker-compose.yml` postgres 服务 `mem_limit: 1g → 3g`。主机 7.3 GiB,各容器 mem_limit 合计由 ~4.1 GiB 升至 ~6.1 GiB,留有 OS 余量(且 mem_limit 是上限非预留)。

### 上线
合并后 prod `git pull` → `docker compose up -d postgres` 重建容器应用新上限。postgres 当前每天已崩溃恢复约 49 次,一次受控重启严格优于现状。

🤖 Generated with [Claude Code](https://claude.com/claude-code)