### PR TITLE
fix(kg): 路径查询收进开关 + 自动缩放改手动

### DIFF
--- a/frontend/src/components/ForceGraph.tsx
+++ b/frontend/src/components/ForceGraph.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import * as d3 from "d3";
+import { CompressOutlined } from "@ant-design/icons";
 import { escapeHtml } from "../utils/sanitize";
 
 interface GraphNode {
@@ -93,6 +94,9 @@ export default function ForceGraph({
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
+  // Holds the current graph's fit-to-view function. The 适应窗口 button
+  // (rendered in JSX, outside the d3 effect) calls it on demand.
+  const fitToViewRef = useRef<(() => void) | null>(null);
   const [containerWidth, setContainerWidth] = useState(propWidth || 800);
 
   // Responsive width via ResizeObserver
@@ -433,18 +437,17 @@ export default function ForceGraph({
       node.attr("transform", (d: any) => `translate(${d.x},${d.y})`);
     });
 
-    // ── Zoom-to-fit once the layout settles ──
-    // Without this the graph can render off-centre or too zoomed and
-    // the user has to pan/zoom manually before they can read anything.
-    // Only fires on the first settle — a later drag must not snap the
-    // user's view back.
-    let fitted = false;
-    simulation.on("end", () => {
-      if (fitted || !simNodes.length) return;
-      fitted = true;
+    // ── Fit-to-view (manual, on-demand) ──
+    // This is deliberately NOT automatic. An earlier version fitted on
+    // simulation "end" — but that fired several seconds after load and
+    // jarringly shrank large graphs to an unreadable size, which users
+    // mistook for a glitch. Now the 适应窗口 button triggers it when the
+    // user actually wants the whole graph in view.
+    const fitToView = () => {
+      if (!simNodes.length) return;
       // Expand the bounds by each node's own radius plus its name-label
-      // extent (~40px below + sideways), so a big hub sitting at the
-      // edge of the layout isn't clipped after the fit.
+      // extent (~40px below + sideways), so a big hub at the edge of the
+      // layout isn't clipped after the fit.
       const pad = 24;
       let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
       for (const n of simNodes as any[]) {
@@ -465,7 +468,8 @@ export default function ForceGraph({
         .transition()
         .duration(450)
         .call(zoom.transform, d3.zoomIdentity.translate(tx, ty).scale(scale));
-    });
+    };
+    fitToViewRef.current = fitToView;
 
     return () => {
       simulation.stop();
@@ -481,6 +485,35 @@ export default function ForceGraph({
         height={height}
         style={{ background: "#fdfcfa" }}
       />
+      {/* 适应窗口 — on-demand fit-to-view (replaces the old jarring auto-fit) */}
+      {nodes.length > 0 && (
+        <button
+          type="button"
+          onClick={() => fitToViewRef.current?.()}
+          title="将整张图谱缩放到适应窗口"
+          style={{
+            position: "absolute",
+            top: 10,
+            right: 10,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "4px 10px",
+            fontSize: 12,
+            fontFamily: '"Noto Serif SC", serif',
+            color: "#5b4a32",
+            background: "rgba(255,255,255,0.92)",
+            border: "1px solid #e8e0d4",
+            borderRadius: 6,
+            cursor: "pointer",
+            boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
+            zIndex: 10,
+          }}
+        >
+          <CompressOutlined />
+          适应窗口
+        </button>
+      )}
       {/* Custom tooltip */}
       <div
         ref={tooltipRef}

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -12,6 +12,7 @@ import {
   UnorderedListOutlined,
   ProfileOutlined,
   FieldTimeOutlined,
+  NodeIndexOutlined,
 } from "@ant-design/icons";
 import ForceGraph, {
   TYPE_COLORS,
@@ -206,6 +207,7 @@ export default function KnowledgeGraphPage() {
   });
   const [showStats, setShowStats] = useState(false);
   const [showTimeline, setShowTimeline] = useState(false);
+  const [showPath, setShowPath] = useState(false);
   const [curatedOpen, setCuratedOpen] = useState(!isMobile);
 
   // ── Progressive expand state ──────────────────────────────────────────────
@@ -446,6 +448,15 @@ export default function KnowledgeGraphPage() {
             <span>时间轴</span>
           </span>
         </Tooltip>
+        <Tooltip title="查询两个实体之间的最短关系路径">
+          <span
+            className={`kg-path-toggle${showPath ? " active" : ""}`}
+            onClick={() => setShowPath((v) => !v)}
+          >
+            <NodeIndexOutlined />
+            <span>路径查询</span>
+          </span>
+        </Tooltip>
       </div>
       {showTimeline && (
         <div className="kg-timeline-panel">
@@ -619,11 +630,13 @@ export default function KnowledgeGraphPage() {
         </div>
       )}
 
-      {/* 路径查询面板 — 当前选中实体作为起点 */}
-      <KGPathQuery
-        fromEntity={entityDetail ?? null}
-        onNodeClick={handleGraphNodeClick}
-      />
+      {/* 路径查询面板 — 收进开关，默认不展开（小众功能，不常驻占位） */}
+      {showPath && (
+        <KGPathQuery
+          fromEntity={entityDetail ?? null}
+          onNodeClick={handleGraphNodeClick}
+        />
+      )}
 
       {/* 搜索结果面板 */}
       {/* 桌面端：渲染在三栏内；移动端：仅 search Tab 激活时渲染 */}

--- a/frontend/src/styles/kg.css
+++ b/frontend/src/styles/kg.css
@@ -598,8 +598,9 @@
   margin-left: 1px;
 }
 
-/* 时间轴切换按钮（紧靠统计按钮右侧） */
-.kg-timeline-toggle {
+/* 头部切换按钮（时间轴 / 路径查询，紧靠统计按钮右侧） */
+.kg-timeline-toggle,
+.kg-path-toggle {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -609,8 +610,10 @@
   font-size: 13px;
   transition: color 0.2s;
 }
-.kg-timeline-toggle:hover { color: var(--fj-ink); }
-.kg-timeline-toggle.active { color: var(--fj-accent); }
+.kg-timeline-toggle:hover,
+.kg-path-toggle:hover { color: var(--fj-ink); }
+.kg-timeline-toggle.active,
+.kg-path-toggle.active { color: var(--fj-accent); }
 
 /* ---------- 响应式 ---------- */
 @media (max-width: 1200px) {


### PR DESCRIPTION
两项用户反馈修复:

### 1. 路径查询收进开关
原先 `<KGPathQuery>` 是常驻面板,每次进 `/kg` 都占一条横向空间 —— 小众功能不该常驻。改为头部「路径查询」开关,默认收起,与「统计」「时间轴」开关一致。

### 2. 自动缩放改手动
图谱原在力导向布局收敛(`simulation` "end",加载后约 3-4 秒)时自动 zoom-to-fit,大图被猛缩到看不清,像故障。移除自动行为,改为图谱右上角「适应窗口」按钮,用户想看全貌时自己点。

均为前端改动,`tsc` 通过、ESLint 0 error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)