### PR TITLE
fix(kg): 路径查询终点下拉无结果(虚拟列表渲染竞态)

### DIFF
--- a/frontend/src/components/kg/KGPathQuery.tsx
+++ b/frontend/src/components/kg/KGPathQuery.tsx
@@ -112,6 +112,12 @@ export default function KGPathQuery({ fromEntity, onNodeClick }: KGPathQueryProp
           <span className="kg-path-label">终点</span>
           <Select
             showSearch
+            // virtual={false}: with async-loaded options the rc-virtual-list
+            // can fail to render items (it measures a 0-height viewport when
+            // options arrive after the dropdown opened, then never re-measures
+            // → an empty dropdown despite results being present). The result
+            // set is capped at 10, so plain rendering costs nothing.
+            virtual={false}
             value={toEntity ? toEntity.name_zh : undefined}
             placeholder="搜索目标实体…"
             filterOption={false}


### PR DESCRIPTION
## 问题
`/kg` 路径查询面板,在「终点」搜索框输入(如「涅槃」)后下拉为空,即便搜索成功。

## 核查(浏览器实地复现)
- 后端 `/kg/entities?q=涅槃` 返回 200,24 条结果 —— API 正常。
- 浏览器复现:`type` 逐字输入「涅槃」→ 网络请求 200(2440B,含结果)、antd 无障碍 listbox 已填入选项 id(19201/18033…),但可见的 `rc-virtual-list` 渲染 **0 条** `.ant-select-item-option`。
- 根因:antd Select 的虚拟列表在「下拉已打开、选项异步到达」时测得 0 高度视口,之后不再重新测量 → 有数据却空下拉。`fill`(一次性赋值)偶然不触发,逐字输入/IME 稳定触发。

## 修复
Select 加 `virtual={false}`。结果集上限 10 条,不需要虚拟化,直接渲染消除竞态。

合并部署后我会在浏览器复验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)