### PR TITLE
feat(admin): 板块使用情况面板（检索/阅读/数据源/问答）

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -8,6 +8,7 @@ from app.models.user import User
 from app.schemas.admin import (
     AdminAnnotationListResponse,
     AdminAuditLogListResponse,
+    AdminModuleUsage,
     AdminOverview,
     AdminTrends,
     AdminUserItem,
@@ -22,6 +23,7 @@ from app.services.admin_service import (
     list_users,
     record_audit,
 )
+from app.services.usage_service import get_module_usage
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -47,6 +49,25 @@ async def stats_trends(
 
     redis = getattr(app.state, "redis", None)
     return AdminTrends(**(await get_trends(db, days, redis)))
+
+
+@router.get("/stats/module-usage", response_model=AdminModuleUsage)
+async def stats_module_usage(
+    days: int = Query(7, ge=1, le=90),
+    _user=Depends(require_role("admin")),
+):
+    """Return Umami-sourced module usage stats (search / read / chat / source_click).
+
+    This endpoint reads the self-hosted Umami analytics database.  It is fully
+    resilient: if Umami is down or unreachable, it returns an empty result
+    (events=[], top_search_keywords=[]) rather than propagating a 500 error.
+    """
+    result = await get_module_usage(days)
+    return AdminModuleUsage(
+        days=days,
+        events=result["events"],
+        top_search_keywords=result["top_search_keywords"],
+    )
 
 
 @router.get("/users", response_model=AdminUserListResponse)

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -91,3 +91,22 @@ class AdminAuditLogListResponse(BaseModel):
     page: int
     size: int
     items: list[AdminAuditLogItem]
+
+
+# --- Module Usage (Umami analytics) ---
+
+class ModuleEventItem(BaseModel):
+    event_name: str
+    label: str
+    count: int
+
+
+class KeywordItem(BaseModel):
+    keyword: str
+    count: int
+
+
+class AdminModuleUsage(BaseModel):
+    days: int
+    events: list[ModuleEventItem]
+    top_search_keywords: list[KeywordItem]

--- a/backend/app/services/usage_service.py
+++ b/backend/app/services/usage_service.py
@@ -1,0 +1,145 @@
+"""Module usage service — reads from the self-hosted Umami analytics database.
+
+The Umami DB lives on the SAME postgres server as the fojin app DB, using the
+same credentials but a different database name ("umami").  We derive its URL
+by replacing the last path segment of settings.database_url.
+
+Design goals:
+- Lazy singleton engine: created on first call, NOT at app startup, so a
+  missing/unreachable Umami DB never prevents the app from booting.
+- Full resilience: every public function catches ALL exceptions from the Umami
+  DB, logs a warning, and returns safe zero/empty defaults.  The admin
+  dashboard must never 500 due to Umami being down.
+- Safe parametrisation: the `days` window is bound via SQLAlchemy text() with
+  a named param — never string-interpolated.
+"""
+
+import logging
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Lazy singleton — None until first successful call to _get_engine().
+_umami_engine = None
+
+# Friendly Chinese labels for known Umami event_name values.
+_EVENT_LABELS: dict[str, str] = {
+    "search": "检索",
+    "chat": "AI问答",
+    "read": "在线阅读",
+    "source_click": "数据源点击",
+    "cbeta-shortcut": "CBETA直跳",
+}
+
+
+def _build_umami_url() -> str:
+    """Derive the Umami async DB URL from the fojin app DB URL.
+
+    The fojin URL looks like:
+        postgresql+asyncpg://user:pass@host:5432/fojin
+
+    We replace the last path segment ("fojin") with "umami".
+    """
+    base, _db = settings.database_url.rsplit("/", 1)
+    return f"{base}/umami"
+
+
+def _get_engine():
+    """Return (or lazily create) the Umami engine singleton."""
+    global _umami_engine
+    if _umami_engine is None:
+        url = _build_umami_url()
+        _umami_engine = create_async_engine(
+            url,
+            # Keep pool small — this is a side-channel analytics DB.
+            pool_size=2,
+            max_overflow=3,
+            pool_pre_ping=True,
+            # Don't hold connections open indefinitely if Umami goes down.
+            pool_recycle=300,
+        )
+        logger.info("Umami engine created: %s", url.split("@")[-1])  # log host/db only
+    return _umami_engine
+
+
+async def get_module_usage(days: int = 7) -> dict[str, Any]:
+    """Return event counts and top search keywords from the Umami DB.
+
+    Args:
+        days: Time window in days (1–90).  Parametrised safely via bound param.
+
+    Returns a dict with:
+        events: list of {event_name, label, count}  — sorted descending by count
+        top_search_keywords: list of {keyword, count}  — top 10 by count
+
+    On any Umami DB error, logs a warning and returns safe empty defaults so
+    that the admin dashboard never 500 because Umami is unavailable.
+    """
+    try:
+        return await _query_module_usage(days)
+    except Exception as exc:
+        logger.warning(
+            "Umami DB unavailable — returning empty module usage (days=%d): %s",
+            days,
+            exc,
+        )
+        return _empty_usage()
+
+
+def _empty_usage() -> dict[str, Any]:
+    return {"events": [], "top_search_keywords": []}
+
+
+async def _query_module_usage(days: int) -> dict[str, Any]:
+    engine = _get_engine()
+
+    event_sql = text(
+        """
+        SELECT event_name, count(*) AS cnt
+        FROM website_event
+        WHERE created_at > now() - make_interval(days => :days)
+          AND event_name IS NOT NULL
+        GROUP BY event_name
+        ORDER BY cnt DESC
+        """
+    )
+
+    keyword_sql = text(
+        """
+        SELECT ed.string_value AS keyword, count(*) AS cnt
+        FROM event_data ed
+        JOIN website_event we ON we.event_id = ed.website_event_id
+        WHERE we.event_name = 'search'
+          AND ed.data_key = 'keyword'
+          AND we.created_at > now() - make_interval(days => :days)
+        GROUP BY ed.string_value
+        ORDER BY cnt DESC
+        LIMIT 10
+        """
+    )
+
+    async with AsyncSession(engine) as session:
+        event_rows = (await session.execute(event_sql, {"days": days})).all()
+        keyword_rows = (await session.execute(keyword_sql, {"days": days})).all()
+
+    events = [
+        {
+            "event_name": row[0],
+            "label": _EVENT_LABELS.get(row[0], row[0]),
+            "count": int(row[1]),
+        }
+        for row in event_rows
+    ]
+
+    top_search_keywords = [
+        {"keyword": row[0], "count": int(row[1])}
+        for row in keyword_rows
+        if row[0]  # skip null/empty keywords
+    ]
+
+    return {"events": events, "top_search_keywords": top_search_keywords}

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,4 +1,4 @@
-"""Admin API tests — stats, user management, annotations."""
+"""Admin API tests — stats, user management, annotations, module usage."""
 
 from datetime import datetime, timezone
 
@@ -91,5 +91,104 @@ async def test_audit_log_non_admin(client):
     try:
         resp = await client.get("/api/admin/audit-log")
         assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+# --- Module usage endpoint ---
+
+@pytest.mark.anyio
+async def test_module_usage_requires_admin(client):
+    """GET /admin/stats/module-usage without auth returns 401."""
+    resp = await client.get("/api/admin/stats/module-usage")
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+async def test_module_usage_non_admin_forbidden(client):
+    """GET /admin/stats/module-usage as regular user returns 403."""
+    fake_user = _fake_user(role="user")
+    from app.main import app
+    from app.core.deps import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    try:
+        resp = await client.get("/api/admin/stats/module-usage")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.mark.anyio
+async def test_module_usage_returns_empty_on_umami_down(client):
+    """Admin call should return 200 with empty lists when Umami DB is unreachable."""
+    fake_admin = _fake_user(role="admin")
+    from app.main import app
+    from app.core.deps import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: fake_admin
+    try:
+        with patch(
+            "app.services.usage_service._query_module_usage",
+            side_effect=Exception("connection refused"),
+        ):
+            resp = await client.get("/api/admin/stats/module-usage?days=7")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["days"] == 7
+            assert body["events"] == []
+            assert body["top_search_keywords"] == []
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.mark.anyio
+async def test_module_usage_returns_data(client):
+    """Admin call should return properly shaped data when Umami responds."""
+    fake_admin = _fake_user(role="admin")
+    from app.main import app
+    from app.core.deps import get_current_user
+
+    mock_result = {
+        "events": [
+            {"event_name": "search", "label": "检索", "count": 42},
+            {"event_name": "chat", "label": "AI问答", "count": 10},
+        ],
+        "top_search_keywords": [
+            {"keyword": "心经", "count": 8},
+        ],
+    }
+
+    app.dependency_overrides[get_current_user] = lambda: fake_admin
+    try:
+        with patch(
+            "app.services.usage_service._query_module_usage",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            resp = await client.get("/api/admin/stats/module-usage?days=14")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["days"] == 14
+            assert len(body["events"]) == 2
+            assert body["events"][0]["event_name"] == "search"
+            assert body["events"][0]["label"] == "检索"
+            assert body["events"][0]["count"] == 42
+            assert body["top_search_keywords"][0]["keyword"] == "心经"
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.mark.anyio
+async def test_module_usage_days_clamped(client):
+    """days param outside 1–90 should return 422."""
+    fake_admin = _fake_user(role="admin")
+    from app.main import app
+    from app.core.deps import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: fake_admin
+    try:
+        resp = await client.get("/api/admin/stats/module-usage?days=0")
+        assert resp.status_code == 422
+        resp2 = await client.get("/api/admin/stats/module-usage?days=91")
+        assert resp2.status_code == 422
     finally:
         app.dependency_overrides.pop(get_current_user, None)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1136,6 +1136,32 @@ export async function getAdminAuditLog(params: {
   return data;
 }
 
+// --- Admin Module Usage (Umami analytics) ---
+
+export interface ModuleEventItem {
+  event_name: string;
+  label: string;
+  count: number;
+}
+
+export interface KeywordItem {
+  keyword: string;
+  count: number;
+}
+
+export interface AdminModuleUsage {
+  days: number;
+  events: ModuleEventItem[];
+  top_search_keywords: KeywordItem[];
+}
+
+export async function getAdminModuleUsage(days: number = 7): Promise<AdminModuleUsage> {
+  const { data } = await api.get<AdminModuleUsage>("/admin/stats/module-usage", {
+    params: { days },
+  });
+  return data;
+}
+
 // --- Similar Passages ---
 
 export interface SimilarPassageItem {

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -10,6 +10,11 @@ import {
   DatabaseOutlined,
   ArrowUpOutlined,
   ArrowDownOutlined,
+  SearchOutlined,
+  RobotOutlined,
+  ReadOutlined,
+  LinkOutlined,
+  ThunderboltOutlined,
 } from "@ant-design/icons";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
@@ -18,7 +23,9 @@ import { Line } from "@ant-design/charts";
 import {
   getAdminOverview,
   getAdminTrends,
+  getAdminModuleUsage,
   type AdminOverview,
+  type ModuleEventItem,
 } from "../api/client";
 import { getPlatformActivity } from "../api/feed";
 
@@ -185,8 +192,100 @@ export default function AdminDashboardPage() {
         </Card>
 
         <PlatformActivityCard />
+        <ModuleUsageCard />
       </div>
     </>
+  );
+}
+
+/** Map event_name → antd icon for the module usage card. */
+function _eventIcon(name: string) {
+  switch (name) {
+    case "search":       return <SearchOutlined />;
+    case "chat":         return <RobotOutlined />;
+    case "read":         return <ReadOutlined />;
+    case "source_click": return <LinkOutlined />;
+    case "cbeta-shortcut": return <ThunderboltOutlined />;
+    default:             return <DatabaseOutlined />;
+  }
+}
+
+function ModuleUsageCard() {
+  const [days, setDays] = useState<number>(7);
+  const { data, isLoading } = useQuery({
+    queryKey: ["adminModuleUsage", days],
+    queryFn: () => getAdminModuleUsage(days),
+    staleTime: 300_000,
+  });
+
+  return (
+    <Card
+      title="板块使用情况"
+      style={{ marginTop: 16 }}
+      extra={
+        <Segmented
+          value={days}
+          onChange={(v) => setDays(v as number)}
+          options={[
+            { label: "7天", value: 7 },
+            { label: "14天", value: 14 },
+            { label: "30天", value: 30 },
+          ]}
+        />
+      }
+    >
+      {isLoading ? (
+        <Spin />
+      ) : !data || data.events.length === 0 ? (
+        <Empty description="暂无 Umami 数据" />
+      ) : (
+        <>
+          <Text type="secondary" style={{ fontSize: 12 }}>各板块事件量</Text>
+          <Row gutter={[16, 16]} style={{ marginTop: 4, marginBottom: 16 }}>
+            {data.events.map((ev: ModuleEventItem) => (
+              <Col xs={12} sm={6} key={ev.event_name}>
+                <Statistic
+                  title={ev.label}
+                  value={ev.count}
+                  prefix={_eventIcon(ev.event_name)}
+                />
+              </Col>
+            ))}
+          </Row>
+
+          {data.top_search_keywords.length > 0 && (
+            <div style={{ marginTop: 8 }}>
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                热门检索词（Top 10）
+              </Text>
+              <div style={{ marginTop: 8 }}>
+                {data.top_search_keywords.map((kw, i) => (
+                  <div
+                    key={`${kw.keyword}-${i}`}
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      padding: "4px 0",
+                      borderBottom: i < data.top_search_keywords.length - 1
+                        ? "1px solid #f0f0f0"
+                        : undefined,
+                    }}
+                  >
+                    <span>
+                      <Text type="secondary" style={{ marginRight: 8 }}>
+                        {i + 1}.
+                      </Text>
+                      {kw.keyword}
+                    </span>
+                    <span style={{ color: "#999" }}>{kw.count} 次</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </Card>
   );
 }
 


### PR DESCRIPTION
## 概述

在 `/admin` 后台新增「板块使用情况」Card，读取自托管 Umami analytics DB，展示各板块事件量和热门检索词。

## 变更内容

- **`backend/app/services/usage_service.py`**（新建）  
  懒加载独立 `create_async_engine` 连接 `umami` DB（同主机、同凭据、不同 db 名）。  
  使用 `make_interval(days => :days)` 安全绑定时间窗口，杜绝 SQL 注入。  
  全路径异常捕获 + 警告日志，Umami 不可达时降级返回 `events=[], top_search_keywords=[]`，admin 页永不因此 500。

- **`backend/app/schemas/admin.py`**  
  新增 `AdminModuleUsage` / `ModuleEventItem` / `KeywordItem` 三个 Pydantic model。

- **`backend/app/api/admin.py`**  
  新增 `GET /admin/stats/module-usage?days=N`（1≤N≤90，`require_role("admin")` 守卫）。

- **`frontend/src/api/client.ts`**  
  新增 `AdminModuleUsage` / `ModuleEventItem` / `KeywordItem` TS 类型 + `getAdminModuleUsage(days)` 函数。

- **`frontend/src/pages/AdminDashboardPage.tsx`**  
  新增 `ModuleUsageCard` 组件（antd Card + Segmented 7/14/30 天切换）：  
  - 各板块事件量：小 Statistic 卡片，带图标（搜索/机器人/阅读/链接/闪电）  
  - 热门检索词 Top 10：排序列表，带编号和次数

- **`backend/tests/test_admin.py`**  
  新增 5 个测试：`auth guard` / `403 non-admin` / `Umami 宕机降级 200` / `正常数据形状` / `days 越界 422`

## 测试

```
backend: pytest tests/ -q -k "admin or stats"  → 22 passed
frontend: tsc --noEmit → 0 errors; eslint → 0 errors (1 pre-existing any warning)
```

## 架构说明

Umami 引擎是模块级懒单例，首次调用时创建，与 app startup 完全解耦。
连接字符串由 `settings.database_url.rsplit("/", 1)[0] + "/umami"` 派生，无需新增环境变量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)