### PR TITLE
fix(admin): 好评率恒为 0.0% — feedback 字面量写错

### DIFF
--- a/backend/app/services/stats_service.py
+++ b/backend/app/services/stats_service.py
@@ -358,11 +358,14 @@ async def get_platform_activity(db: AsyncSession, redis=None, days: int = 7) -> 
         )
     ).scalar() or 0
 
+    # Feedback is stored as "up" / "down" (see schemas/chat.py:
+    # feedback: Literal["up", "down"]). The old "thumbs_up" literal
+    # matched nothing, so 好评率 was permanently stuck at 0.0%.
     positive_feedback = (
         await db.execute(
             select(func.count(ChatMessage.id)).where(
                 ChatMessage.created_at >= cutoff,
-                ChatMessage.feedback == "thumbs_up",
+                ChatMessage.feedback == "up",
             )
         )
     ).scalar() or 0


### PR DESCRIPTION
## 核查发现的 bug

`/admin`「平台活跃度」的「好评率」一直显示 **0.0%**,即便实际有用户点了好评。

**根因**:`stats_service.get_platform_activity` 统计 `ChatMessage.feedback == "thumbs_up"`,但聊天反馈实际存的是 `"up"` / `"down"`(`schemas/chat.py` 里 `feedback: Literal["up", "down"]`,前端 ChatPage/ReaderAIPanel 也都用 `"up"`/`"down"`)。生产库核实:`feedback='up'` 有 2 条,`'thumbs_up'` 0 条 —— 过滤条件匹配不到任何行,好评数恒为 0。

**修复**:`"thumbs_up"` → `"up"`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)