### PR TITLE
feat(sources): surface health_detail in badge tooltip for all problem states

### DIFF
--- a/frontend/src/pages/sources/SourceCard.test.tsx
+++ b/frontend/src/pages/sources/SourceCard.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import SourceCard from "./SourceCard";
+import type { DataSource } from "../../api/client";
+import type { SourceId } from "../../types/branded";
+
+/** 构造 mock 数据源 */
+function makeSource(overrides: Partial<DataSource> = {}): DataSource {
+  return {
+    id: 1 as SourceId,
+    code: "CBETA",
+    name_zh: "中華電子佛典協會",
+    name_en: "CBETA",
+    base_url: "https://cbetaonline.dila.edu.tw",
+    description: null,
+    access_type: "external",
+    region: null,
+    languages: "zh",
+    research_fields: null,
+    supports_search: false,
+    supports_fulltext: false,
+    has_local_fulltext: false,
+    has_remote_fulltext: false,
+    supports_iiif: false,
+    supports_api: false,
+    sort_order: 0,
+    is_active: true,
+    health_status: "ok",
+    health_checked_at: null,
+    health_detail: null,
+    distributions: [],
+    ...overrides,
+  };
+}
+
+function renderCard(source: DataSource) {
+  return render(
+    <MemoryRouter>
+      <SourceCard source={source} searchQuery="" />
+    </MemoryRouter>,
+  );
+}
+
+describe("SourceCard 健康徽章 tooltip", () => {
+  it("ok 源不显示健康徽章", () => {
+    renderCard(makeSource());
+    expect(screen.queryByText("暂无法访问")).not.toBeInTheDocument();
+    expect(screen.queryByText("访问受限")).not.toBeInTheDocument();
+  });
+
+  it("非 moved 状态在 tooltip 中显示 health_detail", async () => {
+    const user = userEvent.setup();
+    renderCard(
+      makeSource({
+        health_status: "degraded",
+        health_detail: "HTTP 404",
+        health_checked_at: "2026-05-16T04:30:00Z",
+      }),
+    );
+    await user.hover(screen.getByText("访问受限"));
+    expect(await screen.findByText(/详情：HTTP 404/)).toBeInTheDocument();
+  });
+
+  it("moved 状态保留「现重定向至」措辞", async () => {
+    const user = userEvent.setup();
+    renderCard(
+      makeSource({
+        health_status: "moved",
+        health_detail: "https://example.org/new",
+        health_checked_at: "2026-05-16T04:30:00Z",
+      }),
+    );
+    await user.hover(screen.getByText("站点已迁移"));
+    expect(
+      await screen.findByText(/现重定向至：https:\/\/example\.org\/new/),
+    ).toBeInTheDocument();
+  });
+
+  it("非 ok 但 health_detail 为空时不显示「详情」行", async () => {
+    const user = userEvent.setup();
+    renderCard(
+      makeSource({ health_status: "unreachable", health_detail: null }),
+    );
+    await user.hover(screen.getByText("暂无法访问"));
+    // 通用 tip 仍在，但不应出现「详情：」前缀。
+    // 注：此断言依赖 HEALTH_BADGE 各 tip 文案均不含「详情：」子串——
+    // 若日后某 tip 引入该词，需改为对 tooltip 容器作用域断言。
+    expect(await screen.findByText(/连接超时或被拒绝/)).toBeInTheDocument();
+    expect(screen.queryByText(/详情：/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -72,14 +72,19 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
   const healthCheckedAt = s.health_checked_at
     ? new Date(s.health_checked_at).toLocaleDateString("zh-CN")
     : null;
-  // For a moved source, health_detail is the redirect target — the one piece
-  // of actionable context worth surfacing in the badge tooltip.
+  // health_detail carries per-source context the generic tip lacks: for a moved
+  // source it's the redirect target, for degraded/unreachable/cert_invalid it's
+  // the probe's specific failure reason. Surface it for every problem state.
+  const healthDetailLine =
+    health && s.health_detail
+      ? s.health_status === "moved"
+        ? `现重定向至：${s.health_detail}`
+        : `详情：${s.health_detail}`
+      : null;
   const healthTooltip = health
     ? [
         health.tip,
-        s.health_status === "moved" && s.health_detail
-          ? `现重定向至：${s.health_detail}`
-          : null,
+        healthDetailLine,
         healthCheckedAt ? `最近巡检：${healthCheckedAt}` : null,
       ]
         .filter(Boolean)


### PR DESCRIPTION
## 背景

数据源健康巡检 cron 为每个非 `ok` 源写入 `health_detail`：`moved` 存重定向目标 URL，`degraded`/`unreachable`/`cert_invalid` 存巡检探测到的具体失败原因（HTTP 404、连接错误等）。

但 `SourceCard` 的健康徽章 tooltip 此前**只对 `moved` 渲染 `health_detail`**——约 115 个 degraded/unreachable/cert_invalid 源的诊断信息存在库里却对读者完全不可见。

## 改动

- tooltip 对**所有问题状态**渲染 `health_detail`：`moved` 保留「现重定向至：<url>」措辞，其余状态用「详情：<原因>」。
- `health_detail` 为空时不显示该行（`.filter(Boolean)` 兜底）。
- 新增 `SourceCard.test.tsx`（此前无测试）：覆盖 ok 无徽章 / moved 措辞 / 非 moved 显示详情 / 空 detail 不显示，4 例全绿。

## 验证

- `npx tsc --noEmit` 通过
- `npx eslint` 通过
- `npx vitest run src/pages/sources/SourceCard.test.tsx` 4/4 通过
- 纯前端，无 migration、无后端改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)