### PR TITLE
refactor(search): 去除综合检索页的「相关问答」区块

### DIFF
--- a/backend/app/api/search_unified.py
+++ b/backend/app/api/search_unified.py
@@ -34,7 +34,6 @@ from sqlalchemy.orm import joinedload
 from app.core.elasticsearch import get_es
 from app.database import async_session, get_db
 from app.models.dictionary import DictionaryEntry
-from app.models.hot_question import HotQuestion
 from app.services.search import (
     search_content,
     search_semantic,
@@ -45,7 +44,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["search"])
 
 _DICT_SECTION_LIMIT = 5
-_HOT_Q_SECTION_LIMIT = 4
 
 
 async def _dict_top_hits(q: str) -> list[dict]:
@@ -88,38 +86,6 @@ async def _dict_top_hits(q: str) -> list[dict]:
     return out
 
 
-async def _hot_question_hits(q: str) -> list[dict]:
-    """Pre-curated hot_questions matching the query as substring.
-
-    These are 200 hand-edited prompts that already exist in the system —
-    surfacing them in unified results steers the 77 empty chat sessions /
-    493 single-turn sessions toward a starting point. Independent session
-    for asyncio.gather concurrency safety.
-    """
-    async with async_session() as db:
-        stmt = (
-            select(HotQuestion)
-            .where(HotQuestion.is_active.is_(True))
-            .where(HotQuestion.display_text.ilike(f"%{q}%"))
-            .order_by(HotQuestion.sort_order.asc())
-            .limit(_HOT_Q_SECTION_LIMIT)
-        )
-        rows = await db.execute(stmt)
-        questions = list(rows.scalars().all())
-
-    out = []
-    for h in questions:
-        out.append(
-            {
-                "slug": h.slug,
-                "category": h.category,
-                "text": h.display_text,
-                "url": f"/chat?q={h.display_text}",
-            }
-        )
-    return out
-
-
 @router.get("/search/unified")
 async def search_unified(
     q: str = Query(..., min_length=1, max_length=200, description="Unified search query"),
@@ -134,7 +100,6 @@ async def search_unified(
             "query": str,
             "sections": {
                 "dictionary": [...]    # top-5 dict hits with /dict/ links
-                "hot_questions": [...] # top-4 curated prompts
                 "catalog": {...}       # SearchResponse — top-10 metadata hits
                 "content": {...}       # ContentSearchResponse — top-5 body hits
                 "semantic": {...}      # SemanticSearchResponse — top-5 vector hits
@@ -145,20 +110,18 @@ async def search_unified(
     es = get_es()
 
     # search_semantic uses the request-scoped session; catalog/content use ES.
-    # dict + hot_q each open their own session for concurrency safety
+    # dict opens its own session for concurrency safety
     # (a single AsyncSession can't service two concurrent execute() calls).
     catalog_coro = search_texts(es, q, page=1, size=10, sources=sources, lang=lang, db=db)
     content_coro = search_content(es, q, page=1, size=5, sources=sources, lang=lang)
     semantic_coro = search_semantic(db, q, size=5, lang=lang, sources=sources)
     dict_coro = _dict_top_hits(q)
-    hot_coro = _hot_question_hits(q)
 
-    catalog_r, content_r, semantic_r, dict_r, hot_r = await asyncio.gather(
+    catalog_r, content_r, semantic_r, dict_r = await asyncio.gather(
         catalog_coro,
         content_coro,
         semantic_coro,
         dict_coro,
-        hot_coro,
         return_exceptions=True,
     )
 
@@ -191,6 +154,5 @@ async def search_unified(
         },
     )
     _attach("dictionary", dict_r)
-    _attach("hot_questions", hot_r)
 
     return {"query": q, "sections": sections, "errors": errors}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -475,12 +475,6 @@ export interface UnifiedSearchSection {
     source?: string | null;
     url: string;
   }> | null;
-  hot_questions?: Array<{
-    slug: string;
-    category: string;
-    text: string;
-    url: string;
-  }> | null;
   catalog?: { total: number; results: SearchHit[] } | null;
   content?: { total: number; total_juans?: number; results: ContentSearchHit[] } | null;
   semantic?: { total: number; results: SemanticSearchHit[] } | null;

--- a/frontend/src/components/search/UnifiedResults.tsx
+++ b/frontend/src/components/search/UnifiedResults.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 /**
  * Unified search results — sectioned overview combining dictionary entries,
- * catalog hits, hot Q&A, and content/semantic snippets in a single view.
+ * catalog hits, and content/semantic snippets in a single view.
  *
  * Sections render in importance order; empty sections are hidden.
  * Used by SearchPage's "全部 / All" tab (default landing tab).
@@ -20,7 +20,6 @@ export default function UnifiedResults({ data }: Props) {
   const sections = data.sections;
 
   const dictionary = sections.dictionary ?? [];
-  const hotQuestions = sections.hot_questions ?? [];
   const catalogResults = sections.catalog?.results ?? [];
   const contentResults = sections.content?.results ?? [];
   const semanticResults = sections.semantic?.results ?? [];
@@ -45,7 +44,6 @@ export default function UnifiedResults({ data }: Props) {
   const hasAny =
     dictionary.length > 0 ||
     catalogResults.length > 0 ||
-    hotQuestions.length > 0 ||
     mergedSnippets.length > 0;
 
   if (!hasAny) {
@@ -127,46 +125,6 @@ export default function UnifiedResults({ data }: Props) {
           {catalogResults.slice(0, 5).map((hit, i) => (
             <ResultCard key={hit.id} hit={hit} rank={i + 1} />
           ))}
-        </section>
-      )}
-
-      {/* 相关问答 */}
-      {hotQuestions.length > 0 && (
-        <section className="s-unified-section">
-          <h3 style={sectionTitleStyle}>{"💡"} 相关问答</h3>
-          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            {hotQuestions.map((q) => (
-              <Link
-                key={q.slug}
-                to={q.url.startsWith("/") ? q.url : `/${q.url}`}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 10,
-                  padding: "10px 14px",
-                  background: "#fff",
-                  border: "1px solid #e8e0d4",
-                  borderRadius: 6,
-                  color: "inherit",
-                  textDecoration: "none",
-                }}
-              >
-                <span
-                  style={{
-                    fontSize: 11,
-                    color: "#9a8e7a",
-                    background: "var(--fj-sand-light, #faf7f2)",
-                    padding: "2px 8px",
-                    borderRadius: 4,
-                    flexShrink: 0,
-                  }}
-                >
-                  {q.category}
-                </span>
-                <span style={{ fontSize: 14, color: "#3d2f1a" }}>{q.text}</span>
-              </Link>
-            ))}
-          </div>
         </section>
       )}
 

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -146,8 +146,8 @@ export default function SearchPage() {
   });
 
   // Unified search powers the default "全部 / All" tab — single round trip
-  // to /search/unified returns sectioned results (dictionary, hot_questions,
-  // catalog, content, semantic) so the user no longer has to pick a tab.
+  // to /search/unified returns sectioned results (dictionary, catalog,
+  // content, semantic) so the user no longer has to pick a tab.
   const { data: unifiedData, isLoading: unifiedLoading, isError: unifiedError, refetch: refetchUnified } = useQuery({
     queryKey: ["searchUnified", query, selectedSources, langFilter],
     queryFn: () => searchUnified({ q: query, sources: selectedSources || undefined, lang: langFilter || undefined }),
@@ -344,7 +344,7 @@ export default function SearchPage() {
         />
         <div className="s-mode-hint">
           {tab === "all"
-            ? "一站式综合检索：辞典释义、经文标题、相关问答、内文片段一次呈现"
+            ? "一站式综合检索：辞典释义、经文标题、内文片段一次呈现"
             : tab === "catalog"
             ? "按经名、译者、编号检索，自动匹配所有语种标题与翻译版本"
             : tab === "content"


### PR DESCRIPTION
## 背景

综合检索（「全部」标签）页的「相关问答」区块夹在「经文标题」和「经文内文片段」之间，把核心检索结果（内文片段）往下挤，对检索意图无增益。用户决定完全去除。

## 改动

- 前端 `UnifiedResults.tsx`：删除「相关问答」section 及相关变量
- 前端 `client.ts`：移除 `UnifiedSearchSection.hot_questions` 类型字段
- 前端 `SearchPage.tsx`：更新 mode hint 文案与注释
- 后端 `search_unified.py`：移除 `_hot_question_hits` 计算与 `hot_questions` section，每次综合检索少一次 DB 查询

聊天页自身的 hot-questions 功能不受影响。

## 验证

- 前端 `tsc --noEmit` 通过
- 后端语法检查通过
- 代码审查：无悬挂引用、无未用 import、`asyncio.gather` 解包匹配

🤖 Generated with [Claude Code](https://claude.com/claude-code)