### PR TITLE
feat(sources): track unreachable_since to measure outage streaks

### DIFF
--- a/backend/alembic/versions/0143_add_source_unreachable_since.py
+++ b/backend/alembic/versions/0143_add_source_unreachable_since.py
@@ -1,0 +1,50 @@
+"""Add data_sources.unreachable_since.
+
+source-health P2: the daily digest needs to flag sources that have been
+*continuously* unreachable long enough to consider deactivating. ``health_status``
+only records the latest verdict, so the start of an unreachable streak was
+unknowable — "down for 30 days" could not be computed.
+
+``unreachable_since`` marks when a source first entered its current unreachable
+streak. ``scripts/health_check_sources.py`` sets it on the first unreachable
+probe, keeps it across consecutive unreachable probes, and clears it (NULL) on
+any other verdict. ``now() - unreachable_since`` is then the streak length.
+
+Nullable, no default: a source not currently unreachable simply has NULL. The
+next cron pass populates it for any source already unreachable.
+
+Revision ID: 0143
+Revises: 0142
+Create Date: 2026-05-19
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0143"
+down_revision = "0142"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            "ALTER TABLE data_sources "
+            "ADD COLUMN IF NOT EXISTS unreachable_since TIMESTAMPTZ"
+        )
+    )
+    op.execute(
+        text(
+            "COMMENT ON COLUMN data_sources.unreachable_since IS "
+            "'When the source first entered its current continuous unreachable "
+            "streak; NULL when not unreachable. Set by "
+            "scripts/health_check_sources.py.'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        text("ALTER TABLE data_sources DROP COLUMN IF EXISTS unreachable_since")
+    )

--- a/backend/app/models/source.py
+++ b/backend/app/models/source.py
@@ -35,6 +35,9 @@ class DataSource(Base):
     # Actionable context for the latest probe: redirect target for moved,
     # failure reason otherwise, NULL when ok.
     health_detail: Mapped[str | None] = mapped_column(String(500))
+    # When the source first entered its current continuous unreachable streak;
+    # NULL when not unreachable. now() - unreachable_since is the streak length.
+    unreachable_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     # embedding column is vector(1024), managed via raw SQL; not mapped here
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/app/services/source_health.py
+++ b/backend/app/services/source_health.py
@@ -12,6 +12,7 @@ Valid statuses: ok | degraded | cert_invalid | unreachable | moved
 
 import ipaddress
 import socket
+from datetime import datetime
 from urllib.parse import urlsplit
 
 # Probe error kinds the caller may report. Anything that is not a clean HTTP
@@ -145,3 +146,32 @@ def classify_health(
     if status_code in (404, 410):
         return "degraded"
     return "ok"
+
+
+def resolve_unreachable_since(
+    status: str,
+    previous: datetime | None,
+    now: datetime,
+) -> datetime | None:
+    """The ``unreachable_since`` value to persist after a probe.
+
+    ``unreachable_since`` marks when a source *first* entered its current
+    continuous unreachable streak. It lets the daily digest flag sources down
+    long enough to consider deactivating, without storing per-probe history.
+    Any non-``unreachable`` verdict ends the streak — including ``degraded``,
+    ``cert_invalid`` and ``moved``, since "30 consecutive days *unreachable*"
+    is specifically about connectivity, not any unhealthy state.
+
+      - newly unreachable (``previous`` is None)  -> ``now`` (streak starts)
+      - still unreachable (``previous`` is set)   -> ``previous`` (streak kept)
+      - any other status                          -> ``None`` (streak cleared)
+
+    The probing/IO caller (``scripts/health_check_sources.py``) is a cron
+    singleton and the sole writer of this column, so the read-then-write it
+    does around this function carries no concurrency hazard. A source that is
+    *skipped* (no probe verdict) is never written, so its streak — like its
+    other health columns — freezes at the last probed value.
+    """
+    if status != "unreachable":
+        return None
+    return now if previous is None else previous

--- a/backend/scripts/health_check_sources.py
+++ b/backend/scripts/health_check_sources.py
@@ -1,7 +1,7 @@
 """Probe every active data source and persist its health_status.
 
 巡检所有活跃数据源的可达性，将结果写入 data_sources.health_status /
-health_checked_at，并失效 sources 列表缓存。
+health_checked_at / health_detail / unreachable_since，并失效 sources 列表缓存。
 
 Designed to run from cron on the deployment host. Independent of ``is_active``:
 a source can be reachable-but-deprecated, or down-but-kept.
@@ -21,6 +21,7 @@ import asyncio
 import os
 import sys
 import warnings
+from datetime import UTC, datetime
 from urllib.parse import urlsplit
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -38,6 +39,7 @@ from app.services.source_health import (
     VALID_STATUSES,
     classify_health,
     host_is_public,
+    resolve_unreachable_since,
 )
 
 TIMEOUT = 15  # seconds per request
@@ -143,11 +145,15 @@ async def main(dry_run: bool) -> None:
         rows = (
             await session.execute(
                 text(
-                    "SELECT code, base_url FROM data_sources "
+                    "SELECT code, base_url, unreachable_since FROM data_sources "
                     "WHERE is_active = true ORDER BY code"
                 )
             )
         ).fetchall()
+
+    # Streak start per source, read once up front: resolve_unreachable_since
+    # needs the prior value to decide whether to start, keep or clear the streak.
+    prev_unreachable: dict[str, datetime | None] = {r[0]: r[2] for r in rows}
 
     print(
         f"Health-checking {len(rows)} active sources "
@@ -177,16 +183,28 @@ async def main(dry_run: bool) -> None:
     # ---- write back ----
     changed = 0
     if not dry_run:
+        # One timestamp for the whole pass: every row's health_checked_at and
+        # any freshly-started unreachable streak share the same probe time.
+        checked_at = datetime.now(UTC)
         async with async_session() as session:
             for r in verdicts:
+                unreachable_since = resolve_unreachable_since(
+                    r["status"], prev_unreachable.get(r["code"]), checked_at
+                )
                 res = await session.execute(
                     text(
                         "UPDATE data_sources "
-                        "SET health_status = :s, health_checked_at = now(), "
-                        "    health_detail = :d "
+                        "SET health_status = :s, health_checked_at = :t, "
+                        "    health_detail = :d, unreachable_since = :u "
                         "WHERE code = :c AND is_active = true"
                     ),
-                    {"s": r["status"], "d": r["detail"], "c": r["code"]},
+                    {
+                        "s": r["status"],
+                        "t": checked_at,
+                        "d": r["detail"],
+                        "u": unreachable_since,
+                        "c": r["code"],
+                    },
                 )
                 changed += res.rowcount or 0
             await session.commit()

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -2,9 +2,16 @@
 
 数据源健康状态分类的单元测试。Pure logic, no DB / network."""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
-from app.services.source_health import _ip_is_blocked, classify_health, host_is_public
+from app.services.source_health import (
+    _ip_is_blocked,
+    classify_health,
+    host_is_public,
+    resolve_unreachable_since,
+)
 
 HOME = "https://example.org/"
 
@@ -172,3 +179,35 @@ def test_host_is_public_allows_public_ip_literal():
 def test_host_is_public_rejects_empty():
     assert host_is_public(None) is False
     assert host_is_public("") is False
+
+
+# --- resolve_unreachable_since: streak tracking ---------------------------
+
+NOW = datetime(2026, 5, 19, 4, 30, tzinfo=UTC)
+EARLIER = NOW - timedelta(days=12)
+
+
+def test_unreachable_streak_starts_when_newly_unreachable():
+    # No prior streak -> the streak starts now.
+    assert resolve_unreachable_since("unreachable", None, NOW) == NOW
+
+
+def test_unreachable_streak_start_is_preserved_while_still_unreachable():
+    # An ongoing streak keeps its original start, so age keeps accruing.
+    assert resolve_unreachable_since("unreachable", EARLIER, NOW) == EARLIER
+
+
+@pytest.mark.parametrize("status", ["ok", "degraded", "cert_invalid", "moved"])
+def test_any_non_unreachable_status_clears_the_streak(status):
+    # "30 consecutive days unreachable" is about connectivity specifically —
+    # every other verdict, healthy or not, ends the streak.
+    assert resolve_unreachable_since(status, EARLIER, NOW) is None
+
+
+def test_non_unreachable_with_no_prior_streak_stays_none():
+    assert resolve_unreachable_since("ok", None, NOW) is None
+
+
+def test_streak_start_is_timezone_aware():
+    # The value lands in a TIMESTAMPTZ column — a naive datetime would shift.
+    assert resolve_unreachable_since("unreachable", None, NOW).tzinfo is not None


### PR DESCRIPTION
## 背景

source-health P2 需要标记**持续**不可达足够久（30 天）、值得考虑下架的数据源。但 `health_status` 只记录最新一次判定，无从得知一段不可达连续期的**起点** —— "连续坏了 30 天"算不出来。

## 改动

- **migration 0143**：`data_sources` 加可空列 `unreachable_since TIMESTAMPTZ`（`down_revision = 0142`，即当前生产 head；`alembic heads` 确认单一 head）。
- **`resolve_unreachable_since()`**（`source_health.py` 纯函数）：
  - 首次 unreachable → 记 `now`（连续期开始）
  - 持续 unreachable → 保留原 `previous`（连续期累积）
  - 任何其它判定（degraded/cert_invalid/moved/ok）→ 清空 `None`（指标专指连通性，非"任何不健康"）
  - 纯逻辑、无 DB，与 `classify_health` 同模块、可单测。
- **cron `health_check_sources.py`**：SELECT 额外读旧 `unreachable_since`，写回时套用解析结果。`health_checked_at` 从 SQL `now()` 改为每轮捕获一个 Python 时间戳 —— 同一行的巡检时间与新开的连续期共用同一瞬间。
- 7 个新单测覆盖 streak 的 start / preserve / clear / tz-aware。

`now() - unreachable_since` 即为连续不可达时长。

## 已知与刻意取舍（供后续 digest 接入者参考）

- **迁移日 backfill 为 NULL**：列新增时所有行为 NULL，首次 cron 才填值。对迁移时已不可达的源，30 天计时实际从部署日重启 —— 这是保守选择（不凭空捏造历史），但意味着 day-1 无法立即标记。
- **skipped 源**（无 base_url，无巡检判定）不写回，`unreachable_since` 与其它健康列一样冻结在上次值。

## 验证

- `alembic heads` → 单一 head `0143`
- `ruff check` 通过
- `pytest tests/test_source_health.py` 41/41 通过
- code review：Ready to merge，无 Critical/Important

🤖 Generated with [Claude Code](https://claude.com/claude-code)