### PR TITLE
refactor(search): 外站搜索区块瘦身 + 语种感知

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -93,7 +93,6 @@
   "search.no_results_for": "No results found for \"{{query}}\"",
   "search.did_you_mean": "Did you mean",
   "search.empty_state_external": "No on-site matches. You can continue searching the external sources below.",
-  "search.external_card_prefix": "Search on external site: {{query}}",
   "language.zh": "中文",
   "language.zh-Hant": "中文（繁體）",
   "language.en": "English",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -93,7 +93,6 @@
   "search.no_results_for": "沒有找到「{{query}}」的結果",
   "search.did_you_mean": "您是否想搜尋",
   "search.empty_state_external": "無站內匹配，可在以下外部資料源繼續搜尋",
-  "search.external_card_prefix": "在外站搜尋：{{query}}",
   "language.zh": "中文簡體",
   "language.zh-Hant": "中文繁體",
   "language.en": "English",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -93,7 +93,6 @@
   "search.no_results_for": "没有找到「{{query}}」的结果",
   "search.did_you_mean": "您是否想搜索",
   "search.empty_state_external": "无站内匹配，可在以下外部数据源继续搜索",
-  "search.external_card_prefix": "在外站搜索：{{query}}",
   "language.zh": "中文简体",
   "language.zh-Hant": "中文繁體",
   "language.en": "English",

--- a/frontend/src/components/search/ExternalCard.tsx
+++ b/frontend/src/components/search/ExternalCard.tsx
@@ -1,41 +1,43 @@
 import { Tag } from "antd";
 import { LinkOutlined, EyeOutlined } from "@ant-design/icons";
-import { useTranslation } from "react-i18next";
 import { buildSearchUrl } from "../../utils/sourceUrls";
 import type { DataSource } from "../../api/client";
 
-export default function ExternalCard({ source, query, rank }: { source: DataSource; query: string; rank: number }) {
-  const { t } = useTranslation();
+/**
+ * Compact single-row launcher for an external data source.
+ *
+ * Not a search result — it carries the current query into the source's
+ * own search page. Deliberately low-chrome: source name + region + two
+ * actions. The fake "排序 #N" rank, duplicate name tag, blanket "外链跳转"
+ * tag and the "馆藏: {name}" line were dropped — they added no information.
+ */
+export default function ExternalCard({ source, query }: { source: DataSource; query: string }) {
   const url = buildSearchUrl(source.code, query) || "#";
   return (
-    <div className="s-card s-card-ext">
-      <div className="s-card-rank">排序<br />#{rank}</div>
-      <div className="s-card-body">
-        <div className="s-card-ext-prefix" style={{ fontSize: 12, color: "#9a8e7a", marginBottom: 2 }}>
-          {t("search.external_card_prefix", { query })}
-        </div>
-        <div className="s-card-title">{source.name_zh}</div>
-        <div className="s-card-tags">
-          <Tag color="blue" style={{ fontSize: 11 }}>{source.name_zh}</Tag>
-          <Tag style={{ fontSize: 11 }}>外链跳转</Tag>
-          {source.region && <Tag style={{ fontSize: 11 }}>{source.region}</Tag>}
-        </div>
-        <div className="s-card-meta">
-          <span>馆藏: {source.name_zh}</span>
-        </div>
-        <div className="s-card-actions">
-          <a className="s-card-btn-primary" href={url} target="_blank" rel="noopener noreferrer"
-            aria-label={`前往 ${source.name_zh} 搜索 ${query}`}>
-            <LinkOutlined /> 前往原站搜索
-          </a>
-          {source.base_url && (
-            <a className="s-card-btn" href={source.base_url} target="_blank" rel="noopener noreferrer"
-              aria-label={`访问 ${source.name_zh} 主页`}>
-              <EyeOutlined /> 访问主页
-            </a>
-          )}
-        </div>
-      </div>
+    <div className="s-ext-row">
+      <span className="s-ext-row-name">{source.name_zh}</span>
+      {source.region && <Tag style={{ fontSize: 11, margin: 0 }}>{source.region}</Tag>}
+      <span className="s-ext-row-spacer" />
+      <a
+        className="s-card-btn-primary"
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`前往 ${source.name_zh} 搜索 ${query}`}
+      >
+        <LinkOutlined /> 前往原站搜索
+      </a>
+      {source.base_url && (
+        <a
+          className="s-card-btn"
+          href={source.base_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`访问 ${source.name_zh} 主页`}
+        >
+          <EyeOutlined /> 访问主页
+        </a>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/search/ExternalSourcesSection.tsx
+++ b/frontend/src/components/search/ExternalSourcesSection.tsx
@@ -1,0 +1,101 @@
+import { useState, useMemo } from "react";
+import ExternalCard from "./ExternalCard";
+import type { DataSource } from "../../api/client";
+
+/** How many language-relevant sources to show before the "展开" toggle. */
+const INITIAL_VISIBLE = 12;
+
+/**
+ * Map the query's script to the language codes a source should carry to
+ * count as relevant. `data_sources.languages` is a comma-separated list of
+ * codes (zh, lzh, sa, pi, bo, en, de, km, …).
+ *
+ * - Han script  → 中文 sources (zh / lzh)
+ * - Tibetan     → bo
+ * - Devanagari  → sa
+ * - Latin/other → romanized Pali/Sanskrit + Western-language sources
+ */
+function preferredLangs(query: string): Set<string> {
+  if (/[㐀-䶿一-鿿豈-﫿]/.test(query)) return new Set(["zh", "lzh"]);
+  if (/[ༀ-࿿]/.test(query)) return new Set(["bo"]);
+  if (/[ऀ-ॿ]/.test(query)) return new Set(["sa"]);
+  return new Set(["pi", "sa", "en", "de"]);
+}
+
+function sourceLangs(s: DataSource): string[] {
+  return (s.languages ?? "").split(",").map((x) => x.trim()).filter(Boolean);
+}
+
+/**
+ * External-source launchers for the search page.
+ *
+ * These are not search results — the same fixed catalogue applies to every
+ * query. To keep the section from burying the real results we:
+ *  1. split sources by whether their language matches the query's script,
+ *  2. show the language-relevant group first (capped, with a 展开 toggle),
+ *  3. collapse the off-script group behind "其他语种来源".
+ */
+export default function ExternalSourcesSection({
+  sources,
+  query,
+}: {
+  sources: DataSource[];
+  query: string;
+}) {
+  const [expandedPrimary, setExpandedPrimary] = useState(false);
+  const [showOther, setShowOther] = useState(false);
+
+  const { primary, other } = useMemo(() => {
+    const pref = preferredLangs(query);
+    const primary: DataSource[] = [];
+    const other: DataSource[] = [];
+    for (const s of sources) {
+      const langs = sourceLangs(s);
+      // Sources with no declared language stay in the primary group — we
+      // demote known mismatches, not unknowns.
+      const relevant = langs.length === 0 || langs.some((l) => pref.has(l));
+      (relevant ? primary : other).push(s);
+    }
+    return { primary, other };
+  }, [sources, query]);
+
+  if (sources.length === 0) return null;
+
+  const visiblePrimary = expandedPrimary ? primary : primary.slice(0, INITIAL_VISIBLE);
+
+  return (
+    <>
+      <div className="s-ext-divider">
+        可在以下 {sources.length} 个外部数据源继续搜索「{query}」
+      </div>
+
+      {visiblePrimary.map((s) => (
+        <ExternalCard key={s.code} source={s} query={query} />
+      ))}
+
+      {primary.length > INITIAL_VISIBLE && (
+        <button
+          type="button"
+          className="s-ext-toggle"
+          onClick={() => setExpandedPrimary((v) => !v)}
+        >
+          {expandedPrimary ? "收起" : `展开剩余 ${primary.length - INITIAL_VISIBLE} 个来源`}
+        </button>
+      )}
+
+      {other.length > 0 && (
+        <>
+          <button
+            type="button"
+            className="s-ext-toggle"
+            onClick={() => setShowOther((v) => !v)}
+          >
+            {showOther ? "收起其他语种来源" : `其他语种来源（${other.length}）`}
+          </button>
+          {showOther &&
+            other.map((s) => <ExternalCard key={s.code} source={s} query={query} />)}
+        </>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/search/index.ts
+++ b/frontend/src/components/search/index.ts
@@ -1,5 +1,6 @@
 export { default as ResultCard } from "./ResultCard";
 export { default as ExternalCard } from "./ExternalCard";
+export { default as ExternalSourcesSection } from "./ExternalSourcesSection";
 export { default as DictCard } from "./DictCard";
 export { default as ContentCard } from "./ContentCard";
 export { default as CrossLangCard } from "./CrossLangCard";

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -13,7 +13,7 @@ import { searchTexts, searchContent, searchDictionary, searchCrossLanguage, sear
 import type { DictGroupedSearchResponse } from "../api/client";
 import { hasDirectSearchUrl } from "../utils/sourceUrls";
 import { addSearchHistory, getSearchHistory, type SearchHistoryItem } from "../utils/history";
-import { ResultCard, ExternalCard, DictCard, ContentCard, CrossLangCard, SemanticCard, UnifiedResults } from "../components/search";
+import { ResultCard, ExternalSourcesSection, DictCard, ContentCard, CrossLangCard, SemanticCard, UnifiedResults } from "../components/search";
 import "../styles/search.css";
 import "../styles/sources.css";
 
@@ -266,7 +266,6 @@ export default function SearchPage() {
   // both the error block AND the "no on-site matches" copy.
   const primaryError = tab === "catalog" ? isError : tab === "content" ? contentError : dictError;
   const showEmptyState = !primaryLoading && !primaryError && localTotal === 0 && !hasSecondaryResults;
-  const extTotal = query.length > 0 ? filteredExtSources.length : 0;
 
   const sortedRegions = useMemo(() => {
     return Object.keys(regionCounts).sort((a, b) => {
@@ -433,14 +432,7 @@ export default function SearchPage() {
                 )}
                 {/* 外部数据源结果 */}
                 {!unifiedLoading && !unifiedError && query.length > 0 && filteredExtSources.length > 0 && (
-                  <>
-                    <div className="s-ext-divider">
-                      以下 {extTotal} 个外部数据源可继续搜索「{query}」
-                    </div>
-                    {filteredExtSources.map((s, i) => (
-                      <ExternalCard key={s.code} source={s} query={query} rank={i + 1} />
-                    ))}
-                  </>
+                  <ExternalSourcesSection sources={filteredExtSources} query={query} />
                 )}
               </>
             ) : (
@@ -657,15 +649,7 @@ export default function SearchPage() {
 
             {/* 外部数据源结果 */}
             {(!loading || showEmptyState) && tab !== "dictionary" && query.length > 0 && filteredExtSources.length > 0 && (
-              <>
-                <div className="s-ext-divider">
-                  以下 {extTotal} 个外部数据源可继续搜索「{query}」
-                </div>
-                {filteredExtSources.map((s, i) => (
-                  <ExternalCard key={s.code} source={s} query={query}
-                    rank={i + 1} />
-                ))}
-              </>
+              <ExternalSourcesSection sources={filteredExtSources} query={query} />
             )}
             </>
             )}

--- a/frontend/src/styles/search.css
+++ b/frontend/src/styles/search.css
@@ -157,16 +157,6 @@
   border-color: var(--fj-gold);
 }
 
-.s-card-ext {
-  border-left: 3px solid var(--fj-border);
-  background: var(--fj-bg-alt);
-  opacity: 0.85;
-}
-
-.s-card-ext:hover {
-  opacity: 1;
-}
-
 .s-card-rank {
   width: 50px;
   flex-shrink: 0;
@@ -297,6 +287,55 @@
   margin: 8px 0;
   border-top: 1px dashed var(--fj-border);
   border-bottom: 1px dashed var(--fj-border);
+}
+
+/* ---------- 外部源紧凑行 ---------- */
+.s-ext-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  margin-bottom: 6px;
+  background: var(--fj-bg-alt);
+  border: 1px solid var(--fj-border);
+  border-radius: 6px;
+  transition: border-color 0.15s;
+}
+
+.s-ext-row:hover {
+  border-color: var(--fj-gold);
+}
+
+.s-ext-row-name {
+  font-family: "Noto Serif SC", serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fj-ink);
+}
+
+.s-ext-row-spacer {
+  flex: 1 1 8px;
+  min-width: 8px;
+}
+
+.s-ext-toggle {
+  display: block;
+  width: 100%;
+  margin: 4px 0 12px;
+  padding: 8px;
+  background: var(--fj-bg-alt);
+  border: 1px dashed var(--fj-border);
+  border-radius: 6px;
+  color: var(--fj-ink-light);
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.s-ext-toggle:hover {
+  border-color: var(--fj-gold);
+  color: var(--fj-ink);
 }
 
 /* ---------- 辞典释义 ---------- */


### PR DESCRIPTION
## 背景

搜索页「外站搜索」区块把约 100 个外部数据源全部铺成大号「排名结果卡片」，问题：

- **「排序 #N」是假排名** —— 只是数组下标，伪装成相关性排序，有误导性
- **源名每张卡片重复 3 次** —— 标题 + 蓝色 Tag + 「馆藏: xxx」整行
- **「外链跳转」标签** 91 张卡片全有 → 零区分度
- 该列表**与查询词完全无关**（任何查询都是同一批源），却用结果卡片重样式承载，淹没真实检索结果

## 改动

- `ExternalCard` 改为**紧凑单行**：源名 + 地区 + 两个操作按钮。去掉假排名、重复名 Tag、「外链跳转」标签、「馆藏」行
- 新增 `ExternalSourcesSection`：按**查询词字符集**与源的 `languages` 字段做语种匹配（汉字→zh/lzh，藏文→bo，天城体→sa，拉丁→pi/sa/en/de）。语种相关源优先展示（默认上限 12，超出可「展开」），不相关语种源折叠进「其他语种来源」
- 移除已无用的 `external_card_prefix` i18n key

## 验证

- `tsc --noEmit` 通过
- `eslint` 通过
- `npm run build` 通过
- 3 个 locale JSON 校验有效
- 代码审查：字符集正则、primary/other 分组（含 null languages 边界）、折叠状态均确认无误

🤖 Generated with [Claude Code](https://claude.com/claude-code)