### PR TITLE
fix(kg): coalesce birth_year into timeline year_start

### DIFF
--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -642,8 +642,8 @@ async def get_timeline_entities(
                 e.id,
                 e.name_zh,
                 e.entity_type,
-                COALESCE(NULLIF(e.properties->>'year_start', ''), e.properties->>'birth_year') AS ys,
-                COALESCE(NULLIF(e.properties->>'year_end', ''),   e.properties->>'death_year')  AS ye
+                COALESCE(NULLIF(e.properties->>'year_start', ''), NULLIF(e.properties->>'birth_year', '')) AS ys,
+                COALESCE(NULLIF(e.properties->>'year_end', ''),   NULLIF(e.properties->>'death_year', ''))  AS ye
             FROM kg_entities e
             WHERE {type_condition}
               AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
@@ -659,13 +659,13 @@ async def get_timeline_entities(
     count_sql = text(
         f"""
         SELECT COUNT(*) FROM (
-            SELECT COALESCE(NULLIF(e.properties->>'year_start', ''), e.properties->>'birth_year') AS ys
+            SELECT COALESCE(NULLIF(e.properties->>'year_start', ''), NULLIF(e.properties->>'birth_year', '')) AS ys
             FROM kg_entities e
             WHERE {type_condition}
               AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
         ) src
         WHERE ys ~ '^-?[0-9]{{1,6}}$'
-        """  # nosec B608
+        """  # nosec B608 - type_condition is a hardcoded clause, not user input
     )
     count_result = await session.execute(count_sql, params)
     total = count_result.scalar() or 0

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -627,23 +627,29 @@ async def get_timeline_entities(
     # crashing the endpoint. year_end is cast through a CASE because it has
     # no WHERE filter of its own — a row with a valid year_start but a
     # garbage year_end must yield NULL, not an error.
+    #
+    # Field fallback: BDRC/Tibetan enrichment writes `year_start`/`year_end`
+    # while DILA/Wikidata enrichment writes `birth_year`/`death_year`. Without
+    # the COALESCE the timeline only saw the BDRC-derived ~95 persons and
+    # appeared Tibetan-only; coalescing surfaces the Chinese/Japanese cohort
+    # too (~2.5k persons total).
     sql = text(
         f"""
-        SELECT
-            e.id,
-            e.name_zh,
-            e.entity_type,
-            (e.properties->>'year_start')::int AS year_start,
-            CASE
-                WHEN (e.properties->>'year_end') ~ '^-?[0-9]{{1,6}}$'
-                THEN (e.properties->>'year_end')::int
-                ELSE NULL
-            END AS year_end
-        FROM kg_entities e
-        WHERE {type_condition}
-          AND (e.properties->>'year_start') ~ '^-?[0-9]{{1,6}}$'
-          AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
-        ORDER BY (e.properties->>'year_start')::int ASC
+        SELECT id, name_zh, entity_type, ys::int AS year_start,
+               CASE WHEN ye ~ '^-?[0-9]{{1,6}}$' THEN ye::int ELSE NULL END AS year_end
+        FROM (
+            SELECT
+                e.id,
+                e.name_zh,
+                e.entity_type,
+                COALESCE(NULLIF(e.properties->>'year_start', ''), e.properties->>'birth_year') AS ys,
+                COALESCE(NULLIF(e.properties->>'year_end', ''),   e.properties->>'death_year')  AS ye
+            FROM kg_entities e
+            WHERE {type_condition}
+              AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
+        ) src
+        WHERE ys ~ '^-?[0-9]{{1,6}}$'
+        ORDER BY ys::int ASC
         LIMIT :limit
         """  # nosec B608 - type_condition is a hardcoded clause, not user input
     )
@@ -652,10 +658,13 @@ async def get_timeline_entities(
 
     count_sql = text(
         f"""
-        SELECT COUNT(*) FROM kg_entities e
-        WHERE {type_condition}
-          AND (e.properties->>'year_start') ~ '^-?[0-9]{{1,6}}$'
-          AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
+        SELECT COUNT(*) FROM (
+            SELECT COALESCE(NULLIF(e.properties->>'year_start', ''), e.properties->>'birth_year') AS ys
+            FROM kg_entities e
+            WHERE {type_condition}
+              AND COALESCE(e.properties->>'is_hidden', 'false') != 'true'
+        ) src
+        WHERE ys ~ '^-?[0-9]{{1,6}}$'
         """  # nosec B608
     )
     count_result = await session.execute(count_sql, params)


### PR DESCRIPTION
## Summary

`/api/kg/timeline` only queried `properties->>'year_start'`, so the historical timeline showed **94 persons total** — and 78% of the labeled ones were Tibetan (Gelug / Kagyu / Nyingma / Sakya / Bon / Jonang). Chinese Buddhist masters were invisible because DILA / Wikidata enrichment writes the date into `birth_year` / `death_year`, while BDRC enrichment writes it into `year_start` / `year_end`. The two field families were never unified.

This PR coalesces both families inside an inner subquery, then applies the bounded year regex and the int cast on the combined value.

### Numbers (verified against prod DB)

| | Before | After |
|---|---|---|
| Timeline-eligible persons | **94** | **2,518** |
| Distinct tradition labels | Tibetan-dominated | Pan-Buddhist |

`backend/app/services/knowledge_graph.py:608`

## Known follow-up (not in this PR)

Famous DILA masters still have empty `birth_year`:

- 玄奘 (3 duplicate rows, all empty; one with wrong `death_year=710`)
- 鸠摩罗什 / 智顗 / 慧能 / 宗喀巴 / 智旭 (all empty)

These need a data backfill against DILA's authority files (or Wikidata Qids) — separate task.

## Test plan

- [x] `pytest backend/tests/test_kg.py` — 14 passed
- [x] Manually ran the new SQL against prod (`100.67.232.7`) — 2,518 persons returned, includes Buddhism / Jōdo Shinshū / Mahāyāna labels (Chinese/Japanese cohorts)
- [ ] After deploy, verify https://fojin.app/kg with timeline toggle shows >2k persons and includes 法藏 (Huayan, 643–712 record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)