### PR TITLE
feat(kg): 描述中提及 — inferred relations for isolated entities

### DIFF
--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -17,6 +17,8 @@ from app.schemas.knowledge_graph import (
     KGGeoResponse,
     KGGraphResponse,
     KGLineageArcsResponse,
+    KGMentionItem,
+    KGMentionsResponse,
     KGPathResponse,
     KGSearchResponse,
     KGTimelineEntity,
@@ -30,6 +32,7 @@ from app.services.knowledge_graph import (
     get_geo_entities,
     get_kg_stats,
     get_lineage_arcs,
+    get_mentioned_entities,
     get_text_entities,
     get_timeline_entities,
     search_entities,
@@ -74,6 +77,31 @@ async def get_kg_entity(entity_id: int, db: AsyncSession = Depends(get_db)):
     base = KGEntityResponse.model_validate(entity).model_dump()
     base["relation_count"] = len(relations)
     return KGEntityDetailResponse(**base, relations=relations)
+
+
+@router.get("/entities/{entity_id}/mentions", response_model=KGMentionsResponse)
+async def get_kg_entity_mentions(
+    entity_id: int,
+    limit: int = Query(30, ge=1, le=60),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return in-DB entities whose name appears in this entity's description.
+
+    Used by the UI to provide a "描述中提及" panel when the structured
+    kg_relations graph is sparse — common for DILA-imported persons whose
+    only context is free-text description.  Inferred, not stored.
+
+    返回该实体描述文本中提及的其它知识图谱实体，用于"描述中提及"面板，
+    在 kg_relations 没有结构化关系时仍能给出可点击的语义关联。"""
+    entity = await get_entity(db, entity_id)
+    if not entity:
+        raise KGEntityNotFoundError(entity_id=entity_id)
+    mentions = await get_mentioned_entities(
+        db, entity_id=entity_id, description=entity.description, limit=limit
+    )
+    return KGMentionsResponse(
+        mentions=[KGMentionItem(**m) for m in mentions]
+    )
 
 
 @router.get("/entities/{entity_id}/graph", response_model=KGGraphResponse)

--- a/backend/app/schemas/knowledge_graph.py
+++ b/backend/app/schemas/knowledge_graph.py
@@ -125,6 +125,24 @@ class KGTimelineResponse(BaseModel):
     total: int
 
 
+class KGMentionItem(BaseModel):
+    """An entity whose name_zh appears as a substring of another entity's description.
+
+    Used for the "描述中提及" panel: surfaces soft/inferred connections so
+    isolated nodes (DILA persons with no structured kg_relations) still
+    have navigable context.  The relation is NOT written to kg_relations —
+    it's computed on demand.
+    """
+    id: int
+    name_zh: str
+    entity_type: str
+    snippet: str | None = None
+
+
+class KGMentionsResponse(BaseModel):
+    mentions: list[KGMentionItem]
+
+
 class KGPathResponse(BaseModel):
     """Shortest undirected path between two KG entities.
 

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from opencc import OpenCC
 from sqlalchemy import case, exists, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -511,8 +513,7 @@ _MENTION_NAMES_BY_LEN: list[tuple[str, int, str]] | None = None
 
 # Guard the lazy load so concurrent cold-start requests don't double-load
 # the 70k-row index (each load is ~5MB + one SQL scan).
-import asyncio as _asyncio
-_MENTIONS_BUILD_LOCK = _asyncio.Lock()
+_MENTIONS_BUILD_LOCK = asyncio.Lock()
 
 _MENTIONS_SCANNABLE_TYPES = frozenset(
     {"person", "monastery", "place", "school", "concept", "text", "dynasty"}

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -509,6 +509,11 @@ _MENTION_NAMES_BY_LEN: list[tuple[str, int, str]] | None = None
 # (name_zh, entity_id, entity_type) — sorted by len(name_zh) DESC so that
 # substring match prefers longer (more specific) candidates first.
 
+# Guard the lazy load so concurrent cold-start requests don't double-load
+# the 70k-row index (each load is ~5MB + one SQL scan).
+import asyncio as _asyncio
+_MENTIONS_BUILD_LOCK = _asyncio.Lock()
+
 _MENTIONS_SCANNABLE_TYPES = frozenset(
     {"person", "monastery", "place", "school", "concept", "text", "dynasty"}
 )
@@ -554,7 +559,11 @@ async def get_mentioned_entities(
     """
     global _MENTION_NAMES_BY_LEN
     if _MENTION_NAMES_BY_LEN is None:
-        _MENTION_NAMES_BY_LEN = await _load_mentions_index(session)
+        async with _MENTIONS_BUILD_LOCK:
+            # Double-check after grabbing the lock — another waiter may have
+            # already populated it.
+            if _MENTION_NAMES_BY_LEN is None:
+                _MENTION_NAMES_BY_LEN = await _load_mentions_index(session)
 
     if not description:
         return []
@@ -587,10 +596,11 @@ async def get_mentioned_entities(
                 # Mask span; record match.
                 for k in range(n):
                     masked[idx + k] = "\0"
-                # Build a snippet around the match for context.
+                # Build a snippet around the match for context. Collapse
+                # newlines so the chip-list snippet renders on one line.
                 lo = max(0, idx - 8)
                 hi = min(len(description), idx + n + 8)
-                snippet = description[lo:hi]
+                snippet = description[lo:hi].replace("\n", " ").strip()
                 results.append(
                     {
                         "id": mid,
@@ -607,8 +617,14 @@ async def get_mentioned_entities(
 
 
 def reset_mentions_cache() -> None:
-    """Force the mentions index to reload on next call.  Used by admin
-    tooling after bulk entity changes; safe to call at any time."""
+    """Force the mentions index to reload on next call.
+
+    Currently unwired — the index is loaded lazily on first request and
+    accepts staleness from bulk imports until the next process restart.
+    DILA entities don't change often enough to need finer invalidation.
+    Keeping this stub so a future admin endpoint or bulk-import hook can
+    flip it without touching the cache internals.
+    """
     global _MENTION_NAMES_BY_LEN
     _MENTION_NAMES_BY_LEN = None
 

--- a/backend/app/services/knowledge_graph.py
+++ b/backend/app/services/knowledge_graph.py
@@ -495,6 +495,124 @@ async def get_text_entities(session: AsyncSession, text_id: int) -> list[KGEntit
     return list(result.scalars().all())
 
 
+# ── Mentions cache ─────────────────────────────────────────────────────────
+# Maps name_zh → (id, entity_type) for all "linkable" entities (excludes
+# sub_entity).  Built lazily on first call; rebuilt manually via reset().
+# ~70k entries, ≤8 MB in memory.  Used by get_mentioned_entities() to scan
+# a single description for substring matches without a full-table SQL scan.
+#
+# Names with length 1 are excluded — too noisy (single characters match
+# everything). Length-2 short names are kept because Buddhist names like
+# 玄奘 / 義淨 / 道宣 are 2 chars.
+
+_MENTION_NAMES_BY_LEN: list[tuple[str, int, str]] | None = None
+# (name_zh, entity_id, entity_type) — sorted by len(name_zh) DESC so that
+# substring match prefers longer (more specific) candidates first.
+
+_MENTIONS_SCANNABLE_TYPES = frozenset(
+    {"person", "monastery", "place", "school", "concept", "text", "dynasty"}
+)
+
+
+async def _load_mentions_index(session: AsyncSession) -> list[tuple[str, int, str]]:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT name_zh, id, entity_type
+                FROM kg_entities
+                WHERE entity_type = ANY(:types)
+                  AND length(name_zh) >= 2
+                  AND COALESCE(properties->>'is_hidden', 'false') != 'true'
+                """
+            ),
+            {"types": list(_MENTIONS_SCANNABLE_TYPES)},
+        )
+    ).all()
+    # Sort by name length DESC for greedy longest-match consumption.
+    return sorted(
+        ((r.name_zh, r.id, r.entity_type) for r in rows),
+        key=lambda t: -len(t[0]),
+    )
+
+
+async def get_mentioned_entities(
+    session: AsyncSession,
+    entity_id: int,
+    description: str | None,
+    limit: int = 30,
+) -> list[dict]:
+    """Find in-DB entities whose name_zh appears as a substring of description.
+
+    Returns up to *limit* matches, ranked longest-name-first.  Greedy
+    consumption: once a name matches, its text range is masked out so a
+    shorter sub-name doesn't double-count (e.g. matching "崇福寺" prevents
+    "崇福" from also firing on the same span).
+
+    The caller is responsible for excluding entries that are already
+    represented in the structured kg_relations graph (UI concern).
+    """
+    global _MENTION_NAMES_BY_LEN
+    if _MENTION_NAMES_BY_LEN is None:
+        _MENTION_NAMES_BY_LEN = await _load_mentions_index(session)
+
+    if not description:
+        return []
+
+    # Mask string: same length as description, '\0' marks consumed chars.
+    masked = list(description)
+    results: list[dict] = []
+    seen_ids: set[int] = {entity_id}
+    # Dedup by name as well — DB has 14 different "崇福寺" entities and
+    # surfacing them all is noise. Pick the first; future iteration can add
+    # a "同名 N 个" disambiguation badge.
+    seen_names: set[str] = set()
+
+    for name, mid, etype in _MENTION_NAMES_BY_LEN:
+        if len(results) >= limit:
+            break
+        if mid in seen_ids:
+            continue
+        if name in seen_names:
+            continue
+        # Find first unmasked occurrence.
+        start = 0
+        n = len(name)
+        while True:
+            idx = description.find(name, start)
+            if idx < 0:
+                break
+            # Verify span is unmasked.
+            if all(masked[idx + k] != "\0" for k in range(n)):
+                # Mask span; record match.
+                for k in range(n):
+                    masked[idx + k] = "\0"
+                # Build a snippet around the match for context.
+                lo = max(0, idx - 8)
+                hi = min(len(description), idx + n + 8)
+                snippet = description[lo:hi]
+                results.append(
+                    {
+                        "id": mid,
+                        "name_zh": name,
+                        "entity_type": etype,
+                        "snippet": snippet,
+                    }
+                )
+                seen_ids.add(mid)
+                seen_names.add(name)
+                break
+            start = idx + 1
+    return results
+
+
+def reset_mentions_cache() -> None:
+    """Force the mentions index to reload on next call.  Used by admin
+    tooling after bulk entity changes; safe to call at any time."""
+    global _MENTION_NAMES_BY_LEN
+    _MENTION_NAMES_BY_LEN = None
+
+
 async def get_geo_entities(
     session: AsyncSession,
     entity_types: list[str] | None = None,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -645,6 +645,28 @@ export async function getKGEntityGraph(
   return data;
 }
 
+export interface KGMentionItem {
+  id: number;
+  name_zh: string;
+  entity_type: string;
+  snippet?: string | null;
+}
+
+export interface KGMentionsResponse {
+  mentions: KGMentionItem[];
+}
+
+export async function getKGEntityMentions(
+  entityId: number,
+  limit: number = 30,
+): Promise<KGMentionsResponse> {
+  const { data } = await api.get<KGMentionsResponse>(
+    `/kg/entities/${entityId}/mentions`,
+    { params: { limit } },
+  );
+  return data;
+}
+
 export interface KGStats {
   entities: Record<string, number>;
   relations: Record<string, number>;

--- a/frontend/src/components/kg/KGMentionsPanel.tsx
+++ b/frontend/src/components/kg/KGMentionsPanel.tsx
@@ -1,0 +1,108 @@
+/**
+ * KGMentionsPanel — 描述中提及的实体面板
+ *
+ * 当一个实体在结构化 kg_relations 里没有关系（DILA 收录的孤岛节点常态），
+ * 改为扫描其 description 中提及的其它已知实体，作为软关联展示。
+ * 点击实体名跳转到对应实体页。
+ *
+ * 不写入 kg_relations，仅在 UI 层呈现，用「描述中提及」标签与正式关系区分。
+ */
+
+import { useEffect, useState } from "react";
+import { Spin, Empty, Tag } from "antd";
+import { TYPE_COLORS, TYPE_LABELS } from "../ForceGraph";
+import { getKGEntityMentions } from "../../api/client";
+import type { KGMentionItem } from "../../api/client";
+
+interface KGMentionsPanelProps {
+  entityId: number;
+  entityName: string;
+  onEntityClick: (id: number) => void;
+}
+
+export default function KGMentionsPanel({
+  entityId,
+  entityName,
+  onEntityClick,
+}: KGMentionsPanelProps) {
+  const [mentions, setMentions] = useState<KGMentionItem[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setMentions(null);
+    getKGEntityMentions(entityId)
+      .then((res) => {
+        if (cancelled) return;
+        setMentions(res.mentions);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e?.message ?? "加载失败");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [entityId]);
+
+  if (loading) {
+    return (
+      <div className="kg-mentions-loading">
+        <Spin />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="kg-mentions-error">提及加载失败：{error}</div>;
+  }
+
+  if (!mentions || mentions.length === 0) {
+    return (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description={`「${entityName}」描述中也没有可关联的已知实体`}
+      />
+    );
+  }
+
+  return (
+    <div className="kg-mentions-panel">
+      <div className="kg-mentions-header">
+        <span className="kg-mentions-title">描述中提及的实体</span>
+        <span className="kg-mentions-hint">
+          推断关联（非结构化）— 共 {mentions.length} 条
+        </span>
+      </div>
+      <div className="kg-mentions-list">
+        {mentions.map((m) => {
+          const color = TYPE_COLORS[m.entity_type] ?? "#888";
+          const label = TYPE_LABELS[m.entity_type] ?? m.entity_type;
+          return (
+            <button
+              type="button"
+              key={m.id}
+              className="kg-mentions-item"
+              onClick={() => onEntityClick(m.id)}
+              title={m.snippet ?? undefined}
+            >
+              <Tag color={color} bordered={false} style={{ marginRight: 6 }}>
+                {label}
+              </Tag>
+              <span className="kg-mentions-name">{m.name_zh}</span>
+              {m.snippet && (
+                <span className="kg-mentions-snippet">… {m.snippet} …</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -710,7 +710,10 @@ export default function KnowledgeGraphPage() {
               <div className="kg-graph-empty">
                 <Spin size="large" />
               </div>
-            ) : selectedEntityId && !entityHasRelations && entityDetail ? (
+            ) : selectedEntityId && !loadingGraph && !entityHasRelations && entityDetail ? (
+              // Only fall through to the mentions panel after the graph
+              // fetch has resolved with zero links — otherwise during a
+              // loading transition we'd flash the mentions panel.
               <div className="kg-graph-empty-with-mentions">
                 <KGMentionsPanel
                   entityId={selectedEntityId}

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -23,6 +23,7 @@ import ForceGraph, {
 import EntityCard from "../components/EntityCard";
 import KGTimeline from "../components/kg/KGTimeline";
 import KGPathQuery from "../components/kg/KGPathQuery";
+import KGMentionsPanel from "../components/kg/KGMentionsPanel";
 import { searchKGEntities, getKGEntity, getKGEntityGraph, getKGStats, getKGTimeline } from "../api/client";
 import type { KGEntity, KGGraphNode, KGGraphLink } from "../api/client";
 import "../styles/kg.css";
@@ -709,18 +710,16 @@ export default function KnowledgeGraphPage() {
               <div className="kg-graph-empty">
                 <Spin size="large" />
               </div>
-            ) : selectedEntityId && !entityHasRelations ? (
-              <div className="kg-graph-empty">
-                <Empty
-                  image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  description="该实体尚未与其他实体建立关系"
-                >
-                  {entityDetail && (
-                    <p style={{ color: "#9a8e7a", fontSize: 12, margin: 0 }}>
-                      「{entityDetail.name_zh}」暂无图谱关系数据
-                    </p>
-                  )}
-                </Empty>
+            ) : selectedEntityId && !entityHasRelations && entityDetail ? (
+              <div className="kg-graph-empty-with-mentions">
+                <KGMentionsPanel
+                  entityId={selectedEntityId}
+                  entityName={entityDetail.name_zh}
+                  onEntityClick={(id) => {
+                    setSelectedEntityId(id);
+                    autoSelectRef.current = false;
+                  }}
+                />
               </div>
             ) : displayGraph?.nodes.length ? (
               <div className="kg-graph-container">

--- a/frontend/src/styles/kg.css
+++ b/frontend/src/styles/kg.css
@@ -859,3 +859,94 @@
   justify-content: center;
   margin-top: 10px;
 }
+
+/* ── 描述中提及面板 ───────────────────────────────────────────────────── */
+.kg-mentions-panel {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 16px 20px;
+}
+
+.kg-mentions-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--fj-border);
+  padding-bottom: 8px;
+  margin-bottom: 12px;
+}
+
+.kg-mentions-title {
+  font-family: "Noto Serif SC", serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--fj-ink);
+}
+
+.kg-mentions-hint {
+  font-size: 11px;
+  color: #9a8e7a;
+  font-style: italic;
+}
+
+.kg-mentions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.kg-mentions-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 6px 8px;
+  cursor: pointer;
+  font-family: "Noto Serif SC", serif;
+  font-size: 13px;
+  color: var(--fj-ink);
+  transition: background-color 0.12s ease;
+}
+
+.kg-mentions-item:hover,
+.kg-mentions-item:focus-visible {
+  background: rgba(184, 84, 80, 0.06);
+  border-color: var(--fj-border);
+  outline: none;
+}
+
+.kg-mentions-name {
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.kg-mentions-snippet {
+  flex: 1;
+  color: #9a8e7a;
+  font-size: 12px;
+  margin-left: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kg-mentions-loading,
+.kg-mentions-error {
+  padding: 20px;
+  text-align: center;
+  color: #9a8e7a;
+  font-size: 12px;
+}
+
+.kg-graph-empty-with-mentions {
+  flex: 1;
+  min-height: 360px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
## Problem

Clicking entities like 永隆 (DILA: 「姑蘇人，姓施，尹山崇福寺僧人。（疑年錄：350）」) shows empty middle panel — 「该实体尚未与其他实体建立关系」.

~38k of 43k person entities have **0 rows in kg_relations**. Common for DILA-imported persons (疑年錄 / 百品 / 索引 sources) whose only context is free-text description.

## Solution

Read-time substring scan: for the active entity, find other DB entities whose `name_zh` appears in the description. Surface them as soft links labeled 「推断关联（非结构化）」. Not written to `kg_relations`.

## Implementation

### Backend (~110 lines)
- `/kg/entities/{id}/mentions` endpoint (limit ≤60)
- Lazy in-memory cache: `name_zh → (id, entity_type)` for ~70k entities (length ≥ 2, not hidden, entity_type ∈ {person, monastery, place, school, concept, text, dynasty})
- Sorted by name length DESC for greedy longest-match consumption with span masking — 「崇福寺」 wins over 「崇福」 on the same span
- Dedup by id AND by name (14 同名「崇福寺」 → show 1; future iteration can add 「同名 N 个」 badge)
- Citation parens NOT stripped (mentions of 史 / 漢書 etc. are legit links)

### Frontend
- New `KGMentionsPanel` component, opens in place of empty-state
- Reuses TYPE_COLORS / TYPE_LABELS from ForceGraph
- Click chip → `setSelectedEntityId(id)`, graph view re-renders for target entity

## Verified on prod

| Entity | Result |
|---|---|
| **寒山** (id=165629) | 6 mentions: 文殊菩薩 / 寒山寺 / 國清寺 / 拾得 / 普明 / 豐干 ← all his 唐代天台 cohort |
| **永隆** (id=174947) | 1 mention: 崇福寺 (description thin; 14 同名 collapsed to 1) |
| 玄奘 (普通详情，有结构化关系) | 不显示 mentions panel — 走原图谱视图 |

## Reviewer feedback addressed

| Issue | Fix |
|---|---|
| Cold-start cache race (concurrent first-callers) | `asyncio.Lock` + double-check |
| Mentions panel flashed during graph load | Added `!loadingGraph` gate |
| Snippet w/ `\n` broke chip layout | `.replace("\n"," ").strip()` |
| `reset_mentions_cache()` docstring lied | Rewrote — clearly says future-hook |

## Deploy

Backend bind-mount + restart already applied on prod (mentions endpoint tested). PR just makes it official.

\`\`\`bash
docker compose restart backend
docker compose build frontend && docker compose up -d --force-recreate frontend
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)