### PR TITLE
fix(kg-timeline): use full container width

### DIFF
--- a/frontend/src/components/kg/KGTimeline.tsx
+++ b/frontend/src/components/kg/KGTimeline.tsx
@@ -10,7 +10,7 @@
  * - 单点和单条都保留键盘可达 + tooltip。
  */
 
-import { useMemo, useRef, useState, useEffect } from "react";
+import { useMemo, useRef, useState, useEffect, useLayoutEffect } from "react";
 import { Spin, Empty, Tooltip, Drawer, List } from "antd";
 import { TYPE_COLORS } from "../ForceGraph";
 import type { KGTimelineEntity } from "../../api/client";
@@ -106,7 +106,15 @@ export default function KGTimeline({
   const [width, setWidth] = useState(800);
   const [openBucket, setOpenBucket] = useState<PersonBucket | null>(null);
 
-  // 响应容器宽度
+  // 响应容器宽度。第一次挂载时同步读 BoundingClientRect 拿到真实宽度
+  // (面板 lazy mount 时 ResizeObserver 首发可能 contentRect.width=0 → 被
+  // 'w > 0' 守卫挡住，width 永远卡在 useState 初值 800px，画布只用一半屏)。
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    const initialW = containerRef.current.getBoundingClientRect().width;
+    if (initialW > 0) setWidth(initialW);
+  }, []);
+
   useEffect(() => {
     if (!containerRef.current) return;
     const ro = new ResizeObserver((entries) => {


### PR DESCRIPTION
## Problem

Timeline panel renders SVG at fixed 800 px, leaving ~50% of screen blank (see user screenshot). On a 1900 px desktop, only the left half of the panel is used.

## Root cause

`KGTimeline.tsx` initializes `const [width, setWidth] = useState(800)`. The `ResizeObserver` is supposed to override this with the real container width, but during the panel's lazy mount (`{showTimeline && ...}`), the observer's first callback can fire with `contentRect.width = 0` — silently discarded by the `if (w > 0)` guard. No subsequent resize occurs, so width stays at 800 forever.

## Fix

Add a `useLayoutEffect` that reads `containerRef.current.getBoundingClientRect().width` synchronously on mount (before browser paint, after DOM measurement is ready). Real container width is captured immediately.

Net: each 50 yr bucket goes from ~22 px to ~42 px on a 1900 px desktop — bars become much easier to distinguish, dynasty band labels all comfortable.

## Deploy

Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)