### PR TITLE
fix(kg-timeline): wrap div must mount before width measurement

### DIFF
--- a/frontend/src/components/kg/KGTimeline.tsx
+++ b/frontend/src/components/kg/KGTimeline.tsx
@@ -195,18 +195,26 @@ export default function KGTimeline({
     (a, b) => (TYPE_ROW[a] ?? 99) - (TYPE_ROW[b] ?? 99)
   );
 
+  // wrap div 始终渲染（即使 loading/empty）— 否则 useLayoutEffect/
+  // ResizeObserver 在 deps=[] 首次执行时 containerRef.current 还是 null
+  // (因为 wrap 未挂载)，宽度永远卡在 useState 初值 800px。loading 状态时
+  // wrap 仍存在，effect 跑、ResizeObserver 接管后续宽度变化。
   if (loading) {
     return (
-      <div className="kg-timeline-loading">
-        <Spin />
+      <div className="kg-timeline-wrap" ref={containerRef}>
+        <div className="kg-timeline-loading">
+          <Spin />
+        </div>
       </div>
     );
   }
 
   if (!entities.length) {
     return (
-      <div className="kg-timeline-empty">
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无时间数据" />
+      <div className="kg-timeline-wrap" ref={containerRef}>
+        <div className="kg-timeline-empty">
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无时间数据" />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Problem

After PR #613 (useLayoutEffect for initial width), live debugging on prod (React fiber inspection via Chrome DevTools) revealed width state STILL stuck at 800 even though container wrap.clientWidth = 1566.

## Root cause

`KGTimeline` early-returns different DOM trees during loading / empty states:

```tsx
if (loading) return <div className='kg-timeline-loading'>...</div>;
if (!entities.length) return <div className='kg-timeline-empty'>...</div>;
return <div className='kg-timeline-wrap' ref={containerRef}>...</div>;
```

On first mount during the loading phase, the wrap div carrying `containerRef` is **never rendered**. `useLayoutEffect` runs once with `deps=[]`, finds `containerRef.current === null`, early-bails. By the time data arrives and wrap actually mounts, the deps=[] effects are gone — they only ran once.

## Fix

Always render the wrap div from the first mount; put loading/empty content inside it. `containerRef` is attached immediately, effects fire on real DOM, width updates correctly.

## Why PR #613 alone wasn't enough

PR #613 was the right idea but missed that the wrap wasn't in the DOM yet when the effect ran. Symptoms identical to the original bug.

## Deploy

Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)