### PR TITLE
fix(kg/timeline): split 民國 into 民國 + 現代

### DIFF
--- a/frontend/src/components/kg/KGTimeline.tsx
+++ b/frontend/src/components/kg/KGTimeline.tsx
@@ -65,8 +65,9 @@ const DYNASTIES: { name: string; startYear: number; endYear: number; fill: strin
   { name: "元", startYear: 1279, endYear: 1368, fill: "#e8dccc" },
   { name: "明", startYear: 1368, endYear: 1644, fill: "#d6c9b3" },
   { name: "清", startYear: 1644, endYear: 1912, fill: "#e8dccc" },
-  // 民國 endYear 用当前年份动态求值，避免硬编码后随时间 drift。
-  { name: "民國", startYear: 1912, endYear: new Date().getFullYear(), fill: "#d6c9b3" },
+  { name: "民國", startYear: 1912, endYear: 1949, fill: "#d6c9b3" },
+  // 現代 endYear 用当前年份动态求值，tooltip 显示「至今」。
+  { name: "現代", startYear: 1949, endYear: new Date().getFullYear(), fill: "#e8dccc" },
 ];
 const DYNASTY_LABEL_MIN_W = 8;    // 段宽 < 8px 才完全省略；其余靠 textLength 压缩
 
@@ -287,7 +288,7 @@ export default function KGTimeline({
           return (
             <Tooltip
               key={d.name}
-              title={`${d.name}（公元 ${d.startYear} — ${d.endYear}）`}
+              title={`${d.name}（公元 ${d.startYear} — ${d.name === "現代" ? "至今" : d.endYear}）`}
               placement="top"
             >
               <g style={{ cursor: "help" }}>


### PR DESCRIPTION
## Summary
- 修正历史不准确：原民國段 1912-至今 → 拆成「民國 1912-1949」+「現代 1949-至今」
- 1949 是中华民国大陆时期终点，也是汉传佛教史的常用分界（虚云圆寂前后大陆/港台分化）
- 「現代」段 Tooltip 显示「公元 1949 — 至今」而非动态年份，避免「公元 1949 — 2026」的别扭表达

## Test plan
- [x] `pnpm build` 通过
- [ ] 部署后核对 /kg 时间轴：清-民國-現代 三段宽度比例 268:37:77，民國段窄但仍可点
- [ ] 鼠标悬停「現代」段，tooltip 显示「現代（公元 1949 — 至今）」

🤖 Generated with [Claude Code](https://claude.com/claude-code)