### PR TITLE
chore(amap): disable V3 fetch, keep only regeo backfill

### DIFF
--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -22,7 +22,7 @@
 |---|---|---|
 | `fetch_academic_feeds.py` | 每日 6:00 | 抓取学术 RSS |
 | `sync_dila_combined.py` | 每日 3:30 | 同步 DILA 人物（RDF 批量 + API 增量） |
-| `run_amap_v3.sh` | 每日 0:30 | 高德 V3 城市级寺院抓取（支持多日续跑） |
+| `run_amap_v3.sh` | 每日 0:30 | 高德逆地理回填（V3 抓取已禁用，free quota 不足） |
 | `backfill_address_regeo.py` | 每日 12:30 | 高德逆地理回填寺院地址 |
 | `health_check_sources.py` | 每日 4:30 | 数据源可达性探测 |
 
@@ -35,8 +35,9 @@
 - `import_cbeta_full.sh` — CBETA 全量导入，依次调用 `import_catalog`、
   `import_content`、`backfill_cbeta_identifiers`、`import_cbeta_alt_translations`、
   `extract_structured_kg`、`import_stats`。
-- `run_amap_v3.sh` — 依次调用 `fetch_amap_temples_v3`、`import_amap_temples_v3`、
-  `backfill_address_regeo`。
+- `run_amap_v3.sh` — 当前仅调用 `backfill_address_regeo`；V3 抓取因免费 quota 卡死
+  16 天（2026-05-23 确认）已禁用，`fetch_amap_temples_v3` + `import_amap_temples_v3`
+  脚本保留供未来 quota 升级后重启。
 
 ### 共享库
 

--- a/backend/scripts/run_amap_v3.sh
+++ b/backend/scripts/run_amap_v3.sh
@@ -1,23 +1,17 @@
 #!/bin/bash
-# Run Amap V3 fetch + import, then use remaining quota for regeo
+# Cron entry: V3 fetch is disabled (Amap free quota too small — V3 search
+# endpoint allows ~100 calls/day, which is exhausted on resume before the
+# first new city completes). 16-day no-progress confirmed 2026-05-23.
+# Existing data: 15863 POIs in data/amap_temples_v3.json (165/396 cities,
+# ~42% coverage), pending typecode/keyword filter pass before import —
+# see project memory `project_fojin_amap_v3.md` for revival path.
+#
+# Reverse-geocoding backfill still has work (9k+ monasteries with empty
+# addresses as of 2026-05-23) and uses a separate quota pool, so we keep
+# running that part on the same cron slot.
 cd /home/admin/fojin
 
-echo "[$(date)] === Amap V3 city-level fetch ==="
-docker compose exec -T backend python scripts/fetch_amap_temples_v3.py 2>&1
-
-# Check if V3 fetch completed (no progress file = done)
-if docker compose exec -T backend test -f data/amap_v3_progress.json; then
-    echo "[$(date)] V3 fetch paused (will resume tomorrow). Skipping import."
-else
-    if docker compose exec -T backend test -f data/amap_temples_v3.json; then
-        echo "[$(date)] V3 fetch complete! Running import..."
-        docker compose exec -T backend python scripts/import_amap_temples_v3.py 2>&1
-        echo "[$(date)] Import done. V3 task complete."
-    fi
-fi
-
-# Use remaining daily quota for reverse geocoding (~1500 calls left)
-echo "[$(date)] === Reverse geocoding (remaining quota) ==="
+echo "[$(date)] === Reverse geocoding (Amap regeo) ==="
 docker compose exec -T -w /app/scripts backend python3 backfill_address_regeo.py --limit 1500 2>&1
 
 echo "[$(date)] All done."


### PR DESCRIPTION
## Summary

- Amap V3 search free quota (~100/day) cannot resume past 165/396 cities — 16-day no-progress confirmed (every nightly run prints `Resuming: 165 cities done, 15863 POIs found` then `OVER_LIMIT` and exits).
- Strip the V3 fetch + import block from `run_amap_v3.sh`; the 15863 POIs already collected in `data/amap_temples_v3.json` (~42% coverage) stay on disk pending a typecode+keyword filter pass — see project memory for the revival path.
- Reverse-geocoding still has 9k+ monasteries with empty `properties->>'address'` and uses a separate quota pool, so the nightly slot keeps running the regeo half.

## Test plan

- [x] `bash -n backend/scripts/run_amap_v3.sh`
- [ ] After merge: watch first post-deploy 0:30 cron run in `/home/admin/fojin-amap-v3.log` — should only print the regeo header + `Found N monasteries to backfill`, no `=== Amap V3 city-level fetch ===` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)