### PR TITLE
fix(privacy): make Umami tracking opt-in via build envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,9 @@ OAUTH_REDIRECT_BASE=http://localhost:3000
 # Umami Analytics（自托管，隐私友好，无 cookie）
 # Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 UMAMI_APP_SECRET=change-me-generate-a-random-secret
+
+# 前端 Umami 注入（构建期 build args）— 两者都为空时前端不发任何遥测脚本，
+# 这是 self-host 默认。设置后浏览器会加载 <VITE_UMAMI_URL> 并以 <VITE_UMAMI_WEBSITE_ID>
+# 上报。一般指向自托管 Umami（例如 https://your-domain/umami/script.js）。
+VITE_UMAMI_URL=
+VITE_UMAMI_WEBSITE_ID=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,9 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        VITE_UMAMI_URL: ${VITE_UMAMI_URL:-}
+        VITE_UMAMI_WEBSITE_ID: ${VITE_UMAMI_WEBSITE_ID:-}
     container_name: fojin-frontend
     restart: always
     logging: *default-logging

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:22-alpine AS build
 
+# Opt-in Umami analytics. Both must be set for the tracking script to be
+# injected at runtime; see frontend/src/umami.ts.
+ARG VITE_UMAMI_URL=""
+ARG VITE_UMAMI_WEBSITE_ID=""
+ENV VITE_UMAMI_URL=$VITE_UMAMI_URL
+ENV VITE_UMAMI_WEBSITE_ID=$VITE_UMAMI_WEBSITE_ID
+
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,8 +28,8 @@
     <link rel="preload" href="/fonts/MaShanZheng-title.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    <!-- Umami Analytics (self-hosted, privacy-first, no cookies) -->
-    <script defer src="https://analytics.fojin.app/script.js" data-website-id="c757a04c-82e0-4f53-a720-830b0e1a7287"></script>
+    <!-- Umami Analytics is opt-in at build time via VITE_UMAMI_URL + VITE_UMAMI_WEBSITE_ID;
+         see src/umami.ts. Self-hosters who don't set both envs get no tracking script. -->
     <title>佛津 FoJin — 全球佛教古籍数字资源聚合平台</title>
 
     <!-- JSON-LD Structured Data -->

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { HelmetProvider } from "react-helmet-async";
 import App from "./App";
 import "./i18n";
 import "./styles/global.css";
+import "./umami";
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/umami.ts
+++ b/frontend/src/umami.ts
@@ -1,0 +1,12 @@
+// Self-hosters opt in by setting both VITE_UMAMI_URL and VITE_UMAMI_WEBSITE_ID
+// at build time. Missing either one means no script is injected — no phone-home.
+const url = import.meta.env.VITE_UMAMI_URL;
+const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID;
+
+if (url && websiteId) {
+  const script = document.createElement("script");
+  script.defer = true;
+  script.src = url;
+  script.dataset.websiteId = websiteId;
+  document.head.appendChild(script);
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,5 +1,14 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_UMAMI_URL?: string;
+  readonly VITE_UMAMI_WEBSITE_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 // Umami Analytics global
 interface Window {
   umami?: {


### PR DESCRIPTION
## Summary

`frontend/index.html` previously hardcoded a `<script>` tag pointing at
`analytics.fojin.app` with the production website-id. **Every self-hosted
deployment silently phoned home** search keywords, chat prompts (first 30
chars), text-reading IDs, and source clicks to my production Umami.

This PR moves the script tag into a build-time loader gated on two envs:

- `VITE_UMAMI_URL`
- `VITE_UMAMI_WEBSITE_ID`

Both must be set for the script to be injected. Missing either → no
script, no tracking. Default for `docker compose up` is now zero
telemetry — self-host friendly.

## Changes

- `frontend/src/umami.ts` — new loader, runs on import, no-op when envs unset
- `frontend/src/main.tsx` — imports the loader
- `frontend/index.html` — remove hardcoded `<script>`; comment points at loader
- `frontend/src/vite-env.d.ts` — type the two new envs
- `frontend/Dockerfile` — `ARG` + `ENV` for both vars before `npm run build`
- `docker-compose.yml` — pass the args through from host env
- `.env.example` — document the opt-in

## Production deploy note (for me)

Prod relies on the old hardcoded script. **Before/after this merges**, set
in production `.env`:

```
VITE_UMAMI_URL=https://analytics.fojin.app/script.js
VITE_UMAMI_WEBSITE_ID=c757a04c-82e0-4f53-a720-830b0e1a7287
```

…then `docker compose build frontend` (no-cache) and verify
`curl https://fojin.app/ | grep analytics.fojin.app` resolves to the new
runtime-injected `<script>` in the `<head>`.

## Test plan

- [x] `npm run build` with both envs unset → grep `dist/` for
      `analytics.fojin.app` → **0 hits**
- [x] `VITE_UMAMI_URL=https://test.example/script.js VITE_UMAMI_WEBSITE_ID=test npm run build`
      → bundle contains `test.example` and `test` → **confirmed**
- [x] `npx tsc --noEmit` clean
- [ ] After merge: set prod `.env`, `docker compose build frontend`, verify
      `<script>` re-injected in prod HTML, watch Umami dashboard for ongoing events

🤖 Generated with [Claude Code](https://claude.com/claude-code)