### PR TITLE
chore(self-host): wrap up #623 — deploy .env-awareness + privacy docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Environment
 .env
 
+# Deploy state (per-host markers used by deploy.sh)
+.deploy-state/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+- Umami analytics tag is no longer hardcoded in `frontend/index.html`. The script is now injected at runtime by `frontend/src/umami.ts` only when both `VITE_UMAMI_URL` and `VITE_UMAMI_WEBSITE_ID` are set at build time (#623). Self-hosted deployments default to **no analytics phone-home** — previously every `docker compose up` silently reported search keywords, chat prompts (first 30 chars), reading IDs, and source clicks to `analytics.fojin.app`.
+
+### Changed
+- `deploy.sh` no longer exits early on "HEAD unchanged". It now also rebuilds frontend when `.env` is newer than the last build (since `VITE_*` envs are baked into the bundle as Dockerfile `ARG`s) and restarts backend when `.env` is newer than the last restart. Adds `--force-frontend` / `--force-backend` flags for manual overrides. Marker files live under `.deploy-state/` (gitignored, per-host). Fixes the silent "I changed .env but deploy says nothing to do" trap.
+
 ### Added
 - Data-source health monitoring. `scripts/health_check_sources.py` probes every active source's `base_url` and records a `health_status` verdict (`ok` / `degraded` / `cert_invalid` / `unreachable` / `moved`) plus `health_checked_at`. The Sources page now shows a warning badge on cards whose source has moved, is unreachable, has an invalid TLS certificate, or returns HTTP errors — healthy sources stay unbadged. Redirects are followed by hand with a per-hop public-IP check so a hijacked source URL cannot turn the cron into an SSRF against internal services. Designed to run from cron; busts the sources-list cache after writing so a stale verdict survives at most one cache TTL. Builds on the `health_status` column added in migration 0132.
 - `data_sources.health_detail` (migration 0136) — the health check now records actionable context for the latest probe: the redirect target for a `moved` source, the failure reason otherwise. A `moved` source's badge tooltip surfaces where it relocated to, so the verdict can be acted on instead of just observed.

--- a/README.md
+++ b/README.md
@@ -334,11 +334,19 @@ cd backend && pytest tests/ -q
 
 - Non-root containers (backend: `app`, frontend: `nginx`)
 - Multi-stage Docker builds (no build tools in production)
-- Internal services bound to `127.0.0.1` only
+- Internal services (Postgres, Redis, Elasticsearch, backend, Umami) bound to `127.0.0.1` only
 - Memory/CPU limits per container
 - CSP, X-Frame-Options, X-Content-Type-Options headers
 - Query length limits on all search parameters
 - JWT with 8h expiry, production requires strong secret
+
+### Self-hosting privacy defaults
+
+- **No analytics phone-home.** The Umami tracking script is opt-in via build-time `VITE_UMAMI_URL` + `VITE_UMAMI_WEBSITE_ID`; if either is unset, the frontend ships without telemetry.
+- **LLM / embedding traffic is upstream by default.** Stock config calls DeepSeek + SiliconFlow with your platform key — user questions go there. Point `LLM_API_URL` / `EMBEDDING_API_URL` at a local OpenAI-compatible server (vLLM, Ollama, LM Studio) for a fully offline setup, or have each user provide their own key via the in-app BYOK flow.
+- **The frontend container is reachable from the docker host network, not only `127.0.0.1`.** On a multi-user LAN this means anyone on the network can hit your instance. Front it with an authenticated reverse proxy, or change the `frontend.ports` mapping in `docker-compose.yml` to bind on `127.0.0.1`.
+
+See [SECURITY.md](SECURITY.md) for the full picture.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,26 @@ FoJin implements the following security practices:
 - **Secrets management**: Environment variables, never committed to git
 - **CI scanning**: Automated secret detection in GitHub Actions
 - **API key encryption**: AES/Fernet for user BYOK keys
+
+## Self-Hosting Privacy Notes
+
+If you run `docker compose up` from a fresh clone, be aware of three defaults
+that shape what leaves your machine:
+
+1. **Frontend analytics are off by default.** No tracking script is injected
+   unless you set both `VITE_UMAMI_URL` and `VITE_UMAMI_WEBSITE_ID` at build
+   time (Dockerfile `ARG`s). See `.env.example`.
+2. **LLM / embedding traffic goes to upstream providers by default.** The
+   stock config calls DeepSeek (`LLM_API_URL`) and SiliconFlow
+   (`EMBEDDING_API_URL`); user questions and document passages are sent to
+   those providers. For a fully local setup, point `LLM_API_URL` /
+   `EMBEDDING_API_URL` at an OpenAI-compatible local server (vLLM, Ollama,
+   LM Studio) and clear the API keys, or have each user supply their own
+   key via the in-app BYOK flow.
+3. **The frontend container publishes its port on the docker host network,
+   not just `127.0.0.1`.** Backend, Postgres, Redis, Elasticsearch, and the
+   Umami container are bound to localhost; the frontend is reachable from
+   anything that can hit your docker host (the LAN, in most setups). If
+   that matters, put it behind an authenticated reverse proxy or change the
+   `frontend.ports` mapping in `docker-compose.yml` to
+   `"127.0.0.1:${FRONTEND_PORT:-3000}:80"`.

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,8 @@
 #
 # fojin 生产部署脚本 —— 幂等、路径感知、带健康检查。
 #
-#   用法:  ./deploy.sh [branch]      (branch 默认 master)
+#   用法:  ./deploy.sh [branch] [--force-frontend] [--force-backend]
+#          branch 默认 master。flags 用于绕过自动判定。
 #
 # 设计要点 (踩过的坑都在这里固化下来):
 #   - 不用 `git pull`: VPS 上多个本地 feature 分支会触发
@@ -10,16 +11,49 @@
 #   - 后端代码走 bind-mount, uvicorn 无 --reload: `docker compose up -d`
 #     不会重建未变镜像的容器, 新代码不会被加载。必须显式 `restart backend`。
 #   - 路径感知: 只重建/重启真正改动的服务, 避免每次全量 build 攒构建缓存。
+#   - .env 感知: frontend Dockerfile 把 VITE_* env 作为 ARG 烘焙进 bundle,
+#     所以 .env 改动也要触发 frontend rebuild — git rev 没动 ≠ 无需部署。
 #   - 部署后做真实健康检查, 不是 `sleep 10` 了事。
 #
 set -euo pipefail
 
-BRANCH="${1:-master}"
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$REPO_DIR"
 
+BRANCH=""
+FORCE_FRONTEND=false
+FORCE_BACKEND=false
+for arg in "$@"; do
+  case "$arg" in
+    --force-frontend) FORCE_FRONTEND=true ;;
+    --force-backend)  FORCE_BACKEND=true ;;
+    -*) printf '!!! 未知参数: %s\n' "$arg" >&2; exit 2 ;;
+    *)
+      if [ -n "$BRANCH" ]; then
+        printf '!!! 只能指定一个 branch (已是 %s, 又收到 %s)\n' "$BRANCH" "$arg" >&2
+        exit 2
+      fi
+      BRANCH="$arg"
+      ;;
+  esac
+done
+BRANCH="${BRANCH:-master}"
+
+STATE_DIR="$REPO_DIR/.deploy-state"
+FRONTEND_BUILD_MARKER="$STATE_DIR/last-frontend-build"
+BACKEND_RESTART_MARKER="$STATE_DIR/last-backend-restart"
+mkdir -p "$STATE_DIR"
+
 log()  { printf '\n\033[1;36m>>> %s\033[0m\n' "$*"; }
 fail() { printf '\n\033[1;31m!!! %s\033[0m\n' "$*" >&2; exit 1; }
+
+# True if reference file is missing or older than .env.
+env_newer_than() {
+  local marker="$1"
+  [ -f .env ] || return 1
+  [ ! -e "$marker" ] && return 0
+  [ .env -nt "$marker" ]
+}
 
 # --- 1. 取最新代码 -----------------------------------------------------------
 log "Fetching origin/$BRANCH ..."
@@ -30,22 +64,44 @@ git merge --ff-only "origin/$BRANCH" \
 NEW_REV="$(git rev-parse HEAD)"
 
 if [ "$OLD_REV" = "$NEW_REV" ]; then
-  log "已是最新 ($(git rev-parse --short HEAD)) — 无需部署。"
-  exit 0
+  log "HEAD 未变 ($(git rev-parse --short HEAD)) — 仅按 .env / flag 判定是否仍要部署。"
+else
+  log "HEAD: $(git rev-parse --short "$OLD_REV") -> $(git rev-parse --short "$NEW_REV")"
 fi
-log "HEAD: $(git rev-parse --short "$OLD_REV") -> $(git rev-parse --short "$NEW_REV")"
 
-# --- 2. 判断改了哪些服务 -----------------------------------------------------
-CHANGED="$(git diff --name-only "$OLD_REV" "$NEW_REV")"
-echo "$CHANGED" | sed 's/^/    /'
+# --- 2. 综合判断改了哪些服务 -------------------------------------------------
+CHANGED=""
+if [ "$OLD_REV" != "$NEW_REV" ]; then
+  CHANGED="$(git diff --name-only "$OLD_REV" "$NEW_REV")"
+  echo "$CHANGED" | sed 's/^/    /'
+fi
 
 frontend_changed=false
 backend_changed=false
 backend_image_changed=false
+
 if echo "$CHANGED" | grep -q '^frontend/'; then frontend_changed=true; fi
 if echo "$CHANGED" | grep -q '^backend/';  then backend_changed=true;  fi
 if echo "$CHANGED" | grep -qE '^backend/(Dockerfile|requirements[^/]*\.txt|pyproject\.toml)$'; then
   backend_image_changed=true
+fi
+
+# .env 时间戳触发: frontend 镜像把 .env 烘焙进 bundle, backend 进程启动时读 env.
+if env_newer_than "$FRONTEND_BUILD_MARKER"; then
+  log ".env 比 frontend 上次构建新 — 触发 frontend rebuild。"
+  frontend_changed=true
+fi
+if env_newer_than "$BACKEND_RESTART_MARKER"; then
+  log ".env 比 backend 上次重启新 — 触发 backend restart。"
+  backend_changed=true
+fi
+
+$FORCE_FRONTEND && { log "--force-frontend 已指定。"; frontend_changed=true; }
+$FORCE_BACKEND  && { log "--force-backend 已指定。"; backend_changed=true; }
+
+if ! $frontend_changed && ! $backend_changed; then
+  log "无任何变更信号 (git/.env/flag) — 无需部署。"
+  exit 0
 fi
 
 # --- 3. 前端: 改了就重建镜像 + 重建容器 --------------------------------------
@@ -53,6 +109,7 @@ if $frontend_changed; then
   log "Frontend changed — building image + recreating container ..."
   docker compose build frontend
   docker compose up -d frontend
+  touch "$FRONTEND_BUILD_MARKER"
 else
   log "Frontend unchanged — skip."
 fi
@@ -64,9 +121,10 @@ if $backend_changed; then
     docker compose build backend
     docker compose up -d backend
   else
-    log "Backend code changed — restarting container (bind-mount reload) ..."
+    log "Backend code/env changed — restarting container (bind-mount reload) ..."
     docker compose restart backend
   fi
+  touch "$BACKEND_RESTART_MARKER"
 else
   log "Backend unchanged — skip."
 fi


### PR DESCRIPTION
## Summary

Three small follow-ups after #623 (Umami env-driven):

- **`deploy.sh` `.env`-awareness.** Yesterday's rollout hit a real silent
  failure: I merged #623, ran `./deploy.sh master`, got "已是最新 —
  无需部署", and walked away with prod **still** serving the hardcoded
  Umami tag — because the script only cares about git rev + path patterns
  and is blind to `.env` edits on the VPS. But `VITE_*` envs are baked
  into the bundle as Dockerfile `ARG`s, so `.env` is part of the build
  surface. Fix: track per-service markers under `.deploy-state/`
  (gitignored), treat `.env` newer than marker as a trigger, and add
  `--force-frontend` / `--force-backend` for manual overrides.
- **CHANGELOG.** Entries for #623 (Security) + this PR (Changed).
- **SECURITY.md + README.** New "Self-Hosting Privacy Notes" sections.
  Documents the three real defaults a fresh `docker compose up` ships
  with: Umami opt-in, upstream LLM traffic, frontend port on `0.0.0.0`.

## Why now

Two of these (the deploy bug + the missing self-host docs) were already
tracked debt; this rollout is what made them concretely costly.

## Test plan

- [x] `bash -n deploy.sh` clean
- [x] `env_newer_than` unit test passes (missing .env, missing marker,
      .env older, .env newer)
- [x] arg parser handles: no args, branch only, flag only,
      flag + branch (any order), two branches → reject, unknown flag → reject
- [ ] Real deploy on VPS — first run after merge should be a no-op
      (since `.env` was already updated yesterday, marker absent → triggers
      rebuild; this is expected and harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)