### PR TITLE
deps(backend): fastapi 0.121.0 → 0.136.3 (closes PYSEC-2026-161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 - Umami analytics tag is no longer hardcoded in `frontend/index.html`. The script is now injected at runtime by `frontend/src/umami.ts` only when both `VITE_UMAMI_URL` and `VITE_UMAMI_WEBSITE_ID` are set at build time (#623). Self-hosted deployments default to **no analytics phone-home** — previously every `docker compose up` silently reported search keywords, chat prompts (first 30 chars), reading IDs, and source clicks to `analytics.fojin.app`.
+- Bumped `fastapi` 0.121.0 → 0.136.3, which transitively pulls `starlette` from 0.49.3 → 1.1.0 and closes PYSEC-2026-161 (Host-header URL-reconstruction inconsistency that could enable auth bypass when authentication compares against the reconstructed URL path). FoJin itself was not exploitable — `request.base_url` is only used in SEO sitemap/canonical generation, never in auth decisions — but the audit pipeline had been red for weeks. 334 backend tests pass under the new deps.
 
 ### Changed
 - `deploy.sh` no longer exits early on "HEAD unchanged". It now also rebuilds frontend when `.env` is newer than the last build (since `VITE_*` envs are baked into the bundle as Dockerfile `ARG`s) and restarts backend when `.env` is newer than the last restart. Adds `--force-frontend` / `--force-backend` flags for manual overrides. Marker files live under `.deploy-state/` (gitignored, per-host). Fixes the silent "I changed .env but deploy says nothing to do" trap.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.121.0
+fastapi==0.136.3
 uvicorn[standard]==0.34.0
 asyncpg==0.30.0
 sqlalchemy[asyncio]==2.0.36


### PR DESCRIPTION
## Summary

`pip-audit` has been red for weeks on a single transitive vuln —
**PYSEC-2026-161** in starlette 0.49.3, fixed in starlette 1.0.1+.
FastAPI 0.121.0 caps starlette at `<0.50.0`, so the only honest fix is
to bump FastAPI itself. Latest 0.136.3 relaxes the pin to
`starlette>=0.46.0` and pip resolves to starlette 1.1.0.

## Is FoJin actually exploitable by PYSEC-2026-161?

**No.** The CVE is a Host-header → URL-reconstruction inconsistency that
can bypass auth *when the auth layer compares against the reconstructed
URL path*. FoJin:

- `request.url.path` (main.py, rate_limit.py) — Starlette returns the
  routed path, not parsed from the Host header. Not affected.
- `request.base_url` (seo.py, seo_dict.py, seo_persons.py) — used only
  to build sitemap / canonical / JSON-LD URLs. Not in auth.

Still worth landing because the audit pipeline visibility matters and
the upgrade was overdue.

## Starlette 1.0 breaking changes audit

Grepped the codebase against the official 0.49 → 1.0 breakage list:

| Breakage | FoJin usage |
|---|---|
| `@app.route()`, `@app.websocket_route()` removed | not used |
| `@app.exception_handler()`, `@app.middleware()`, `@app.on_event()` removed from **Starlette** | not affected — FastAPI 0.136.3 still provides its own `@app.exception_handler` on the FastAPI class (used at `main.py:329`) |
| `on_startup` / `on_shutdown` params removed | not used |
| `Jinja2Templates` env/signature changes | no templates |
| `FileResponse(method=...)` removed | not used |
| Jinja2 autoescape default flipped | n/a |
| `StaticFiles.lookup_path` rejects abs paths | n/a |

Only middleware imports `from starlette.middleware.base import BaseHTTPMiddleware` (still supported).

## Test plan

- [x] `pip-audit --desc --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357` → "No known vulnerabilities found"
- [x] Local: `pytest -q tests/ --ignore=tests/test_annotations_workflow.py -k "not test_kg_entity_detail"` → **334 passed** (same subset CI runs)
- [ ] CI: Backend smoke tests + Python dependency audit should both go green
- [ ] Post-merge: deploy on VPS, verify backend `/api/health` + a chat round-trip (live test of the upgraded request-handling stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)