### PR TITLE
fix(sources): cut health-check false positives + retire dead sources

### DIFF
--- a/backend/alembic/versions/0144_retire_dead_sources_and_fix_moved_urls.py
+++ b/backend/alembic/versions/0144_retire_dead_sources_and_fix_moved_urls.py
@@ -1,0 +1,112 @@
+"""Retire dead-domain sources and repoint four relocated ones.
+
+From the 2026-05-29 content audit (verified by independent DNS + browser-UA
+probes, not the in-VPS cron alone):
+
+DEAD — domain no longer resolves anywhere (DNS NXDOMAIN). Retired from the
+public catalog via is_active=false; the resource may still exist behind a new
+domain and can be re-added later under the usual "add sources" migration.
+
+  yungang-digital      www.yungang.org          (云冈石窟数字博物馆)
+  dunhuang-snupg       dunhuang.snupg.com       (敦煌文献专题数据库)
+  bib-buddhiststudies  bib.buddhiststudies.net  (中国佛教数字目录)
+  colombo-tripitaka    www.tripitaka.lk         (科伦坡巴利三藏)
+  fragile-palm-leaves  www.fragilepalm.org      (脆弱的棕榈叶基金会)
+  femc-khmer           femc.huma-num.fr         (柬埔寨写本编辑基金会 FEMC)
+  histochtext          www.orioles.uni-mainz.de (历史吐火罗文本库)
+  icabs-nara-chokujo   nara-chokyo.icabs.ac.jp  (奈良朝敕定一切经数据库)
+  korcis               korcis.nl.go.kr          (韩国 KORCIS 古籍信息系统)
+  utokyo-shuanghong    shuanghong.ioc.u-tokyo.ac.jp (东京大学双红堂文库)
+  buryat-buddhism      www.imbtit.ru            (布里亚特佛教文献;
+                       likely a typo for imbt.ru — left retired pending a
+                       confirmed replacement URL)
+
+MOVED — institution alive, base_url relocated. Each new URL was verified by
+hand to return the intended content:
+
+  84000-glossary  read.84000.co/glossary/search.html (gone)
+                  -> scholar.84000.co/glossary  (84000 moved its glossary)
+  bza-dila        buddhistinformatics.dila.edu.tw/BZA/ (old DILA host)
+                  -> bza.dila.edu.tw/  (別譯雜阿含經 digital edition)
+  adarsha         adarsha.dharma-treasure.org (old domain)
+  adarsha-pechamaker  adarsha.dharma-treasure.org
+                  -> adarshah.org/  (明镜藏文大藏经 / Adarsha 校勘平台 new domain)
+
+is_active (editorial removal) and health_status (cron reachability) are
+independent by design (see migration 0132); this migration only touches
+is_active and base_url. The next health-check pass re-probes the four moved
+sources at their new URLs and updates their badges.
+
+Revision ID: 0144
+Revises: 0143
+Create Date: 2026-05-29
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0144"
+down_revision = "0143"
+branch_labels = None
+depends_on = None
+
+# Domains that no longer resolve — retired from the public catalog.
+DEAD_SOURCES = (
+    "yungang-digital",
+    "dunhuang-snupg",
+    "bib-buddhiststudies",
+    "colombo-tripitaka",
+    "fragile-palm-leaves",
+    "femc-khmer",
+    "histochtext",
+    "icabs-nara-chokujo",
+    "korcis",
+    "utokyo-shuanghong",
+    "buryat-buddhism",
+)
+
+# code -> (old_base_url, new_base_url) for relocated-but-alive sources.
+URL_UPDATES = {
+    "84000-glossary": (
+        "https://read.84000.co/glossary/search.html",
+        "https://scholar.84000.co/glossary",
+    ),
+    "bza-dila": (
+        "http://buddhistinformatics.dila.edu.tw/BZA/",
+        "https://bza.dila.edu.tw/",
+    ),
+    "adarsha": (
+        "https://adarsha.dharma-treasure.org/",
+        "https://adarshah.org/",
+    ),
+    "adarsha-pechamaker": (
+        "https://adarsha.dharma-treasure.org/",
+        "https://adarshah.org/",
+    ),
+}
+
+
+def _set_active(active: bool) -> None:
+    # DEAD_SOURCES are fixed ASCII slugs — safe to inline, and an inline IN-list
+    # renders under `alembic --sql` offline mode (a bound list does not).
+    codes = ", ".join(f"'{c}'" for c in DEAD_SOURCES)
+    value = "true" if active else "false"
+    op.execute(text(f"UPDATE data_sources SET is_active = {value} WHERE code IN ({codes})"))
+
+
+def _set_base_url(code: str, url: str) -> None:
+    op.execute(
+        text("UPDATE data_sources SET base_url = :u WHERE code = :c").bindparams(u=url, c=code)
+    )
+
+
+def upgrade() -> None:
+    _set_active(False)
+    for code, (_old, new) in URL_UPDATES.items():
+        _set_base_url(code, new)
+
+
+def downgrade() -> None:
+    _set_active(True)
+    for code, (old, _new) in URL_UPDATES.items():
+        _set_base_url(code, old)

--- a/backend/app/services/source_health.py
+++ b/backend/app/services/source_health.py
@@ -18,8 +18,37 @@ from urllib.parse import urlsplit
 # Probe error kinds the caller may report. Anything that is not a clean HTTP
 # response with a status code falls into one of these.
 SSL_ERROR = "ssl"
+# A cert chain that is merely *incomplete* — the server omitted an intermediate
+# certificate ("unable to get local issuer certificate"). AIA-fetching browsers
+# (Chrome/Edge/Safari, the large majority of readers) complete the chain and
+# load the page normally, so this is not worth a "证书异常" badge. The probe
+# assigns this token only after confirming both that the host serves content and
+# that the leaf advertises an AIA caIssuers URL — so a genuinely untrusted root,
+# which raises the same OpenSSL error, is not downgraded. See
+# scripts/health_check_sources.py.
+SSL_CHAIN_INCOMPLETE = "ssl_chain_incomplete"
 
 VALID_STATUSES = frozenset({"ok", "degraded", "cert_invalid", "unreachable", "moved"})
+
+
+def is_incomplete_chain_error(message: str | None) -> bool:
+    """True for the *missing-intermediate* TLS family — OpenSSL's "unable to get
+    local issuer certificate" (verify code 20).
+
+    This is a coarse pre-filter, not a final verdict. Code 20 covers two cases:
+    a server that merely omitted an intermediate (AIA-capable browsers refetch
+    it and load the page) and, less commonly, a leaf signed by a CA absent from
+    every trust store with no AIA pointer (browsers reject it). The caller only
+    downgrades to ``ok`` after a second check confirms the leaf actually
+    advertises an AIA caIssuers URL — see ``_chain_gap_is_browser_recoverable``
+    in scripts/health_check_sources.py — so this function deliberately stays
+    broad. Hard failures with a different signature (expired, hostname mismatch,
+    self-signed leaf, weak key, old-TLS alert) never match here and stay
+    ``cert_invalid``.
+    """
+    if not message:
+        return False
+    return "unable to get local issuer certificate" in message.lower()
 
 
 def _ip_is_blocked(ip: str) -> bool:
@@ -125,6 +154,10 @@ def classify_health(
     """
     if error == SSL_ERROR:
         return "cert_invalid"
+    if error == SSL_CHAIN_INCOMPLETE:
+        # Only a missing-intermediate chain gap, and the probe already confirmed
+        # the host serves content — browsers load it, so no badge.
+        return "ok"
     if error is not None:
         return "unreachable"
 

--- a/backend/scripts/health_check_sources.py
+++ b/backend/scripts/health_check_sources.py
@@ -19,6 +19,8 @@ Usage:
 import argparse
 import asyncio
 import os
+import socket
+import ssl
 import sys
 import warnings
 from datetime import UTC, datetime
@@ -28,6 +30,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import httpx
 import redis.asyncio as aioredis
+from cryptography import x509
+from cryptography.x509.oid import AuthorityInformationAccessOID
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -35,16 +39,22 @@ from sqlalchemy.orm import sessionmaker
 from app.api.sources import SOURCES_LIST_CACHE_KEY
 from app.config import settings
 from app.services.source_health import (
+    SSL_CHAIN_INCOMPLETE,
     SSL_ERROR,
     VALID_STATUSES,
     classify_health,
     host_is_public,
+    is_incomplete_chain_error,
     resolve_unreachable_since,
 )
 
-TIMEOUT = 15  # seconds per request
+TIMEOUT = 30  # seconds per request — small academic/library sites are often slow
 CONCURRENCY = 10  # max concurrent probes — be gentle on small academic sites
 MAX_REDIRECTS = 5  # redirect hops to follow before giving up
+# A single probe from one VPS vantage is noisy: a transient timeout, a dropped
+# connection or a 5xx blip would otherwise badge a healthy source. Retry those
+# (and only those) once before recording a verdict.
+RETRY_BACKOFF = 2  # seconds to wait before the single retry of a transient fail
 USER_AGENT = "Mozilla/5.0 (compatible; FoJin-HealthCheck/1.0; +https://fojin.app)"
 
 
@@ -81,20 +91,90 @@ def _verdict(code: str, status: str | None, detail: str | None) -> dict:
     return {"code": code, "status": status, "detail": detail}
 
 
-async def probe(client: httpx.AsyncClient, code: str, url: str | None) -> dict:
-    """Probe one source into a {code, status, detail} verdict.
+async def _serves_content(client: httpx.AsyncClient, url: str) -> bool:
+    """True when ``url``'s host returns any non-5xx response with cert
+    verification disabled.
+
+    Used only to confirm that a source which failed the verified probe with a
+    *missing-intermediate* cert error is nonetheless live — so a chain gap
+    (which AIA browsers paper over) downgrades to ``ok`` instead of a dead host
+    being badged healthy. ``follow_redirects=False`` preserves the SSRF
+    guarantee: the caller already vetted this exact host with
+    :func:`host_is_public`, and an unvetted redirect target is never chased."""
+    try:
+        resp = await client.get(url, follow_redirects=False, timeout=TIMEOUT)
+        return resp.status_code < 500
+    except Exception:
+        return False
+
+
+def _leaf_declares_aia_issuer(host: str, port: int) -> bool:
+    """True when the server's leaf certificate carries an AIA caIssuers URL.
+
+    This is the signal that separates a *recoverable* missing-intermediate chain
+    — AIA-capable browsers (Chrome/Edge/Safari) fetch the named issuer and
+    complete the chain — from a genuinely untrusted leaf (e.g. a private root
+    with no AIA), which yields the same OpenSSL "unable to get local issuer"
+    code yet every browser rejects. The handshake runs with verification
+    disabled so the presented leaf can be read even when the chain doesn't
+    validate; the cert is only inspected, never trusted.
+
+    Any failure (connect error, no peer cert, no AIA extension, parse error)
+    returns False — the conservative answer that keeps the source cert_invalid.
+    Blocking socket/TLS work; call via ``asyncio.to_thread``."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        with (
+            socket.create_connection((host, port), timeout=TIMEOUT) as sock,
+            ctx.wrap_socket(sock, server_hostname=host) as ssock,
+        ):
+            der = ssock.getpeercert(binary_form=True)
+        if not der:
+            return False
+        cert = x509.load_der_x509_certificate(der)
+        aia = cert.extensions.get_extension_for_class(x509.AuthorityInformationAccess).value
+        return any(
+            desc.access_method == AuthorityInformationAccessOID.CA_ISSUERS for desc in aia
+        )
+    except Exception:
+        return False
+
+
+async def _chain_gap_is_browser_recoverable(
+    insecure_client: httpx.AsyncClient, url: str
+) -> bool:
+    """True when a missing-intermediate TLS failure is one browsers recover from.
+
+    Both conditions are required, so neither a dead host nor a genuinely
+    untrusted leaf is laundered into ``ok``:
+      - the host actually serves content (insecure re-fetch, non-5xx) — it's a
+        live source, not a host that merely failed at the TLS layer;
+      - the leaf certificate declares an AIA caIssuers URL — AIA-capable
+        browsers can fetch the absent intermediate and complete the chain."""
+    if not await _serves_content(insecure_client, url):
+        return False
+    parts = urlsplit(url)
+    if not parts.hostname:
+        return False
+    return await asyncio.to_thread(_leaf_declares_aia_issuer, parts.hostname, parts.port or 443)
+
+
+async def _probe_once(
+    client: httpx.AsyncClient, insecure_client: httpx.AsyncClient, code: str, url: str
+) -> tuple[dict, bool]:
+    """Probe ``url`` once into a ``(verdict, transient)`` pair.
+
+    ``transient`` is True for failures a retry might clear — a timeout, a
+    dropped connection, or a 5xx — so the caller can re-probe before recording
+    a verdict. A missing-intermediate cert that the insecure re-fetch confirms
+    is live downgrades to ``ok`` (see :func:`_serves_content`); every other cert
+    failure stays ``cert_invalid``.
 
     Redirects are followed by hand (``follow_redirects=False``) so every hop's
     host can be vetted with :func:`host_is_public` before a request is sent —
     this is what stops a redirect chain from reaching internal services."""
-    if not url or url == "None":
-        # No URL to probe — leave it as-is rather than inventing a verdict.
-        return _verdict(code, None, "no base_url")
-    parts = urlsplit(url)
-    if parts.scheme not in ("http", "https") or not parts.hostname:
-        # A malformed base_url is a config error, not a reachability verdict.
-        return _verdict(code, None, f"bad base_url: {url[:80]}")
-
     current = url
     try:
         for _ in range(MAX_REDIRECTS + 1):
@@ -103,7 +183,10 @@ async def probe(client: httpx.AsyncClient, code: str, url: str | None) -> dict:
                 # Host does not resolve, or resolves to a non-public address —
                 # refuse to probe it. From an editor's view the source is
                 # effectively unreachable.
-                return _verdict(code, "unreachable", f"unresolvable or non-public host: {host}")
+                return (
+                    _verdict(code, "unreachable", f"unresolvable or non-public host: {host}"),
+                    False,
+                )
             resp = await client.get(current, follow_redirects=False, timeout=TIMEOUT)
             if resp.is_redirect and "location" in resp.headers:
                 current = str(httpx.URL(current).join(resp.headers["location"]))
@@ -124,17 +207,50 @@ async def probe(client: httpx.AsyncClient, code: str, url: str | None) -> dict:
                 detail = current
             else:
                 detail = f"HTTP {resp.status_code}"
-            return _verdict(code, status, detail)
+            # A 5xx is the one HTTP outcome worth retrying; ok / moved / degraded
+            # and the 4xx the classifier already reads as reachable are stable.
+            return _verdict(code, status, detail), resp.status_code >= 500
 
         # Redirect budget exhausted.
         status = classify_health(
             error="redirect_loop", status_code=None, requested_url=url, final_url=None
         )
-        return _verdict(code, status, f"exceeded {MAX_REDIRECTS} redirect hops")
+        return _verdict(code, status, f"exceeded {MAX_REDIRECTS} redirect hops"), False
     except Exception as exc:  # every probe failure maps to a health verdict
         kind = _error_kind(exc)
+        if (
+            kind == SSL_ERROR
+            and is_incomplete_chain_error(str(exc))
+            and await _chain_gap_is_browser_recoverable(insecure_client, current)
+        ):
+            # Missing-intermediate chain on a live host whose leaf advertises an
+            # AIA issuer — AIA-capable browsers complete the chain and load it.
+            status = classify_health(
+                error=SSL_CHAIN_INCOMPLETE, status_code=None, requested_url=url, final_url=current
+            )
+            return _verdict(code, status, None), False
         status = classify_health(error=kind, status_code=None, requested_url=url, final_url=None)
-        return _verdict(code, status, f"{kind}: {str(exc)[:160]}")
+        return _verdict(code, status, f"{kind}: {str(exc)[:160]}"), kind in ("timeout", "connect")
+
+
+async def probe(
+    client: httpx.AsyncClient, insecure_client: httpx.AsyncClient, code: str, url: str | None
+) -> dict:
+    """Probe one source into a {code, status, detail} verdict, retrying once on
+    a transient failure (timeout / dropped connection / 5xx)."""
+    if not url or url == "None":
+        # No URL to probe — leave it as-is rather than inventing a verdict.
+        return _verdict(code, None, "no base_url")
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https") or not parts.hostname:
+        # A malformed base_url is a config error, not a reachability verdict.
+        return _verdict(code, None, f"bad base_url: {url[:80]}")
+
+    verdict, transient = await _probe_once(client, insecure_client, code, url)
+    if transient:
+        await asyncio.sleep(RETRY_BACKOFF)
+        verdict, _ = await _probe_once(client, insecure_client, code, url)
+    return verdict
 
 
 async def main(dry_run: bool) -> None:
@@ -162,11 +278,17 @@ async def main(dry_run: bool) -> None:
 
     semaphore = asyncio.Semaphore(CONCURRENCY)
     # verify=True is intentional — detecting cert_invalid is a goal of this job.
-    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, verify=True) as client:
+    # The insecure client is used *only* to re-confirm a missing-intermediate
+    # source is live (see _serves_content); it never produces a verdict on its
+    # own, so a real cert failure can't be laundered into "ok".
+    async with (
+        httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, verify=True) as client,
+        httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, verify=False) as insecure_client,
+    ):
 
         async def bounded(code: str, url: str | None) -> dict:
             async with semaphore:
-                return await probe(client, code, url)
+                return await probe(client, insecure_client, code, url)
 
         results = await asyncio.gather(*(bounded(r[0], r[1]) for r in rows))
 

--- a/backend/tests/test_health_check_probe.py
+++ b/backend/tests/test_health_check_probe.py
@@ -1,0 +1,138 @@
+"""Orchestration tests for the source health-probe (retry + SSL re-confirm).
+
+巡检探测的编排逻辑测试：瞬时失败重试、证书链不全的二次确认。Pure logic with
+stubbed httpx clients — no real network. The classification rules themselves
+live in ``test_source_health.py``; here we test that ``probe`` calls them with
+the right inputs and retries the right failures."""
+
+import importlib.util
+import pathlib
+
+import httpx
+import pytest
+
+# health_check_sources.py is a cron script, not an importable package module —
+# load it by path so we can exercise its probe orchestration directly.
+_HC_PATH = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "health_check_sources.py"
+_spec = importlib.util.spec_from_file_location("health_check_sources", _HC_PATH)
+hc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hc)
+
+URL = "https://src.example.org/"
+
+
+class FakeResp:
+    def __init__(self, status_code: int, location: str | None = None):
+        self.status_code = status_code
+        self.headers = {"location": location} if location else {}
+        self.is_redirect = location is not None
+
+
+class FakeClient:
+    """Yields one scripted outcome (a FakeResp or an exception) per .get()."""
+
+    def __init__(self, *actions):
+        self._actions = list(actions)
+        self.calls = 0
+
+    async def get(self, url, follow_redirects=False, timeout=None):
+        self.calls += 1
+        if not self._actions:
+            raise AssertionError(f"unexpected extra .get({url})")
+        act = self._actions.pop(0)
+        if isinstance(act, BaseException):
+            raise act
+        return act
+
+
+@pytest.fixture(autouse=True)
+def _patch(monkeypatch):
+    # We test probe orchestration, not the SSRF/DNS guard (covered elsewhere) or
+    # the real TLS/AIA handshake: treat every host as public, the leaf as
+    # AIA-advertising by default, and drop the retry backoff so tests are fast.
+    monkeypatch.setattr(hc, "host_is_public", lambda host: True)
+    monkeypatch.setattr(hc, "_leaf_declares_aia_issuer", lambda host, port: True)
+    monkeypatch.setattr(hc, "RETRY_BACKOFF", 0)
+
+
+async def test_incomplete_chain_live_host_with_aia_downgrades_to_ok():
+    # Missing intermediate + the host serves content + the leaf advertises an
+    # AIA issuer (default patch) -> browsers recover, so no badge.
+    client = FakeClient(
+        httpx.ConnectError(
+            "[SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate"
+        )
+    )
+    insecure = FakeClient(FakeResp(200))
+    v = await hc.probe(client, insecure, "src", URL)
+    assert v["status"] == "ok"
+    assert v["detail"] is None
+    assert insecure.calls == 1  # the liveness re-confirm fetch happened
+
+
+async def test_incomplete_chain_without_aia_issuer_stays_cert_invalid(monkeypatch):
+    # Same OpenSSL code-20 error, host is live, but the leaf advertises no AIA
+    # issuer (a genuinely untrusted root) -> browsers reject -> keep the badge.
+    monkeypatch.setattr(hc, "_leaf_declares_aia_issuer", lambda host, port: False)
+    client = FakeClient(httpx.ConnectError("unable to get local issuer certificate"))
+    insecure = FakeClient(FakeResp(200))
+    v = await hc.probe(client, insecure, "src", URL)
+    assert v["status"] == "cert_invalid"
+
+
+async def test_hard_cert_error_stays_cert_invalid_without_reprobe():
+    client = FakeClient(httpx.ConnectError("certificate has expired (_ssl.c:1010)"))
+    insecure = FakeClient()  # must NOT be consulted for a hard cert failure
+    v = await hc.probe(client, insecure, "src", URL)
+    assert v["status"] == "cert_invalid"
+    assert insecure.calls == 0
+
+
+async def test_incomplete_chain_but_dead_host_stays_cert_invalid():
+    # Chain gap, but the insecure re-fetch also fails — don't launder to ok.
+    client = FakeClient(httpx.ConnectError("unable to get local issuer certificate"))
+    insecure = FakeClient(httpx.ConnectError("connection reset"))
+    v = await hc.probe(client, insecure, "src", URL)
+    assert v["status"] == "cert_invalid"
+    assert insecure.calls == 1
+
+
+async def test_timeout_then_success_on_retry_is_ok():
+    client = FakeClient(httpx.TimeoutException("timed out"), FakeResp(200))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "ok"
+    assert client.calls == 2  # original probe + one retry
+
+
+async def test_persistent_timeout_is_unreachable():
+    client = FakeClient(httpx.TimeoutException("t1"), httpx.TimeoutException("t2"))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "unreachable"
+    assert v["detail"].startswith("timeout")
+    assert client.calls == 2
+
+
+async def test_5xx_then_200_on_retry_is_ok():
+    client = FakeClient(FakeResp(502), FakeResp(200))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "ok"
+    assert client.calls == 2
+
+
+async def test_stable_404_is_degraded_and_not_retried():
+    client = FakeClient(FakeResp(404))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "degraded"
+    assert client.calls == 1  # a 4xx is a stable verdict — no retry
+
+
+async def test_cross_domain_redirect_is_moved():
+    client = FakeClient(FakeResp(301, location="https://newsite.example.net/"), FakeResp(200))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "moved"
+    assert v["detail"] == "https://newsite.example.net/"
+
+
+async def test_missing_url_is_skipped():
+    v = await hc.probe(FakeClient(), FakeClient(), "src", None)
+    assert v["status"] is None  # no verdict invented for an absent base_url

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -10,6 +10,7 @@ from app.services.source_health import (
     _ip_is_blocked,
     classify_health,
     host_is_public,
+    is_incomplete_chain_error,
     resolve_unreachable_since,
 )
 
@@ -105,6 +106,48 @@ def test_ssl_error_is_cert_invalid():
         classify_health(error="ssl", status_code=None, requested_url=HOME, final_url=None)
         == "cert_invalid"
     )
+
+
+def test_ssl_chain_incomplete_is_ok():
+    # A missing-intermediate chain gap, already confirmed content-reachable by
+    # the probe's insecure re-fetch: AIA-fetching browsers load it, so no badge.
+    assert (
+        classify_health(
+            error="ssl_chain_incomplete", status_code=None, requested_url=HOME, final_url=None
+        )
+        == "ok"
+    )
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to "
+        "get local issuer certificate (_ssl.c:1010)",
+        "unable to get local issuer certificate",
+        "UNABLE TO GET LOCAL ISSUER CERTIFICATE",  # case-insensitive
+    ],
+)
+def test_incomplete_chain_messages_detected(msg):
+    assert is_incomplete_chain_error(msg) is True
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "certificate has expired",
+        "Hostname mismatch, certificate is not valid for 'example.org'",
+        "self-signed certificate",
+        "self-signed certificate in certificate chain",  # private root -> hard fail
+        "EE certificate key too weak",
+        "no alternative certificate subject name matches target host name",
+        "tlsv1 alert internal error",
+        "",
+        None,
+    ],
+)
+def test_hard_cert_errors_are_not_incomplete_chain(msg):
+    assert is_incomplete_chain_error(msg) is False
 
 
 def test_timeout_and_connect_errors_are_unreachable():


### PR DESCRIPTION
## 背景

数据源健康巡检 cron（单一新加坡 VPS 出口、`verify=True`、15s 超时、无重试）把 **~30 个正常源误标为坏**。本次审计（独立 DNS + 浏览器 UA 复测 625 个源）发现 65 个"非健康"中真正坏的只有约 17 个。

## 改动

### 1. cron 降误报（`scripts/health_check_sources.py`, `services/source_health.py`）
- **超时 15→30s + 瞬时失败重试 1 次**（timeout/connect/5xx）——救活 CADAL、Bodleian、kanripo、OPenn、温州图书馆、etipitaka 等慢站误报。
- **SSL 分级**：缺中间证书（OpenSSL code-20 `unable to get local issuer`）时，仅当 ① verify=False 复探确认站点存活 **且** ② 叶证书声明 AIA `caIssuers` URL（AIA 浏览器可补全链）才降级为 `ok`。私有不受信根 CA 报同样错误但无 AIA → 保留 `cert_invalid`。硬证书错误（过期/主机名不符/自签/弱密钥/旧TLS）不匹配。insecure 路径永不单独产出判定，真证书错误无法被洗成 ok。

### 2. 数据迁移 0144
- **停用 11 个 NXDOMAIN 死链**（域名全球不解析，独立 DNS 核实）：云冈数字博物馆、敦煌专题库、tripitaka.lk、FEMC、双红堂、KORCIS 等。
- **修 4 个搬迁源 URL**：84000-glossary→scholar.84000.co、bza-dila→bza.dila.edu.tw、adarsha/adarsha-pechamaker→adarshah.org。
- `is_active`（编辑性下架）与 `health_status`（cron 可达性）保持独立（沿用 0132 设计）。

## 测试
- 探测编排测试：重试成功/耗尽、5xx 重试、稳定 404 不重试、SSL 软/硬/死站、AIA 有/无、跨域 moved。
- 分类器测试：新 chain-incomplete 处理。
- **AIA 判据真实站点验证**：kabc.dongguk.edu / 印度国博 / ngmcp / 冬宫 → True（降级）；badssl self-signed / untrusted-root → False（保留 cert_invalid）。
- 64 passed，ruff clean，alembic 单 head（0143→0144）。

## 经过 code review
独立 reviewer 提的 Important 项（code-20 歧义可能把私有根误降为 ok）已用 AIA 扩展判据根除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)