### PR TITLE
fix(chat): stop citation guards from disfiguring correct answers

### DIFF
--- a/backend/app/services/citation_guard.py
+++ b/backend/app/services/citation_guard.py
@@ -11,9 +11,15 @@ backstop after the prompt's moral one.
 Two failure modes are caught:
 
 1. **Hallucinated title** — ``【《X》第N卷】`` where ``X`` does not appear
-   in the retrieved sources or their aligned parallels. Rewritten to
-   ``《X》（未在检索结果中验证，请谨慎）`` so the user keeps the model's
-   intent but loses the false air of authority a 【】 reference carries.
+   in the retrieved sources or their aligned parallels. Rewritten to plain
+   prose ``《X》`` — the clickable 【】 wrapper is stripped (so the user can
+   never click through to an empty sidebar), but no inline warning is
+   injected. An un-retrieved title becoming a bare ``《X》`` mention is exactly
+   the prose fallback the system prompt already asks for; an inline
+   "（未验证）" scold mid-sentence/mid-table only disfigured otherwise-correct
+   answers (the LLM routinely names real canonical texts that retrieval — which
+   favours dense commentaries over base sutras — simply didn't surface). The
+   mutation is still logged for drift monitoring.
 
 2. **Wrong fascicle** — title ``X`` is in the whitelist but ``N`` does
    not match any source's ``juan_num`` for that title. Rewritten to use
@@ -118,7 +124,7 @@ def enforce_citation_whitelist(
         def _strip(match: re.Match[str]) -> str:
             title = match.group(1)
             juan, _ = _parse_juan(match.group(2))
-            replacement = f"《{title}》（未在检索结果中验证，请谨慎）"
+            replacement = f"《{title}》"
             mutations.append(
                 CitationMutation(
                     kind="unverified_title",
@@ -141,7 +147,7 @@ def enforce_citation_whitelist(
         original_juan, juan_is_placeholder = _parse_juan(match.group(2))
 
         if title not in whitelist:
-            replacement = f"《{title}》（未在检索结果中验证，请谨慎）"
+            replacement = f"《{title}》"
             mutations.append(
                 CitationMutation(
                     kind="unverified_title",

--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -32,9 +32,13 @@ The check is deliberately conservative:
   quote inside a 繁-script source citation has already lost the
   attribution chain it claimed to preserve, so failing the check is
   the correct behaviour.
-- On miss we **annotate inline** rather than rewrite — preserving the
-  LLM's prose lets the user see what was claimed while making the
-  unverified status obvious.
+- On miss we append **one consolidated caveat** at the end of the answer
+  (before any ``[追问]`` block) rather than annotating each quote inline.
+  The earlier per-quote inline ⚠️ markers fired so often on *correct*
+  canonical quotes — retrieval favours dense commentaries over the base
+  sutra that actually contains the line — that they disfigured sound answers
+  mid-sentence and inside tables. The single trailing caveat keeps the
+  unverified-status signal; per-quote detail still reaches the logs.
 
 The verifier is wired *after* ``enforce_citation_whitelist`` so quotes
 attached to citations the guard already stripped (unverified titles)
@@ -193,24 +197,48 @@ def _find_sources(
     return exact or title_only
 
 
+# A single, unobtrusive caveat appended once when ≥1 quote fails verification,
+# replacing the previous per-quote inline ⚠️ markers. Because retrieval favours
+# dense commentaries over base sutras, those inline markers fired on the LLM's
+# *correct* canonical quotes (e.g. 「照见五蕴皆空」 under a 心经 commentary that
+# doesn't contain the line) and disfigured otherwise-sound answers mid-sentence
+# and inside tables. One caveat paragraph (placed before any [追问] block) keeps
+# the scholarly signal without breaking the prose; per-quote detail still goes to
+# the logs via QuoteMutation.
+_QUOTE_CAVEAT = "> ⚠️ 本回答中部分直接引文未能在检索到的经文片段中逐字核实，建议点按引用链接核对原文。"
+
+
+def _append_caveat(answer: str) -> str:
+    """Insert the quote caveat as its own paragraph, before any trailing
+    ``[追问]`` suggestion lines so it reads as part of the answer body rather
+    than after the follow-up buttons (which the frontend renders separately and
+    the backend strips before persistence)."""
+    lines = answer.split("\n")
+    for i, line in enumerate(lines):
+        if line.strip().startswith("[追问]"):
+            head = "\n".join(lines[:i]).rstrip()
+            tail = "\n".join(lines[i:])
+            return f"{head}\n\n{_QUOTE_CAVEAT}\n\n{tail}"
+    return answer.rstrip() + f"\n\n{_QUOTE_CAVEAT}"
+
+
 def verify_quoted_content(
     answer: str, sources: list[ChatSource]
 ) -> tuple[str, list[QuoteMutation]]:
-    """Annotate quoted segments that aren't substrings of the cited
-    source's chunk_text. Unchanged answers (no quote-citation pairs,
-    or all quotes verified) are returned identical, with empty
-    mutations list.
+    """Flag quoted segments that aren't substrings of the cited source's
+    chunk_text. Unchanged answers (no quote-citation pairs, or all quotes
+    verified) are returned identical, with an empty mutations list.
 
-    Implementation: regex scans for ``「…」【《X》第N卷】`` proximity
-    pairs, normalises both sides, and inserts an inline ⚠️ marker
-    after any failing pair. Multiple failing pairs in one answer get
-    individual annotations.
+    Implementation: regex scans for ``「…」【《X》第N卷】`` proximity pairs and
+    normalises both sides. Any failing pair is recorded as a QuoteMutation
+    (for logging); if there is at least one, a single consolidated caveat is
+    appended once to the answer (before any ``[追问]`` block). Multiple
+    failures share the one caveat rather than each getting an inline marker.
     """
     if not answer or "【《" not in answer:
         return answer, []
 
     mutations: list[QuoteMutation] = []
-    annotations: list[tuple[int, str]] = []  # (insert_at_index, marker)
 
     for m in _QUOTE_CITATION_RE.finditer(answer):
         quote = m.group("quote").strip()
@@ -228,9 +256,6 @@ def verify_quoted_content(
                     reason="no_matching_source",
                 )
             )
-            annotations.append(
-                (m.end(), "[⚠️ 引文出处未在检索结果中找到]")
-            )
             continue
 
         # Pass if the quote is a substring of ANY retrieved chunk for the
@@ -246,18 +271,11 @@ def verify_quoted_content(
                     reason="quote_not_in_source",
                 )
             )
-            annotations.append(
-                (m.end(), "[⚠️ 引文未在该卷原文中验证到，请谨慎引用]")
-            )
 
-    if not annotations:
+    if not mutations:
         return answer, mutations
 
-    # Insert markers from right-to-left so earlier indices stay valid.
-    annotated = answer
-    for index, marker in sorted(annotations, key=lambda x: x[0], reverse=True):
-        annotated = annotated[:index] + marker + annotated[index:]
-    return annotated, mutations
+    return _append_caveat(answer), mutations
 
 
 def log_quote_mutations(

--- a/backend/tests/test_citation_guard.py
+++ b/backend/tests/test_citation_guard.py
@@ -44,7 +44,8 @@ def test_rewrites_unknown_title_when_whitelist_has_other_titles():
     sources = [_src(7, "心经", 1)]
     out, muts = enforce_citation_whitelist(answer, sources)
     assert "【《某伪经》第3卷】" not in out
-    assert "《某伪经》（未在检索结果中验证，请谨慎）" in out
+    assert "《某伪经》" in out  # stripped to plain prose
+    assert "未在检索结果中验证" not in out  # no inline warning disfiguring the answer
     assert len(muts) == 1
     assert muts[0].kind == "unverified_title"
     assert muts[0].title == "某伪经"
@@ -83,7 +84,8 @@ def test_literal_X_placeholder_for_unknown_title_is_flagged():
     answer = "据【《伪造经》第X卷】所言。"
     out, muts = enforce_citation_whitelist(answer, [_src(7, "心经", 1)])
     assert "第X卷" not in out
-    assert "（未在检索结果中验证，请谨慎）" in out
+    assert "《伪造经》" in out
+    assert "未在检索结果中验证" not in out
     assert muts[0].kind == "unverified_title"
 
 
@@ -114,7 +116,7 @@ def test_title_only_citation_for_unknown_title_is_flagged():
     answer = "参见【《不存在经》】。"
     out, muts = enforce_citation_whitelist(answer, [_src(7, "心经", 1)])
     assert "【《不存在经》】" not in out
-    assert "《不存在经》（未在检索结果中验证，请谨慎）" in out
+    assert "《不存在经》" in out
     assert muts[0].original_juan is None
 
 
@@ -145,8 +147,9 @@ def test_empty_sources_strips_all_citations_with_caveats():
     answer = "如【《心经》第1卷】与【《金刚经》】所言。"
     out, muts = enforce_citation_whitelist(answer, [])
     assert "【《" not in out
-    assert "《心经》（未在检索结果中验证，请谨慎）" in out
-    assert "《金刚经》（未在检索结果中验证，请谨慎）" in out
+    assert "《心经》" in out
+    assert "《金刚经》" in out
+    assert "未在检索结果中验证" not in out
     assert len(muts) == 2
     assert {m.kind for m in muts} == {"unverified_title"}
 
@@ -157,7 +160,7 @@ def test_text_id_zero_sources_excluded_from_whitelist():
     answer = "依据【《心经》第1卷】所述。"
     out, muts = enforce_citation_whitelist(answer, [_src(0, "心经", 1)])
     assert "【《心经》第1卷】" not in out
-    assert "《心经》（未在检索结果中验证，请谨慎）" in out
+    assert "《心经》" in out
     assert muts[0].kind == "unverified_title"
 
 
@@ -201,4 +204,4 @@ def test_mutation_is_dataclass_with_full_audit_fields():
     assert m.title == "伪经"
     assert m.original_juan == 1
     assert m.corrected_juan is None
-    assert "未在检索结果中验证" in m.replacement
+    assert m.replacement == "《伪经》"

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -105,7 +105,7 @@ def test_quote_not_in_source_gets_annotated():
     answer = "经文明示：「众生皆有佛性，如来藏不空妙有」【《心經》第1卷】"
     out, muts = verify_quoted_content(answer, [src])
     assert "⚠️" in out
-    assert "未在该卷原文中验证到" in out
+    assert "未能在检索到的经文片段中逐字核实" in out  # single consolidated caveat
     assert len(muts) == 1
     assert muts[0].reason == "quote_not_in_source"
     assert muts[0].title == "心經"
@@ -120,8 +120,9 @@ def test_no_matching_source_gets_annotated_differently():
     src = _src(7, "心經", 1, "...")
     answer = "云：「众生皆有佛性，如来藏不空妙有」【《不存在经》第1卷】"
     out, muts = verify_quoted_content(answer, [src])
-    assert "⚠️" in out
-    assert "出处未在检索结果中找到" in out
+    assert "⚠️" in out  # consolidated caveat present
+    # Both failure reasons now share one user-facing caveat; the distinction
+    # ('wrong text' vs 'wrong content') survives only in the audit mutation.
     assert len(muts) == 1
     assert muts[0].reason == "no_matching_source"
 
@@ -188,18 +189,31 @@ def test_simplified_answer_quote_verifies_against_traditional_source():
     assert "⚠️" not in out
 
 
-def test_multiple_failing_quotes_all_annotated():
-    """Two fabricated quotes in one answer must both be marked, and
-    the markers must not interfere with each other (right-to-left
-    insertion preserves earlier indices)."""
+def test_multiple_failing_quotes_share_one_caveat():
+    """Two fabricated quotes in one answer are both logged, but the user
+    sees a single consolidated caveat rather than two inline markers."""
     src = _src(7, "心經", 1, "无关原文")
     answer = (
         "云：「假引文片段一假引文片段一假引文片段一」【《心經》第1卷】然后："
         "「假引文片段二假引文片段二假引文片段二」【《心經》第1卷】"
     )
     out, muts = verify_quoted_content(answer, [src])
-    assert out.count("⚠️") == 2
-    assert len(muts) == 2
+    assert out.count("⚠️") == 1  # one consolidated caveat regardless of count
+    assert len(muts) == 2  # but every failing quote is still logged
+
+
+def test_caveat_inserted_before_followup_block():
+    """The consolidated caveat must sit in the answer body, above any trailing
+    [追问] lines — not after the follow-up buttons (which render separately)."""
+    src = _src(7, "心經", 1, "无关原文")
+    answer = (
+        "云：「假引文片段一假引文片段一假引文片段一」【《心經》第1卷】\n"
+        "[追问] 问题一\n"
+        "[追问] 问题二\n"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert len(muts) == 1
+    assert out.index("⚠️") < out.index("[追问]")  # caveat above the follow-up block
 
 
 def test_distant_quote_and_citation_not_treated_as_pair():


### PR DESCRIPTION
## 背景

 实测发现：模型回答内容其实不错，但**两个答案后处理 guard 把正确答案毁成满屏警告**。根因是检索偏好密集注疏而非本经，导致 LLM 正确引用的经典被判未验证：

- **citation_guard** 把未命中检索的 `【《X》第N卷】` 改写成 `《X》（未在检索结果中验证，请谨慎）`——这句未验证出现在句中、甚至比较表格的每一格里（实测唯识/中观对比表 ~10 处）。
- **quote_verifier** 给每条没在 chunk 逐字命中的引文插入内联 `[⚠️ 引文未在该卷原文中验证到]`——实测心经核心答案里 LLM 引用**真实的**心经名句（照见五蕴皆空）被打了 2 个 ⚠️，因为检索返回的是心经注疏而非本经。

## 改动（改表现，不改检测）

1. **citation_guard**：未命中白名单的引用 → 降级为纯散文 `《X》`（去掉可点击的 `【】` 外壳=消除点开空侧栏这个 guard 真正要防的失败，但不再注入吓人警告）。这正是系统 prompt 本就要求的散文兜底。**错卷号修正 + mutation 日志不变。**
2. **quote_verifier**：逐句内联 ⚠️ → 答案末尾（`[追问]` 之前）**单条**汇总提示。每条失败引文仍记 QuoteMutation 入日志供漂移监控。

两条路径（非流式 + 流式 `citation_correction` 事件）共用这两个函数，所以前后端都生效。

## 测试
- 更新 citation/quote 测试断言；新增 `[追问]` 位置测试。45 passed，ruff clean。

## Code review
经独立 reviewer：**Ready to merge: Yes**，无 Critical/Important；确认坏链防护与 mutation 审计链完整保留，各边界（追问位置/流式持久化/空答案/真伪造）均验证。

## 后续
检索精度根因（本经优先于注疏 + 跨编码器 reranker）是 PR-B。

🤖 Generated with [Claude Code](https://claude.com/claude-code)