### PR TITLE
feat(chat): enable cross-encoder reranker + widen RAG candidate pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,11 +43,12 @@ LLM_API_URL=https://api.deepseek.com/v1
 EMBEDDING_API_KEY=sk-your-embedding-api-key
 EMBEDDING_API_URL=https://api.siliconflow.cn/v1
 
-# Reranker（可选，API 交叉编码器重排序，提升 RAG 检索质量）
-# 不配置时使用内置关键词重排序（零配置，免费）
-# RERANKER_API_URL=https://api.siliconflow.cn/v1
+# Reranker（API 交叉编码器重排序，显著提升 RAG 检索质量——建议启用）
+# 留空则回退到内置关键词重排序（粗糙）。SiliconFlow 同一账号即托管 embedding 与
+# bge-reranker-v2-m3；RERANKER_API_KEY 可省略，自动回退到 EMBEDDING_API_KEY。
+RERANKER_API_URL=https://api.siliconflow.cn/v1
 # RERANKER_API_KEY=sk-your-reranker-api-key
-# RERANKER_MODEL=BAAI/bge-reranker-v2-m3
+RERANKER_MODEL=BAAI/bge-reranker-v2-m3
 
 # 典津 API（古籍跨平台检索，可选）
 DIANJIN_API_KEY=

--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -19,12 +19,21 @@ from app.services.precise_retrieval import try_precise_text_retrieval
 
 logger = logging.getLogger(__name__)
 
-# Minimum cosine similarity score to include a chunk in RAG context.
-# Chunks below this threshold are considered irrelevant and filtered out.
-MIN_RELEVANCE_SCORE = 0.35
+# Minimum first-stage (vector cosine) score for a chunk to survive into the
+# rerank candidate pool. Kept deliberately low because the cross-encoder reranker
+# — not this coarse cosine floor — is the real relevance filter: a base sutra can
+# lose the cosine race to its own dense commentaries yet score highest under the
+# reranker, so an aggressive pre-filter here would discard it before the reranker
+# ever sees it. The final top-MAX_CONTEXT_CHUNKS is chosen on the blended
+# (vector + cross-encoder) score, which keeps genuine noise out of the answer.
+MIN_RELEVANCE_SCORE = 0.25
 
 # Maximum chunks to send to LLM after reranking (fewer but more relevant = better answers)
 MAX_CONTEXT_CHUNKS = 5
+
+# Upper bound on candidates cross-encoded per query (latency/cost + request-size
+# guardrail). The post-dedup pool is well under this today; it just caps growth.
+RERANK_CANDIDATE_LIMIT = 32
 
 # Trilingual RAG: enable per-language retrieval + alignment-aware merging.
 # When True, retrieve_rag_context fetches separately from lzh/pi/bo and then
@@ -34,7 +43,13 @@ ENABLE_PARALLEL_RAG = settings.enable_parallel_rag if hasattr(settings, "enable_
 
 # Per-lang top-k budgets for parallel mode. Total retrieved = LZH_K + PI_K + BO_K.
 # Keep larger for lzh since 95%+ users read Chinese and primary narrative stays in lzh.
-PARALLEL_LZH_K = 8
+# LZH_K is deliberately generous (well above MAX_CONTEXT_CHUNKS): the cross-encoder
+# reranker only re-scores what vector search already retrieved, so a base sutra
+# that loses the first-stage cosine race to its own dense commentaries (the 心经
+# 本经 vs 心經注疏 failure mode) must still be inside this candidate pool for the
+# reranker to be able to promote it. Final context is still capped at
+# MAX_CONTEXT_CHUNKS after reranking.
+PARALLEL_LZH_K = 15
 PARALLEL_PI_K = 4
 PARALLEL_BO_K = 4
 
@@ -243,10 +258,16 @@ async def _api_rerank(query: str, results: list[dict]) -> list[dict]:
     api_key = settings.reranker_api_key or settings.embedding_api_key or settings.llm_api_key
     model = settings.reranker_model
 
-    documents = [r["chunk_text"][:500] for r in results]
+    # Cap how many docs we cross-encode: bounds latency/cost and the request
+    # body even if a future caller widens the candidate pool. Today the pool is
+    # ~15-20 after dedup, well under this; results beyond it keep vector-only
+    # score (api defaults to 0.0 below) and rank last.
+    documents = [r["chunk_text"][:500] for r in results[:RERANK_CANDIDATE_LIMIT]]
 
     try:
-        async with httpx.AsyncClient(timeout=15) as client:
+        # Short timeout: the keyword fallback is cheap and local, so don't make a
+        # reranker hiccup cost the user 15s of dead air on an interactive query.
+        async with httpx.AsyncClient(timeout=6) as client:
             resp = await client.post(
                 f"{api_url}/rerank",
                 headers={"Authorization": f"Bearer {api_key}"},
@@ -409,7 +430,7 @@ async def retrieve_rag_context(
     query: str,
     *,
     prev_query: str | None = None,
-    pgvector_limit: int = 10,
+    pgvector_limit: int = 15,
     scope_text_ids: list[int] | None = None,
 ) -> tuple[list[ChatSource], str]:
     """Run pgvector similarity search and return (sources, context_text).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,14 @@ services:
       EMBEDDING_API_URL: ${EMBEDDING_API_URL:-}
       EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-BAAI/bge-m3}
+      # Cross-encoder reranker. When RERANKER_API_URL is set, rag_retrieval
+      # re-scores vector candidates with a cross-encoder (the single biggest
+      # RAG-precision lever); empty → falls back to keyword reranking.
+      # RERANKER_API_KEY is optional: rag_retrieval falls back to
+      # EMBEDDING_API_KEY (same SiliconFlow account hosts bge-reranker-v2-m3).
+      RERANKER_API_URL: ${RERANKER_API_URL:-}
+      RERANKER_API_KEY: ${RERANKER_API_KEY:-}
+      RERANKER_MODEL: ${RERANKER_MODEL:-BAAI/bge-reranker-v2-m3}
       DIANJIN_API_KEY: ${DIANJIN_API_KEY:-}
       AMAP_KEY: ${AMAP_KEY:-}
       # OAuth & SMS


### PR DESCRIPTION
## 背景

PR #628（止血 guard）的检索精度根因修复。实测 `/chat` 检索常返回**密集注疏/旁支汇编**而非问题需要的**本经**：心经题只返回心經注疏、无本经；唯识/中观题返回宗鏡錄/賢首五教儀、无中论/成唯识论。LLM 正确点名了本典，检索却没召回 → guard 标记。#628 治标，本 PR 治本。

## 改动

1. **docker-compose.yml**：把 `RERANKER_API_URL/KEY/MODEL` 透传给 backend。代码本就支持跨编码器 reranker（bge-reranker-v2-m3），但 backend 用**显式 environment 白名单**且从没列 reranker 变量 → 静默回退到粗糙的字符重叠 rerank。URL 指向 SiliconFlow（与 embedding 同账号，key 回退到 EMBEDDING_API_KEY）。
2. **.env.example**：取消注释 RERANKER_API_URL/MODEL，让"启用态"可发现，防 .env 重建再次静默失效（回应 review 的配置漂移点）。
3. **候选池**：lzh 8→15、scoped pgvector_limit 10→15。跨编码器只能提升 stage-1 召回到的内容，本经必须先进候选池。
4. **MIN_RELEVANCE_SCORE 0.35→0.25**（review）：原 cosine 预过滤在 rerank 之前，会把 reranker 会青睐的本经挡掉。reranker 现在是真过滤器，最终 top-5 按混合分选，噪声仍被挡。
5. **_api_rerank 加固**（review）：跨编码文档数上限 32 + reranker 超时 15s→6s（命中故障时不让交互查询空等 15s，回退到本地关键词 rerank）。

## 测试
backend 测试全过、ruff clean、compose YAML 含 reranker 变量校验通过。

## Code review
独立 reranker：**Ready to merge — With fixes**，无 correctness 阻塞；本提交已并入其 2 个 important/minor 修复（.env.example 暴露 + MIN_RELEVANCE 预过滤）。

## 部署后验证
prod .env 已预置 RERANKER_API_URL；合并+重建 backend 后实测 心经/唯识题检索是否召回本经。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
