### PR TITLE
feat(works): FRBR Work 脊椎 — schema + build_works 回填 + 只读 API (P1 MVP)

### DIFF
--- a/backend/alembic/versions/0145_add_works_frbr_spine.py
+++ b/backend/alembic/versions/0145_add_works_frbr_spine.py
@@ -1,0 +1,107 @@
+"""add works, work_witnesses, work_aliases (FRBR Work spine)
+
+Revision ID: 0145
+Revises: 0144
+Create Date: 2026-05-30
+
+Pure additive: introduces a Work layer above buddhist_texts to aggregate
+cross-language / cross-canon witnesses of the same work. Does NOT touch
+buddhist_texts / text_identifiers / alignment_pairs. Zero-downtime,
+reversible. Backfill is handled out-of-band by scripts/build_works.py.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0145"
+down_revision: str | None = "0144"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "works",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("slug", sa.String(200), nullable=False),
+        sa.Column("title_primary", sa.String(500), nullable=False),
+        sa.Column("title_sa", sa.String(500), nullable=True),
+        sa.Column("title_pi", sa.String(500), nullable=True),
+        sa.Column("sc_root_uid", sa.String(200), nullable=True),
+        sa.Column("toh_number", sa.String(50), nullable=True),
+        sa.Column("category", sa.String(100), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_works_slug", "works", ["slug"], unique=True)
+    op.create_index("ix_works_title_primary", "works", ["title_primary"])
+    op.create_index("ix_works_title_sa", "works", ["title_sa"])
+    op.create_index("ix_works_sc_root_uid", "works", ["sc_root_uid"])
+    op.create_index("ix_works_toh_number", "works", ["toh_number"])
+
+    op.create_table(
+        "work_witnesses",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "work_id",
+            sa.Integer(),
+            sa.ForeignKey("works.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "text_id",
+            sa.Integer(),
+            sa.ForeignKey("buddhist_texts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.String(20), server_default="translation", nullable=False),
+        sa.Column("lang", sa.String(10), nullable=False),
+        sa.Column("canon", sa.String(50), nullable=True),
+        sa.Column("confidence", sa.String(20), server_default="auto", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("work_id", "text_id", name="uq_work_witness_work_text"),
+    )
+    op.create_index("ix_work_witnesses_work_id", "work_witnesses", ["work_id"])
+    op.create_index("ix_work_witnesses_text_id", "work_witnesses", ["text_id"])
+
+    op.create_table(
+        "work_aliases",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "work_id",
+            sa.Integer(),
+            sa.ForeignKey("works.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("scheme", sa.String(50), nullable=False),
+        sa.Column("value", sa.String(300), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("scheme", "value", name="uq_work_alias_scheme_value"),
+    )
+    op.create_index("ix_work_aliases_work_id", "work_aliases", ["work_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("work_aliases")
+    op.drop_table("work_witnesses")
+    op.drop_table("works")

--- a/backend/app/api/works.py
+++ b/backend/app/api/works.py
@@ -1,0 +1,219 @@
+"""Read-only FRBR Work API.
+
+Exposes the Work spine that aggregates cross-language / cross-canon witnesses
+(BuddhistText rows) under an abstract work identity. All endpoints are
+read-only — no INSERT / UPDATE / DELETE.
+
+只读：作品详情、见证本列表、作品分页检索。
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFoundError
+from app.database import get_db
+from app.models.text import BuddhistText
+from app.models.work import Work, WorkWitness
+from app.schemas.work import (
+    WorkDetailResponse,
+    WorkListItem,
+    WorkListResponse,
+    WorkWitnessResponse,
+)
+
+router = APIRouter(prefix="/works", tags=["works"])
+
+
+def _work_not_found(slug: str) -> NotFoundError:
+    """Build a 404 for a missing work.
+
+    Uses the base ``NotFoundError`` (registered → 404 in the global
+    ``STATUS_MAP``) rather than a new subclass, so no edits to the exception
+    module / status map are needed.
+    """
+    return NotFoundError(f"作品未找到: {slug}")
+
+
+# Per-witness-lang preference for the enriched witness title. The witness's own
+# lang wins; otherwise fall back to title_en, then title_zh.
+_LANG_TITLE_ATTR: dict[str, str] = {
+    "lzh": "title_zh",
+    "zh": "title_zh",
+    "pi": "title_pi",
+    "pli": "title_pi",
+    "bo": "title_bo",
+    "sa": "title_sa",
+}
+
+
+def _witness_title(text: BuddhistText, lang: str) -> str | None:
+    """Pick the best available title for a witness given its language.
+
+    Prefer the title matching the witness lang (title_zh for lzh, title_pi for
+    pi, title_bo for bo, title_sa for sa); else fall back to title_en, then
+    title_zh.
+    """
+    attr = _LANG_TITLE_ATTR.get(lang)
+    if attr:
+        val = getattr(text, attr, None)
+        if val:
+            return val
+    return text.title_en or text.title_zh
+
+
+@router.get("", response_model=WorkListResponse)
+async def list_works(
+    q: str | None = Query(None, description="标题模糊匹配 (title_primary / title_sa)"),
+    lang: str | None = Query(None, description="按见证本语言过滤，如 lzh、pi、sa"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> WorkListResponse:
+    """Paginated list of works.
+
+    ``q`` does an ILIKE on title_primary / title_sa; ``lang`` keeps only works
+    that have at least one witness in that language. Witness counts and the set
+    of covered languages are aggregated in a single follow-up query (no N+1).
+
+    作品分页检索：q 模糊匹配标题，lang 过滤含该语言见证本的作品。"""
+    base = select(Work)
+
+    if q:
+        pattern = f"%{q}%"
+        base = base.where(
+            or_(
+                Work.title_primary.ilike(pattern),
+                Work.title_sa.ilike(pattern),
+            )
+        )
+
+    if lang:
+        base = base.where(
+            Work.id.in_(
+                select(WorkWitness.work_id).where(WorkWitness.lang == lang)
+            )
+        )
+
+    # total count over the filtered set
+    total = (
+        await db.execute(select(func.count()).select_from(base.subquery()))
+    ).scalar() or 0
+
+    stmt = (
+        base.order_by(Work.title_primary, Work.id)
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    works = (await db.execute(stmt)).scalars().all()
+
+    items: list[WorkListItem] = []
+    work_ids = [w.id for w in works]
+    if work_ids:
+        # Single aggregate query for witness_count + covered langs across the page.
+        agg_stmt = (
+            select(
+                WorkWitness.work_id,
+                func.count(WorkWitness.id).label("witness_count"),
+                func.array_agg(func.distinct(WorkWitness.lang)).label("langs"),
+            )
+            .where(WorkWitness.work_id.in_(work_ids))
+            .group_by(WorkWitness.work_id)
+        )
+        agg = {
+            row.work_id: (row.witness_count, row.langs)
+            for row in (await db.execute(agg_stmt)).all()
+        }
+        for w in works:
+            count, langs = agg.get(w.id, (0, []))
+            items.append(
+                WorkListItem(
+                    slug=w.slug,
+                    title_primary=w.title_primary,
+                    title_sa=w.title_sa,
+                    witness_count=count,
+                    langs=sorted(lng for lng in (langs or []) if lng),
+                )
+            )
+
+    return WorkListResponse(
+        total=int(total), page=page, page_size=page_size, items=items
+    )
+
+
+@router.get("/{slug}", response_model=WorkDetailResponse)
+async def get_work(slug: str, db: AsyncSession = Depends(get_db)) -> WorkDetailResponse:
+    """Get a single work by slug, including its witness count.
+
+    按 slug 获取作品详情（含见证本计数）。404 if slug not found."""
+    work = (
+        await db.execute(select(Work).where(Work.slug == slug))
+    ).scalar_one_or_none()
+    if work is None:
+        raise _work_not_found(slug)
+
+    witness_count = (
+        await db.execute(
+            select(func.count(WorkWitness.id)).where(WorkWitness.work_id == work.id)
+        )
+    ).scalar() or 0
+
+    return WorkDetailResponse.model_validate(
+        {
+            "id": work.id,
+            "slug": work.slug,
+            "title_primary": work.title_primary,
+            "title_sa": work.title_sa,
+            "title_pi": work.title_pi,
+            "sc_root_uid": work.sc_root_uid,
+            "toh_number": work.toh_number,
+            "category": work.category,
+            "note": work.note,
+            "created_at": work.created_at,
+            "witness_count": int(witness_count),
+        }
+    )
+
+
+@router.get("/{slug}/witnesses", response_model=list[WorkWitnessResponse])
+async def list_work_witnesses(
+    slug: str, db: AsyncSession = Depends(get_db)
+) -> list[WorkWitnessResponse]:
+    """List a work's witnesses, each enriched by joining BuddhistText.
+
+    Order: role='root' first, then by lang asc, then text_id. The title is the
+    best available for the witness language (see ``_witness_title``).
+
+    列出作品的见证本（root 优先、再按语言、再按 text_id），并 join 经文表富化标题。
+    404 if slug not found."""
+    work = (
+        await db.execute(select(Work.id).where(Work.slug == slug))
+    ).scalar_one_or_none()
+    if work is None:
+        raise _work_not_found(slug)
+
+    stmt = (
+        select(WorkWitness, BuddhistText)
+        .join(BuddhistText, BuddhistText.id == WorkWitness.text_id)
+        .where(WorkWitness.work_id == work)
+        .order_by(
+            (WorkWitness.role != "root"),  # False (root) sorts before True
+            WorkWitness.lang.asc(),
+            WorkWitness.text_id.asc(),
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+
+    return [
+        WorkWitnessResponse(
+            text_id=witness.text_id,
+            cbeta_id=text.cbeta_id,
+            title=_witness_title(text, witness.lang),
+            lang=witness.lang,
+            canon=witness.canon,
+            role=witness.role,
+            confidence=witness.confidence,
+            has_content=bool(text.has_content),
+        )
+        for witness, text in rows
+    ]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -54,6 +54,7 @@ from app.api import (
     sources,
     stats,
     texts,
+    works,
 )
 
 try:
@@ -360,6 +361,9 @@ app.include_router(annotations.router, prefix="/api")
 
 # Dictionary
 app.include_router(dictionary.router, prefix="/api")
+
+# Works (FRBR work spine) — read-only
+app.include_router(works.router, prefix="/api")
 
 # Citations
 app.include_router(citations.router, prefix="/api")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.models.relation import TextRelation
 from app.models.source import DataSource, SourceDistribution, TextIdentifier
 from app.models.text import BuddhistText, TextContent
 from app.models.user import Bookmark, ReadingHistory, User
+from app.models.work import Work, WorkAlias, WorkWitness
 
 __all__ = [
     "AcademicFeed",
@@ -35,4 +36,7 @@ __all__ = [
     "TextIdentifier",
     "TextRelation",
     "User",
+    "Work",
+    "WorkAlias",
+    "WorkWitness",
 ]

--- a/backend/app/models/work.py
+++ b/backend/app/models/work.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class Work(Base):
+    """FRBR Work 层：抽象作品，聚合跨语言 / 跨藏的多个见证本 (BuddhistText)。
+
+    纯增量叠加，不改动 BuddhistText / text_identifiers / alignment_pairs。
+    身份复用既有权威号：sc_root_uid (SuttaCentral) / toh_number (84000) /
+    title_sa (Skt 题名，跨柱主桥梁)。
+    """
+
+    __tablename__ = "works"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    slug: Mapped[str] = mapped_column(String(200), unique=True, index=True)
+    title_primary: Mapped[str] = mapped_column(String(500), index=True)
+    title_sa: Mapped[str | None] = mapped_column(String(500), index=True)
+    title_pi: Mapped[str | None] = mapped_column(String(500))
+    sc_root_uid: Mapped[str | None] = mapped_column(String(200), index=True)
+    toh_number: Mapped[str | None] = mapped_column(String(50), index=True)
+    category: Mapped[str | None] = mapped_column(String(100))
+    note: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    witnesses: Mapped[list["WorkWitness"]] = relationship(
+        back_populates="work", cascade="all, delete-orphan"
+    )
+    aliases: Mapped[list["WorkAlias"]] = relationship(
+        back_populates="work", cascade="all, delete-orphan"
+    )
+
+
+class WorkWitness(Base):
+    """Work ↔ 见证本 (BuddhistText) 映射。一个见证本通常只属一个 Work。"""
+
+    __tablename__ = "work_witnesses"
+    __table_args__ = (
+        UniqueConstraint("work_id", "text_id", name="uq_work_witness_work_text"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    work_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("works.id", ondelete="CASCADE"), index=True
+    )
+    text_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("buddhist_texts.id", ondelete="CASCADE"), index=True
+    )
+    # root | translation | commentary | edition | fragment
+    role: Mapped[str] = mapped_column(String(20), server_default="translation")
+    lang: Mapped[str] = mapped_column(String(10))
+    # taisho | xuzang | pali | kangyur | gretil | ...
+    canon: Mapped[str | None] = mapped_column(String(50))
+    # verified | auto | tentative
+    confidence: Mapped[str] = mapped_column(String(20), server_default="auto")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    work: Mapped["Work"] = relationship(back_populates="witnesses")
+
+
+class WorkAlias(Base):
+    """Work 的备用作品号 / 异名（scheme: sc_uid|toh|taisho|skt_title|...）。"""
+
+    __tablename__ = "work_aliases"
+    __table_args__ = (
+        UniqueConstraint("scheme", "value", name="uq_work_alias_scheme_value"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    work_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("works.id", ondelete="CASCADE"), index=True
+    )
+    scheme: Mapped[str] = mapped_column(String(50))
+    value: Mapped[str] = mapped_column(String(300))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    work: Mapped["Work"] = relationship(back_populates="aliases")

--- a/backend/app/schemas/work.py
+++ b/backend/app/schemas/work.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class WorkDetailResponse(BaseModel):
+    """FRBR Work 详情：聚合作品的全部元数据 + 见证本计数。"""
+
+    id: int
+    slug: str
+    title_primary: str
+    title_sa: str | None = None
+    title_pi: str | None = None
+    sc_root_uid: str | None = None
+    toh_number: str | None = None
+    category: str | None = None
+    note: str | None = None
+    created_at: datetime
+    witness_count: int = 0
+
+    model_config = {"from_attributes": True}
+
+
+class WorkWitnessResponse(BaseModel):
+    """Work 的单个见证本，已 join BuddhistText 富化标题 / 内容标志。"""
+
+    text_id: int
+    cbeta_id: str | None = None
+    title: str | None = None
+    lang: str
+    canon: str | None = None
+    role: str
+    confidence: str
+    has_content: bool = False
+
+
+class WorkListItem(BaseModel):
+    """Work 列表项：精简元数据 + 见证本计数 + 涵盖语言。"""
+
+    slug: str
+    title_primary: str
+    title_sa: str | None = None
+    witness_count: int = 0
+    langs: list[str] = []
+
+
+class WorkListResponse(BaseModel):
+    total: int
+    page: int
+    page_size: int
+    items: list[WorkListItem]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest>=8.0
 pytest-asyncio>=0.24.0
 anyio>=4.0
 pytest-anyio==0.0.0
+aiosqlite>=0.20  # in-memory async DB for build_works integration tests

--- a/backend/scripts/build_works.py
+++ b/backend/scripts/build_works.py
@@ -1,0 +1,567 @@
+"""Build the FRBR Work spine from existing buddhist_texts (idempotent backfill).
+
+Populates works / work_witnesses / work_aliases purely additively — nothing in
+buddhist_texts / text_identifiers / alignment_pairs is touched.
+
+Each buddhist_text ends up in exactly ONE work. Assignment runs in four passes,
+in priority order; once a text is claimed by a witness it is skipped by later
+passes:
+
+  Pass 1 — cross-pillar Skt-title clustering (the high-value bit)
+      Every text with a non-empty title_sa is grouped by a normalized Skt-title
+      key (lowercase + diacritics stripped + whitespace collapsed). Each distinct
+      key becomes one Work that may span 漢 (T/X), 藏 (84K), and Skt (GRETIL)
+      witnesses. alias(scheme='skt_title', value=<normkey>).
+
+  Pass 2 — SuttaCentral works
+      Each remaining `SC-<uid>` text → a Work anchored by sc_root_uid=<uid>,
+      witness role='root' lang='pi' canon='pali' confidence='verified'.
+      alias(scheme='sc_uid', value=<uid>).
+
+  Pass 3 — 84000 works
+      Each remaining `84K-toh<N>` text → a Work anchored by toh_number=<N>,
+      witness role='translation' lang='bo' canon='kangyur' confidence='verified'.
+      alias(scheme='toh', value=<N>).
+
+  Pass 4 — singletons
+      Every remaining text → a singleton Work keyed by its cbeta_id, so every
+      text belongs to exactly one work. confidence='auto'.
+
+Idempotency
+-----------
+Re-running is a no-op. Before each pass we load the set of text_ids that already
+have a witness (from the DB plus an in-run set) and skip them. Works are reused
+via their natural keys: alias (scheme, value) for Skt clusters, sc_root_uid for
+SC, toh_number for 84000, and slug for singletons. UNIQUE(work_id, text_id) and
+UNIQUE(scheme, value) are respected by lookup-before-insert.
+
+Usage
+-----
+  python scripts/build_works.py --dry-run            # compute + log, no writes
+  python scripts/build_works.py --dry-run --limit 500
+  python scripts/build_works.py                      # write
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import async_session
+from app.models.text import BuddhistText
+from app.models.work import Work, WorkAlias, WorkWitness
+
+# ---------------------------------------------------------------------------
+# Pure logic (no DB) — unit-testable in isolation
+# ---------------------------------------------------------------------------
+
+_WS_RE = re.compile(r"\s+")
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9]+")
+
+# A Skt-title cluster larger than this is treated as an over-broad / class-level
+# title (e.g. bare "Prajñāpāramitā" / "Sūtra" / "Dhāraṇī") and is NOT merged —
+# its texts fall through to singleton works instead, so a single generic title
+# can never silently fuse dozens of unrelated texts into one giant Work. Tune
+# via --max-skt-cluster after inspecting the largest clusters with --dry-run.
+MAX_SKT_CLUSTER_DEFAULT = 15
+
+
+def normalize_skt_title(title: str | None) -> str:
+    """Normalize a Sanskrit title to a clustering key.
+
+    Lowercase, NFKD-decompose and drop combining marks (so ``ā``/``a``,
+    ``ṣ``/``s``, ``ñ``/``n`` collapse), then collapse all whitespace runs to a
+    single space and strip. Returns "" for empty/whitespace input.
+
+    The diacritic-folding is deliberately aggressive: production Skt titles are
+    transliterated inconsistently across pillars, so folding to ASCII letters is
+    what actually merges ``Vajracchedikā`` with ``vajracchedika``.
+    """
+    if not title:
+        return ""
+    # NFKD then drop combining marks (category Mn).
+    decomposed = unicodedata.normalize("NFKD", title)
+    folded = "".join(c for c in decomposed if not unicodedata.combining(c))
+    folded = folded.lower()
+    folded = _WS_RE.sub(" ", folded).strip()
+    return folded
+
+
+def canon_from_cbeta_id(cbeta_id: str | None) -> str | None:
+    """Map a cbeta_id prefix to a canon label.
+
+    T... → taisho, X... → xuzang, SC-... → pali, 84K-toh... → kangyur,
+    GRETIL-... → gretil, VRI-... → pali. Unknown → None.
+    """
+    if not cbeta_id:
+        return None
+    if cbeta_id.startswith("SC-"):
+        return "pali"
+    if cbeta_id.startswith("84K-toh"):
+        return "kangyur"
+    if cbeta_id.startswith("GRETIL-"):
+        return "gretil"
+    if cbeta_id.startswith("VRI-"):
+        return "pali"
+    if cbeta_id.startswith("T"):
+        return "taisho"
+    if cbeta_id.startswith("X"):
+        return "xuzang"
+    return None
+
+
+def role_from_lang(lang: str | None) -> str:
+    """root for primary-language witnesses (sa/pi), translation otherwise."""
+    return "root" if lang in ("sa", "pi") else "translation"
+
+
+def sanitize_slug_base(raw: str) -> str:
+    """Sanitize an arbitrary string into a slug fragment ``[a-z0-9-]+``.
+
+    Diacritics are folded (NFKD + drop combining marks), everything that is not
+    ``[a-z0-9]`` becomes a hyphen, runs of hyphens collapse, and leading/trailing
+    hyphens are stripped. Returns "" if nothing survives.
+    """
+    decomposed = unicodedata.normalize("NFKD", raw)
+    folded = "".join(c for c in decomposed if not unicodedata.combining(c))
+    folded = folded.lower()
+    folded = _SLUG_STRIP_RE.sub("-", folded)
+    return folded.strip("-")
+
+
+def make_unique_slug(base: str, taken: set[str], *, fallback: str = "work") -> str:
+    """Return a slug derived from ``base`` not present in ``taken``.
+
+    ``base`` is sanitized first. On collision, append ``-2``, ``-3``, …. The
+    returned slug is added to ``taken`` so successive calls stay unique within a
+    run. Truncated to 200 chars to fit the column.
+    """
+    sanitized = sanitize_slug_base(base) or fallback
+    sanitized = sanitized[:200]
+    if sanitized not in taken:
+        taken.add(sanitized)
+        return sanitized
+    n = 2
+    while True:
+        suffix = f"-{n}"
+        candidate = f"{sanitized[: 200 - len(suffix)]}{suffix}"
+        if candidate not in taken:
+            taken.add(candidate)
+            return candidate
+        n += 1
+
+
+def pick_display_title(group: list[BuddhistText], norm_key: str) -> str:
+    """Best display title for a Skt cluster: prefer a 漢 title, else the Skt one.
+
+    A zh title is preferred because it is the most human-readable for FoJin's
+    primary audience. Falls back to any text's title_sa, then the raw norm_key.
+    """
+    for t in group:
+        if t.title_zh and t.title_zh.strip():
+            return t.title_zh.strip()
+    for t in group:
+        if t.title_sa and t.title_sa.strip():
+            return t.title_sa.strip()
+    return norm_key
+
+
+def representative_skt_title(group: list[BuddhistText]) -> str | None:
+    """A representative original (un-normalized) Skt title for the cluster."""
+    for t in group:
+        if t.title_sa and t.title_sa.strip():
+            return t.title_sa.strip()
+    return None
+
+
+def toh_number_from_cbeta_id(cbeta_id: str) -> str:
+    """Extract ``<N>`` from ``84K-toh<N>`` (returns the part after ``84K-toh``)."""
+    return cbeta_id[len("84K-toh"):]
+
+
+def sc_uid_from_cbeta_id(cbeta_id: str) -> str:
+    """Extract ``<uid>`` from ``SC-<uid>``."""
+    return cbeta_id[len("SC-"):]
+
+
+# ---------------------------------------------------------------------------
+# Build engine (DB-bound)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BuildStats:
+    works_created: int = 0
+    witnesses_created: int = 0
+    aliases_created: int = 0
+    per_pass: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    # (normalized key, size) of the largest Skt-title clusters, for inspection.
+    top_skt_clusters: list[tuple[str, int]] = field(default_factory=list)
+    # clusters skipped for exceeding --max-skt-cluster (left as singletons).
+    skipped_skt_clusters: list[tuple[str, int]] = field(default_factory=list)
+
+    def summary(self) -> str:
+        lines = [
+            "=== build_works summary ===",
+            f"works created:     {self.works_created}",
+            f"witnesses created: {self.witnesses_created}",
+            f"aliases created:   {self.aliases_created}",
+            "witnesses per pass:",
+        ]
+        for name in ("pass1_skt", "pass2_sc", "pass3_toh", "pass4_singleton"):
+            lines.append(f"  {name:<16} {self.per_pass.get(name, 0)}")
+        if self.top_skt_clusters:
+            lines.append("largest Skt-title clusters (size × key) — eyeball these:")
+            for key, size in self.top_skt_clusters:
+                lines.append(f"  {size:>4}  {key[:70]}")
+        if self.skipped_skt_clusters:
+            lines.append(
+                f"SKIPPED {len(self.skipped_skt_clusters)} over-broad cluster(s) "
+                "(> --max-skt-cluster) — left as singletons:"
+            )
+            for key, size in self.skipped_skt_clusters:
+                lines.append(f"  {size:>4}  {key[:70]}")
+        return "\n".join(lines)
+
+
+class WorkBuilder:
+    """Stateful, idempotent builder over an open AsyncSession.
+
+    Caches in-run lookups so a single run never double-creates, and consults the
+    DB up front so a *second* run is a no-op.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        dry_run: bool,
+        stats: BuildStats,
+        max_skt_cluster: int = MAX_SKT_CLUSTER_DEFAULT,
+    ):
+        self.session = session
+        self.dry_run = dry_run
+        self.stats = stats
+        self.max_skt_cluster = max_skt_cluster
+        # text_id -> already has a witness (DB or this run)
+        self.assigned_text_ids: set[int] = set()
+        # natural-key -> Work (reused across passes / runs)
+        self.work_by_alias: dict[tuple[str, str], Work] = {}
+        self.work_by_sc_uid: dict[str, Work] = {}
+        self.work_by_toh: dict[str, Work] = {}
+        self.work_by_slug: dict[str, Work] = {}
+        self.taken_slugs: set[str] = set()
+        # (scheme, value) already present (DB or this run)
+        self.existing_aliases: set[tuple[str, str]] = set()
+
+    async def load_existing(self) -> None:
+        """Prime caches from the DB so re-runs reuse rather than duplicate."""
+        works = (await self.session.execute(select(Work))).scalars().all()
+        for w in works:
+            self.taken_slugs.add(w.slug)
+            self.work_by_slug[w.slug] = w
+            if w.sc_root_uid:
+                self.work_by_sc_uid[w.sc_root_uid] = w
+            if w.toh_number:
+                self.work_by_toh[w.toh_number] = w
+
+        aliases = (await self.session.execute(select(WorkAlias))).scalars().all()
+        # work_id -> Work, to attach aliased works into the alias cache.
+        works_by_id = {w.id: w for w in works}
+        for a in aliases:
+            self.existing_aliases.add((a.scheme, a.value))
+            w = works_by_id.get(a.work_id)
+            if w is not None:
+                self.work_by_alias[(a.scheme, a.value)] = w
+
+        witnesses = (await self.session.execute(select(WorkWitness.text_id))).all()
+        for (text_id,) in witnesses:
+            self.assigned_text_ids.add(text_id)
+
+    # -- low-level helpers ---------------------------------------------------
+
+    def _new_work(self, **kwargs) -> Work:
+        work = Work(**kwargs)
+        if not self.dry_run:
+            self.session.add(work)
+        self.stats.works_created += 1
+        self.work_by_slug[work.slug] = work
+        if work.sc_root_uid:
+            self.work_by_sc_uid[work.sc_root_uid] = work
+        if work.toh_number:
+            self.work_by_toh[work.toh_number] = work
+        return work
+
+    def _add_alias(self, work: Work, scheme: str, value: str) -> None:
+        key = (scheme, value)
+        if key in self.existing_aliases:
+            return
+        self.existing_aliases.add(key)
+        self.work_by_alias[key] = work
+        if not self.dry_run:
+            self.session.add(WorkAlias(work=work, scheme=scheme, value=value))
+        self.stats.aliases_created += 1
+
+    def _add_witness(
+        self,
+        work: Work,
+        text: BuddhistText,
+        *,
+        role: str,
+        lang: str,
+        canon: str | None,
+        confidence: str,
+        pass_name: str,
+    ) -> bool:
+        if text.id in self.assigned_text_ids:
+            return False
+        self.assigned_text_ids.add(text.id)
+        if not self.dry_run:
+            self.session.add(
+                WorkWitness(
+                    work=work,
+                    text_id=text.id,
+                    role=role,
+                    lang=lang,
+                    canon=canon,
+                    confidence=confidence,
+                )
+            )
+        self.stats.witnesses_created += 1
+        self.stats.per_pass[pass_name] += 1
+        return True
+
+    def _slug(self, base: str, fallback: str) -> str:
+        return make_unique_slug(base, self.taken_slugs, fallback=fallback)
+
+    def _stamp_anchor(self, work: Work, cbeta_id: str) -> None:
+        """Preserve a cross-pillar witness's canonical anchor on its Work, so the
+        Work stays reachable by sc_root_uid / toh_number even when it was first
+        created in pass 1 (Skt-title clustering). First anchor of each kind wins.
+        """
+        if cbeta_id.startswith("SC-") and not work.sc_root_uid:
+            uid = sc_uid_from_cbeta_id(cbeta_id)
+            work.sc_root_uid = uid
+            self.work_by_sc_uid[uid] = work
+            self._add_alias(work, "sc_uid", uid)
+        elif cbeta_id.startswith("84K-toh") and not work.toh_number:
+            toh = toh_number_from_cbeta_id(cbeta_id)
+            work.toh_number = toh
+            self.work_by_toh[toh] = work
+            self._add_alias(work, "toh", toh)
+
+    # -- passes --------------------------------------------------------------
+
+    async def pass1_skt(self, texts: list[BuddhistText]) -> None:
+        """Cluster every text carrying a title_sa by normalized Skt key.
+
+        Over-broad clusters (size > max_skt_cluster, i.e. a generic class-level
+        Skt title shared by many unrelated texts) are NOT merged; their texts
+        fall through to singleton works in pass 4. The largest clusters are
+        recorded on stats for --dry-run inspection.
+        """
+        groups: dict[str, list[BuddhistText]] = defaultdict(list)
+        for t in texts:
+            key = normalize_skt_title(t.title_sa)
+            if not key:
+                continue
+            groups[key].append(t)
+
+        # Record the largest clusters for human inspection (esp. under --dry-run).
+        by_size = sorted(groups.items(), key=lambda kv: len(kv[1]), reverse=True)
+        self.stats.top_skt_clusters = [(k, len(g)) for k, g in by_size[:20] if len(g) > 1]
+
+        for norm_key, group in groups.items():
+            # Over-broad title → do NOT merge; leave for pass-4 singletons.
+            if len(group) > self.max_skt_cluster:
+                self.stats.skipped_skt_clusters.append((norm_key, len(group)))
+                continue
+
+            alias_key = ("skt_title", norm_key)
+            work = self.work_by_alias.get(alias_key)
+            if work is None:
+                display = pick_display_title(group, norm_key)
+                rep_skt = representative_skt_title(group)
+                slug = self._slug(f"sk-{norm_key}", fallback="sk-work")
+                work = self._new_work(
+                    slug=slug,
+                    title_primary=display[:500],
+                    title_sa=(rep_skt[:500] if rep_skt else None),
+                )
+            self._add_alias(work, "skt_title", norm_key)
+
+            for t in group:
+                lang = t.lang or "lzh"
+                added = self._add_witness(
+                    work,
+                    t,
+                    role=role_from_lang(lang),
+                    lang=lang,
+                    canon=canon_from_cbeta_id(t.cbeta_id),
+                    confidence="auto",
+                    pass_name="pass1_skt",
+                )
+                # Keep cross-pillar Works reachable by their canonical IDs.
+                if added and t.cbeta_id:
+                    self._stamp_anchor(work, t.cbeta_id)
+
+    async def pass2_sc(self, texts: list[BuddhistText]) -> None:
+        for t in texts:
+            if t.id in self.assigned_text_ids:
+                continue
+            if not t.cbeta_id or not t.cbeta_id.startswith("SC-"):
+                continue
+            uid = sc_uid_from_cbeta_id(t.cbeta_id)
+            work = self.work_by_sc_uid.get(uid) or self.work_by_alias.get(("sc_uid", uid))
+            if work is None:
+                slug = self._slug(f"sc-{uid}", fallback="sc-work")
+                work = self._new_work(
+                    slug=slug,
+                    title_primary=(t.title_zh or t.title_pi or t.title_en or uid)[:500],
+                    title_pi=(t.title_pi[:500] if t.title_pi else None),
+                    sc_root_uid=uid,
+                )
+            self._add_alias(work, "sc_uid", uid)
+            self._add_witness(
+                work,
+                t,
+                role="root",
+                lang="pi",
+                canon="pali",
+                confidence="verified",
+                pass_name="pass2_sc",
+            )
+
+    async def pass3_toh(self, texts: list[BuddhistText]) -> None:
+        for t in texts:
+            if t.id in self.assigned_text_ids:
+                continue
+            if not t.cbeta_id or not t.cbeta_id.startswith("84K-toh"):
+                continue
+            toh = toh_number_from_cbeta_id(t.cbeta_id)
+            work = self.work_by_toh.get(toh) or self.work_by_alias.get(("toh", toh))
+            if work is None:
+                slug = self._slug(f"toh-{toh}", fallback="toh-work")
+                work = self._new_work(
+                    slug=slug,
+                    title_primary=(t.title_zh or t.title_bo or t.title_en or f"Toh {toh}")[:500],
+                    toh_number=toh,
+                )
+            self._add_alias(work, "toh", toh)
+            self._add_witness(
+                work,
+                t,
+                role="translation",
+                lang="bo",
+                canon="kangyur",
+                confidence="verified",
+                pass_name="pass3_toh",
+            )
+
+    async def pass4_singletons(self, texts: list[BuddhistText]) -> None:
+        for t in texts:
+            if t.id in self.assigned_text_ids:
+                continue
+            cbeta_id = t.cbeta_id or f"text-{t.id}"
+            alias_key = ("cbeta_id", cbeta_id)
+            work = self.work_by_alias.get(alias_key)
+            if work is None:
+                slug = self._slug(cbeta_id, fallback=f"text-{t.id}")
+                work = self._new_work(
+                    slug=slug,
+                    title_primary=(t.title_zh or t.title_en or t.title_sa or cbeta_id)[:500],
+                    title_sa=(t.title_sa[:500] if t.title_sa else None),
+                )
+            self._add_alias(work, "cbeta_id", cbeta_id)
+            lang = t.lang or "lzh"
+            self._add_witness(
+                work,
+                t,
+                role=role_from_lang(lang),
+                lang=lang,
+                canon=canon_from_cbeta_id(t.cbeta_id),
+                confidence="auto",
+                pass_name="pass4_singleton",
+            )
+
+    async def run(self, texts: list[BuddhistText]) -> None:
+        await self.pass1_skt(texts)
+        await self.pass2_sc(texts)
+        await self.pass3_toh(texts)
+        await self.pass4_singletons(texts)
+
+
+async def build(
+    session: AsyncSession,
+    *,
+    dry_run: bool,
+    limit: int | None = None,
+    max_skt_cluster: int = MAX_SKT_CLUSTER_DEFAULT,
+) -> BuildStats:
+    """Load texts, run all four passes, commit (unless dry-run). Returns stats."""
+    stats = BuildStats()
+    builder = WorkBuilder(
+        session, dry_run=dry_run, stats=stats, max_skt_cluster=max_skt_cluster
+    )
+    await builder.load_existing()
+
+    stmt = select(BuddhistText).order_by(BuddhistText.id)
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    texts = list((await session.execute(stmt)).scalars().all())
+
+    await builder.run(texts)
+
+    if dry_run:
+        await session.rollback()
+    else:
+        await session.commit()
+    return stats
+
+
+async def main_async(*, dry_run: bool, limit: int | None, max_skt_cluster: int) -> None:
+    async with async_session() as session:
+        stats = await build(
+            session, dry_run=dry_run, limit=limit, max_skt_cluster=max_skt_cluster
+        )
+    if dry_run:
+        print("(dry-run; no DB writes)")
+    print(stats.summary())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--dry-run", action="store_true", help="compute + log only; no DB writes"
+    )
+    ap.add_argument(
+        "--limit", type=int, default=None, help="cap texts processed (testing)"
+    )
+    ap.add_argument(
+        "--max-skt-cluster",
+        type=int,
+        default=MAX_SKT_CLUSTER_DEFAULT,
+        help="Skt-title clusters larger than this are left as singletons "
+        "(guards against over-broad generic titles)",
+    )
+    args = ap.parse_args()
+    asyncio.run(
+        main_async(
+            dry_run=args.dry_run, limit=args.limit, max_skt_cluster=args.max_skt_cluster
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_build_works.py
+++ b/backend/tests/test_build_works.py
@@ -1,0 +1,447 @@
+"""Tests for scripts/build_works.py.
+
+Two layers:
+
+  * Pure-logic unit tests — no DB, no fixtures. Always run.
+  * One integration test against an in-memory SQLite async DB created with
+    ``Base.metadata.create_all``. This needs ``aiosqlite`` (a dev dep) but no
+    external services (PG/ES/Redis), matching the conftest philosophy. If
+    ``aiosqlite`` is unavailable the integration test is skipped, not failed.
+
+Run:  python -m pytest tests/test_build_works.py -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make ``scripts`` importable (repo layout has no package for it).
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_BACKEND_ROOT))
+sys.path.insert(0, str(_BACKEND_ROOT / "scripts"))
+
+import build_works as bw
+
+# ---------------------------------------------------------------------------
+# Pure logic — normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_merges_case_space_diacritics():
+    a = bw.normalize_skt_title("Vajracchedikā Prajñāpāramitā")
+    b = bw.normalize_skt_title("vajracchedika  prajnaparamita")
+    c = bw.normalize_skt_title("  VAJRACCHEDIKĀ\tPRAJÑĀPĀRAMITĀ  ")
+    assert a == b == c
+    assert a == "vajracchedika prajnaparamita"
+
+
+def test_normalize_empty_inputs():
+    assert bw.normalize_skt_title(None) == ""
+    assert bw.normalize_skt_title("") == ""
+    assert bw.normalize_skt_title("   \t \n ") == ""
+
+
+def test_normalize_collapses_internal_whitespace():
+    assert bw.normalize_skt_title("a\t\n  b   c") == "a b c"
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — canon from prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cbeta_id,expected",
+    [
+        ("T0251", "taisho"),
+        ("X1551", "xuzang"),
+        ("SC-an10.1", "pali"),
+        ("SC-dn1", "pali"),
+        ("84K-toh2", "kangyur"),
+        ("GRETIL-foo", "gretil"),
+        ("VRI-bar", "pali"),
+        ("ZZZ-unknown", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_canon_from_cbeta_id(cbeta_id, expected):
+    assert bw.canon_from_cbeta_id(cbeta_id) == expected
+
+
+def test_canon_sc_prefix_beats_t_prefix():
+    # SC- must be checked before the bare "T"/"X" rule (it is not, but it does
+    # not start with T anyway — guard the ordering against future edits).
+    assert bw.canon_from_cbeta_id("SC-thig1.1") == "pali"
+    assert bw.canon_from_cbeta_id("84K-toh100") == "kangyur"
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — role
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "lang,expected",
+    [("sa", "root"), ("pi", "root"), ("lzh", "translation"), ("bo", "translation"), (None, "translation")],
+)
+def test_role_from_lang(lang, expected):
+    assert bw.role_from_lang(lang) == expected
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — slug sanitize + uniqueness
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_slug_base():
+    assert bw.sanitize_slug_base("Vajracchedikā Prajñā") == "vajracchedika-prajna"
+    assert bw.sanitize_slug_base("T0251") == "t0251"
+    assert bw.sanitize_slug_base("SC-an10.1") == "sc-an10-1"
+    assert bw.sanitize_slug_base("  --weird__name!!  ") == "weird-name"
+    assert bw.sanitize_slug_base("妙法蓮華經") == ""  # no ascii survives
+
+
+def test_sanitize_slug_only_allowed_chars():
+    import re
+
+    for raw in ["Héllo Wörld", "T0251", "84K-toh2", "a/b\\c.d", "ṣaḍ-akṣarī"]:
+        out = bw.sanitize_slug_base(raw)
+        assert out == "" or re.fullmatch(r"[a-z0-9-]+", out), out
+
+
+def test_make_unique_slug_collisions():
+    taken: set[str] = set()
+    s1 = bw.make_unique_slug("sk-foo", taken)
+    s2 = bw.make_unique_slug("sk-foo", taken)
+    s3 = bw.make_unique_slug("sk-foo", taken)
+    assert s1 == "sk-foo"
+    assert s2 == "sk-foo-2"
+    assert s3 == "sk-foo-3"
+    assert len(taken) == 3
+
+
+def test_make_unique_slug_empty_uses_fallback():
+    taken: set[str] = set()
+    s = bw.make_unique_slug("妙法蓮華經", taken, fallback="text-7")
+    assert s == "text-7"
+
+
+def test_make_unique_slug_truncates_to_200():
+    taken: set[str] = set()
+    s = bw.make_unique_slug("a" * 300, taken)
+    assert len(s) <= 200
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — display title / toh / sc extraction
+# ---------------------------------------------------------------------------
+
+
+class _FakeText:
+    def __init__(self, **kw):
+        self.title_zh = kw.get("title_zh")
+        self.title_sa = kw.get("title_sa")
+        self.title_en = kw.get("title_en")
+        self.title_bo = kw.get("title_bo")
+        self.title_pi = kw.get("title_pi")
+
+
+def test_pick_display_title_prefers_zh():
+    g = [_FakeText(title_sa="Vajracchedikā"), _FakeText(title_zh="金剛經", title_sa="Vajracchedikā")]
+    assert bw.pick_display_title(g, "vajracchedika") == "金剛經"
+
+
+def test_pick_display_title_falls_back_to_skt_then_key():
+    g = [_FakeText(title_sa="Vajracchedikā")]
+    assert bw.pick_display_title(g, "vajracchedika") == "Vajracchedikā"
+    g2 = [_FakeText()]
+    assert bw.pick_display_title(g2, "somekey") == "somekey"
+
+
+def test_toh_and_sc_extraction():
+    assert bw.toh_number_from_cbeta_id("84K-toh2") == "2"
+    assert bw.toh_number_from_cbeta_id("84K-toh100") == "100"
+    assert bw.sc_uid_from_cbeta_id("SC-an10.1") == "an10.1"
+    assert bw.sc_uid_from_cbeta_id("SC-dn1") == "dn1"
+
+
+# ---------------------------------------------------------------------------
+# Integration — in-memory SQLite async DB (skips if aiosqlite unavailable)
+# ---------------------------------------------------------------------------
+
+_HAS_AIOSQLITE = importlib.util.find_spec("aiosqlite") is not None
+
+pytestmark_db = pytest.mark.skipif(
+    not _HAS_AIOSQLITE, reason="aiosqlite not installed; integration test needs a DB"
+)
+
+
+@pytest.fixture
+async def db_session():
+    """A throwaway in-memory SQLite async session with the schema created.
+
+    Uses the real ORM models (Work/WorkWitness/WorkAlias/BuddhistText), so the
+    build runs against genuine SQLAlchemy 2.0 mappings — just on SQLite instead
+    of PG. No external services.
+    """
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401  (register all mappers / FKs)
+    from app.database import Base
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(session):
+    """1 zh + 1 sa sharing a title_sa, 1 SC-, 1 84K-toh, 1 plain T (no title_sa)."""
+    from app.models.text import BuddhistText
+
+    rows = [
+        # cross-pillar pair sharing the same Skt title (diacritic/case variant)
+        BuddhistText(
+            cbeta_id="T0235", title_zh="金剛般若波羅蜜經", title_sa="Vajracchedikā Prajñāpāramitā",
+            lang="lzh",
+        ),
+        BuddhistText(
+            cbeta_id="GRETIL-vajra", title_zh="", title_sa="vajracchedika prajnaparamita",
+            lang="sa",
+        ),
+        # SuttaCentral
+        BuddhistText(cbeta_id="SC-an10.1", title_zh="", title_pi="Kimatthiya Sutta", lang="pi"),
+        # 84000
+        BuddhistText(cbeta_id="84K-toh2", title_zh="", title_bo="bo title", lang="bo"),
+        # plain Taisho, no title_sa → singleton
+        BuddhistText(cbeta_id="T0251", title_zh="般若波羅蜜多心經", lang="lzh"),
+    ]
+    session.add_all(rows)
+    await session.commit()
+
+
+@pytestmark_db
+async def test_build_integration_clusters_and_anchors(db_session):
+    from sqlalchemy import func, select
+
+    from app.models.text import BuddhistText
+    from app.models.work import Work, WorkAlias, WorkWitness
+
+    await _seed(db_session)
+    stats = await bw.build(db_session, dry_run=False)
+
+    # 5 texts → 4 works (the zh+sa pair merges into one).
+    n_works = (await db_session.execute(select(func.count()).select_from(Work))).scalar()
+    n_wit = (await db_session.execute(select(func.count()).select_from(WorkWitness))).scalar()
+    assert n_works == 4
+    assert n_wit == 5  # every text is a witness of exactly one work
+    assert stats.works_created == 4
+    assert stats.witnesses_created == 5
+
+    # The Skt cluster: find the work via the skt_title alias, assert 2 witnesses.
+    norm = bw.normalize_skt_title("Vajracchedikā Prajñāpāramitā")
+    alias = (
+        await db_session.execute(
+            select(WorkAlias).where(WorkAlias.scheme == "skt_title", WorkAlias.value == norm)
+        )
+    ).scalar_one()
+    cluster_witnesses = (
+        await db_session.execute(
+            select(WorkWitness).where(WorkWitness.work_id == alias.work_id)
+        )
+    ).scalars().all()
+    assert len(cluster_witnesses) == 2
+    canons = {w.canon for w in cluster_witnesses}
+    assert canons == {"taisho", "gretil"}
+    # the sa witness is a root, the lzh one a translation
+    roles = {w.lang: w.role for w in cluster_witnesses}
+    assert roles == {"sa": "root", "lzh": "translation"}
+
+    # SC anchored, verified, role=root, canon=pali
+    sc_text = (
+        await db_session.execute(select(BuddhistText).where(BuddhistText.cbeta_id == "SC-an10.1"))
+    ).scalar_one()
+    sc_wit = (
+        await db_session.execute(select(WorkWitness).where(WorkWitness.text_id == sc_text.id))
+    ).scalar_one()
+    assert sc_wit.confidence == "verified"
+    assert sc_wit.role == "root"
+    assert sc_wit.canon == "pali"
+    sc_work = (await db_session.execute(select(Work).where(Work.id == sc_wit.work_id))).scalar_one()
+    assert sc_work.sc_root_uid == "an10.1"
+
+    # 84000 anchored, verified, translation, kangyur
+    toh_text = (
+        await db_session.execute(select(BuddhistText).where(BuddhistText.cbeta_id == "84K-toh2"))
+    ).scalar_one()
+    toh_wit = (
+        await db_session.execute(select(WorkWitness).where(WorkWitness.text_id == toh_text.id))
+    ).scalar_one()
+    assert toh_wit.confidence == "verified"
+    assert toh_wit.role == "translation"
+    assert toh_wit.canon == "kangyur"
+    toh_work = (await db_session.execute(select(Work).where(Work.id == toh_wit.work_id))).scalar_one()
+    assert toh_work.toh_number == "2"
+
+    # plain T0251 → singleton, confidence auto, its own work
+    plain = (
+        await db_session.execute(select(BuddhistText).where(BuddhistText.cbeta_id == "T0251"))
+    ).scalar_one()
+    plain_wit = (
+        await db_session.execute(select(WorkWitness).where(WorkWitness.text_id == plain.id))
+    ).scalar_one()
+    assert plain_wit.confidence == "auto"
+    plain_work_wit_count = (
+        await db_session.execute(
+            select(func.count()).select_from(WorkWitness).where(WorkWitness.work_id == plain_wit.work_id)
+        )
+    ).scalar()
+    assert plain_work_wit_count == 1  # singleton
+
+
+@pytestmark_db
+async def test_build_is_idempotent(db_session):
+    from sqlalchemy import func, select
+
+    from app.models.work import Work, WorkAlias, WorkWitness
+
+    await _seed(db_session)
+
+    s1 = await bw.build(db_session, dry_run=False)
+    works_1 = (await db_session.execute(select(func.count()).select_from(Work))).scalar()
+    wit_1 = (await db_session.execute(select(func.count()).select_from(WorkWitness))).scalar()
+    alias_1 = (await db_session.execute(select(func.count()).select_from(WorkAlias))).scalar()
+
+    # Second run must be a no-op.
+    s2 = await bw.build(db_session, dry_run=False)
+    works_2 = (await db_session.execute(select(func.count()).select_from(Work))).scalar()
+    wit_2 = (await db_session.execute(select(func.count()).select_from(WorkWitness))).scalar()
+    alias_2 = (await db_session.execute(select(func.count()).select_from(WorkAlias))).scalar()
+
+    assert (works_1, wit_1, alias_1) == (works_2, wit_2, alias_2)
+    assert s2.works_created == 0
+    assert s2.witnesses_created == 0
+    assert s2.aliases_created == 0
+    # first run actually did the work
+    assert s1.works_created == 4
+    assert s1.witnesses_created == 5
+
+
+@pytestmark_db
+async def test_build_dry_run_writes_nothing(db_session):
+    from sqlalchemy import func, select
+
+    from app.models.work import Work, WorkWitness
+
+    await _seed(db_session)
+    stats = await bw.build(db_session, dry_run=True)
+
+    n_works = (await db_session.execute(select(func.count()).select_from(Work))).scalar()
+    n_wit = (await db_session.execute(select(func.count()).select_from(WorkWitness))).scalar()
+    assert n_works == 0
+    assert n_wit == 0
+    # stats still report what WOULD be created
+    assert stats.works_created == 4
+    assert stats.witnesses_created == 5
+
+
+@pytestmark_db
+async def test_oversized_skt_cluster_left_as_singletons(db_session):
+    """A generic Skt title shared by many texts must NOT fuse into one Work."""
+    from sqlalchemy import func, select
+
+    from app.models.text import BuddhistText
+    from app.models.work import Work, WorkAlias, WorkWitness
+
+    session = db_session
+    session.add_all(
+        [
+            BuddhistText(
+                cbeta_id=f"T100{i}", title_zh=f"经{i}", title_sa="Prajñāpāramitā", lang="lzh"
+            )
+            for i in range(4)
+        ]
+    )
+    await session.commit()
+
+    # max_skt_cluster=2 → the 4-member cluster is over-broad and skipped.
+    stats = await bw.build(session, dry_run=False, max_skt_cluster=2)
+
+    n_skt_alias = (
+        await session.execute(
+            select(func.count())
+            .select_from(WorkAlias)
+            .where(WorkAlias.scheme == "skt_title")
+        )
+    ).scalar()
+    assert n_skt_alias == 0  # no merge happened
+    assert len(stats.skipped_skt_clusters) == 1
+    assert stats.skipped_skt_clusters[0][1] == 4  # cluster size recorded
+
+    # All 4 fell through to singleton works (one witness each) via pass 4.
+    n_works = (await session.execute(select(func.count()).select_from(Work))).scalar()
+    n_wit = (await session.execute(select(func.count()).select_from(WorkWitness))).scalar()
+    assert n_works == 4
+    assert n_wit == 4
+    assert stats.per_pass.get("pass4_singleton") == 4
+    assert stats.per_pass.get("pass1_skt", 0) == 0
+
+
+@pytestmark_db
+async def test_pass1_preserves_cross_pillar_anchor(db_session):
+    """A SC- text clustered by title_sa keeps its sc_root_uid + sc_uid alias."""
+    from sqlalchemy import select
+
+    from app.models.text import BuddhistText
+    from app.models.work import Work, WorkAlias, WorkWitness
+
+    session = db_session
+    session.add_all(
+        [
+            BuddhistText(cbeta_id="T0251b", title_zh="心経", title_sa="Hṛdaya", lang="lzh"),
+            BuddhistText(
+                cbeta_id="SC-pp.heart", title_zh="", title_pi="Heart", title_sa="hrdaya", lang="pi"
+            ),
+        ]
+    )
+    await session.commit()
+
+    await bw.build(session, dry_run=False)
+
+    norm = bw.normalize_skt_title("Hṛdaya")
+    alias = (
+        await session.execute(
+            select(WorkAlias).where(
+                WorkAlias.scheme == "skt_title", WorkAlias.value == norm
+            )
+        )
+    ).scalar_one()
+    wits = (
+        await session.execute(
+            select(WorkWitness).where(WorkWitness.work_id == alias.work_id)
+        )
+    ).scalars().all()
+    assert len(wits) == 2  # merged into one work
+
+    # the SC canonical anchor is preserved on the Work (issue #2 from review)
+    work = (
+        await session.execute(select(Work).where(Work.id == alias.work_id))
+    ).scalar_one()
+    assert work.sc_root_uid == "pp.heart"
+    sc_alias = (
+        await session.execute(
+            select(WorkAlias).where(
+                WorkAlias.scheme == "sc_uid", WorkAlias.value == "pp.heart"
+            )
+        )
+    ).scalar_one_or_none()
+    assert sc_alias is not None
+    assert sc_alias.work_id == alias.work_id

--- a/backend/tests/test_works_api.py
+++ b/backend/tests/test_works_api.py
@@ -1,0 +1,254 @@
+"""Read-only FRBR Work API tests.
+
+The backend has no live Postgres in CI, so — following the established pattern
+in test_smoke.py / test_source_stats.py — we override the ``get_db`` dependency
+with an ``AsyncMock`` session and feed each ``execute`` call a controlled result
+object via ``side_effect``. This exercises the real router logic (title-per-lang
+selection, root-first ordering, witness_count, q filtering) without a DB.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_work(**kw):
+    """A fake Work ORM row."""
+    w = MagicMock()
+    w.id = kw.get("id", 1)
+    w.slug = kw.get("slug", "lotus-sutra")
+    w.title_primary = kw.get("title_primary", "妙法蓮華經")
+    w.title_sa = kw.get("title_sa", "Saddharmapuṇḍarīka")
+    w.title_pi = kw.get("title_pi")
+    w.sc_root_uid = kw.get("sc_root_uid")
+    w.toh_number = kw.get("toh_number")
+    w.category = kw.get("category", "sutra")
+    w.note = kw.get("note")
+    w.created_at = kw.get("created_at", datetime.now(UTC))
+    return w
+
+
+def _make_witness(**kw):
+    wit = MagicMock()
+    wit.text_id = kw["text_id"]
+    wit.work_id = kw.get("work_id", 1)
+    wit.role = kw.get("role", "translation")
+    wit.lang = kw.get("lang", "lzh")
+    wit.canon = kw.get("canon")
+    wit.confidence = kw.get("confidence", "auto")
+    return wit
+
+
+def _make_text(**kw):
+    t = MagicMock()
+    t.id = kw["id"]
+    t.cbeta_id = kw.get("cbeta_id")
+    t.title_zh = kw.get("title_zh")
+    t.title_en = kw.get("title_en")
+    t.title_sa = kw.get("title_sa")
+    t.title_bo = kw.get("title_bo")
+    t.title_pi = kw.get("title_pi")
+    t.has_content = kw.get("has_content", False)
+    return t
+
+
+def _scalar_result(value):
+    """Mock result whose ``.scalar()`` / ``.scalar_one_or_none()`` returns value."""
+    r = MagicMock()
+    r.scalar.return_value = value
+    r.scalar_one_or_none.return_value = value
+    return r
+
+
+def _scalars_all_result(items):
+    """Mock result whose ``.scalars().all()`` returns items."""
+    r = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = items
+    r.scalars.return_value = scalars
+    return r
+
+
+def _all_result(rows):
+    """Mock result whose ``.all()`` returns rows (list of row tuples / objects)."""
+    r = MagicMock()
+    r.all.return_value = rows
+    return r
+
+
+def _override_db(side_effect):
+    """Install a mock DB session with the given execute() side_effect; returns
+    a teardown callable."""
+    from app.database import get_db as real_get_db
+    from app.main import app
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(side_effect=side_effect)
+    app.dependency_overrides[real_get_db] = lambda: mock_session
+
+    def teardown():
+        app.dependency_overrides.pop(real_get_db, None)
+
+    return teardown
+
+
+# --------------------------------------------------------------------------- #
+# GET /works/{slug}
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_get_work_detail_with_witness_count(client):
+    work = _make_work()
+    # call 1: select Work by slug ; call 2: count witnesses
+    teardown = _override_db([_scalar_result(work), _scalar_result(2)])
+    try:
+        resp = await client.get("/api/works/lotus-sutra")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["slug"] == "lotus-sutra"
+        assert data["title_primary"] == "妙法蓮華經"
+        assert data["title_sa"] == "Saddharmapuṇḍarīka"
+        assert data["witness_count"] == 2
+    finally:
+        teardown()
+
+
+@pytest.mark.anyio
+async def test_get_work_404_for_missing_slug(client):
+    teardown = _override_db([_scalar_result(None)])
+    try:
+        resp = await client.get("/api/works/does-not-exist")
+        assert resp.status_code == 404, resp.text
+    finally:
+        teardown()
+
+
+# --------------------------------------------------------------------------- #
+# GET /works/{slug}/witnesses
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_list_witnesses_enriched_root_first_and_title_per_lang(client):
+    # A Pali translation witness (non-root) + a Chinese root witness.
+    # DB returns them root-first already (router does ORDER BY in SQL); we feed
+    # them in the router's expected order to verify enrichment + shape.
+    root_wit = _make_witness(
+        text_id=10, role="root", lang="lzh", canon="taisho", confidence="verified"
+    )
+    root_text = _make_text(
+        id=10,
+        cbeta_id="T0262",
+        title_zh="妙法蓮華經",
+        title_en="Lotus Sutra",
+        has_content=True,
+    )
+    pi_wit = _make_witness(
+        text_id=20, role="translation", lang="pi", canon="pali", confidence="auto"
+    )
+    pi_text = _make_text(
+        id=20,
+        cbeta_id=None,
+        title_zh="法華經(巴利)",
+        title_pi="Saddhammapuṇḍarīka",
+        title_en="Lotus (Pali)",
+        has_content=False,
+    )
+
+    # call 1: select Work.id by slug ; call 2: join select witnesses+texts
+    rows = [(root_wit, root_text), (pi_wit, pi_text)]
+    teardown = _override_db([_scalar_result(1), _all_result(rows)])
+    try:
+        resp = await client.get("/api/works/lotus-sutra/witnesses")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data) == 2
+
+        # root-first ordering preserved
+        assert data[0]["role"] == "root"
+        assert data[0]["text_id"] == 10
+        assert data[0]["cbeta_id"] == "T0262"
+        # lzh witness -> title_zh
+        assert data[0]["title"] == "妙法蓮華經"
+        assert data[0]["lang"] == "lzh"
+        assert data[0]["canon"] == "taisho"
+        assert data[0]["confidence"] == "verified"
+        assert data[0]["has_content"] is True
+
+        # pi witness -> title_pi (not title_zh, not title_en)
+        assert data[1]["role"] == "translation"
+        assert data[1]["lang"] == "pi"
+        assert data[1]["title"] == "Saddhammapuṇḍarīka"
+        assert data[1]["cbeta_id"] is None
+        assert data[1]["has_content"] is False
+    finally:
+        teardown()
+
+
+@pytest.mark.anyio
+async def test_list_witnesses_404_for_missing_slug(client):
+    teardown = _override_db([_scalar_result(None)])
+    try:
+        resp = await client.get("/api/works/nope/witnesses")
+        assert resp.status_code == 404, resp.text
+    finally:
+        teardown()
+
+
+# --------------------------------------------------------------------------- #
+# GET /works?q=
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_list_works_finds_by_query(client):
+    work = _make_work()
+
+    # Aggregate row for the page: work_id -> (witness_count, langs)
+    agg_row = MagicMock()
+    agg_row.work_id = 1
+    agg_row.witness_count = 2
+    agg_row.langs = ["pi", "lzh"]
+
+    # call 1: count ; call 2: select works ; call 3: aggregate
+    teardown = _override_db(
+        [
+            _scalar_result(1),
+            _scalars_all_result([work]),
+            _all_result([agg_row]),
+        ]
+    )
+    try:
+        resp = await client.get("/api/works", params={"q": "法華"})
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["page"] == 1
+        assert data["page_size"] == 20
+        assert len(data["items"]) == 1
+        item = data["items"][0]
+        assert item["slug"] == "lotus-sutra"
+        assert item["title_primary"] == "妙法蓮華經"
+        assert item["witness_count"] == 2
+        assert item["langs"] == ["lzh", "pi"]  # sorted
+    finally:
+        teardown()
+
+
+@pytest.mark.anyio
+async def test_list_works_empty(client):
+    teardown = _override_db([_scalar_result(0), _scalars_all_result([])])
+    try:
+        resp = await client.get("/api/works", params={"q": "zzz-no-match"})
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+    finally:
+        teardown()


### PR DESCRIPTION
## 目标
在 `buddhist_texts`（manifestation 层）之上**增量叠加** Work（作品）层，把跨语言/跨藏的多个见证本聚合成一个作品——解锁"作品级全版本视图 / 跨藏对齐规模化 / 跨语 RAG"的地基。设计文档见讨论。

**纯增量、零停机、可逆**：不碰 `buddhist_texts` / `text_identifiers` / `alignment_pairs`。

## 内容
- **models + alembic `0145`**：`works` / `work_witnesses` / `work_aliases`（down_revision 0144，已核 prod 链一致；`alembic-dry-run` CI 会验证）。
- **`scripts/build_works.py`**：幂等 4-pass 回填——
  1. **Skt 题名聚类**（跨柱主桥梁；带**过度合并护栏** `--max-skt-cluster`，泛标题不会把无关文本并成巨型 Work）；
  2. SuttaCentral `SC-<uid>` 锚定（verified/root/pali）；
  3. 84000 `84K-toh<N>` 锚定（verified/translation/kangyur）；
  4. 其余 → 单例。`--dry-run`/`--limit`，跨柱见证本保留 sc_root_uid/toh_number 锚。
- **只读 API**：`GET /works/{slug}`、`/works/{slug}/witnesses`（按见证本富化 + root 优先排序）、`/works`（搜索，无 N+1）。
- **测试**：纯逻辑单测 + SQLite 集成测试（含过度合并护栏、跨柱锚保留、幂等、dry-run）。`aiosqlite` 加入 dev 依赖让 CI 真跑集成测试。

## 数据形态（实测 prod）
SC- 4948 / T 2951 / X 1231 / 84K-toh 1109 / GRETIL- 261 / VRI- 31；title_sa 覆盖 647 lzh + 330 bo + 261 sa（跨柱桥梁）。

## 验证
- `ruff` 干净（app/ 全过）；`py_compile` 全过。
- 后端测试：**397 passed**，仅 7 个 pre-existing 失败（test_annotations_workflow + test_kg_entity_detail，CI 已显式排除，与本 PR 无关，已 stash 核实在 master 同样失败）。
- 过 code-reviewer：裁定 *无 Critical 阻断，迁移可上 prod*；提的 2 个 Important（过度合并护栏、跨柱锚保留）已在代码治本 + 补测试。

## 部署后
迁移随部署在 prod 跑（建表，零数据风险）。回填**单独手动**跑：先 `build_works.py --dry-run` 检查最大 Skt 簇，确认无泛标题误并后再实跑。Phase 2：题名匹配 + 200 经人校扩全量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)