### PR TITLE
feat(works): 阅读页"其他版本"对照入口 (P2)

### DIFF
--- a/backend/app/api/works.py
+++ b/backend/app/api/works.py
@@ -16,6 +16,7 @@ from app.database import get_db
 from app.models.text import BuddhistText
 from app.models.work import Work, WorkWitness
 from app.schemas.work import (
+    WorkByTextResponse,
     WorkDetailResponse,
     WorkListItem,
     WorkListResponse,
@@ -60,6 +61,36 @@ def _witness_title(text: BuddhistText, lang: str) -> str | None:
         if val:
             return val
     return text.title_en or text.title_zh
+
+
+async def _enriched_witnesses(
+    db: AsyncSession, work_id: int
+) -> list[WorkWitnessResponse]:
+    """All witnesses of a work, joined to BuddhistText, root-first then lang/id."""
+    stmt = (
+        select(WorkWitness, BuddhistText)
+        .join(BuddhistText, BuddhistText.id == WorkWitness.text_id)
+        .where(WorkWitness.work_id == work_id)
+        .order_by(
+            (WorkWitness.role != "root"),  # False (root) sorts before True
+            WorkWitness.lang.asc(),
+            WorkWitness.text_id.asc(),
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        WorkWitnessResponse(
+            text_id=witness.text_id,
+            cbeta_id=text.cbeta_id,
+            title=_witness_title(text, witness.lang),
+            lang=witness.lang,
+            canon=witness.canon,
+            role=witness.role,
+            confidence=witness.confidence,
+            has_content=bool(text.has_content),
+        )
+        for witness, text in rows
+    ]
 
 
 @router.get("", response_model=WorkListResponse)
@@ -192,28 +223,31 @@ async def list_work_witnesses(
     if work is None:
         raise _work_not_found(slug)
 
-    stmt = (
-        select(WorkWitness, BuddhistText)
-        .join(BuddhistText, BuddhistText.id == WorkWitness.text_id)
-        .where(WorkWitness.work_id == work)
-        .order_by(
-            (WorkWitness.role != "root"),  # False (root) sorts before True
-            WorkWitness.lang.asc(),
-            WorkWitness.text_id.asc(),
-        )
-    )
-    rows = (await db.execute(stmt)).all()
+    return await _enriched_witnesses(db, work)
 
-    return [
-        WorkWitnessResponse(
-            text_id=witness.text_id,
-            cbeta_id=text.cbeta_id,
-            title=_witness_title(text, witness.lang),
-            lang=witness.lang,
-            canon=witness.canon,
-            role=witness.role,
-            confidence=witness.confidence,
-            has_content=bool(text.has_content),
+
+@router.get("/by-text/{text_id}", response_model=WorkByTextResponse)
+async def get_work_by_text(
+    text_id: int, db: AsyncSession = Depends(get_db)
+) -> WorkByTextResponse:
+    """Given a text id, return the Work it belongs to + all its witnesses.
+
+    Powers the reader's "其他版本 / 对照本" panel. 404 if the text is not yet
+    assigned to any work (e.g. imported after the last build_works run).
+    """
+    work_id = (
+        await db.execute(
+            select(WorkWitness.work_id).where(WorkWitness.text_id == text_id)
         )
-        for witness, text in rows
-    ]
+    ).scalar_one_or_none()
+    if work_id is None:
+        raise NotFoundError(f"该经文尚未归入任何作品: {text_id}")
+    work = (await db.execute(select(Work).where(Work.id == work_id))).scalar_one()
+    witnesses = await _enriched_witnesses(db, work_id)
+    return WorkByTextResponse(
+        slug=work.slug,
+        title_primary=work.title_primary,
+        title_sa=work.title_sa,
+        witness_count=len(witnesses),
+        witnesses=witnesses,
+    )

--- a/backend/app/schemas/work.py
+++ b/backend/app/schemas/work.py
@@ -49,3 +49,13 @@ class WorkListResponse(BaseModel):
     page: int
     page_size: int
     items: list[WorkListItem]
+
+
+class WorkByTextResponse(BaseModel):
+    """给定一条经文，返回它所属作品 + 全部见证本（含自身，前端按需排除自身）。"""
+
+    slug: str
+    title_primary: str
+    title_sa: str | None = None
+    witness_count: int = 0
+    witnesses: list[WorkWitnessResponse] = []

--- a/backend/tests/test_works_api.py
+++ b/backend/tests/test_works_api.py
@@ -130,6 +130,50 @@ async def test_get_work_404_for_missing_slug(client):
 
 
 # --------------------------------------------------------------------------- #
+# GET /works/by-text/{text_id}
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_get_work_by_text_returns_siblings(client):
+    work = _make_work(slug="lotus-sutra", title_primary="妙法蓮華經", title_sa="Saddharmapuṇḍarīka")
+    w_sa = _make_witness(text_id=10, role="root", lang="sa", canon="gretil")
+    t_sa = _make_text(id=10, cbeta_id="GRETIL-sdp", title_sa="Saddharmapuṇḍarīka", has_content=True)
+    w_zh = _make_witness(text_id=20, role="translation", lang="lzh", canon="taisho")
+    t_zh = _make_text(id=20, cbeta_id="T0262", title_zh="妙法蓮華經", has_content=True)
+
+    # call 1: WorkWitness.work_id for the text ; 2: Work by id ; 3: enriched rows
+    work_res = MagicMock()
+    work_res.scalar_one.return_value = work
+    teardown = _override_db(
+        [_scalar_result(1), work_res, _all_result([(w_sa, t_sa), (w_zh, t_zh)])]
+    )
+    try:
+        resp = await client.get("/api/works/by-text/20")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["slug"] == "lotus-sutra"
+        assert data["witness_count"] == 2
+        assert {w["text_id"] for w in data["witnesses"]} == {10, 20}
+        # title-per-lang: the lzh witness surfaces title_zh
+        lzh = next(w for w in data["witnesses"] if w["lang"] == "lzh")
+        assert lzh["title"] == "妙法蓮華經"
+    finally:
+        teardown()
+
+
+@pytest.mark.anyio
+async def test_get_work_by_text_404_when_unassigned(client):
+    # No WorkWitness row → text not yet in any work → 404.
+    teardown = _override_db([_scalar_result(None)])
+    try:
+        resp = await client.get("/api/works/by-text/99999")
+        assert resp.status_code == 404, resp.text
+    finally:
+        teardown()
+
+
+# --------------------------------------------------------------------------- #
 # GET /works/{slug}/witnesses
 # --------------------------------------------------------------------------- #
 

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import axios from "axios";
 import type { AxiosError, InternalAxiosRequestConfig, AxiosResponse } from "axios";
 import { useAuthStore } from "../stores/authStore";
@@ -178,5 +178,24 @@ describe("axios 实例配置", () => {
   it("超时设置为 15 秒", async () => {
     const clientModule = await import("./client");
     expect(clientModule.default.defaults.timeout).toBe(15000);
+  });
+});
+
+describe("getWorkByText", () => {
+  it("文本未挂作品时后端 404 → 吞掉返回 null", async () => {
+    const { api, getWorkByText } = await import("./client");
+    const spy = vi
+      .spyOn(api, "get")
+      .mockRejectedValueOnce({ isAxiosError: true, response: { status: 404 } });
+    await expect(getWorkByText(123)).resolves.toBeNull();
+    spy.mockRestore();
+  });
+
+  it("非 404 错误照常抛出", async () => {
+    const { api, getWorkByText } = await import("./client");
+    const err = { isAxiosError: true, response: { status: 500 } };
+    const spy = vi.spyOn(api, "get").mockRejectedValueOnce(err);
+    await expect(getWorkByText(123)).rejects.toBe(err);
+    spy.mockRestore();
   });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1767,3 +1767,44 @@ export async function getTextVersions(textId: number): Promise<TextVersionsRespo
   const { data } = await api.get<TextVersionsResponse>(`/texts/${textId}/versions`);
   return data;
 }
+
+// --- Work spine (FRBR Work witnesses) ---
+
+/** 单个见证本（同一 FRBR Work 下的某一具体文本，可能跨语言/跨藏经）。 */
+export interface WorkWitnessInfo {
+  // 后端在 Work 接口返回纯数字 text_id，故不品牌化。
+  text_id: number;
+  cbeta_id: string;
+  title: string | null;
+  lang: string;
+  canon: string | null;
+  role: string;
+  confidence: string;
+  has_content: boolean;
+}
+
+/** GET /api/works/by-text/{text_id} 的响应：当前文本所属的 Work 及其全部见证本。 */
+export interface WorkByText {
+  slug: string;
+  title_primary: string;
+  title_sa: string | null;
+  witness_count: number;
+  witnesses: WorkWitnessInfo[];
+}
+
+/**
+ * 取某文本所属 FRBR Work 及其全部见证本（跨语言/跨藏经的同一经的不同版本）。
+ * 文本未挂任何 Work 时后端返回 404 —— 此处吞掉 404 返回 null，调用方据此不渲染。
+ * 其他错误照常抛出。
+ */
+export async function getWorkByText(textId: number): Promise<WorkByText | null> {
+  try {
+    const { data } = await api.get<WorkByText>(`/works/by-text/${textId}`);
+    return data;
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response?.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}

--- a/frontend/src/components/OtherVersions.test.tsx
+++ b/frontend/src/components/OtherVersions.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import OtherVersions from "./OtherVersions";
+import { getWorkByText, type WorkByText, type WorkWitnessInfo } from "../api/client";
+
+// jsdom 不实现 matchMedia，而 antd List 内部用到响应式断点（useBreakpoint）。
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList;
+  }
+});
+
+// mock API client
+vi.mock("../api/client", () => ({
+  getWorkByText: vi.fn(),
+}));
+
+const mockGetWorkByText = vi.mocked(getWorkByText);
+
+function witness(o: Partial<WorkWitnessInfo> = {}): WorkWitnessInfo {
+  return {
+    text_id: 10,
+    cbeta_id: "GRETIL-sdp",
+    title: "Saddharmapuṇḍarīka",
+    lang: "sa",
+    canon: "gretil",
+    role: "root",
+    confidence: "auto",
+    has_content: true,
+    ...o,
+  };
+}
+
+function makeWork(o: Partial<WorkByText> = {}): WorkByText {
+  return {
+    slug: "lotus-sutra",
+    title_primary: "妙法蓮華經",
+    title_sa: "Saddharmapuṇḍarīka",
+    witness_count: 2,
+    witnesses: [],
+    ...o,
+  };
+}
+
+function renderPanel(textId: number) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <OtherVersions textId={textId} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("OtherVersions 其他版本面板", () => {
+  beforeEach(() => {
+    mockGetWorkByText.mockReset();
+  });
+
+  it("接口返回 null（404）时不渲染任何内容", async () => {
+    mockGetWorkByText.mockResolvedValue(null);
+    const { container } = renderPanel(20);
+    await waitFor(() => expect(mockGetWorkByText).toHaveBeenCalledWith(20));
+    expect(container.querySelector(".ant-card")).toBeNull();
+    expect(screen.queryByText(/其他版本/)).toBeNull();
+  });
+
+  it("仅有当前文本一个见证本（无兄弟）时不渲染任何内容", async () => {
+    mockGetWorkByText.mockResolvedValue(
+      makeWork({
+        witness_count: 1,
+        witnesses: [witness({ text_id: 20, role: "translation" })],
+      }),
+    );
+    const { container } = renderPanel(20);
+    await waitFor(() => expect(mockGetWorkByText).toHaveBeenCalledWith(20));
+    expect(container.querySelector(".ant-card")).toBeNull();
+    expect(screen.queryByText(/其他版本/)).toBeNull();
+  });
+
+  it("存在其他见证本时渲染版本列表（标题、阅读链接、语言标签、底本标记）", async () => {
+    mockGetWorkByText.mockResolvedValue(
+      makeWork({
+        witness_count: 2,
+        witnesses: [
+          witness({
+            text_id: 10,
+            cbeta_id: "GRETIL-sdp",
+            title: "Saddharmapuṇḍarīka",
+            lang: "sa",
+            canon: "gretil",
+            role: "root",
+            has_content: true,
+          }),
+          witness({
+            text_id: 20,
+            cbeta_id: "T0262",
+            title: "妙法蓮華經",
+            lang: "lzh",
+            canon: "taisho",
+            role: "translation",
+            has_content: true,
+          }),
+        ],
+      }),
+    );
+
+    // 当前文本是 text_id=20，所以只应展示 text_id=10 这个兄弟见证本
+    renderPanel(20);
+
+    await waitFor(() =>
+      expect(screen.getByText("Saddharmapuṇḍarīka")).toBeInTheDocument(),
+    );
+
+    // 标题区显示见证本数量
+    expect(screen.getByText(/其他版本 · 2 个见证本/)).toBeInTheDocument();
+
+    // 当前文本（妙法蓮華經, T0262）不应出现在兄弟列表中
+    expect(screen.queryByText("妙法蓮華經")).toBeNull();
+    expect(screen.queryByText("T0262")).toBeNull();
+
+    // 兄弟见证本链接到阅读页（has_content=true → /read）
+    const link = screen.getByText("Saddharmapuṇḍarīka").closest("a");
+    expect(link).toHaveAttribute("href", "/texts/10/read");
+
+    // 语言标签映射为中文（sa → 梵文）
+    expect(screen.getByText("梵文")).toBeInTheDocument();
+    // 藏经标签（gretil → GRETIL）
+    expect(screen.getByText("GRETIL")).toBeInTheDocument();
+    // CBETA 编号
+    expect(screen.getByText("GRETIL-sdp")).toBeInTheDocument();
+    // root 角色标记「底本」
+    expect(screen.getByText("底本")).toBeInTheDocument();
+  });
+
+  it("无内容的见证本链接到详情页而非阅读页", async () => {
+    mockGetWorkByText.mockResolvedValue(
+      makeWork({
+        witness_count: 2,
+        witnesses: [
+          witness({
+            text_id: 30,
+            cbeta_id: "T0263",
+            title: "正法華經",
+            lang: "lzh",
+            canon: "taisho",
+            role: "translation",
+            has_content: false,
+          }),
+        ],
+      }),
+    );
+
+    renderPanel(20);
+
+    await waitFor(() =>
+      expect(screen.getByText("正法華經")).toBeInTheDocument(),
+    );
+
+    const link = screen.getByText("正法華經").closest("a");
+    expect(link).toHaveAttribute("href", "/texts/30");
+    // 中文语言标签
+    expect(screen.getByText("中文")).toBeInTheDocument();
+    expect(screen.getByText("大正藏")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/OtherVersions.tsx
+++ b/frontend/src/components/OtherVersions.tsx
@@ -1,0 +1,107 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, List, Tag, Typography } from "antd";
+import { SwapOutlined } from "@ant-design/icons";
+import { Link } from "react-router-dom";
+import { getWorkByText, type WorkWitnessInfo } from "../api/client";
+
+const { Text } = Typography;
+
+/** lang code → 中文标签 */
+const LANG_LABELS: Record<string, string> = {
+  lzh: "中文",
+  zh: "中文",
+  pi: "巴利",
+  pli: "巴利",
+  sa: "梵文",
+  san: "梵文",
+  bo: "藏文",
+  tib: "藏文",
+  en: "英文",
+};
+
+/** canon code → 中文藏经名（仅常见者，未知则原样不展示） */
+const CANON_LABELS: Record<string, string> = {
+  taisho: "大正藏",
+  xuzangjing: "卍續藏",
+  xuzang: "卍續藏",
+  pali: "巴利",
+  kangyur: "甘珠爾",
+  gretil: "GRETIL",
+};
+
+function langLabel(lang: string): string {
+  return LANG_LABELS[lang] || lang;
+}
+
+function canonLabel(canon: string | null | undefined): string | null {
+  if (!canon) return null;
+  return CANON_LABELS[canon] || null;
+}
+
+function witnessHref(w: WorkWitnessInfo): string {
+  return w.has_content ? `/texts/${w.text_id}/read` : `/texts/${w.text_id}`;
+}
+
+/**
+ * 「其他版本 / 对照本」面板：展示当前文本所属 FRBR Work 下、除自身以外的
+ * 全部见证本（跨语言/跨藏经的同一经的不同版本），各自链向其阅读页。
+ *
+ * 不渲染的情况：加载中 / 无数据 / 接口 404（null）/ 仅有自身一个见证本。
+ */
+export default function OtherVersions({ textId }: { textId: number }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["work-by-text", textId],
+    queryFn: () => getWorkByText(textId),
+    enabled: !!textId,
+  });
+
+  if (isLoading) return null;
+  if (!data) return null;
+
+  const siblings = data.witnesses.filter((w) => w.text_id !== textId);
+  if (siblings.length === 0) return null;
+
+  return (
+    <Card
+      title={
+        <span>
+          <SwapOutlined /> 其他版本 · {data.witness_count} 个见证本
+        </span>
+      }
+      size="small"
+    >
+      <List
+        size="small"
+        dataSource={siblings}
+        rowKey={(w) => String(w.text_id)}
+        renderItem={(w) => {
+          const lang = langLabel(w.lang);
+          const canon = canonLabel(w.canon);
+          return (
+            <List.Item>
+              <List.Item.Meta
+                title={
+                  <Link to={witnessHref(w)} style={{ fontWeight: 500 }}>
+                    {w.title || w.cbeta_id}
+                    {w.role === "root" && (
+                      <Tag color="gold" style={{ marginLeft: 8 }}>
+                        底本
+                      </Tag>
+                    )}
+                  </Link>
+                }
+                description={
+                  <Text type="secondary">
+                    <Tag color="blue">{lang}</Tag>
+                    {canon && <Tag>{canon}</Tag>}
+                    {w.cbeta_id}
+                  </Text>
+                }
+              />
+            </List.Item>
+          );
+        }}
+      />
+    </Card>
+  );
+}

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -22,6 +22,7 @@ import { getTextDetail } from "../api/client";
 import { buildCbetaReadUrl } from "../utils/sourceUrls";
 import BookmarkButton from "../components/BookmarkButton";
 import { RelatedTextsStandalone as RelatedTexts } from "../components/RelatedTexts";
+import OtherVersions from "../components/OtherVersions";
 import CitationGenerator from "../components/CitationGenerator";
 import { addViewHistory } from "../utils/history";
 
@@ -208,6 +209,8 @@ export default function TextDetailPage() {
           open={citationOpen}
           onClose={() => setCitationOpen(false)}
         />
+
+        <OtherVersions textId={text.id} />
 
         <RelatedTexts textId={text.id} />
       </Space>


### PR DESCRIPTION
## 目标
把 P1 的 FRBR Work 脊椎**接到用户能看见的层**：看某部经时，显示同一作品的其他版本（跨语言/跨藏经的不同译本），各自链向阅读页。让作品聚合从"后端隐形"变成用户可用。

## 内容
- **后端**：`GET /api/works/by-text/{text_id}` —— 给定经文返回其所属 Work + 全部见证本；抽出共享 `_enriched_witnesses()`（与 `/{slug}/witnesses` 复用，DRY）；文本未挂作品时 404。只读。
- **前端**：`getWorkByText`(404→null) + `<OtherVersions>` 卡片挂到 TextDetailPage —— 单例作品/无兄弟版本时**不渲染**；列见证本（语言/藏经标签、底本 tag、阅读链接）。
- **测试**：后端 4（含 by-text siblings + 404 + getWorkByText 404/rethrow）；前端 4（排除自身、链接、空时不渲染）。

## 验证
- 后端：py_compile/ruff app/ 全过，works 测试 8 passed。
- 前端：tsc 0 错、vitest **83 passed**、build ✓、eslint 未恶化(51)。
- 过 code-reviewer：**Ready to merge，无 Critical/Important**；3 个 Minor（title 可空+回退、List rowKey、getWorkByText 单测）已全部补上。

无迁移、无数据改动——纯只读端点 + UI。部署后端重启 + 前端重建。

🤖 Generated with [Claude Code](https://claude.com/claude-code)