### PR TITLE
feat(works): 统一跨藏 UX — "其他版本"并入阅读器"跨藏对照"面板

### DIFF
--- a/frontend/src/components/OtherVersions.tsx
+++ b/frontend/src/components/OtherVersions.tsx
@@ -69,6 +69,7 @@ export default function OtherVersions({ textId }: { textId: number }) {
         </span>
       }
       size="small"
+      style={{ marginBottom: 12 }}
     >
       <List
         size="small"

--- a/frontend/src/components/ReaderParallelPanel.tsx
+++ b/frontend/src/components/ReaderParallelPanel.tsx
@@ -4,6 +4,7 @@ import { LinkOutlined, BookOutlined, ExpandAltOutlined } from "@ant-design/icons
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { getJuanAlignment, getCanonicalParallels, getFullParallelContent } from "../api/client";
+import OtherVersions from "./OtherVersions";
 
 interface Props {
   textId: number;
@@ -333,15 +334,20 @@ function ChunkView({ textId, juanNum }: Props) {
 }
 
 /**
- * Reader 右侧"多语对读"内联面板（非 modal）。
- *
- * 两个视图：
- *  - 按经对读（默认）：SuttaCentral 权威经级对应，来源 text_relations
+ * Reader 右侧"跨藏对照"统一面板（非 modal）。一处汇聚三种跨藏视角：
+ *  - 其他版本：同一 FRBR Work 的不同译本（Work 脊椎，来源 work_witnesses）
+ *  - 按经对读（默认 tab）：SuttaCentral 权威经级对应，来源 text_relations
  *  - 按段对读（实验）：embedding+LLM 段级对齐，来源 alignment_pairs
+ *
+ * 「其他版本」= 同一部经的不同语言译本（最直接的跨藏入口），无则不渲染；
+ * 「对读」= 相关但不同的经文之间的平行关系。
  */
 export default function ReaderParallelPanel({ textId, juanNum }: Props) {
   return (
     <div className="reader-parallel-panel">
+      <div style={{ padding: "0 12px" }}>
+        <OtherVersions textId={textId} />
+      </div>
       <Tabs
         defaultActiveKey="canonical"
         size="small"

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -608,14 +608,14 @@ export default function TextReaderPage() {
           >
             引用
           </Button>
-          <Tooltip title="多语对读（汉 · 英译 · 梵 · Pāli 原文）">
+          <Tooltip title="跨藏对照（其他版本 · 经级/段级对读）">
             <Button
               size="small"
               type={parallelPanelOpen ? "primary" : "default"}
               icon={<GlobalOutlined />}
               onClick={() => setParallelPanelOpen((v) => !v)}
             >
-              多语对读
+              跨藏对照
             </Button>
           </Tooltip>
           <div className="reader-font-controls">
@@ -756,7 +756,7 @@ export default function TextReaderPage() {
         <div className="reader-ai-divider" onMouseDown={handleParallelDragStart} />
         <div className="reader-ai-sidebar" style={{ width: parallelPanelWidth }}>
           <div className="reader-ai-sidebar-header">
-            <span className="reader-ai-sidebar-title"><GlobalOutlined /> 多语对读</span>
+            <span className="reader-ai-sidebar-title"><GlobalOutlined /> 跨藏对照</span>
             <Button type="text" size="small" onClick={() => setParallelPanelOpen(false)}>✕</Button>
           </div>
           <ReaderParallelPanel textId={textId} juanNum={juanNum} />


### PR DESCRIPTION
## 目标
把两个分散的跨藏功能在阅读器里**打通**：Work 脊椎的"其他版本"(同作品译本) + 已有"多语对读"(SuttaCentral 经级/段级对应)。一处汇聚三种跨藏视角。

## 内容
- 阅读器 `ReaderParallelPanel` 顶部渲染 `<OtherVersions>`(复用已测组件)，下接原"按经对读/按段对读"两 tab。
- 面板/按钮/tooltip 文案 `多语对读` → `跨藏对照`。
- 其他版本卡片加底部间距（reviewer minor）。
- 纯前端组合，零后端/数据改动。

## 验证
- tsc 0 错、vitest 83 passed、build ✓、eslint 改动文件 0。
- 过 code-reviewer：**Ready to merge，无 Critical/Important**；唯一 Minor(间距)已修。
- null 时不渲染（无空隙）；detail/reader 共享 react-query 缓存，无双拉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)