### PR TITLE
feat(works): Work 详情页 /works/:slug — 可分享的全版本视图落地页

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ const PersonPage = lazy(() => import("./pages/PersonPage"));
 const ChatPage = lazy(() => import("./pages/ChatPage"));
 const DictionaryPage = lazy(() => import("./pages/DictionaryPage"));
 const SutraLandingPage = lazy(() => import("./pages/SutraLandingPage"));
+const WorkDetailPage = lazy(() => import("./pages/WorkDetailPage"));
 const ExportsPage = lazy(() => import("./pages/ExportsPage"));
 const CollectionsPage = lazy(() => import("./pages/CollectionsPage"));
 const TopicsPage = lazy(() => import("./pages/TopicsPage"));
@@ -71,6 +72,7 @@ function App() {
             <Route path="/collections" element={<CollectionsPage />} />
             <Route path="/topics" element={<TopicsPage />} />
             <Route path="/sutras/:slug" element={<SutraLandingPage />} />
+            <Route path="/works/:slug" element={<RouteErrorBoundary><WorkDetailPage /></RouteErrorBoundary>} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/dictionary" element={<DictionaryPage />} />
             <Route path="/chat" element={<RouteErrorBoundary><ChatPage /></RouteErrorBoundary>} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1808,3 +1808,32 @@ export async function getWorkByText(textId: number): Promise<WorkByText | null> 
     throw err;
   }
 }
+
+/** GET /api/works/{slug} 的响应：FRBR Work 详情（聚合元数据 + 见证本计数）。 */
+export interface WorkDetail {
+  id: number;
+  slug: string;
+  title_primary: string;
+  title_sa: string | null;
+  title_pi: string | null;
+  sc_root_uid: string | null;
+  toh_number: string | null;
+  category: string | null;
+  note: string | null;
+  created_at: string;
+  witness_count: number;
+}
+
+/** 取作品详情。404 时抛出（由调用方/路由处理）。 */
+export async function getWork(slug: string): Promise<WorkDetail> {
+  const { data } = await api.get<WorkDetail>(`/works/${encodeURIComponent(slug)}`);
+  return data;
+}
+
+/** 取作品的全部见证本（root 优先，已富化标题/内容标志）。 */
+export async function getWorkWitnesses(slug: string): Promise<WorkWitnessInfo[]> {
+  const { data } = await api.get<WorkWitnessInfo[]>(
+    `/works/${encodeURIComponent(slug)}/witnesses`,
+  );
+  return data;
+}

--- a/frontend/src/components/OtherVersions.test.tsx
+++ b/frontend/src/components/OtherVersions.test.tsx
@@ -146,6 +146,10 @@ describe("OtherVersions 其他版本面板", () => {
     expect(screen.getByText("GRETIL-sdp")).toBeInTheDocument();
     // root 角色标记「底本」
     expect(screen.getByText("底本")).toBeInTheDocument();
+
+    // 「查看作品全部版本」链接指向作品详情页 /works/{slug}
+    const worksLink = screen.getByText(/查看作品全部 2 个版本/).closest("a");
+    expect(worksLink).toHaveAttribute("href", "/works/lotus-sutra");
   });
 
   it("无内容的见证本链接到详情页而非阅读页", async () => {

--- a/frontend/src/components/OtherVersions.tsx
+++ b/frontend/src/components/OtherVersions.tsx
@@ -2,45 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, List, Tag, Typography } from "antd";
 import { SwapOutlined } from "@ant-design/icons";
 import { Link } from "react-router-dom";
-import { getWorkByText, type WorkWitnessInfo } from "../api/client";
+import { getWorkByText } from "../api/client";
+import { workLangLabel, workCanonLabel, witnessHref } from "../utils/works";
 
 const { Text } = Typography;
-
-/** lang code → 中文标签 */
-const LANG_LABELS: Record<string, string> = {
-  lzh: "中文",
-  zh: "中文",
-  pi: "巴利",
-  pli: "巴利",
-  sa: "梵文",
-  san: "梵文",
-  bo: "藏文",
-  tib: "藏文",
-  en: "英文",
-};
-
-/** canon code → 中文藏经名（仅常见者，未知则原样不展示） */
-const CANON_LABELS: Record<string, string> = {
-  taisho: "大正藏",
-  xuzangjing: "卍續藏",
-  xuzang: "卍續藏",
-  pali: "巴利",
-  kangyur: "甘珠爾",
-  gretil: "GRETIL",
-};
-
-function langLabel(lang: string): string {
-  return LANG_LABELS[lang] || lang;
-}
-
-function canonLabel(canon: string | null | undefined): string | null {
-  if (!canon) return null;
-  return CANON_LABELS[canon] || null;
-}
-
-function witnessHref(w: WorkWitnessInfo): string {
-  return w.has_content ? `/texts/${w.text_id}/read` : `/texts/${w.text_id}`;
-}
 
 /**
  * 「其他版本 / 对照本」面板：展示当前文本所属 FRBR Work 下、除自身以外的
@@ -76,8 +41,8 @@ export default function OtherVersions({ textId }: { textId: number }) {
         dataSource={siblings}
         rowKey={(w) => String(w.text_id)}
         renderItem={(w) => {
-          const lang = langLabel(w.lang);
-          const canon = canonLabel(w.canon);
+          const lang = workLangLabel(w.lang);
+          const canon = workCanonLabel(w.canon);
           return (
             <List.Item>
               <List.Item.Meta
@@ -103,6 +68,11 @@ export default function OtherVersions({ textId }: { textId: number }) {
           );
         }}
       />
+      <div style={{ textAlign: "right", marginTop: 4 }}>
+        <Link to={`/works/${data.slug}`} style={{ fontSize: 12 }}>
+          查看作品全部 {data.witness_count} 个版本 →
+        </Link>
+      </div>
     </Card>
   );
 }

--- a/frontend/src/pages/WorkDetailPage.test.tsx
+++ b/frontend/src/pages/WorkDetailPage.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import WorkDetailPage from "./WorkDetailPage";
+import {
+  getWork,
+  getWorkWitnesses,
+  type WorkDetail,
+  type WorkWitnessInfo,
+} from "../api/client";
+
+// jsdom 不实现 matchMedia；antd List 内部用到响应式断点。
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList;
+  }
+});
+
+vi.mock("../api/client", () => ({
+  getWork: vi.fn(),
+  getWorkWitnesses: vi.fn(),
+}));
+
+const mockGetWork = vi.mocked(getWork);
+const mockGetWorkWitnesses = vi.mocked(getWorkWitnesses);
+
+function work(o: Partial<WorkDetail> = {}): WorkDetail {
+  return {
+    id: 1,
+    slug: "lotus-sutra",
+    title_primary: "妙法蓮華經",
+    title_sa: "Saddharmapuṇḍarīka",
+    title_pi: null,
+    sc_root_uid: null,
+    toh_number: null,
+    category: null,
+    note: null,
+    created_at: "2026-05-30T00:00:00Z",
+    witness_count: 2,
+    ...o,
+  };
+}
+
+function witness(o: Partial<WorkWitnessInfo> = {}): WorkWitnessInfo {
+  return {
+    text_id: 10,
+    cbeta_id: "GRETIL-sdp",
+    title: "Saddharmapuṇḍarīka",
+    lang: "sa",
+    canon: "gretil",
+    role: "root",
+    confidence: "auto",
+    has_content: true,
+    ...o,
+  };
+}
+
+function renderPage(slug = "lotus-sutra") {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[`/works/${slug}`]}>
+          <Routes>
+            <Route path="/works/:slug" element={<WorkDetailPage />} />
+            <Route path="/404" element={<div>NOT FOUND</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+}
+
+describe("WorkDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("渲染作品标题、梵文别名、见证本列表与阅读链接", async () => {
+    mockGetWork.mockResolvedValue(work());
+    mockGetWorkWitnesses.mockResolvedValue([
+      witness({ text_id: 10, lang: "sa", role: "root", has_content: true }),
+      witness({
+        text_id: 20,
+        cbeta_id: "T0262",
+        title: "妙法蓮華經",
+        lang: "lzh",
+        canon: "taisho",
+        role: "translation",
+        has_content: true,
+      }),
+    ]);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("妙法蓮華經").length).toBeGreaterThan(0),
+    );
+    // 梵文别名 tag（标题区 + 见证本标题各出现，故用 getAllByText）
+    expect(screen.getAllByText(/Saddharmapuṇḍarīka/).length).toBeGreaterThan(0);
+    // 底本标记
+    expect(screen.getByText("底本")).toBeInTheDocument();
+    // 两个版本各有阅读链接，指向阅读器
+    const readLinks = screen
+      .getAllByRole("link")
+      .filter((a) => a.getAttribute("href")?.includes("/read"));
+    expect(readLinks.length).toBeGreaterThanOrEqual(2);
+    expect(
+      readLinks.some((a) => a.getAttribute("href") === "/texts/20/read"),
+    ).toBe(true);
+  });
+
+  it("作品不存在（getWork 报错）时跳转 404", async () => {
+    mockGetWork.mockRejectedValue(new Error("404"));
+    mockGetWorkWitnesses.mockResolvedValue([]);
+
+    renderPage("does-not-exist");
+
+    await waitFor(() =>
+      expect(screen.getByText("NOT FOUND")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/pages/WorkDetailPage.tsx
+++ b/frontend/src/pages/WorkDetailPage.tsx
@@ -1,0 +1,182 @@
+import { useParams, useNavigate, Navigate, Link } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
+import {
+  Typography,
+  Card,
+  List,
+  Tag,
+  Breadcrumb,
+  Spin,
+  Space,
+  Empty,
+} from "antd";
+import {
+  HomeOutlined,
+  SwapOutlined,
+  ReadOutlined,
+  BookOutlined,
+} from "@ant-design/icons";
+import { useQuery } from "@tanstack/react-query";
+import { getWork, getWorkWitnesses } from "../api/client";
+import { workLangLabel, workCanonLabel, witnessHref } from "../utils/works";
+
+const { Title, Text, Paragraph } = Typography;
+
+/**
+ * 作品详情页 /works/:slug —— FRBR Work 的落地页。
+ * 聚合一部作品的全部跨语言 / 跨藏经见证本，各自链向其阅读页。
+ * 这是"作品级全版本视图"的独立可分享 / 可 SEO 入口。
+ */
+export default function WorkDetailPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+
+  const {
+    data: work,
+    isLoading: workLoading,
+    error: workError,
+  } = useQuery({
+    queryKey: ["work", slug],
+    queryFn: () => getWork(slug!),
+    enabled: !!slug,
+    retry: false,
+  });
+
+  const { data: witnesses = [], isLoading: witLoading } = useQuery({
+    queryKey: ["work-witnesses", slug],
+    queryFn: () => getWorkWitnesses(slug!),
+    enabled: !!slug,
+    retry: false,
+  });
+
+  if (workLoading || witLoading) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (workError || !work) {
+    return <Navigate to="/404" replace />;
+  }
+
+  const canonicalUrl = `https://fojin.app/works/${work.slug}`;
+  const altTitles = [work.title_sa, work.title_pi].filter(Boolean) as string[];
+  const langs = [...new Set(witnesses.map((w) => workLangLabel(w.lang)))];
+  const metaDesc =
+    `《${work.title_primary}》的跨语言 / 跨藏经全版本对照` +
+    (altTitles.length ? `（${altTitles.join(" · ")}）` : "") +
+    `，共 ${work.witness_count} 个见证本，涵盖 ${langs.join("、")}。`;
+
+  const schemaBook = {
+    "@context": "https://schema.org",
+    "@type": "Book",
+    name: work.title_primary,
+    alternateName: altTitles,
+    url: canonicalUrl,
+    genre: "Buddhist Scripture",
+    provider: { "@type": "WebSite", name: "佛津 FoJin", url: "https://fojin.app/" },
+  };
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: "24px 16px" }}>
+      <Helmet>
+        <title>{`${work.title_primary} — 全版本对照 | 佛津 FoJin`}</title>
+        <meta name="description" content={metaDesc} />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:type" content="book" />
+        <meta property="og:title" content={`${work.title_primary} — 全版本对照`} />
+        <meta property="og:description" content={metaDesc} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:site_name" content="佛津 FoJin" />
+        <script type="application/ld+json">{JSON.stringify(schemaBook)}</script>
+      </Helmet>
+
+      <Space direction="vertical" size="large" style={{ width: "100%" }}>
+        <Breadcrumb
+          items={[
+            {
+              title: (
+                <span style={{ cursor: "pointer" }} onClick={() => navigate("/")}>
+                  <HomeOutlined /> 首页
+                </span>
+              ),
+            },
+            { title: "作品" },
+            { title: work.title_primary },
+          ]}
+        />
+
+        <div>
+          <Title level={2} style={{ marginBottom: 8 }}>
+            <SwapOutlined style={{ marginRight: 8, color: "#8b6914" }} />
+            {work.title_primary}
+          </Title>
+          <Space size={[8, 8]} wrap>
+            {work.title_sa && <Tag color="purple">梵 {work.title_sa}</Tag>}
+            {work.title_pi && <Tag color="cyan">巴利 {work.title_pi}</Tag>}
+            {work.sc_root_uid && <Tag>SuttaCentral {work.sc_root_uid}</Tag>}
+            {work.toh_number && <Tag>Toh {work.toh_number}</Tag>}
+            <Tag color="gold">{work.witness_count} 个见证本</Tag>
+          </Space>
+          <Paragraph type="secondary" style={{ marginTop: 12 }}>
+            本作品聚合了跨语言 / 跨藏经的不同译本与见证本。点击任一版本即可阅读，
+            或在阅读器内使用「跨藏对照」逐经 / 逐段对读。
+          </Paragraph>
+        </div>
+
+        <Card title="全部版本" size="small">
+          {witnesses.length === 0 ? (
+            <Empty description="暂无见证本" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+          ) : (
+            <List
+              dataSource={witnesses}
+              rowKey={(w) => String(w.text_id)}
+              renderItem={(w) => {
+                const canon = workCanonLabel(w.canon);
+                return (
+                  <List.Item
+                    actions={[
+                      <Link key="read" to={witnessHref(w)}>
+                        {w.has_content ? (
+                          <>
+                            <ReadOutlined /> 阅读
+                          </>
+                        ) : (
+                          <>
+                            <BookOutlined /> 详情
+                          </>
+                        )}
+                      </Link>,
+                    ]}
+                  >
+                    <List.Item.Meta
+                      title={
+                        <Link to={witnessHref(w)} style={{ fontWeight: 500 }}>
+                          {w.title || w.cbeta_id}
+                          {w.role === "root" && (
+                            <Tag color="gold" style={{ marginLeft: 8 }}>
+                              底本
+                            </Tag>
+                          )}
+                        </Link>
+                      }
+                      description={
+                        <Text type="secondary">
+                          <Tag color="blue">{workLangLabel(w.lang)}</Tag>
+                          {canon && <Tag>{canon}</Tag>}
+                          {w.cbeta_id}
+                        </Text>
+                      }
+                    />
+                  </List.Item>
+                );
+              }}
+            />
+          )}
+        </Card>
+      </Space>
+    </div>
+  );
+}

--- a/frontend/src/utils/works.ts
+++ b/frontend/src/utils/works.ts
@@ -1,0 +1,38 @@
+import type { WorkWitnessInfo } from "../api/client";
+
+/** 见证本语言 code → 中文标签 */
+export const WORK_LANG_LABELS: Record<string, string> = {
+  lzh: "中文",
+  zh: "中文",
+  pi: "巴利",
+  pli: "巴利",
+  sa: "梵文",
+  san: "梵文",
+  bo: "藏文",
+  tib: "藏文",
+  en: "英文",
+};
+
+/** 见证本藏经 code → 中文藏经名（仅常见者，未知返回 null 不展示） */
+export const WORK_CANON_LABELS: Record<string, string> = {
+  taisho: "大正藏",
+  xuzangjing: "卍續藏",
+  xuzang: "卍續藏",
+  pali: "巴利",
+  kangyur: "甘珠爾",
+  gretil: "GRETIL",
+};
+
+export function workLangLabel(lang: string): string {
+  return WORK_LANG_LABELS[lang] || lang;
+}
+
+export function workCanonLabel(canon: string | null | undefined): string | null {
+  if (!canon) return null;
+  return WORK_CANON_LABELS[canon] || null;
+}
+
+/** 见证本的阅读链接：有正文进阅读器，否则进详情页。 */
+export function witnessHref(w: Pick<WorkWitnessInfo, "text_id" | "has_content">): string {
+  return w.has_content ? `/texts/${w.text_id}/read` : `/texts/${w.text_id}`;
+}


### PR DESCRIPTION
## 目标
给每个 FRBR Work 一个**独立页面**：聚合一部经的全部跨语言/跨藏经见证本，可分享、可 SEO。形成闭环 **阅读页 →「其他版本」→ 作品页 → 各版本阅读页**。

## 内容
- **前端**：`getWork`/`getWorkWitnesses` client；`WorkDetailPage`（标题 + 梵/巴利别名 + SC/Toh 号 + 见证本列表带阅读链接 + Helmet SEO/JSON-LD Book）；路由 `/works/:slug`。
- `OtherVersions` 卡片加「查看作品全部 N 个版本 →」链到 `/works/{slug}`。
- 抽 `utils/works.ts`（lang/canon 标签 + witnessHref，OtherVersions 与新页共用）。
- **测试**：WorkDetailPage 2（渲染 + 404 跳转）；OtherVersions 补 /works 链接断言。

## 验证
- tsc 0、vitest **85 passed**、build ✓、eslint 未恶化(51)、新文件 0 警告。
- 过 code-reviewer：**Ready to merge，无 Critical/Important**；其建议的 OtherVersions /works 链接测试已补。

无后端/数据改动（复用现有 `/works/{slug}` + `/witnesses`）。纯前端，部署仅重建 frontend。

🤖 Generated with [Claude Code](https://claude.com/claude-code)