### PR TITLE
fix(sources): retire 2 defunct sources + honest single-vantage health badge

### DIFF
--- a/backend/alembic/versions/0146_retire_defunct_sources.py
+++ b/backend/alembic/versions/0146_retire_defunct_sources.py
@@ -1,0 +1,59 @@
+"""Retire two defunct sources confirmed dead by the 2026-06-01 source audit.
+
+Verified by independent browser-UA probes from two vantages (a residential
+egress AND the in-VPS cron's Singapore egress) plus a web search for a current
+URL — not the single-vantage cron alone, which over-reports unreachable for
+live sites that block datacenter IPs.
+
+DEFUNCT — retired via is_active=false (row kept; re-addable later if a stable
+public URL appears):
+
+  hdcg-wenyuan   wenyuan.aliyun.com   (汉典重光 / 阿里达摩院海外古籍数字化平台)
+                 The 2021 research project was officially wound down; the host
+                 now returns 404 at every path. A successor exists in spirit —
+                 识典古籍 (北大 + 字节跳动) — but at a different project/URL, so
+                 it is a separate "add source" decision, not a URL repoint.
+
+  t1index-dila   dev.dila.edu.tw/t1index/  (长阿含经注解索引数据库)
+                 Lives only on DILA's *dev* subdomain, which fails the TLS
+                 handshake from every vantage. A curated directory should not
+                 link a staging host; retired pending a confirmed production
+                 URL (then re-add under the usual "add sources" migration).
+
+Mirrors migration 0144's idiom: is_active (editorial removal) and health_status
+(cron reachability) stay independent — this migration only flips is_active.
+
+Revision ID: 0146
+Revises: 0145
+Create Date: 2026-06-01
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0146"
+down_revision = "0145"
+branch_labels = None
+depends_on = None
+
+# Domains confirmed defunct / staging-only — retired from the public catalog.
+DEFUNCT_SOURCES = (
+    "hdcg-wenyuan",
+    "t1index-dila",
+)
+
+
+def _set_active(active: bool) -> None:
+    # Fixed ASCII slugs — safe to inline so the statement renders under
+    # `alembic --sql` offline mode (a bound IN-list does not).
+    codes = ", ".join(f"'{c}'" for c in DEFUNCT_SOURCES)
+    value = "true" if active else "false"
+    op.execute(text(f"UPDATE data_sources SET is_active = {value} WHERE code IN ({codes})"))
+
+
+def upgrade() -> None:
+    _set_active(False)
+
+
+def downgrade() -> None:
+    _set_active(True)

--- a/frontend/src/pages/sources/SourceCard.test.tsx
+++ b/frontend/src/pages/sources/SourceCard.test.tsx
@@ -46,7 +46,7 @@ function renderCard(source: DataSource) {
 describe("SourceCard 健康徽章 tooltip", () => {
   it("ok 源不显示健康徽章", () => {
     renderCard(makeSource());
-    expect(screen.queryByText("暂无法访问")).not.toBeInTheDocument();
+    expect(screen.queryByText("巡检未达")).not.toBeInTheDocument();
     expect(screen.queryByText("访问受限")).not.toBeInTheDocument();
   });
 
@@ -83,11 +83,11 @@ describe("SourceCard 健康徽章 tooltip", () => {
     renderCard(
       makeSource({ health_status: "unreachable", health_detail: null }),
     );
-    await user.hover(screen.getByText("暂无法访问"));
+    await user.hover(screen.getByText("巡检未达"));
     // 通用 tip 仍在，但不应出现「详情：」前缀。
     // 注：此断言依赖 HEALTH_BADGE 各 tip 文案均不含「详情：」子串——
     // 若日后某 tip 引入该词，需改为对 tooltip 容器作用域断言。
-    expect(await screen.findByText(/连接超时或被拒绝/)).toBeInTheDocument();
+    expect(await screen.findByText(/浏览器通常仍可正常访问/)).toBeInTheDocument();
     expect(screen.queryByText(/详情：/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -34,9 +34,9 @@ const HEALTH_BADGE: Record<
     tip: "原站 HTTPS 证书校验失败，浏览器访问时可能弹出安全警告。",
   },
   unreachable: {
-    label: "暂无法访问",
-    color: "red",
-    tip: "最近一次巡检时原站连接超时或被拒绝，可能为临时故障。",
+    label: "巡检未达",
+    color: "default",
+    tip: "本站自动巡检从单一服务器未能连接该源——多为数据中心 IP 被目标站限制或临时网络问题，你的浏览器通常仍可正常访问。长期持续不可达的源会被定期复核、必要时下架。",
   },
   moved: {
     label: "站点已迁移",


### PR DESCRIPTION
## What

Two source-quality fixes from the 2026-06-01 data-source audit (614 sources, dual-vantage browser-UA probing).

### 1. Retire 2 confirmed-defunct sources (migration 0146)
- **hdcg-wenyuan** (汉典重光): the 2021 Aliyun/达摩院 research project was wound down; `wenyuan.aliyun.com` now 404s at every path (confirmed via web search + dual-vantage probe).
- **t1index-dila**: lives only on DILA's `dev.` subdomain, which fails the TLS handshake from every vantage — a curated directory shouldn't link a staging host.
- Both via `is_active=false` (row kept, reversible), mirroring migration 0144's idiom. Chain: 0145 → **0146**.

### 2. Honest "unreachable" badge
The cron probes from a single sg-vps (Singapore) vantage. The audit found this over-reports unreachable: live institutional sites (Bodleian, Princeton, OPenn, pali-hub, …) that block datacenter IPs were getting a red 「暂无法访问」 badge though they load fine in a browser. Softened to neutral 「巡检未达」 with an honest tip (datacenter-IP limit / transient; browser usually still works; long-dead sources get periodically re-reviewed). Test updated.

## Audit conclusion (why this PR is small)
Of 614 sources, **~0 are truly dead** — the 40 "unhealthy" are mostly a single-vantage measurement artifact, and the multi-entry families (CBETA×7, DILA×11, CDSL×7) are **distinct tools, not duplicates** (deleting them would be wrong). So the genuine cleanup is tiny: 2 defunct sources + making the misleading badge honest.

## Verify
Migration is data-only (is_active flip), reversible. Frontend: 4 SourceCard tests pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)