### PR TITLE
docs: correct deepseek-v4-pro price comments (75% off made permanent)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ LLM_API_KEY=sk-your-llm-api-key
 LLM_API_URL=https://api.deepseek.com/v1
 # Model selection (uncomment to override the gpt-4o-mini default in config.py)
 #   deepseek-v4-flash : fast tier, $0.28/1M output  (replaces legacy deepseek-chat)
-#   deepseek-v4-pro   : pro tier,  $0.87/1M output  (75% promo until 2026-05-31; post-promo $3.48/1M)
+#   deepseek-v4-pro   : pro tier,  $0.87/1M output  (75% off made permanent 2026-05-23 — now the standard rate, no rollback)
 # LLM_MODEL=deepseek-v4-pro
 
 # Embedding

--- a/backend/scripts/archive/misc/build_alignments.py
+++ b/backend/scripts/archive/misc/build_alignments.py
@@ -83,7 +83,7 @@ LLM_PRICE_PER_1K = {
     "deepseek-chat": 0.00028,         # legacy alias → deepseek-v4-flash (non-thinking)
     "deepseek-reasoner": 0.0014,      # legacy alias → deepseek-v4-flash (thinking)
     "deepseek-v4-flash": 0.00028,     # output $0.28/1M tokens
-    "deepseek-v4-pro": 0.00087,       # output $0.87/1M @ 75% promo until 2026-05-31 15:59 UTC; post-promo $3.48/1M (4×) — REVISIT BEFORE 2026-05-31
+    "deepseek-v4-pro": 0.00087,       # output $0.87/1M (75% off made permanent 2026-05-23 — now the standard rate, no rollback)
 }
 DEFAULT_PRICE_PER_1K = 0.0008    # unknown model → use Haiku estimate
 


### PR DESCRIPTION
## What

Two code comments warned that deepseek-v4-pro pricing would 4× after the 75% promo expired 2026-05-31. That **did not happen** — DeepSeek made the 75% discount **permanent** on 2026-05-23. The [official pricing page](https://api-docs.deepseek.com/quick_start/pricing) states the post-promo rate is "1/4 of the original price" = $0.435 input / $0.87 output, identical to the promo rate.

## Changes (comment-only, no runtime impact)

- `.env.example` — drop "post-promo $3.48/1M" warning
- `backend/scripts/archive/misc/build_alignments.py` — drop "(4×) — REVISIT BEFORE 2026-05-31" from the cost map

v4-pro stays at $0.87/1M output permanently; no config change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)