### PR TITLE
fix(parser): exclude front-matter preface (cb:div type="xu") from juan content

### DIFF
--- a/backend/app/core/xml_parser.py
+++ b/backend/app/core/xml_parser.py
@@ -176,6 +176,7 @@ def parse_tei_xml(xml_path: str | Path) -> list[dict]:
     juans: list[dict] = []
     current_juan = 1
     current_lines: list[str] = []
+    preface_lines: list[str] = []  # sidelined <cb:div type="xu"> paratext
 
     def flush_juan():
         nonlocal current_lines
@@ -191,7 +192,7 @@ def parse_tei_xml(xml_path: str | Path) -> list[dict]:
         current_lines = []
 
     def process_element(elem):
-        nonlocal current_juan, current_lines
+        nonlocal current_juan, current_lines, preface_lines
 
         tag = elem.tag
 
@@ -256,6 +257,20 @@ def parse_tei_xml(xml_path: str | Path) -> list[dict]:
                 process_element(child)
             return
 
+        # Sideline front-matter preface divs (序 / type="xu"). These are paratext
+        # — e.g. the imperial 御製序 prepended to short sutras like 心經 (T0251) —
+        # which would otherwise fold into juan 1, bury the scripture body, and
+        # cripple RAG recall of the root text. Captured separately (not into
+        # current_lines) so it is excluded from the scripture body, yet still
+        # available as a fallback below if a work has NO other content (some
+        # CBETA fragments are preface-only) — never silently emptied.
+        # Deliberately narrow: only type="xu", not a general front-matter filter.
+        if tag == f"{{{CB_NS}}}div" and elem.get("type") == "xu":
+            preface_text = _extract_text(elem).strip()
+            if preface_text:
+                preface_lines.append(preface_text)
+            return
+
         # For div/cb:div and other container elements, recurse
         if tag in (f"{{{TEI_NS}}}div", f"{{{CB_NS}}}div",
                    f"{{{TEI_NS}}}body", f"{{{TEI_NS}}}text",
@@ -274,6 +289,18 @@ def parse_tei_xml(xml_path: str | Path) -> list[dict]:
     # If no juans were found but there is content, treat everything as juan 1
     if not juans and current_lines:
         text = "\n".join(line for line in current_lines if line.strip()).strip()
+        if text:
+            juans.append({
+                "juan_num": 1,
+                "content": text,
+                "char_count": len(text.replace("\n", "").replace(" ", "")),
+            })
+
+    # Last resort: a preface-only work (no scripture body at all). Emit the
+    # sidelined paratext rather than returning [] — which import_work would
+    # silently skip, leaving the work with has_content=False and unindexed.
+    if not juans and preface_lines:
+        text = "\n".join(preface_lines).strip()
         if text:
             juans.append({
                 "juan_num": 1,

--- a/backend/tests/test_xml_parser.py
+++ b/backend/tests/test_xml_parser.py
@@ -23,6 +23,30 @@ CATALOG_XML = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
+# Short sutra (T0251 心經) with a prepended imperial preface in a <cb:div type="xu">.
+# The 御製序 sits BEFORE the <cb:juan>; the actual scripture is in <cb:div type="jing">.
+# Old parser merged the preface into juan 1, burying the sutra body (觀自在…) and
+# wrecking RAG recall for the most-cited sutra. The preface must be excluded.
+PREFACE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:cb="http://www.cbeta.org/ns/1.0">
+<teiHeader><fileDesc><titleStmt><title>x</title></titleStmt>
+<publicationStmt><p>x</p></publicationStmt>
+<sourceDesc><bibl>x</bibl></sourceDesc></fileDesc></teiHeader>
+<text><body>
+<cb:div type="xu"><cb:mulu level="1" type="序">大明太祖高皇帝御製序</cb:mulu><head>大明太祖高皇帝御製般若心經序</head>
+<p>二儀久判，萬物備周，子民者君君。</p>
+<p>斯空相，前代帝王被所惑而幾喪天下者。</p>
+</cb:div>
+<cb:juan fun="open" n="001"><cb:jhead>般若波羅蜜多心經</cb:jhead></cb:juan>
+<cb:div type="jing">
+<p>觀自在菩薩行深般若波羅蜜多時，照見五蘊皆空，度一切苦厄。</p>
+<p>色不異空，空不異色，色即是空，空即是色。</p>
+</cb:div>
+<cb:juan n="001" fun="close"/>
+</body></text></TEI>
+"""
+
+
 PARAGRAPH_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:cb="http://www.cbeta.org/ns/1.0">
 <teiHeader><fileDesc><titleStmt><title>x</title></titleStmt>
@@ -60,6 +84,49 @@ def test_catalog_items_are_extracted(tmp_path):
     # Pre-fix: char_count was 32 (byline + trailing <p> only).
     # After fix: 3 titles add ~22 chars on top.
     assert juans[0]["char_count"] >= 48
+
+
+def test_preface_xu_div_is_excluded(tmp_path):
+    """Imperial/front-matter prefaces (<cb:div type="xu">) are paratext, not
+    scripture. They must NOT be folded into the sutra body — otherwise a short
+    sutra like 心經 (T0251) gets its 御製序 ranked as 'the text', and the real
+    body never surfaces in retrieval.
+    """
+    juans = parse_tei_xml(_write(tmp_path, PREFACE_XML))
+    assert len(juans) == 1
+    content = juans[0]["content"]
+    # Scripture body is kept …
+    assert "觀自在菩薩行深般若波羅蜜多時" in content
+    assert "色即是空" in content
+    # … and the preface is gone.
+    assert "御製" not in content
+    assert "大明太祖" not in content
+    assert "二儀久判" not in content
+    # Body leads the content (no preface prefix burying it).
+    assert content.lstrip().startswith("般若波羅蜜多心經") or content.lstrip().startswith("觀自在菩薩")
+
+
+PREFACE_ONLY_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:cb="http://www.cbeta.org/ns/1.0">
+<teiHeader><fileDesc><titleStmt><title>x</title></titleStmt>
+<publicationStmt><p>x</p></publicationStmt>
+<sourceDesc><bibl>x</bibl></sourceDesc></fileDesc></teiHeader>
+<text><body>
+<cb:div type="xu"><head>某經御製序</head>
+<p>此序乃全文，別無正文。</p>
+</cb:div>
+</body></text></TEI>
+"""
+
+
+def test_preface_only_work_not_silently_emptied(tmp_path):
+    """A work whose ONLY content is a <cb:div type="xu"> must still yield content.
+    Returning [] would make import_work skip it silently (has_content stays
+    False, nothing indexed). Fall back to the preface as juan 1.
+    """
+    juans = parse_tei_xml(_write(tmp_path, PREFACE_ONLY_XML))
+    assert len(juans) == 1
+    assert "此序乃全文" in juans[0]["content"]
 
 
 def test_paragraphs_still_extracted(tmp_path):


### PR DESCRIPTION
## Problem

The most-cited sutra in the corpus, **T0251 般若波羅蜜多心經 (Heart Sutra)**, was unretrievable. A diagnostic on prod showed that for a query like "心经的核心思想是什么", the vector top-15 candidates were **100% commentaries** — the root sutra never appeared, so /chat grounded its answer on 注疏 and the citation guard flagged the LLM's correct citation of the root text as "unverified."

Root cause (confirmed on real `T08n0251.xml`): CBETA TEI puts paratext like the Ming imperial preface 大明太祖高皇帝御製序 in `<cb:div type="xu">`, positioned **before** `<cb:juan>`. `parse_tei_xml` recursed into every `cb:div` regardless of `type`, so the preface folded into juan 1 ahead of the scripture. T0251 came out **1282 chars** with the first ~1000 being the preface and the actual 觀自在菩薩… body buried at offset 1004.

## Fix

Sideline `cb:div[@type="xu"]` into a separate preface accumulator instead of folding it into the body. T0251 now parses to **351 clean chars** starting with title + 觀自在菩薩… body.

A preface-only work (no scripture body) falls back to emitting the paratext as juan 1, so it is **never silently dropped** — `import_work` skips works that parse to zero juans (this defends the edge case raised in review).

## Scope / blast radius

- Parser change only; existing DB data is unchanged until texts are re-imported (separate ops step — I'll re-import the 4 materially-polluted short sutras + re-embed after merge).
- 65 texts carry an imperial preface, but only **4 short ones** were materially polluted (preface dominated); long texts had 1 negligible preface chunk among many.
- Deliberately narrow: only `type="xu"`, not a general front-matter filter.

## Tests

`test_preface_xu_div_is_excluded` (preface gone, body leads), `test_preface_only_work_not_silently_emptied` (fallback), plus existing catalog/paragraph regressions — **4 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)