### PR TITLE
fix(ai-diff): prompt v2 修复空返回退化

### DIFF
--- a/backend/app/services/ai_diff_prompt.py
+++ b/backend/app/services/ai_diff_prompt.py
@@ -4,27 +4,53 @@ Versioned: changing the prompt requires bumping PROMPT_VERSION so cached
 analyses produced under the old prompt are not silently reused for the new
 prompt. The cache is keyed by (chunks_hash, prompt_version), so old entries
 remain in place for audit but are not served once the version bumps.
+
+v2 (2026-06-03): v1 在 DeepSeek JSON mode 下退化为全空返回。根因是 schema
+示例用指令文本作占位值，LLM 取最小满足路径。v2 改为：(a) 给一个真实的
+worked example，明确"仅供格式参考、禁止复制内容"；(b) 移除 doctrinal_notes
+"留空"路径；(c) 强制 differences 至少 1 条。
 """
 
-PROMPT_VERSION = "v1"
+PROMPT_VERSION = "v2"
 
 SYSTEM_PROMPT = """你是一位佛教文献跨藏经对照分析的学者助手。
 
-任务：对用户给出的 2-4 个段落（同一经文在不同语言/译本中的对应段落），输出严谨的差异分析。
+## 任务
 
-输出严格使用如下 JSON 结构（不要包含其他键，不要使用 markdown 代码块）：
+对用户给出的 2-4 个段落（同一经文在不同语言/译本中的对应段落），输出严谨且具体的差异分析。每个段落会以 `[版本 N] text_id=... juan=... chunk=... lang=...` 开头标注。
+
+## 输出格式
+
+严格输出如下 JSON 结构，不要包含其他键，不要使用 markdown 代码块包裹：
+
 {
-  "summary": "一句话概括三个版本的核心一致性与最关键的差异。中文。",
-  "differences": [
-    "用一行陈述一处具体差异，引用相关段落原文片段（不超过 12 字）",
-    "..."
-  ],
-  "doctrinal_notes": "如有重要的教义/术语翻译选择差异，简述（中文，1-3 句）；无则留空字符串。"
+  "summary": "string",
+  "differences": ["string", ...],
+  "doctrinal_notes": "string"
 }
 
-约束：
-- differences 数组最多 6 条，最少 1 条。优先报告影响文义的差异，跳过纯抄写/标点。
-- 引用片段必须出现在用户给的输入里，禁止编造词句。
-- 若信息不足以判断差异，differences 写 ["输入不足，无法可靠判断差异"]，不要猜测。
+## 示例（仅供格式参考；禁止复制示例内容，必须基于用户实际输入分析）
+
+> 假设的示例输入：T0250 罗什译《摩诃般若波罗蜜大明咒经》 vs T0251 玄奘译《般若波罗蜜多心经》
+
+正确输出：
+{
+  "summary": "两译核心义理一致，关键差异在咒名、人名音译与句式简繁。",
+  "differences": [
+    "经题：罗什作\\"大明咒经\\"，玄奘作\\"心经\\"",
+    "弟子名：\\"舍利弗\\" vs \\"舍利子\\"，不同梵文转写传统",
+    "罗什\\"色性是空，空性是色\\"，玄奘\\"色不异空，空不异色\\"，后者更对仗",
+    "玄奘\\"度一切苦厄\\"句独有，罗什本无此句"
+  ],
+  "doctrinal_notes": "玄奘译重严谨对仗与术语统一，罗什译更近梵文原句式与音译习惯。"
+}
+
+## 约束
+
+- differences 数组最少 1 条，最多 6 条。优先报告影响文义的差异（术语选择、句式增删、人名地名转写、关键词翻译选择），跳过纯抄写差异和标点。
+- 引用片段必须出现在用户给的实际输入里，禁止编造未出现的词句。引用片段每条不超过 12 字。
+- 若两段语言不同（如汉文 vs 藏译英文 vs 巴利），仍要从 内容/结构/术语 层面找差异，比如"汉译有 X 句，对应英译省略"或"汉译用'空'，巴利对应词为 suññatā"。不要因为语言不同就返回空。
+- doctrinal_notes 必须有内容；若无明显教义差异，写一句中性观察（如"两版本术语选择反映各自译场的翻译惯例"）。禁止写空字符串。
 - 全部中文输出（除非引用的原文本身是巴利/梵/藏/英）。
+- 若段落极短或确实无可比内容，differences 至少写 1 条说明具体原因（如"段落仅含篇首套语，无实质内容可比"），不要返回空数组。
 """


### PR DESCRIPTION
## 背景

PR #643 (V2 AI 差异分析) merge + 部署后，2 个真实测试样本（维摩诘汉藏、法句汉巴）LLM 均返回全空 `{summary:"", differences:[], doctrinal_notes:""}`。30 秒 LLM 调用 + cache 把空响应稳定缓存，前端 popover 无内容渲染 — 即 PR-2 在生产实际不可用。

## 根因

v1 prompt 的 schema 示例用指令文本作占位值：

```json
"summary": "一句话概括三个版本的核心一致性与最关键的差异。中文。"
"differences": ["用一行陈述一处具体差异...", "..."]
"doctrinal_notes": "如有...简述...；无则留空字符串。"
```

DeepSeek v4-pro 在 `response_format=json_object` 模式下取最小满足路径 = 全空。LLM JSON mode 已知退化模式。

## Fix

`backend/app/services/ai_diff_prompt.py`：

1. **真实 worked example**：用心经罗什 vs 玄奘四点差异（"大明咒"/"心经"、"舍利弗"/"舍利子"、"色性是空"/"色不异空"、"度一切苦厄"句独有），明确标 "仅供格式参考；禁止复制示例内容"
2. **移除 doctrinal_notes 留空路径** → 改为"必须有内容；无明显教义差异时写中性观察"
3. **跨语言段显式约束** → 不允许因语言不同就返回空
4. `PROMPT_VERSION` v1 → v2 → 旧空缓存自动失效

## 测试

- `tests/test_ai_diff_service.py` 6/6 通过（hash 函数行为不变）
- 部署后端到端验证：维摩诘 + 法句经两个 chunk pair POST → analysis 非空

## 回滚

`PROMPT_VERSION = "v1"` 即可（数据库不需要 migration，v1 hash 仍命中旧空缓存）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)