### PR TITLE
fix(ai-diff): use deepseek-chat (v4-pro is reasoning model, eats budget)

### DIFF
--- a/backend/app/services/ai_diff.py
+++ b/backend/app/services/ai_diff.py
@@ -83,8 +83,17 @@ async def get_or_create_diff(
 
 
 def _resolve_model() -> str:
-    """Server-side default model — same source as chat fallback path."""
-    return getattr(settings, "llm_default_model", None) or "deepseek-v4-pro"
+    """AI diff 的 model 决策 — 独立于 /chat 路径。
+
+    deepseek-v4-pro / v4-flash 都是 reasoning models（像 o1），输出分为
+    reasoning_tokens + content。结构化对照任务不需要推理，但 reasoning
+    阶段会无差别消耗 max_tokens；2026-06-03 实测 max_tokens=1500 + v4-pro
+    导致 reasoning_tokens 吃掉全部 budget、content="" 的空返回 bug。
+
+    deepseek-chat 是 chat-only model（V3.x 系列），无 reasoning 阶段，
+    适合结构化 JSON 输出。可用 settings.ai_diff_model 覆盖（保留切换通道）。
+    """
+    return getattr(settings, "ai_diff_model", None) or "deepseek-chat"
 
 
 async def _call_llm(chunks: list[AiDiffChunk], model: str) -> dict[str, Any]:


### PR DESCRIPTION
## 背景

PR #644 改 prompt v2 后，AI diff 端点仍然返回 `{summary:"", differences:[], doctrinal_notes:""}`。

## 调试路径

1. **PR #644 假设**：prompt schema 占位文本误导 LLM → 部署 v2 后仍空 → 假设错
2. **看 backend log**：抓到 "LLM returned non-JSON content" → 说明 raw content 是空字符串
3. **VPS 容器内直连 DeepSeek**：

   ```
   content=''
   completion_tokens=200
   reasoning_tokens=200    ← 全部 token 都是 reasoning
   ```

4. **真因明确**：`deepseek-v4-pro` 是 **reasoning model**（类 o1），输出分 reasoning + content。生产 `max_tokens=1500` + 长输入（system prompt + worked example + 2-3k 字用户内容）全被 reasoning 阶段吃光，content 一个字都不剩。

## 实测 DeepSeek 模型分类

| Model | 状态 | reasoning? |
|---|---|---|
| `deepseek-chat` | ✅ 200, content 正常 | 否 |
| `deepseek-v4-flash` | ✅ 200, content="" | **是** (rt=50) |
| `deepseek-v4-pro` | ✅ 200, content="" | **是** (rt=50) |
| `deepseek-v3` / `deepseek-v4-chat` | ❌ 400 | — |

## Fix

`backend/app/services/ai_diff.py::_resolve_model()`：

- 改用 `deepseek-chat`（chat-only，非 reasoning model）
- 独立于 `/chat` 路径 — chat 端继续用 `settings.llm_default_model`（v4-pro 有 reasoning 反而帮助 RAG 复杂推理）
- 保留 `settings.ai_diff_model` 覆盖通道

为什么 `/chat` 没出过这个 bug：chat path 是流式输出，max_tokens 通常远大（4000+），且 reasoning_tokens 在 chat 里反而提升答案质量；ai diff 这种"短结构化输出"任务用 reasoning model 是 anti-pattern。

## 测试

- `tests/test_ai_diff_service.py` 6/6 通过（hash 函数未变）
- 部署后端到端：维摩诘 + 法句经 两个 chunk pair POST，验证 `analysis.summary` 与 `differences` 非空

## 回滚

env 设 `AI_DIFF_MODEL=deepseek-v4-pro` 即可（但会回到空返回，仅作 emergency 切回历史行为用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)