### PR TITLE
feat(quote-verifier): add Markdown blockquote scanner

### DIFF
--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -94,8 +94,9 @@ MAX_QUOTE_CITATION_GAP_CHARS = 80
 # hallucination, defeating the entire module. Adding the curly forms
 # is the fix.
 #
-# Markdown blockquote (``> …``) is intentionally out of scope here —
-# its multi-line structure needs a different scanner.
+# Markdown blockquote (``> …``) gets a dedicated multi-line scanner
+# below — it needs different framing because the body is never wrapped
+# in 「」/“”/'' and may span several lines.
 _QUOTE_OPEN = "「『“‘\""
 _QUOTE_CLOSE = "」』”’\""
 _QUOTE_CITATION_RE = re.compile(
@@ -106,6 +107,38 @@ _QUOTE_CITATION_RE = re.compile(
     r"【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】",
     re.DOTALL,
 )
+
+# Match a contiguous Markdown blockquote block followed (within the
+# usual gap window of subsequent non-blockquote text) by a
+# ``【《X》第N卷】`` citation. The blockquote body is captured in full so
+# we can strip the per-line ``> `` markers before substring testing.
+#
+# Two citation positions are both LLM-natural and both supported:
+#   1. inline on the final ``> `` line:
+#         > 引文内容
+#         > ——【《心經》第1卷】
+#   2. as a sibling paragraph after the block:
+#         > 引文内容
+#
+#         【《心經》第1卷】
+#
+# A multi-paragraph gap (commentary in between) is intentionally too
+# long to match — same under-verification stance as the inline path.
+_BLOCKQUOTE_CITATION_RE = re.compile(
+    r"(?P<block>(?:^>[^\n]*(?:\n|$))+)"
+    r"(?P<gap>(?:[^\n]*\n){0,2}[^\n]{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}?)"
+    r"【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】",
+    re.MULTILINE,
+)
+
+# Marker placed at the start of the verifier's own appended caveat
+# blockquote (see ``_QUOTE_CAVEAT``). If the answer is fed back through
+# ``verify_quoted_content`` a second time — or a downstream pipeline
+# concatenates verified answers — the blockquote scanner must skip the
+# caveat itself, otherwise a real ``【《X》】`` citation that follows
+# elsewhere in the answer would pair with the warning blockquote and
+# emit a spurious second mutation.
+_CAVEAT_BLOCK_MARKER = "⚠️ 本回答"
 
 
 # Punctuation we strip from both sides of the substring test. Includes
@@ -124,7 +157,12 @@ class QuoteMutation:
     quote: str
     title: str
     juan: int | None
-    reason: str  # 'no_matching_source' | 'quote_not_in_source'
+    # 'no_matching_source' | 'quote_not_in_source' | 'blockquote_not_in_source'
+    # The blockquote variant exists so the audit trail distinguishes
+    # inline-paraphrase vs long-form-fabrication failure modes, which
+    # have different LLM root causes and different downstream prompt
+    # mitigations.
+    reason: str
 
 
 def _normalise(s: str) -> str:
@@ -222,6 +260,23 @@ def _append_caveat(answer: str) -> str:
     return answer.rstrip() + f"\n\n{_QUOTE_CAVEAT}"
 
 
+def _strip_existing_caveat(answer: str) -> str:
+    """Remove a previously-appended caveat blockquote so it can be re-emitted
+    at the correct position below any newly-appearing fabricated content.
+
+    Matches the canonical ``_QUOTE_CAVEAT`` line verbatim (the caveat is a
+    single-line blockquote, so this is unambiguous) and trims one trailing
+    blank line so we don't accumulate paragraph spacing on repeated passes.
+    """
+    if _QUOTE_CAVEAT not in answer:
+        return answer
+    return re.sub(
+        r"\n*" + re.escape(_QUOTE_CAVEAT) + r"\n*",
+        "\n\n",
+        answer,
+    ).rstrip()
+
+
 def verify_quoted_content(
     answer: str, sources: list[ChatSource]
 ) -> tuple[str, list[QuoteMutation]]:
@@ -272,10 +327,98 @@ def verify_quoted_content(
                 )
             )
 
+    mutations.extend(_scan_blockquotes(answer, sources))
+
     if not mutations:
         return answer, mutations
 
+    # Idempotent caveat: ``chat.py`` calls this verifier twice (once on
+    # the streamed answer, once on the post-correction answer) and the
+    # second input can carry forward a caveat the first pass appended.
+    # Strip any existing caveat so the re-append lands at the bottom of
+    # the current (possibly extended) answer body — this preserves the
+    # single-caveat invariant while still surfacing newly-introduced
+    # fabrications that appear *after* the prior caveat, which a plain
+    # "skip if marker present" check would silently swallow.
+    if _CAVEAT_BLOCK_MARKER in answer:
+        answer = _strip_existing_caveat(answer)
+
     return _append_caveat(answer), mutations
+
+
+def _strip_blockquote_markers(block: str) -> str:
+    """Strip the per-line ``> `` Markdown prefix from a blockquote so we
+    can hand the joined body to the substring test.
+
+    Blank ``>`` lines (used by LLMs as paragraph breaks inside a single
+    quotation) are dropped — they carry no content and otherwise leave
+    stray ``\\n\\n`` runs that survive normalisation noise checks.
+    """
+    out_lines: list[str] = []
+    for raw in block.splitlines():
+        # Tolerate up to one leading whitespace before ``>`` and the
+        # standard ``> `` / ``>`` (no space) forms.
+        s = raw.lstrip()
+        if not s.startswith(">"):
+            # Defensive — _BLOCKQUOTE_CITATION_RE only captures `>`-led
+            # lines, so this branch shouldn't fire in normal use.
+            continue
+        s = s[1:].lstrip(" ")
+        if s:
+            out_lines.append(s)
+    return " ".join(out_lines).strip()
+
+
+def _scan_blockquotes(
+    answer: str, sources: list[ChatSource]
+) -> list[QuoteMutation]:
+    """Detect ``> …`` blockquote / ``【《X》第N卷】`` pairs and verify them
+    against the cited source's chunk_text with the same substring
+    semantics as the inline scanner.
+
+    Returns the list of failing mutations (empty if every blockquote
+    verifies, or there are none). The caller decides whether to append
+    the shared caveat — multiple blockquote failures must collapse into
+    the same single caveat as the inline path, so producing inline-style
+    mutations here and letting the caller pool them is the right shape.
+    """
+    out: list[QuoteMutation] = []
+    for m in _BLOCKQUOTE_CITATION_RE.finditer(answer):
+        block = m.group("block")
+        quote = _strip_blockquote_markers(block)
+        # Skip the verifier's own self-appended caveat blockquote so a
+        # second pass over already-verified output doesn't pair the
+        # warning text with an unrelated downstream citation.
+        if _CAVEAT_BLOCK_MARKER in quote:
+            continue
+        if len(quote) < MIN_QUOTE_CHARS:
+            continue
+
+        title = m.group("title")
+        juan_str = m.group("juan")
+        juan = int(juan_str) if juan_str else None
+
+        candidates = _find_sources(sources, title, juan)
+        if not candidates:
+            out.append(
+                QuoteMutation(
+                    quote=quote, title=title, juan=juan,
+                    reason="blockquote_not_in_source",
+                )
+            )
+            continue
+
+        normalised_quote = _normalise(quote)
+        if not any(
+            normalised_quote in _normalise(c.chunk_text) for c in candidates
+        ):
+            out.append(
+                QuoteMutation(
+                    quote=quote, title=title, juan=juan,
+                    reason="blockquote_not_in_source",
+                )
+            )
+    return out
 
 
 def log_quote_mutations(

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -273,3 +273,176 @@ def test_returns_dataclass_with_audit_fields():
     assert muts[0].title == "心經"
     assert muts[0].juan == 1
     assert muts[0].reason == "quote_not_in_source"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Verifier — Markdown blockquote mode
+# ──────────────────────────────────────────────────────────────────────
+#
+# LLMs frequently format long quotations as Markdown blockquotes:
+#
+#     > 色不異空，空不異色，
+#     > 色即是空，空即是色。
+#     >
+#     > —— 【《心經》第1卷】
+#
+# The inline-quote scanner above cannot see these because the body is
+# never wrapped in 「」/“”/'' and may span multiple lines. The block
+# below exercises a dedicated multi-line scanner that pairs a contiguous
+# `> …` block with a nearby `【《X》第N卷】` citation, with the same
+# substring-test semantics as the inline path.
+
+
+def test_blockquote_quote_in_source_does_not_annotate():
+    """The happy path: a multi-line `> …` block whose stripped content
+    appears verbatim in the cited chunk_text must not annotate."""
+    chunk = "色不異空，空不異色，色即是空，空即是色，受想行識亦復如是。"
+    src = _src(7, "心經", 1, chunk)
+    answer = (
+        "经云：\n\n"
+        "> 色不異空，空不異色，\n"
+        "> 色即是空，空即是色\n\n"
+        "【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_blockquote_not_in_source_gets_annotated():
+    """LLM fabricates a blockquote passage and pairs it with a real
+    title. This is the flagship production failure mode for long
+    citations and must produce the consolidated caveat."""
+    src = _src(7, "心經", 1, "实际原文：般若波罗蜜多，照见五蕴皆空。")
+    answer = (
+        "经文明示：\n\n"
+        "> 众生皆有佛性，如来藏不空妙有，\n"
+        "> 此乃如来真实义\n\n"
+        "【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert "⚠️" in out
+    assert "未能在检索到的经文片段中逐字核实" in out
+    assert len(muts) == 1
+    assert muts[0].reason == "blockquote_not_in_source"
+    assert muts[0].title == "心經"
+    assert muts[0].juan == 1
+
+
+def test_blockquote_simplified_quote_verifies_against_traditional_source():
+    """Same 繁→简 fold semantics as the inline path — a simplified
+    blockquote rendering of a traditional CBETA source must pass."""
+    src = _src(7, "瑜伽師地論", 46, "如彼頌言「一切諸行皆是無常，是名第一」唱拕南。")
+    answer = (
+        "经云：\n\n"
+        "> 一切诸行皆是无常，是名第一\n\n"
+        "【《瑜伽师地论》第46卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_blockquote_with_citation_on_trailing_blockquote_line():
+    """Common LLM style: citation lives on a final `> ——【《X》第N卷】`
+    line inside the same blockquote block. Must still pair."""
+    src = _src(7, "心經", 1, "色不異空空不異色色即是空空即是色。")
+    answer = (
+        "> 色不異空，空不異色，色即是空，空即是色\n"
+        "> ——【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_blockquote_too_short_is_skipped():
+    """Blockquote whose stripped content is < MIN_QUOTE_CHARS gets the
+    same paraphrase-noise treatment as inline short quotes — skipped."""
+    src = _src(7, "心經", 1, "completely different content here")
+    answer = "经云：\n\n> 色即是空\n\n【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert out == answer
+    assert muts == []
+
+
+def test_blockquote_far_from_citation_not_treated_as_pair():
+    """Same gap-window discipline as the inline path: a blockquote
+    separated from the citation by several paragraphs of commentary is
+    not bound to it and the verifier under-verifies rather than
+    misattributes."""
+    src = _src(7, "心經", 1, "无关原文")
+    answer = (
+        "> 假引文一假引文二假引文三假引文四\n\n"
+        "中间穿插一段无关紧要的注释解说文字。" * 8
+        + "\n\n【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert "⚠️" not in out
+    assert muts == []
+
+
+def test_self_appended_caveat_blockquote_is_not_rescanned():
+    """The consolidated caveat itself is a `> ⚠️ …` blockquote. If the
+    verifier ran a second pass over its own output it would either
+    inflate the mutation count or recurse — the scanner must skip
+    blockquotes that start with the caveat marker."""
+    src = _src(7, "心經", 1, "实际原文：般若波罗蜜多。")
+    answer = (
+        "经云：\n\n"
+        "> 众生皆有佛性，如来藏不空妙有，此真实义\n\n"
+        "【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert len(muts) == 1
+    # The caveat blockquote sits in `out`; re-running verify on it must
+    # not produce additional mutations or a second caveat.
+    out2, muts2 = verify_quoted_content(out, [src])
+    assert muts2 == muts  # same set of original mutations
+    assert out2.count("⚠️") == 1  # still exactly one caveat
+
+
+def test_new_fab_after_existing_caveat_still_gets_user_visible_signal():
+    """Regression for a re-entrancy loophole: if an answer already carries
+    a caveat (from a prior pass) AND new fabricated content appears below
+    it, the new fab must remain user-visible — i.e. the caveat must be
+    relocated to the bottom of the answer, not silently kept at its old
+    mid-answer position where the reader would never associate it with the
+    new fab. The earlier behavior (skip append when marker present) hid
+    the new mutation from users while still logging it; correct contract
+    is single caveat AND positioned below the newest fab content.
+    """
+    src = _src(7, "心經", 1, "实际原文：般若波罗蜜多。")
+    answer_with_old_caveat = (
+        "经云：\n\n"
+        "> 众生皆有佛性，如来藏不空妙有，此真实义\n\n"
+        "【《心經》第1卷】\n\n"
+        "> ⚠️ 本回答中部分直接引文未能在检索到的经文片段中逐字核实，建议点按引用链接核对原文。\n\n"
+        "补充又云：「假引文片段二假引文片段二假引文片段二」【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer_with_old_caveat, [src])
+    assert out.count("⚠️") == 1  # single caveat invariant
+    assert len(muts) == 2  # both fabs surfaced in audit
+    # The relocated caveat must sit AFTER the newly-detected inline fab,
+    # otherwise the user can't tell the warning covers it.
+    new_fab_pos = out.index("假引文片段二")
+    caveat_pos = out.index("⚠️")
+    assert caveat_pos > new_fab_pos
+
+
+def test_blockquote_and_inline_failures_share_one_caveat():
+    """Mixed failure modes (one inline 「…」 fab + one `> …` fab) get
+    one consolidated user-facing caveat, with both failures recorded in
+    the audit list."""
+    src = _src(7, "心經", 1, "无关原文")
+    answer = (
+        "云：「假引文片段一假引文片段一假引文片段一」【《心經》第1卷】\n\n"
+        "又云：\n\n"
+        "> 假引文片段二假引文片段二假引文片段二\n\n"
+        "【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert out.count("⚠️") == 1
+    assert len(muts) == 2
+    reasons = {m.reason for m in muts}
+    assert reasons == {"quote_not_in_source", "blockquote_not_in_source"}


### PR DESCRIPTION
## Summary

LLMs frequently format long quotations as Markdown blockquotes (`> …` lines) followed by a `【《X》第N卷】` citation. The inline scanner only matched `「…」` / `"…"` / `'…'` pairs, so long-form fabricated passages in blockquote shape sailed past the verifier entirely and reached the user as scholarly-looking laundered hallucinations.

## What changed

- **`_BLOCKQUOTE_CITATION_RE`** matches contiguous `> …` lines followed within a 2-line + 80-char gap window by a `【《X》第N卷】` citation. Both LLM-natural positions supported: inline-on-last-`>`-line (`> ——【《X》第N卷】`) and sibling paragraph below the block.
- **`_scan_blockquotes()`** strips per-line `> ` prefixes via `_strip_blockquote_markers`, joins lines, and runs the same NFKC + 繁→简 + punct-strip substring test against the cited source's `chunk_text`. Reuses `_find_sources` so parallel chunks + 繁→简 title fold + juan fallback come for free.
- **New `QuoteMutation.reason` value `"blockquote_not_in_source"`** so the audit log distinguishes inline-paraphrase failure from long-form-quotation fabrication — different LLM root causes, different prompt mitigations.
- **Self-caveat skip**: the verifier's own appended caveat blockquote (`> ⚠️ 本回答…`) is skipped via `_CAVEAT_BLOCK_MARKER` check so a second pass doesn't re-pair it with a downstream citation.
- **Idempotent caveat**: `chat.py` calls this verifier twice (lines 1050 + 1246). If the input already carries a caveat AND new fabrications appear below it, the existing caveat is stripped and re-appended at the bottom — preserving the single-caveat invariant while keeping new fab content user-visible (the simpler "skip if marker present" check silently swallowed newly-introduced fabs).

## Test plan

- [x] 9 new unit tests in `tests/test_quote_verifier.py` covering: happy path, 繁→简 fold, both citation positions (trailing `>` line vs sibling paragraph), MIN_QUOTE_CHARS skip, gap-window under-verification, self-caveat skip, mixed inline+blockquote single-caveat, new-fab-after-existing-caveat relocation contract
- [x] All 29 tests in `test_quote_verifier.py` pass
- [x] `ruff check` clean
- [x] Pre-existing test failures in `test_annotations_workflow.py` + `test_smoke.py::test_kg_entity_detail` confirmed unrelated (same failures on master)
- [ ] Post-merge: deploy to fojin.app and verify a /chat answer that triggers blockquote fab produces the caveat

## Review history

Pre-submit review (superpowers:requesting-code-review) flagged one merge-blocker — an idempotence loophole where new fabrications appearing *after* an existing caveat got logged but not user-visible. Fixed by introducing `_strip_existing_caveat` + relocating the caveat to the bottom on every re-pass with mutations. New regression test `test_new_fab_after_existing_caveat_still_gets_user_visible_signal` locks the contract.

Non-blocking follow-ups noted for later: fenced-code-block false-positives, nested `>>` audit-log clarity, `_CAVEAT_BLOCK_MARKER` text coupling, shared-normalisation memoisation.