### PR TITLE
fix(chat): raise reader-context payload caps to admit long CBETA juan (422 fix)

### DIFF
--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -8,11 +8,21 @@ class ChatRequest(BaseModel):
     message: str = Field(..., min_length=1, max_length=2000)
     session_id: int | None = None
     master_id: str | None = None
-    # Reading context (sent when AI is invoked from the reader page)
+    # Reading context (sent when AI is invoked from the reader page).
+    # selected_text / page_content caps must accommodate real CBETA juan
+    # lengths — many fascicles (e.g. 大般若經) exceed 50K chars and the
+    # whole juan rides along as page_content when a user asks from the
+    # reader. The previous 1000 / 15000 caps rejected those requests with
+    # a generic 422 before the service-side truncation in
+    # ``_build_reader_context_prompt`` (500 / 10000 chars into the LLM
+    # context) ever got a chance to run, surfacing as "请求失败，请重试"
+    # for every long-juan reader question. Caps are now sized to admit
+    # any practical CBETA payload; the LLM-context safety cut still
+    # happens server-side regardless of what the client sent.
     text_id: int | None = None
     juan_num: int | None = None
-    selected_text: str | None = Field(None, max_length=1000)
-    page_content: str | None = Field(None, max_length=15000)
+    selected_text: str | None = Field(None, max_length=5000)
+    page_content: str | None = Field(None, max_length=200000)
     # Welcome-card shortcut: when set, backend swaps the user turn sent to
     # the LLM for the matching hot-question prompt template, keeping the
     # natural display_text in history/RAG.


### PR DESCRIPTION
## Summary

Reader-page AI questions were returning 422 Unprocessable Entity → frontend shows "请求失败，请重试" for every juan longer than ~15K chars. Single field cap raise fixes it.

## Root cause

`ChatRequest.page_content` was capped at `max_length=15000`, but the reader's AI panel posts the **entire juan** as `page_content`. Many CBETA fascicles (e.g. 大般若經) exceed 50K chars, so the request was rejected by Pydantic validation before any service logic could run.

The 15000 cap wasn't even a real safety contract — `_build_reader_context_prompt` in `chat.py:300` already truncates `page_content[:10000]` before the LLM call. The schema cap just shadowed the service cap with a hard-fail wall above it.

`selected_text` had the same mismatch (schema 1000 / service `[:500]`), bumped to 5000 for symmetry.

## What changed

`backend/app/schemas/chat.py`:
- `selected_text` max_length: 1000 → 5000
- `page_content` max_length: 15000 → 200000

200000 chars covers any practical CBETA juan; LLM-context safety still enforced server-side via the existing `[:10000]` truncation.

## Evidence

VPS backend log (2026-06-04):
```
fojin-backend | INFO: 10.255.1.1:55054 - "POST /api/chat/stream HTTP/1.0" 422 Unprocessable Entity
```
Single 422, no Traceback, followed by re-login. Pattern matches a Pydantic validation rejection on long `page_content`, not a runtime exception.

## Test plan

- [x] Pydantic schema accepts 50K-char `page_content` + 2K-char `selected_text`
- [x] Pydantic schema still rejects 250K (cap holds)
- [x] All 37 chat/schema tests in backend pass
- [x] ruff clean
- [ ] Post-deploy: ask original user to retry the failed question