### PR TITLE
fix(chat): raise message cap to 20000 to admit long-passage paste questions

### DIFF
--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -5,7 +5,16 @@ from pydantic import BaseModel, Field
 
 
 class ChatRequest(BaseModel):
-    message: str = Field(..., min_length=1, max_length=2000)
+    # message cap raised from 2000 → 20000 to admit the natural reader
+    # workflow where a user pastes a multi-paragraph passage into the
+    # input as their "question" (e.g. "解读以下这段经文：…"). 2000 chars
+    # ≈ 660 Chinese characters and was routinely overshot, surfacing as
+    # a generic 422 → "请求失败，请重试" on the frontend. 20000 chars
+    # comfortably fits any single-message LLM payload (≈ 6-7K tokens for
+    # CJK) and still keeps a hard upper guard against DoS / runaway
+    # paste accidents. Frontend has no client-side maxLength on this
+    # input so the backend cap is the only wall; pick it generously.
+    message: str = Field(..., min_length=1, max_length=20000)
     session_id: int | None = None
     master_id: str | None = None
     # Reading context (sent when AI is invoked from the reader page).


### PR DESCRIPTION
## Summary

Backend logs (with PR #648's RequestValidationError logger live) caught the actual failing request:

\`\`\`
422 validation_error path=/api/chat/stream method=POST errors=[{'loc': ('body', 'message'), 'type': 'string_too_long', 'msg': 'String should have at most 2000 characters', 'ctx': {'max_length': 2000}, 'input_len': 2745}]
\`\`\`

\`ChatRequest.message\` was capped at \`max_length=2000\` (≈ 660 Chinese chars). The reader workflow naturally has users pasting multi-paragraph passages as their question ("解读以下这段经文：…") and the frontend has no client-side maxLength on the textarea, so the 2000-char backend cap was the only wall.

## What changed

- \`message\` max_length: 2000 → 20000 (≈ 6-7K tokens for CJK)

## Why this is the third cap raise in one session

PR #647 (page_content 15000→200000) and PR #649 (DB pool 30+90) were aimed at the wrong root cause. The actual blocker was \`message\` length, but without PR #648's logger live there was no way to see which Pydantic field had failed validation — every 422 looked identical at the access-log level.

The methodological lesson is now in memory \`feedback_chat_reader_payload_caps.md\`: when /chat/stream returns 422, the RequestValidationError logger output names the exact field; don't keep guessing at fields one by one.

## Test plan

- [x] Schema accepts 2745-char message (the specific input that 422'd in production)
- [x] All 33 chat tests pass
- [x] ruff clean
- [ ] Post-deploy: user retries the same 2745-char question and gets an answer