### PR TITLE
fix(chat): log SSE prepare errors + raise client stream timeout

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -1108,6 +1108,15 @@ async def send_message_stream(
             hot_question_id=hot_question_id, model_id=model_id, attachment_ids=attachment_ids,
         )
     except (ValidationError, QuotaExceededError, AccessDeniedError, ServiceError) as exc:
+        # Surface app-level rejections (quota, auth, attachment ownership, RAG
+        # underflow, etc.) into backend logs. The frontend already gets the
+        # message via the SSE 'error' event, but server-side these used to be
+        # invisible — every chat that failed at the prepare phase looked like
+        # an HTTP 200 in the access log and the maintainer had no breadcrumb.
+        logger.warning(
+            "chat/stream prepare rejected: %s: %s (user_id=%s session_id=%s)",
+            type(exc).__name__, exc, user_id, session_id,
+        )
         yield f"data: {json.dumps({'type': 'error', 'message': str(exc)}, ensure_ascii=False)}\n\n"
         yield f"data: {json.dumps({'type': 'done'})}\n\n"
         return

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1404,7 +1404,7 @@ export async function sendChatMessage(
   const { data } = await api.post<ChatResponse>("/chat", {
     message,
     session_id: sessionId,
-  }, { timeout: 90000 });
+  }, { timeout: 300000 });
   return data;
 }
 
@@ -1651,7 +1651,12 @@ export function sendChatMessageStream(
       }
     };
 
-    xhr.timeout = 90000;
+    // 5 min — must exceed the backend's per-LLM-call timeout (120s for
+    // reader-mode page_content + retry/fallback chain) so a slow reasoning
+    // model on a long passage doesn't get killed by the client mid-stream
+    // and surface as the generic "请求失败，请重试". 90s was the original
+    // cap and routinely tripped on DeepSeek V4 Pro + reader-mode juan.
+    xhr.timeout = 300000;
 
     // AbortSignal support
     if (signal) {

--- a/frontend/src/components/ReaderAIPanel.tsx
+++ b/frontend/src/components/ReaderAIPanel.tsx
@@ -149,7 +149,9 @@ export default function ReaderAIPanel({
 
     const abortController = new AbortController();
     abortRef.current = abortController;
-    const timeoutId = setTimeout(() => abortController.abort(), 90_000);
+    // 5 min — see client.ts xhr.timeout comment. Reader mode regularly
+    // hits 90-180s end-to-end on long juan + reasoning models.
+    const timeoutId = setTimeout(() => abortController.abort(), 300_000);
 
     await sendChatMessageStream(msg, sessionId, null, {
       onToken: (content: string) => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -629,8 +629,10 @@ export default function ChatPage() {
     const abortController = new AbortController();
     abortRef.current = abortController;
 
-    // Auto-timeout after 90 seconds
-    const timeoutId = setTimeout(() => abortController.abort(), 90_000);
+    // 5 min — must exceed backend LLM call budget (120s for reader page_content)
+    // plus the fallback chain, otherwise reasoning models on long passages
+    // abort mid-stream and surface as "请求失败，请重试".
+    const timeoutId = setTimeout(() => abortController.abort(), 300_000);
 
     await sendChatMessageStream(msg, sessionId, masterId, {
       onToken: (content: string) => {


### PR DESCRIPTION
## Summary

Production /chat/stream returning a stream-level error within seconds with no backend log breadcrumb. Two related fixes:

1. **Backend log**: add \`logger.warning\` at the prepare-error branch so app-level rejections (quota, auth, attachment, validation, service) surface server-side
2. **Frontend timeout**: 90s → 300s to match the backend's 120s LLM budget + fallback chain

## Why both in one PR

The two failure modes (SSE prepare-error vs client-side abort) produce the *same* generic "请求失败，请重试" in the UI, so the maintainer couldn't tell them apart. The log breadcrumb is now the disambiguator: if it's logged, it's prepare; if not, the client aborted.

## Test plan

- [x] All 33 backend chat tests pass
- [x] tsc + eslint clean (one pre-existing warning unrelated)
- [ ] Post-deploy: user retries; if same fast-fail, backend log now names the failing class