### PR TITLE
fix(chat): align service-layer message cap with Pydantic schema (20000)

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -590,11 +590,19 @@ async def _check_anonymous_quota(redis, client_ip: str) -> None:
 
 
 def _validate_message(message: str) -> None:
-    """Validate chat message content."""
+    """Validate chat message content.
+
+    The length cap must stay aligned with ``ChatRequest.message.max_length``
+    in app/schemas/chat.py — if the schema admits a longer message but
+    this service-layer check rejects it, the result is a stream-internal
+    ValidationError that surfaces in the UI as a generic
+    "请求失败，请重试" with no breadcrumb until you look at backend logs
+    (PR #651). Keep the two numbers in sync.
+    """
     if not message or not message.strip():
         raise ValidationError("消息不能为空")
-    if len(message) > 2000:
-        raise ValidationError("消息长度不能超过2000字")
+    if len(message) > 20000:
+        raise ValidationError("消息长度不能超过20000字")
 
 
 async def _resolve_session(


### PR DESCRIPTION
## TL;DR — actual root cause

PR #651's prepare-error logger surfaced it:

\`\`\`
chat/stream prepare rejected: ValidationError: 消息长度不能超过2000字 (user_id=3 session_id=None)
\`\`\`

PR #650 raised \`ChatRequest.message\` max_length 2000 → 20000, but a **second** hard-coded check at \`_validate_message\` (chat.py:596) kept the 2000-char wall in place. The Pydantic layer admitted the long message, then \`_prepare_chat\` rejected it inside the SSE generator and yielded a stream-internal error event — HTTP 200 OK at the access-log level, generic "请求失败" in the UI.

## Fix

\`backend/app/services/chat.py:596\` cap 2000 → 20000 + docstring guard to keep the two layers in lockstep. Error message also updated to quote the correct ceiling.

## Why this slipped past PR #650

When I bumped the schema cap I grepped for \`max_length\`, not for \`len(message) >\`. The service-layer check uses a raw \`if len(message) >\` form and didn't show up. The docstring guard added here documents the relationship so the next person doesn't repeat this.

## Test plan

- [x] All 33 chat tests pass
- [x] ruff clean
- [ ] Post-deploy: same 2745-char question now succeeds