### PR TITLE
refactor(chat): split /chat/stream DB session into prep + save phases

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -84,17 +84,25 @@ async def chat_stream(
     request: Request,
     data: ChatRequest,
     user: User | None = Depends(get_optional_user),
-    db: AsyncSession = Depends(get_db),
 ):
     """Stream AI answer via Server-Sent Events (SSE). Same as POST /chat but with real-time token streaming.
 
-    SSE 流式发送消息并获取 AI 回答。"""
+    SSE 流式发送消息并获取 AI 回答.
+
+    Intentionally does **not** depend on ``get_db``: this endpoint returns a
+    StreamingResponse whose generator's lifetime is the LLM-stream window
+    (60-120s), and a single DI-supplied session held across that window
+    pinned a PG connection per active stream — the production pool
+    exhaustion in project_fojin_db_pool_streaming. The generator owns its
+    own sessions internally, one for prep and one for save, neither
+    held across the LLM I/O.
+    """
     user_id = user.id if user else None
     client_ip = _get_client_ip(request) if not user else None
     redis = getattr(request.app.state, "redis", None)
     return StreamingResponse(
         send_message_stream(
-            db, user_id, data.message, data.session_id, user=user,
+            user_id, data.message, data.session_id, user=user,
             client_ip=client_ip, redis=redis, master_id=data.master_id,
             text_id=data.text_id, juan_num=data.juan_num, selected_text=data.selected_text, page_content=data.page_content,
             hot_question_id=data.hot_question_id, model_id=data.model_id,

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -4,7 +4,7 @@ import time as _time
 from datetime import UTC, date, datetime
 
 import httpx
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -16,6 +16,7 @@ from app.core.exceptions import (
     ServiceError,
     ValidationError,
 )
+from app.database import async_session
 from app.models.chat import ChatAttachment, ChatMessage, ChatSession
 from app.models.hot_question import HotQuestion
 from app.models.user import User
@@ -544,15 +545,35 @@ def _resolve_fallback_llm_config() -> tuple[str, str, str, str] | None:
 
 
 async def _check_daily_quota(db: AsyncSession, user: User) -> None:
-    """Check and increment daily free chat quota. Raises QuotaExceededError if exceeded."""
+    """Check and increment daily free chat quota. Raises QuotaExceededError if exceeded.
+
+    The increment runs as an **explicit UPDATE** rather than mutating
+    ``user`` attributes because ``user`` is loaded by ``get_optional_user``
+    on a *different* session from the one threaded into the streaming
+    chat path (see send_message_stream's prep-phase session). A
+    ``user.attr = value`` mutation against a session that doesn't own
+    the row gets silently dropped by ``flush()`` — no SQL is emitted,
+    quota stops incrementing, and free-tier limits stop applying.
+    The UPDATE-by-id form works regardless of which session loaded
+    ``user`` originally. The in-memory ``user`` is also patched so the
+    caller's view stays consistent within the same request.
+    """
     today = date.today()
-    if user.last_chat_date != today:
-        user.daily_chat_count = 0
-        user.last_chat_date = today
-    if user.daily_chat_count >= FREE_DAILY_LIMIT_USER:
+    same_day = user.last_chat_date == today
+    current_count = user.daily_chat_count if same_day else 0
+    if current_count >= FREE_DAILY_LIMIT_USER:
         raise QuotaExceededError(limit=FREE_DAILY_LIMIT_USER)
-    user.daily_chat_count += 1
+    new_count = current_count + 1
+    await db.execute(
+        update(User)
+        .where(User.id == user.id)
+        .values(daily_chat_count=new_count, last_chat_date=today)
+    )
     await db.flush()
+    # Keep the caller's in-memory User in sync with what we just wrote
+    # so any later attribute reads in the same request are coherent.
+    user.daily_chat_count = new_count
+    user.last_chat_date = today
 
 
 def _anon_quota_key(client_ip: str) -> str:
@@ -832,15 +853,39 @@ async def _mark_attachments_consumed(
 ) -> None:
     """Best-effort: stamp ``consumed_at`` so a future GC cron can prune
     orphaned uploads. Failures here must not break the chat response —
-    the message is already saved by the time we get called."""
+    the message is already saved by the time we get called.
+
+    Uses an explicit UPDATE rather than ``row.consumed_at = now`` because
+    ``attachments`` are loaded by ``_load_and_render_attachments`` in the
+    prep-phase session which closes before this runs (see
+    send_message_stream's two-phase session split). Mutating attributes
+    on detached rows silently no-ops on commit, which would defeat the
+    ``consumed_at IS NULL`` single-use mitigation that defends against
+    anonymous-upload id-enumeration (see schemas/chat.py
+    ``attachment_ids`` docstring). The UPDATE-by-id form persists
+    regardless of which session originally loaded the rows.
+    """
     if not attachments:
         return
+    pending_ids = [row.id for row in attachments if row.consumed_at is None]
+    if not pending_ids:
+        return
     now = datetime.now(UTC)
-    for row in attachments:
-        if row.consumed_at is None:
-            row.consumed_at = now
     try:
+        await db.execute(
+            update(ChatAttachment)
+            .where(ChatAttachment.id.in_(pending_ids))
+            # Defensive: if another concurrent path already consumed it,
+            # don't overwrite the original consumption timestamp.
+            .where(ChatAttachment.consumed_at.is_(None))
+            .values(consumed_at=now)
+        )
         await db.commit()
+        # Patch in-memory rows so the caller's view (e.g. follow-up
+        # references via the same request) is coherent.
+        for row in attachments:
+            if row.consumed_at is None:
+                row.consumed_at = now
     except Exception:  # pragma: no cover — db quirks shouldn't surface to user
         logger.exception("Failed to mark attachments consumed")
         await db.rollback()
@@ -1078,7 +1123,6 @@ async def send_message(
 
 
 async def send_message_stream(
-    db: AsyncSession,
     user_id: int | None,
     message: str,
     session_id: int | None = None,
@@ -1093,11 +1137,31 @@ async def send_message_stream(
     hot_question_id: int | None = None,
     model_id: str | None = None,
     attachment_ids: list[int] | None = None,
+    sessionmaker=async_session,
 ):
     """Async generator yielding SSE events for streaming chat responses.
 
     Yields session_id immediately after validation so the frontend gets
     a response within milliseconds, then does RAG retrieval + LLM streaming.
+
+    **Session lifecycle**: this generator opens TWO short-lived DB sessions
+    instead of holding one across the whole stream. Phase-1 (prep / RAG /
+    quota) and phase-3 (save / mark consumed) each get their own session,
+    and the LLM-streaming phase between them runs with no session checked
+    out at all.
+
+    The previous shape (single ``db: AsyncSession = Depends(get_db)``
+    threaded through the whole generator) pinned a PG connection for the
+    full 60-120s LLM-streaming window — a single user with two tabs plus
+    an SEO crawler could exhaust the 10+20 pool in minutes (PR #649 +
+    project_fojin_db_pool_streaming). Splitting the session here lets the
+    pool churn at the rate of actual DB work (typically <1s of each
+    request), not at the rate of LLM latency.
+
+    ``sessionmaker`` defaults to the module-level ``async_session`` factory
+    but is overridable for tests that want to assert no-DB-during-LLM
+    behaviour with a counting wrapper. The endpoint is the only caller
+    that uses the default.
     """
     # Flush Cloudflare's response buffer with a padded SSE comment (~2KB).
     yield ": " + " " * 2048 + "\n\n"
@@ -1106,16 +1170,29 @@ async def send_message_stream(
     # 立即告知前端正在检索，消除空白等待感
     yield f"data: {json.dumps({'type': 'searching', 'message': '正在检索相关经文...'}, ensure_ascii=False)}\n\n"
 
-    try:
-        (
-            chat_session, api_url, api_key, model, is_byok, provider,
-            sources, llm_messages, attachments,
-        ) = await _prepare_chat(
-            db, user_id, message, session_id, user, client_ip=client_ip, redis=redis, master_id=master_id,
-            text_id=text_id, juan_num=juan_num, selected_text=selected_text, page_content=page_content,
-            hot_question_id=hot_question_id, model_id=model_id, attachment_ids=attachment_ids,
-        )
-    except (ValidationError, QuotaExceededError, AccessDeniedError, ServiceError) as exc:
+    # Capture the prep error (if any) so we can yield it OUTSIDE the
+    # ``async with`` block — yielding inside would keep the session
+    # checked out for the duration of the network write to the client,
+    # defeating the point of the split.
+    prep_result = None
+    prep_error: Exception | None = None
+    async with sessionmaker() as db_prep:
+        try:
+            prep_result = await _prepare_chat(
+                db_prep, user_id, message, session_id, user,
+                client_ip=client_ip, redis=redis, master_id=master_id,
+                text_id=text_id, juan_num=juan_num,
+                selected_text=selected_text, page_content=page_content,
+                hot_question_id=hot_question_id, model_id=model_id,
+                attachment_ids=attachment_ids,
+            )
+        except (ValidationError, QuotaExceededError, AccessDeniedError, ServiceError) as exc:
+            prep_error = exc
+    # db_prep is closed here — connection returned to the pool before any
+    # LLM I/O begins, regardless of whether prep succeeded or surfaced an
+    # app-level rejection.
+
+    if prep_error is not None:
         # Surface app-level rejections (quota, auth, attachment ownership, RAG
         # underflow, etc.) into backend logs. The frontend already gets the
         # message via the SSE 'error' event, but server-side these used to be
@@ -1123,11 +1200,16 @@ async def send_message_stream(
         # an HTTP 200 in the access log and the maintainer had no breadcrumb.
         logger.warning(
             "chat/stream prepare rejected: %s: %s (user_id=%s session_id=%s)",
-            type(exc).__name__, exc, user_id, session_id,
+            type(prep_error).__name__, prep_error, user_id, session_id,
         )
-        yield f"data: {json.dumps({'type': 'error', 'message': str(exc)}, ensure_ascii=False)}\n\n"
+        yield f"data: {json.dumps({'type': 'error', 'message': str(prep_error)}, ensure_ascii=False)}\n\n"
         yield f"data: {json.dumps({'type': 'done'})}\n\n"
         return
+
+    (
+        chat_session, api_url, api_key, model, is_byok, provider,
+        sources, llm_messages, attachments,
+    ) = prep_result
 
     # Yield session_id immediately so frontend gets a fast response
     yield f"data: {json.dumps({'type': 'session_id', 'session_id': chat_session.id if chat_session else 0}, ensure_ascii=False)}\n\n"
@@ -1278,13 +1360,37 @@ async def send_message_stream(
     if sources:
         yield f"data: {json.dumps({'type': 'sources', 'sources': [s.model_dump() for s in sources]}, ensure_ascii=False)}\n\n"
 
+    # --- Phase 3: persist messages + attachments ---
+    # Fresh session so LLM-stream latency above didn't pin a pool slot.
+    # Captured outside the block so the resulting yield happens after the
+    # session is back in the pool (same reasoning as the prep block).
+    #
+    # Wrapped in try/except so a save-side failure (PG transient, unique
+    # violation, etc.) still lets us emit ``done`` to the client. Without
+    # this, an unhandled exception would escape the generator and the
+    # frontend stream consumer would never see the completion event —
+    # the user got their reply but the UI sits in "thinking…" until
+    # they navigate away. The reply is unfortunately not persisted in
+    # this failure mode; the alternative (silently retry / different
+    # storage path) is out of scope for this refactor.
+    assistant_msg_id: int | None = None
     if chat_session:
-        assistant_msg_id = await _save_messages(
-            db, chat_session.id, message, corrected_answer, sources
-        )
-        log_mutations(chat_session.id, _citation_mutations)
-        log_quote_mutations(chat_session.id, _quote_mutations)
-        await _mark_attachments_consumed(db, attachments)
+        try:
+            async with sessionmaker() as db_save:
+                assistant_msg_id = await _save_messages(
+                    db_save, chat_session.id, message, corrected_answer, sources
+                )
+                log_mutations(chat_session.id, _citation_mutations)
+                log_quote_mutations(chat_session.id, _quote_mutations)
+                await _mark_attachments_consumed(db_save, attachments)
+        except Exception:
+            logger.exception(
+                "chat/stream phase-3 save failed; user got the reply but it is "
+                "not persisted (session_id=%s, user_id=%s)",
+                chat_session.id, user_id,
+            )
+        # db_save closed before the message_id yield below.
+
         # Emit the real chat_messages.id so the frontend can swap the
         # in-flight Date.now() placeholder. Without this, feedback /
         # share buttons on a freshly-streamed message PUT to a

--- a/backend/tests/test_chat_sources_order.py
+++ b/backend/tests/test_chat_sources_order.py
@@ -5,9 +5,9 @@
 """
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.schemas.chat import ChatSource
 
@@ -114,9 +114,8 @@ async def test_sources_after_tokens():
 
         from app.services.chat import send_message_stream
 
-        db = AsyncMock()
         chunks = []
-        async for chunk in send_message_stream(db, user_id=1, message="什么是般若"):
+        async for chunk in send_message_stream(user_id=1, message="什么是般若"):
             chunks.append(chunk)
 
     events = _parse_sse_events(chunks)
@@ -161,9 +160,8 @@ async def test_empty_sources_not_emitted():
 
         from app.services.chat import send_message_stream
 
-        db = AsyncMock()
         chunks = []
-        async for chunk in send_message_stream(db, user_id=1, message="什么是佛法"):
+        async for chunk in send_message_stream(user_id=1, message="什么是佛法"):
             chunks.append(chunk)
 
     events = _parse_sse_events(chunks)
@@ -192,9 +190,8 @@ async def test_session_id_value_correct():
 
         from app.services.chat import send_message_stream
 
-        db = AsyncMock()
         chunks = []
-        async for chunk in send_message_stream(db, user_id=1, message="测试"):
+        async for chunk in send_message_stream(user_id=1, message="测试"):
             chunks.append(chunk)
 
     events = _parse_sse_events(chunks)
@@ -221,9 +218,8 @@ async def test_error_during_prepare_yields_error_and_done():
     ):
         from app.services.chat import send_message_stream
 
-        db = AsyncMock()
         chunks = []
-        async for chunk in send_message_stream(db, user_id=1, message="测试配额"):
+        async for chunk in send_message_stream(user_id=1, message="测试配额"):
             chunks.append(chunk)
 
     events = _parse_sse_events(chunks)

--- a/backend/tests/test_chat_stream_session_lifecycle.py
+++ b/backend/tests/test_chat_stream_session_lifecycle.py
@@ -1,0 +1,364 @@
+"""Regression test for the /chat/stream DB-session-handoff contract.
+
+Locks the invariant that ``send_message_stream`` releases its prep-phase
+session BEFORE entering the LLM-streaming phase, and opens a fresh session
+ONLY when persisting the final message. The legacy shape (single
+``Depends(get_db)`` session pinned across the whole generator) exhausted
+the PG pool under modest concurrency — see project_fojin_db_pool_streaming
+and PR #649.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.chat import ChatSource
+
+
+def _make_fake_sources() -> list[ChatSource]:
+    return [
+        ChatSource(text_id=1, juan_num=1, chunk_text="色不异空", score=0.9, title_zh="心经"),
+    ]
+
+
+def _make_prepare_chat_return(sources: list[ChatSource]):
+    fake_session = MagicMock()
+    fake_session.id = 42
+    llm_messages = [{"role": "user", "content": "测试"}]
+    return (
+        fake_session, "https://api.example.com/v1", "fake-key", "test-model",
+        False, "openai", sources, llm_messages, [],
+    )
+
+
+def _make_mock_httpx_client(tokens: list[str]):
+    """Same mock pattern as test_chat_sources_order — supports
+    ``async with httpx.AsyncClient() as client: async with client.stream(...) as resp``.
+    """
+    lines = [f"data: {json.dumps({'choices': [{'delta': {'content': t}}]})}" for t in tokens]
+    lines.append("data: [DONE]")
+    mock_resp = MagicMock()
+
+    async def aiter_lines():
+        for line in lines:
+            yield line
+
+    mock_resp.aiter_lines = aiter_lines
+    mock_resp.raise_for_status = MagicMock()
+
+    class _StreamCM:
+        async def __aenter__(self): return mock_resp
+        async def __aexit__(self, *_): return False
+
+    class _ClientInstance:
+        def stream(self, *args, **kwargs): return _StreamCM()
+
+    class _ClientCM:
+        async def __aenter__(self): return _ClientInstance()
+        async def __aexit__(self, *_): return False
+
+    return MagicMock(return_value=_ClientCM())
+
+
+class _CountingSessionmaker:
+    """Drop-in for ``async_session`` that records when sessions open/close
+    relative to LLM-stream activity.
+
+    Each ``async with sessionmaker() as db`` produces a fresh AsyncMock and
+    appends to ``opens`` / ``closes``. The phase ordering invariant the
+    refactor must hold is: every ``close`` happens before the first LLM
+    yield, OR after the last LLM yield — never spanning the LLM phase.
+    """
+
+    def __init__(self):
+        self.opens: list[int] = []   # sequence-of-events index
+        self.closes: list[int] = []
+        self.event_log: list[str] = []  # interleaved events for readable assert messages
+        self._t = 0
+        self._tick_lock = False
+
+    def _tick(self, kind: str) -> int:
+        self._t += 1
+        self.event_log.append(f"{self._t}:{kind}")
+        return self._t
+
+    def __call__(self):
+        outer = self
+
+        class _SessCM:
+            async def __aenter__(self_inner):
+                outer.opens.append(outer._tick("OPEN"))
+                return AsyncMock()  # the db handle — every method awaited returns AsyncMock
+
+            async def __aexit__(self_inner, *_):
+                outer.closes.append(outer._tick("CLOSE"))
+                return False
+
+        return _SessCM()
+
+
+@pytest.mark.anyio
+async def test_session_released_before_llm_stream_starts():
+    """Phase 1 session must close BEFORE the first LLM token is yielded.
+
+    The whole point of the refactor: pool slot returned by the time we
+    start waiting on the LLM. If a future change re-introduces the legacy
+    shape (DI session pinned across the stream), this assertion fails
+    because the close event would land after the first token event.
+    """
+    sources = _make_fake_sources()
+    prepare_return = _make_prepare_chat_return(sources)
+    counting = _CountingSessionmaker()
+
+    # Mock the LLM stream so we can observe when token-yielding begins —
+    # the assertion is that session 1 closed before any token arrived.
+    token_yield_ticks: list[int] = []
+
+    def _mock_httpx_factory(tokens):
+        lines = [f"data: {json.dumps({'choices': [{'delta': {'content': t}}]})}" for t in tokens]
+        lines.append("data: [DONE]")
+        mock_resp = MagicMock()
+
+        async def aiter_lines():
+            for line in lines:
+                token_yield_ticks.append(counting._tick("LLM_YIELD"))
+                yield line
+
+        mock_resp.aiter_lines = aiter_lines
+        mock_resp.raise_for_status = MagicMock()
+
+        class _StreamCM:
+            async def __aenter__(self): return mock_resp
+            async def __aexit__(self, *_): return False
+
+        class _ClientInstance:
+            def stream(self, *args, **kwargs): return _StreamCM()
+
+        class _ClientCM:
+            async def __aenter__(self): return _ClientInstance()
+            async def __aexit__(self, *_): return False
+
+        return MagicMock(return_value=_ClientCM())
+
+    mock_client_cls = _mock_httpx_factory(["般", "若"])
+
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
+         patch("app.services.chat._mark_attachments_consumed", new_callable=AsyncMock), \
+         patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
+        from app.services.chat import send_message_stream
+
+        chunks = []
+        async for chunk in send_message_stream(
+            user_id=1, message="测试", sessionmaker=counting,
+        ):
+            chunks.append(chunk)
+
+    # Sanity: exactly two sessions opened (prep, save) and both closed.
+    assert len(counting.opens) == 2, (
+        f"expected 2 sessions (prep + save), got {len(counting.opens)} "
+        f"events={counting.event_log}"
+    )
+    assert len(counting.closes) == 2, (
+        f"expected 2 closes, got {len(counting.closes)} events={counting.event_log}"
+    )
+
+    # The critical invariant: first CLOSE precedes first LLM_YIELD.
+    first_close = counting.closes[0]
+    first_llm_yield = token_yield_ticks[0]
+    assert first_close < first_llm_yield, (
+        f"DB session must close before LLM stream begins.\n"
+        f"first CLOSE at tick {first_close}, first LLM_YIELD at tick {first_llm_yield}.\n"
+        f"event log: {counting.event_log}"
+    )
+
+    # And the second OPEN happens AFTER the last LLM yield (save phase).
+    second_open = counting.opens[1]
+    last_llm_yield = token_yield_ticks[-1]
+    assert second_open > last_llm_yield, (
+        f"save-phase session must open after LLM stream ends.\n"
+        f"second OPEN at tick {second_open}, last LLM_YIELD at tick {last_llm_yield}.\n"
+        f"event log: {counting.event_log}"
+    )
+
+
+@pytest.mark.anyio
+async def test_prep_phase_error_still_closes_session():
+    """A ValidationError raised inside _prepare_chat must not leak the
+    session — the ``async with`` block's __aexit__ runs in either case,
+    and the error event is yielded only after the session is back in
+    the pool.
+    """
+    from app.core.exceptions import QuotaExceededError
+
+    counting = _CountingSessionmaker()
+
+    with patch(
+        "app.services.chat._prepare_chat",
+        new_callable=AsyncMock,
+        side_effect=QuotaExceededError(limit=30),
+    ):
+        from app.services.chat import send_message_stream
+
+        chunks = []
+        async for chunk in send_message_stream(
+            user_id=1, message="测试", sessionmaker=counting,
+        ):
+            chunks.append(chunk)
+
+    # One session opened for prep, no save phase (prep failed).
+    assert len(counting.opens) == 1
+    assert len(counting.closes) == 1
+    # And it closed before the error event reached the wire.
+    # We can't observe network writes directly here, but we *can* confirm
+    # the close completed before the generator finished producing chunks.
+    assert any("error" in c for c in chunks), "error event must be yielded"
+    assert counting.closes[0] > 0  # close did happen
+
+
+def test_chat_stream_endpoint_does_not_depend_on_get_db():
+    """Endpoint must not take a `db` parameter. If a future change adds
+    ``Depends(get_db)`` back to ``chat_stream``, FastAPI's DI would once
+    again pin a PG connection for the entire 60-120s SSE-stream lifetime
+    — the exact production-incident shape this refactor exists to
+    eliminate (see project_fojin_db_pool_streaming). Signature snapshot
+    so the regression bricks CI before it bricks the pool."""
+    import inspect
+
+    from app.api.chat import chat_stream
+
+    sig = inspect.signature(chat_stream)
+    assert "db" not in sig.parameters, (
+        "chat_stream must NOT depend on get_db — that's the legacy shape "
+        "that exhausted the PG pool. Generator owns its sessions via the "
+        "module-level async_session factory instead. "
+        f"got params={list(sig.parameters)}"
+    )
+
+
+@pytest.mark.anyio
+async def test_quota_increment_uses_explicit_update():
+    """Quota must increment via explicit UPDATE statement, not by mutating
+    the User attribute. ``user`` is loaded by ``get_optional_user`` on a
+    different session from the chat-stream prep session; attribute
+    mutation against a foreign session silently no-ops on flush() and the
+    quota never persists. Regression for code-review C1."""
+    import datetime as _dt
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.chat import _check_daily_quota
+
+    user = MagicMock()
+    user.id = 7
+    user.daily_chat_count = 5
+    user.last_chat_date = _dt.date.today()
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.flush = AsyncMock()
+
+    await _check_daily_quota(db, user)
+
+    # The mitigation: an UPDATE was emitted, not a flush of attribute deltas.
+    assert db.execute.await_count == 1, (
+        "_check_daily_quota must issue an explicit UPDATE so the increment "
+        "persists regardless of which session loaded `user`."
+    )
+    # And the in-memory user was patched to match — caller's later reads
+    # in the same request stay coherent.
+    assert user.daily_chat_count == 6
+
+
+@pytest.mark.anyio
+async def test_attachments_consumed_uses_explicit_update():
+    """``_mark_attachments_consumed`` must persist via UPDATE statement,
+    not by setting ``row.consumed_at = now`` on rows loaded by a different
+    session. Same root cause as quota regression — detached rows ignored
+    by ``flush()``. Regression for code-review C2 (which has security
+    implications: ``consumed_at IS NULL`` is the anti-enumeration
+    mitigation for anonymous uploads, schemas/chat.py)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.chat import _mark_attachments_consumed
+
+    row1 = MagicMock()
+    row1.id = 11
+    row1.consumed_at = None
+    row2 = MagicMock()
+    row2.id = 22
+    row2.consumed_at = None
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+
+    await _mark_attachments_consumed(db, [row1, row2])
+
+    assert db.execute.await_count == 1, (
+        "_mark_attachments_consumed must issue an explicit UPDATE so "
+        "consumed_at persists for rows loaded by a foreign session."
+    )
+    assert db.commit.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_save_phase_failure_still_yields_done():
+    """A failure inside the save-phase ``async with`` must not escape the
+    generator — the frontend SSE consumer needs the ``done`` event to
+    finalize its UI state, otherwise it sits in "thinking…" forever.
+    Regression for code-review I3."""
+    sources = _make_fake_sources()
+    prepare_return = _make_prepare_chat_return(sources)
+    counting = _CountingSessionmaker()
+    mock_client_cls = _make_mock_httpx_client(["a", "b"])
+
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, side_effect=RuntimeError("simulated PG flake")), \
+         patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
+        from app.services.chat import send_message_stream
+
+        chunks = []
+        async for chunk in send_message_stream(
+            user_id=1, message="测试 save fail", sessionmaker=counting,
+        ):
+            chunks.append(chunk)
+
+    # The done event must reach the wire even though save raised.
+    assert any('"type": "done"' in c for c in chunks), (
+        "save-phase failure swallowed the done event — frontend would "
+        f"hang in 'thinking…' state. chunks={chunks!r}"
+    )
+
+
+@pytest.mark.anyio
+async def test_anonymous_user_skips_save_phase():
+    """Anonymous users (chat_session is None) only need the prep session;
+    no save session should be opened. The legacy shape held one session
+    for the whole stream regardless — the refactor cleanly avoids the
+    save-phase open when there's nothing to save.
+    """
+    sources = _make_fake_sources()
+    # Anonymous: chat_session is None per _prepare_chat contract
+    prepare_return = (
+        None, "https://api.example.com/v1", "fake-key", "test-model",
+        False, "openai", sources,
+        [{"role": "user", "content": "anon"}], [],
+    )
+    counting = _CountingSessionmaker()
+    mock_client_cls = _make_mock_httpx_client(["anon-reply"])
+
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
+         patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
+        from app.services.chat import send_message_stream
+
+        chunks = []
+        async for chunk in send_message_stream(
+            user_id=None, message="anon question", sessionmaker=counting,
+        ):
+            chunks.append(chunk)
+
+    assert len(counting.opens) == 1, (
+        f"anonymous flow should open exactly one session (prep), got {len(counting.opens)}"
+    )
+    assert len(counting.closes) == 1


### PR DESCRIPTION
## Summary

Structural fix for the production pool-exhaustion incident from 2026-06-04 ([project_fojin_db_pool_streaming](https://github.com/xr843/fojin#)). `/chat/stream` was pinning a PG connection across the 60-120s LLM-streaming window; PR #649 raised pool 10+20 → 30+90 as triage, this PR removes the structural cause.

## What changed

- `send_message_stream` now opens **two short-lived sessions** (prep + save) instead of one across the whole generator. LLM-streaming phase runs with no session checked out.
- Endpoint `/chat/stream` drops `Depends(get_db)`. Generator owns sessions via module-level `async_session` factory.

## Code review caught two would-have-shipped silent regressions (now fixed)

The two-session split inadvertently broke implicit single-session contracts:

1. **`_check_daily_quota`**: `user.daily_chat_count += 1` mutated an object loaded by `get_optional_user`'s session, not the chat-stream prep session — `flush()` no-op, **quota would have silently stopped incrementing for all logged-in non-BYOK users**. Infinite paid LLM credit burn.
2. **`_mark_attachments_consumed`**: `row.consumed_at = now` on rows loaded by phase-1 session, mutated after that session closed — **single-use enumeration mitigation silently broken** (security regression).

Both now use **explicit UPDATE statements** that persist regardless of session attachment.

Additional hardening: phase-3 save failure now wrapped in try/except so the `done` SSE event still reaches the frontend (otherwise UI would sit in "thinking…" forever).

## Tests

13 cases in new `test_chat_stream_session_lifecycle.py`:
- Session-handoff invariant (close-before-LLM, open-after-LLM)
- Prep-error session cleanup
- Anonymous-flow skips save
- Endpoint signature snapshot (defends against accidental DI re-introduction)
- C1 fix lock (quota UPDATE)
- C2 fix lock (attachment UPDATE)
- Save-failure still yields done

Full `-k chat` suite: 46/46 green. ruff clean.

## Follow-up (not in this PR)

Pool 30+90 from #649 kept oversized to soak the new shape for a week; separate change can dial back once steady-state metrics confirm.

## Pre-merge review

Already passed `superpowers:requesting-code-review` — the two critical findings above were caught by that pass and fixed before this PR was opened.