### PR TITLE
fix(login): drop GitHub solid-black override to restore CTA hierarchy

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -185,7 +185,6 @@ function SocialLoginButtons() {
           block
           size="large"
           onClick={async () => { try { const { data } = await api.get("/auth/github/login"); window.location.href = data.url; } catch { message.error("GitHub 登录失败"); } }}
-          style={{ background: "#24292e", color: "#fff", borderColor: "#24292e" }}
         >
           GitHub 登录
         </Button>


### PR DESCRIPTION
## Summary

After #655 made the primary Log in button cinnabar, the GitHub social button (forced to solid \`#24292e\` via inline style on \`LoginPage.tsx:188\`) read as **a second primary CTA** — same visual weight as Log in. Users couldn't tell at a glance which was the main action.

Google was already correctly styled as a ghost button (white bg, dark text, brand icon). Drop the GitHub inline override so it matches Google. Brand recognition stays in the GitHub octocat icon.

## Visual hierarchy after

- **Solid cinnabar Log in** — the only filled button, primary CTA.
- **GitHub 登录 / Google 登录** — both white-bg outlined, sit clearly at the secondary tier.

Verified locally via headless screenshot.