### PR TITLE
fix(alignment): commit per-N-chunks to bound transaction age

### DIFF
--- a/backend/scripts/build_alignments.py
+++ b/backend/scripts/build_alignments.py
@@ -67,6 +67,7 @@ EMBED_TOP_K = 20                     # pgvector candidates per source chunk
 MAX_PARALLEL_PER_CHUNK = 3           # stop after accepting this many targets for one src chunk
 COST_CEILING_USD = 5.0               # abort if estimated LLM spend exceeds (override via --max-spend-usd)
 AVG_TOKENS_PER_CALL = 2000           # realistic for deepseek verify: ~1.5K input (bilingual chunks + prompt) + ~200 output
+COMMIT_EVERY_N_CHUNKS = 10           # checkpoint to DB every N processed text_a chunks (was: end of outer loop only)
 
 # Verification LLM configuration.
 # Defaults: reuse FoJin's main LLM (settings.llm_api_url + llm_model), detect
@@ -598,6 +599,7 @@ async def process_pair(
     limit_chunks: int | None,
     threshold: float,
     cost_guard: CostGuard,
+    commit_every: int = COMMIT_EVERY_N_CHUNKS,
 ) -> dict[str, int]:
     """Process one MVP pair. Returns counters dict."""
     stats = {"accepted": 0, "rejected_llm": 0, "rejected_embed": 0, "errors": 0}
@@ -649,6 +651,15 @@ async def process_pair(
 
                     if not candidates:
                         stats["rejected_embed"] += 1
+                        # still maybe time for periodic commit
+                        if (not dry_run) and i % commit_every == 0:
+                            await session.commit()
+                            logger.info(
+                                "  [a:%d/%d] checkpoint at chunk %d/%d: ✓%d ✗llm=%d ✗embed=%d spent=$%.3f",
+                                a_idx, len(a_resolved), i, len(a_chunks),
+                                stats["accepted"], stats["rejected_llm"], stats["rejected_embed"],
+                                cost_guard.spend_usd(),
+                            )
                         continue
 
                     if dry_run:
@@ -700,7 +711,19 @@ async def process_pair(
                         else:
                             stats["rejected_llm"] += 1
 
-                # Commit + progress log after each source text completes
+                    # Periodic checkpoint so a long single-text_a pair (e.g.
+                    # lotus_zh_bo: 182 chunks × ~20 candidates × ~4s/LLM-call
+                    # would otherwise hold one transaction open for ~3h).
+                    if i % commit_every == 0:
+                        await session.commit()
+                        logger.info(
+                            "  [a:%d/%d] checkpoint at chunk %d/%d: ✓%d ✗llm=%d ✗embed=%d spent=$%.3f",
+                            a_idx, len(a_resolved), i, len(a_chunks),
+                            stats["accepted"], stats["rejected_llm"], stats["rejected_embed"],
+                            cost_guard.spend_usd(),
+                        )
+
+                # Final commit + progress log after each source text completes
                 await session.commit()
                 logger.info(
                     "  [a:%d/%d] done: ✓total=%d ✗llm=%d ✗embed=%d spent=$%.3f",
@@ -712,7 +735,7 @@ async def process_pair(
     return stats
 
 
-async def main_async(pair_key: str, dry_run: bool, limit_chunks: int | None, threshold: float, max_spend_usd: float, force_reasoning_model: bool) -> None:
+async def main_async(pair_key: str, dry_run: bool, limit_chunks: int | None, threshold: float, max_spend_usd: float, force_reasoning_model: bool, commit_every: int) -> None:
     pairs_to_run = (
         MVP_PAIRS if pair_key == "all"
         else [p for p in MVP_PAIRS if p.key == pair_key]
@@ -745,7 +768,7 @@ async def main_async(pair_key: str, dry_run: bool, limit_chunks: int | None, thr
         logger.info("=" * 70)
         logger.info("Pair: %s — %s", pair.name, pair.description)
         logger.info("=" * 70)
-        stats = await process_pair(pair, dry_run, limit_chunks, threshold, cost_guard)
+        stats = await process_pair(pair, dry_run, limit_chunks, threshold, cost_guard, commit_every)
         for k, v in stats.items():
             overall[k] += v
 
@@ -777,9 +800,18 @@ if __name__ == "__main__":
         help="Allow a real run with a reasoning model (deepseek-v4-pro / o1 / …). "
              "Disabled by default because reasoning_tokens make cost estimates unreliable.",
     )
+    parser.add_argument(
+        "--commit-every",
+        type=int,
+        default=COMMIT_EVERY_N_CHUNKS,
+        help=f"Commit DB transaction every N processed text_a chunks "
+             f"(default {COMMIT_EVERY_N_CHUNKS}). Prevents long open transactions "
+             "on single-text_a pairs (e.g. lotus_zh_bo: 182 chunks otherwise "
+             "held one transaction open ~3h). Set higher for faster pairs.",
+    )
     args = parser.parse_args()
 
     asyncio.run(main_async(
         args.pair, args.dry_run, args.limit_chunks, args.threshold,
-        args.max_spend_usd, args.force_reasoning_model,
+        args.max_spend_usd, args.force_reasoning_model, args.commit_every,
     ))


### PR DESCRIPTION
## Problem

PR #658 enabled \`lotus_zh_bo\` (T0262 法华 ↔ Toh 113), a **single-text_a** pair with 182 chunks. The existing script commits once at end of each text_a outer-loop iteration — for single-text_a pairs that's once, at the very end. lotus took 115+ min in prod with the DB transaction \`idle in transaction\` the entire time. I killed it before completion.

Observed: \`pg_stat_activity\` showed PID 44508 \`idle in transaction\` for 6,895 sec. DeepSeek connection healthy throughout (~88 LLM calls/min, 4400+ requests issued). The work was happening; it just couldn't be checkpointed.

## Fix

\`COMMIT_EVERY_N_CHUNKS=10\` constant + \`--commit-every\` CLI flag. Inner loop now commits after every N processed text_a chunks. A SIGTERM mid-run loses ≤ N-1 chunks of work.

Also: each checkpoint logs progress (\`✓X ✗llm=Y ✗embed=Z spent=\$W\`), so live monitoring no longer requires tail-f'ing stderr.

## Why agama_* didn't hit this

\`agama_mn\` / \`agama_dn\` etc. are multi-text_a pairs (152 / 34 Pali suttas). The outer-loop commit fires once per sutta — natural batching. lotus_zh_bo is the first single-text_a Mahayana pair, which makes it the first to expose this.

## Validation plan after merge

\`\`\`bash
docker exec -e VERIFY_LLM_MODEL=deepseek-v4-flash fojin-backend \\
  python -m scripts.build_alignments \\
    --pair lotus_zh_bo \\
    --max-spend-usd 5 \\
    --commit-every 10
\`\`\`

- [ ] First checkpoint log line within ~3-5 min (vs ~30-40 min for first DB row before)
- [ ] \`SELECT COUNT(*) FROM alignment_pairs WHERE text_a_id=6513 AND text_b_id=5267\` grows over time, not in a single big jump at end
- [ ] Total runtime similar (\~ 2h based on observed 88 calls/min) but progress is now visible and SIGTERM-safe
- [ ] Final FINAL line confirms total accepted vs rejected

## Test plan

- [x] AST-parses
- [ ] Lint/CI green
- [ ] Merge
- [ ] Re-run lotus_zh_bo (this time to completion)
- [ ] Verify per-chunk commits via DB COUNT growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)