### PR TITLE
feat(alignment): Batch 1.5 — 八千颂般若 汉藏 (T0227 ↔ Toh 11)

### DIFF
--- a/backend/scripts/build_alignments.py
+++ b/backend/scripts/build_alignments.py
@@ -264,6 +264,21 @@ MVP_PAIRS: list[AlignmentPair] = [
         text_b=TextResolver(source_code="84000", text_id=5267),  # Toh 113, 1307 chunks
         description="T0262《妙法莲华经》罗什译 ↔ 84000 Toh 113 Saddharmapuṇḍarīka 藏译",
     ),
+    # ------------------------------------------------------------------
+    # Batch 1.5: 般若部 / 楞伽 / 涅槃 / 楞严 一档（2026-06-09 加入）
+    # 优先 8k 颂般若 — 双侧都 embedded、规模与 lotus 同级、最早可上线。
+    # 楞严 (T0945)↔Toh 506 和 涅槃 (T0374)↔Toh 119 暂不加 pair —
+    # 84000 这两本藏译目前 chunks=0 未 ingest（参考 prod 2026-06-09 实测）。
+    # 25k 颂般若 (T0223↔Toh 9, 815×12022 chunks) 留 Batch 2，需先决定
+    # 切片策略 / cron 多日跑。
+    # ------------------------------------------------------------------
+    AlignmentPair(
+        key="prajna_8k_zh_bo",
+        name="八千颂般若 汉藏",
+        text_a=TextResolver(source_code="cbeta", text_id=6482),  # T0227 小品般若波罗蜜经 (鸠摩罗什), 193 chunks
+        text_b=TextResolver(source_code="84000", text_id=5165),  # Toh 11 Aṣṭasāhasrikā Prajñāpāramitā, 4706 chunks
+        description="T0227《小品般若波罗蜜经》罗什译 ↔ 84000 Toh 11 Aṣṭasāhasrikā Prajñāpāramitā 藏译",
+    ),
 ]
 
 
@@ -782,7 +797,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--pair",
         required=True,
-        help="Pair key: heart|satipatthana|dhammacakka|dhamma_pali|vimalakirti|agama_mn|agama_dn|agama_sn56|agama_an4|lotus_zh_bo|all",
+        help="Pair key: heart|satipatthana|dhammacakka|dhamma_pali|vimalakirti|agama_mn|agama_dn|agama_sn56|agama_an4|lotus_zh_bo|prajna_8k_zh_bo|all",
     )
     parser.add_argument("--dry-run", action="store_true", help="Skip LLM calls, print embedding candidates only")
     parser.add_argument("--limit-chunks", type=int, default=None, help="Cap chunks per text (for smoke testing)")


### PR DESCRIPTION
## Summary

Add the next cross-canon pair after Batch 1's lotus: **小品般若 / 8k-vers Prajñāpāramitā**.

| | source | target |
|--|--|--|
| Pair key | \`prajna_8k_zh_bo\` | |
| Chinese | T0227 小品般若波罗蜜经 (鸠摩罗什) | id=6482, **193 lzh chunks** |
| Tibetan | 84000 Toh 11 Aṣṭasāhasrikā Prajñāpāramitā | id=5165, **4,706 bo chunks** |

Same shape as \`lotus_zh_bo\`: single-text_a, small Chinese side (193 vs Lotus's 182), rich Tibetan target pool (4,706 vs Lotus's 1,307). Expected runtime ~2.5–3h at the observed 50 s/chunk with \`--commit-every 10\`. Expected cost <\$2 (Lotus was \$1.70/259 pairs). Idempotent over the existing \`uq_align_chunk_pair\` index.

## Other Batch 1.5 candidates deliberately skipped this PR

I probed prod for all five Mahayana 汉藏 candidates before drafting this PR ([results in script comment](backend/scripts/build_alignments.py)):

| Pair | Decision | Why |
|--|--|--|
| T0945 楞严 ↔ Toh 506 | ❌ skip | Toh 506 has **0 ingested chunks** in our 84000 import |
| T0374 涅槃 ↔ Toh 119 | ❌ skip | Toh 119 has **0 ingested chunks** |
| T0223 摩诃般若 25k ↔ Toh 9 | ⏭ Batch 2 | viable (Toh 9 = 12,022 chunks) but 815 source × 50 s ≈ 11 h, needs slicing strategy |
| T0397 大集经 (2,494 chunks) | ⏭ later | Tibetan parallel not yet identified; needs research |
| T0671/T0672 楞伽 | ⏭ later | needs Toh mapping verification |

## Test plan

- [ ] CI green
- [ ] Merge
- [ ] On prod: \`docker exec -e VERIFY_LLM_MODEL=deepseek-v4-flash fojin-backend python -m scripts.build_alignments --pair prajna_8k_zh_bo --max-spend-usd 5 --commit-every 10\`
- [ ] Watch for first checkpoint at chunk 10 within ~5 min (smoke that the pair resolves)
- [ ] Verify via \`SELECT COUNT(*) FROM alignment_pairs WHERE text_a_id=6482 AND text_b_id=5165\` grows over time
- [ ] After completion: hit \`/api/alignment/texts/6482/juans/1\` and inspect reader 「跨藏对照」 → 「按段对读」 panel at \`/texts/6482/read\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)