### PR TITLE
feat(chat): SSE heartbeat + phase markers for /chat/stream

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -1155,16 +1155,18 @@ async def _interleave_heartbeat(inner_gen, heartbeat_interval: float):
     outer fallback / retry logic is unchanged.
     """
     queue: asyncio.Queue = asyncio.Queue(maxsize=64)
-    _DONE = object()
 
     async def _producer():
         try:
             async for chunk in inner_gen:
                 await queue.put(("content", chunk))
-            await queue.put(("done", _DONE))
+            await queue.put(("done", None))
         except asyncio.CancelledError:
             raise
         except Exception as exc:
+            # If the consumer already exited (e.g. cancelled the wrapper before
+            # we got here), this put would block until the outer ``finally``
+            # cancels us — which is fine, just non-obvious from this line alone.
             await queue.put(("error", exc))
 
     task = asyncio.create_task(_producer())

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time as _time
@@ -31,6 +32,14 @@ logger = logging.getLogger(__name__)
 # Free daily limits for users without their own API key
 FREE_DAILY_LIMIT_USER = 200      # Logged-in users — effectively unlimited for normal use, caps abuse
 FREE_DAILY_LIMIT_ANONYMOUS = 10  # Anonymous users (encourage registration)
+
+# SSE keepalive cadence during LLM streaming. Sized for the tightest
+# documented idle-cut on the path: Cloudflare free-plan edge ≈100s,
+# nginx ``proxy_read_timeout`` 120s. 25s gives ~4× headroom on both,
+# while staying quiet enough that a fast-streaming model rarely emits
+# a heartbeat at all. Comment-style SSE (``:\n\n``) is ignored by
+# browsers per spec, so this is invisible to the frontend consumer.
+LLM_STREAM_HEARTBEAT_INTERVAL_S = 25.0
 
 # Provider → base URL mapping (most are OpenAI-compatible; Anthropic uses its own format)
 PROVIDER_URLS = {
@@ -1122,6 +1131,66 @@ async def send_message(
     )
 
 
+async def _interleave_heartbeat(inner_gen, heartbeat_interval: float):
+    """Wrap an async generator so heartbeat markers interleave during idle gaps.
+
+    Yields ``("content", chunk)`` for each item produced by ``inner_gen`` and
+    ``("ping", None)`` whenever ``heartbeat_interval`` seconds pass without a
+    new chunk. The caller is expected to translate ``ping`` into a comment-style
+    SSE frame (``: keepalive\\n\\n``) so intermediate proxies see traffic and
+    don't reap an idle connection.
+
+    Why this exists: ``/chat/stream`` in reader mode (``page_content`` set)
+    runs DeepSeek V4 Pro for up to 120s on a long juan. When the model pauses
+    generation for tens of seconds near the end, the underlying TCP stays
+    quiet, and Cloudflare's free-plan edge (~100s) or nginx
+    ``proxy_read_timeout`` (120s) silently sever the connection. The frontend
+    XHR sees ``onerror`` (not a clean ``done`` event) and shows the
+    "网络错误，请稍后重试" toast even though the answer was almost complete.
+    See ``feedback_log_before_second_guess`` and the 2026-06-09 reader-mode
+    incident on T1579 juan 7.
+
+    Exceptions from ``inner_gen`` (e.g. ``httpx.TimeoutException``) are
+    re-raised on the consumer side after the producer task finishes, so the
+    outer fallback / retry logic is unchanged.
+    """
+    queue: asyncio.Queue = asyncio.Queue(maxsize=64)
+    _DONE = object()
+
+    async def _producer():
+        try:
+            async for chunk in inner_gen:
+                await queue.put(("content", chunk))
+            await queue.put(("done", _DONE))
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            await queue.put(("error", exc))
+
+    task = asyncio.create_task(_producer())
+    try:
+        while True:
+            try:
+                kind, payload = await asyncio.wait_for(
+                    queue.get(), timeout=heartbeat_interval
+                )
+            except TimeoutError:
+                yield ("ping", None)
+                continue
+            if kind == "done":
+                return
+            if kind == "error":
+                raise payload  # type: ignore[misc]
+            yield ("content", payload)
+    finally:
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except BaseException:
+                pass
+
+
 async def send_message_stream(
     user_id: int | None,
     message: str,
@@ -1270,10 +1339,20 @@ async def send_message_stream(
 
     full_answer = ""
     received_first_token = False
+    phase2_start = _time.monotonic()
     try:
         for idx, (att_url, att_key, att_model, att_provider, is_fb) in enumerate(attempts):
             try:
-                async for content in _stream_llm_once(att_url, att_key, att_model, att_provider):
+                async for kind, content in _interleave_heartbeat(
+                    _stream_llm_once(att_url, att_key, att_model, att_provider),
+                    heartbeat_interval=LLM_STREAM_HEARTBEAT_INTERVAL_S,
+                ):
+                    if kind == "ping":
+                        # SSE comment frame — browsers ignore lines starting
+                        # with ":", but the bytes keep CF/nginx from reaping
+                        # the connection while the LLM pauses generation.
+                        yield ": keepalive\n\n"
+                        continue
                     if not received_first_token:
                         received_first_token = True
                         if is_fb:
@@ -1324,6 +1403,14 @@ async def send_message_stream(
         yield f"data: {json.dumps({'type': 'error', 'message': error_msg}, ensure_ascii=False)}\n\n"
         full_answer = full_answer or error_msg
 
+    logger.info(
+        "chat/stream phase-2 LLM done in %.2fs (%d chars, session_id=%s, provider=%s)",
+        _time.monotonic() - phase2_start,
+        len(full_answer),
+        chat_session.id if chat_session else 0,
+        provider,
+    )
+
     # Citation guard: rewrite any 【《X》第N卷】 not anchored in the
     # retrieved sources. The user has already seen the raw stream; we
     # emit a final 'citation_correction' event so the frontend can swap
@@ -1339,10 +1426,17 @@ async def send_message_stream(
     # text, a late `token` would re-append the LLM's raw output and
     # silently re-introduce the hallucination this guard exists to
     # prevent.
+    cg_start = _time.monotonic()
     corrected_answer, _citation_mutations = enforce_citation_whitelist(full_answer, sources)
     # Quote verifier runs after citation_guard so flagged-and-stripped
     # citations don't carry their quotes into a second annotation.
     corrected_answer, _quote_mutations = verify_quoted_content(corrected_answer, sources)
+    logger.info(
+        "chat/stream phase-cg %.2fs (citations=%d, quotes=%d)",
+        _time.monotonic() - cg_start,
+        len(_citation_mutations),
+        len(_quote_mutations),
+    )
     # Emit one merged `citation_correction` event covering both
     # rewrites (citation + quote annotations) so the frontend swap is a
     # single state mutation rather than two.
@@ -1375,6 +1469,7 @@ async def send_message_stream(
     # storage path) is out of scope for this refactor.
     assistant_msg_id: int | None = None
     if chat_session:
+        save_start = _time.monotonic()
         try:
             async with sessionmaker() as db_save:
                 assistant_msg_id = await _save_messages(
@@ -1389,6 +1484,12 @@ async def send_message_stream(
                 "not persisted (session_id=%s, user_id=%s)",
                 chat_session.id, user_id,
             )
+        logger.info(
+            "chat/stream phase-3 save %.2fs (session_id=%s, assistant_msg_id=%s)",
+            _time.monotonic() - save_start,
+            chat_session.id,
+            assistant_msg_id,
+        )
         # db_save closed before the message_id yield below.
 
         # Emit the real chat_messages.id so the frontend can swap the

--- a/backend/tests/test_chat_stream_heartbeat.py
+++ b/backend/tests/test_chat_stream_heartbeat.py
@@ -1,0 +1,116 @@
+"""Heartbeat watchdog for ``/chat/stream`` SSE.
+
+Locks the contract that ``_interleave_heartbeat`` emits ``("ping", None)``
+markers whenever the wrapped inner generator goes quiet for longer than
+``heartbeat_interval``. The outer ``send_message_stream`` translates these
+into ``: keepalive\\n\\n`` SSE comment frames so Cloudflare's free-plan
+edge (~100s) and nginx ``proxy_read_timeout`` (120s) don't sever the
+connection while DeepSeek V4 Pro pauses generation near the end of a
+long reader-mode answer. See ``feedback_log_before_second_guess`` and
+the 2026-06-09 T1579 juan-7 incident write-up.
+"""
+
+import asyncio
+
+import pytest
+
+from app.services.chat import _interleave_heartbeat
+
+
+async def _fast_gen():
+    for chunk in ["a", "b", "c"]:
+        yield chunk
+
+
+async def _slow_first_token(delay: float):
+    await asyncio.sleep(delay)
+    yield "late"
+
+
+async def _raises_mid_stream():
+    yield "ok"
+    raise RuntimeError("boom")
+
+
+@pytest.mark.anyio
+async def test_no_ping_when_inner_fast():
+    """A generator that yields immediately should produce zero ping markers —
+    the wrapper must not introduce phantom traffic on the happy path.
+    """
+    events: list[tuple[str, object]] = []
+    async for kind, payload in _interleave_heartbeat(_fast_gen(), heartbeat_interval=1.0):
+        events.append((kind, payload))
+
+    assert events == [("content", "a"), ("content", "b"), ("content", "c")]
+
+
+@pytest.mark.anyio
+async def test_ping_emitted_when_inner_idle_longer_than_interval():
+    """When the inner generator stalls past ``heartbeat_interval``, the
+    wrapper must emit at least one ``ping`` before the late token, then
+    pass the token through unchanged.
+    """
+    events: list[tuple[str, object]] = []
+    async for kind, payload in _interleave_heartbeat(
+        _slow_first_token(delay=0.3), heartbeat_interval=0.1
+    ):
+        events.append((kind, payload))
+
+    pings = [e for e in events if e[0] == "ping"]
+    contents = [e for e in events if e[0] == "content"]
+    assert pings, "expected at least one ping before slow first token, got none"
+    assert contents == [("content", "late")]
+    # All pings must come before the content (consumer expects pings during
+    # the idle gap, not interleaved after content has arrived).
+    assert events.index(("ping", None)) < events.index(("content", "late"))
+
+
+@pytest.mark.anyio
+async def test_exception_from_inner_propagates():
+    """An exception raised by the inner generator must surface on the
+    consumer side after any already-buffered ``content`` is delivered, so
+    the existing ``except (httpx.TimeoutException, ...)`` in
+    ``send_message_stream`` keeps its fallback semantics.
+    """
+    events: list[tuple[str, object]] = []
+    with pytest.raises(RuntimeError, match="boom"):
+        async for kind, payload in _interleave_heartbeat(
+            _raises_mid_stream(), heartbeat_interval=1.0
+        ):
+            events.append((kind, payload))
+
+    assert events == [("content", "ok")]
+
+
+@pytest.mark.anyio
+async def test_consumer_cancellation_cleans_up_producer():
+    """When the consumer side is cancelled (e.g. client disconnects mid-
+    stream), the internal producer task must be cancelled too — otherwise
+    we leak a background task holding an open httpx connection.
+    """
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _hang_after_start():
+        started.set()
+        try:
+            await asyncio.sleep(10)
+            yield "unreachable"
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def _consume():
+        async for _ in _interleave_heartbeat(_hang_after_start(), heartbeat_interval=5.0):
+            pass
+
+    task = asyncio.create_task(_consume())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Give the event loop one tick to let the producer's cancellation finalise.
+    await asyncio.sleep(0)
+    assert cancelled.is_set(), "inner producer was not cancelled when consumer aborted"

--- a/backend/tests/test_chat_stream_heartbeat.py
+++ b/backend/tests/test_chat_stream_heartbeat.py
@@ -27,8 +27,9 @@ async def _slow_first_token(delay: float):
     yield "late"
 
 
-async def _raises_mid_stream():
-    yield "ok"
+async def _raises_after_n(n: int):
+    for i in range(n):
+        yield f"chunk-{i}"
     raise RuntimeError("boom")
 
 
@@ -66,20 +67,24 @@ async def test_ping_emitted_when_inner_idle_longer_than_interval():
 
 
 @pytest.mark.anyio
-async def test_exception_from_inner_propagates():
+async def test_exception_from_inner_propagates_after_buffered_content():
     """An exception raised by the inner generator must surface on the
-    consumer side after any already-buffered ``content`` is delivered, so
-    the existing ``except (httpx.TimeoutException, ...)`` in
-    ``send_message_stream`` keeps its fallback semantics.
+    consumer side ONLY after every already-yielded ``content`` chunk is
+    delivered — the producer side puts items into a queue, so a naive
+    implementation could swallow buffered content if the error skipped
+    ahead. We yield several items before raising to lock the FIFO contract
+    that ``send_message_stream``'s post-first-token error path depends on
+    (it records ``full_answer`` from every delivered chunk and only then
+    emits the "回答中途中断" SSE error event).
     """
     events: list[tuple[str, object]] = []
     with pytest.raises(RuntimeError, match="boom"):
         async for kind, payload in _interleave_heartbeat(
-            _raises_mid_stream(), heartbeat_interval=1.0
+            _raises_after_n(8), heartbeat_interval=1.0
         ):
             events.append((kind, payload))
 
-    assert events == [("content", "ok")]
+    assert events == [("content", f"chunk-{i}") for i in range(8)]
 
 
 @pytest.mark.anyio
@@ -111,6 +116,9 @@ async def test_consumer_cancellation_cleans_up_producer():
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    # Give the event loop one tick to let the producer's cancellation finalise.
-    await asyncio.sleep(0)
+    # The cancellation chain (consumer → wrapper.finally → producer.cancel →
+    # inner gen.except CancelledError → cancelled.set()) crosses several
+    # event-loop ticks. Wait up to 1s rather than asserting on a single
+    # ``sleep(0)`` so the test doesn't flake under shared-runner load.
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)
     assert cancelled.is_set(), "inner producer was not cancelled when consumer aborted"


### PR DESCRIPTION
## Why

2026-06-09 reader-mode incident on T1579 卷七: user saw partial AI 解读 stream then "网络错误，请稍后重试" toast around the 99-second mark. Backend logged 200 OK with zero WARN/ERROR. Frontend `xhr.onerror` fired before any `done` event arrived — classic intermediate-proxy idle-cut on a long-running SSE.

Two layers of fix in one PR.

## What

**1. Heartbeat watchdog (treats the symptom for every long stream, not just this one)**

`_interleave_heartbeat()` wraps the LLM stream generator. Whenever the inner generator goes quiet for >25s, the outer SSE generator emits a spec-compliant comment frame (`: keepalive\n\n`). 25s gives ~4× headroom on Cloudflare's free-plan edge idle (~100s) and nginx `proxy_read_timeout 120s` — the two paths that have been demonstrably reaping reader-mode streams. The frontend XHR consumer already filters non-`data:` lines (`client.ts:1575`), so this is invisible end-to-end.

**2. Phase logger.info markers (closes the diagnostic gap)**

Three new `logger.info` lines around the LLM stream:

- `chat/stream phase-2 LLM done in %.2fs (%d chars, ...)` — fires on every exit including bare `except Exception:` so we can see how long failing calls took.
- `chat/stream phase-cg %.2fs (citations=%d, quotes=%d)` — citation_guard + verify_quoted_content cost on real answers.
- `chat/stream phase-3 save %.2fs (...)` — phase-3 DB save cost.

Next time a reader-mode answer dies, prod logs will say which phase ran long, instead of just 200 OK.

## Test plan

- [x] `tests/test_chat_stream_heartbeat.py` (4 tests × 2 anyio backends = 8 cases):
  - No ping when inner generator is fast (no phantom traffic on happy path).
  - Ping emitted before content when inner stalls past `heartbeat_interval`.
  - Exception from inner propagates AFTER all 8 buffered chunks deliver (FIFO contract).
  - Consumer cancellation cleans up producer task (no leaked httpx connections).
- [x] Existing regression suite green: `test_chat_stream_session_lifecycle.py` (8) + `test_chat_sources_order.py` (8) + `test_chat_attachments.py` (14) + `test_citation_guard.py` (15).
- [x] `ruff check` clean.
- [ ] Post-deploy: tail `docker logs fojin-backend` after a reader-mode answer and confirm the three new phase-N lines appear.

## Risk

- Behavior change to SSE is comment-only. Browsers ignore `:`-prefixed lines per spec, frontend `client.ts:1575` filters them too. No frontend change required.
- Fallback / retry semantics for LLM exceptions are unchanged — the wrapper re-raises so the outer `except (httpx.TimeoutException, httpx.HTTPStatusError, httpx.RequestError)` still fires.
- Logger lines are 3 `INFO` per stream, no hot-path regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)