### PR TITLE
chore(logging): lift app.* loggers to INFO

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,29 @@ try:
 except ImportError:
     _HAS_DIANJIN = False
 
+# Lift application loggers to INFO so the ~13 ``logger.info`` calls we
+# already place at notable boundaries (auth events, chat phase markers,
+# model fallback, attachment parse failures, etc.) actually surface in
+# ``docker logs fojin-backend``. Python's root logger defaults to WARNING
+# and uvicorn never reconfigures it, so anything under the ``app.*``
+# namespace was silently dropped — a chronic diagnostic gap (see
+# feedback_log_before_second_guess and the 2026-06-09 T1579 juan-7
+# reader-mode incident write-up). Scoped to ``app.*`` to avoid spamming
+# logs with INFO from third-party libraries (sqlalchemy, httpx, etc.).
+_app_logger = logging.getLogger("app")
+_app_logger.setLevel(logging.INFO)
+if not _app_logger.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    ))
+    _app_logger.addHandler(_h)
+    # Don't propagate to root — uvicorn doesn't install a handler there
+    # and the lastResort filter would re-drop INFO anyway, but it also
+    # avoids duplicate lines if a future change adds a root handler.
+    _app_logger.propagate = False
+
 logger = logging.getLogger(__name__)
 from datetime import UTC
 


### PR DESCRIPTION
## Why

Smoke-testing PR #662 just exposed a deeper diagnostic gap: the new chat phase markers I added (and ran in prod) produced **zero output** in \`docker logs fojin-backend\`. Root cause is older than this branch — Python's root logger defaults to WARNING, uvicorn never reconfigures it, and there's no \`basicConfig\` anywhere in the app. So every \`logger.info\` we've ever written has been silently dropped before reaching docker stdout.

That's why the 2026-06-09 T1579 reader-mode incident showed up as 200 OK with no breadcrumb — even though the codebase has \`logger.info(\"Serving via fallback LLM ...\")\` and \`logger.warning(\"chat/stream prepare rejected ...\")\` that *should* have helped. The WARNING-level ones did surface; the INFO ones never did.

## What

One block in \`backend/app/main.py\`:

\`\`\`python
_app_logger = logging.getLogger("app")
_app_logger.setLevel(logging.INFO)
if not _app_logger.handlers:
    _h = logging.StreamHandler()
    _h.setFormatter(logging.Formatter(
        "%(asctime)s %(levelname)s %(name)s: %(message)s",
        datefmt="%Y-%m-%dT%H:%M:%S",
    ))
    _app_logger.addHandler(_h)
    _app_logger.propagate = False
\`\`\`

Scoped to \`app.*\` so sqlalchemy / httpx / elasticsearch INFO chatter stays off. \`propagate=False\` prevents duplicates if a future change adds a root handler.

## Blast radius

13 existing \`logger.info\` call-sites become visible. None are per-request hot-path:
- \`app.api.auth\` (login events) — already gated to event boundaries
- \`app.api.chat\` (attachment parse failure)
- \`app.services.auth\` (token rotation)
- \`app.services.chat\` (model fallback, unknown model_id, phase markers from #662)
- \`app.services.precise_retrieval\` (1 line)
- \`app.services.usage_service\` (umami engine init — startup only)
- \`app.core.xml_parser\` (gaiji cache — startup only)
- \`app.main\` (startup events)

Expected steady-state extra volume: ~3 lines per \`/chat/stream\` request (the phase markers). Other logger.info lines fire on edge events only.

## Test plan

- [x] Local: \`ruff check\` clean, \`test_smoke.py\` matches master baseline (2 pre-existing kg_entity_detail failures unrelated to this change).
- [ ] Post-deploy: trigger an \`/api/chat/stream\` and verify the three \`chat/stream phase-...\` lines appear in \`docker logs fojin-backend\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)