### PR TITLE
fix(deploy): skip backend restart for scripts/tests/eval/alembic-only changes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -129,14 +129,30 @@ elif ! is_known_commit "$BE_BASE"; then
   backend_image_changed=true
 elif [ "$BE_BASE" != "$NEW_REV" ]; then
   BE_DIFF="$(git diff --name-only "$BE_BASE" "$NEW_REV")"
-  if echo "$BE_DIFF" | grep -q '^backend/'; then
-    log "backend/ 自 ${BE_BASE:0:7} 起有变更 — 触发 restart。"
-    echo "$BE_DIFF" | grep '^backend/' | sed 's/^/    /'
+  # Live API path: backend/ minus dirs that don't ride the uvicorn process.
+  # - backend/scripts/   : CLI tools (build_alignments, build_works, audits, …)
+  # - backend/tests/     : pytest fixtures / unit tests
+  # - backend/eval/      : RAG eval harness
+  # - backend/alembic/   : migration files (apply via `alembic upgrade`, not restart)
+  # Changing any of these MUST NOT bounce a running uvicorn — and, more importantly,
+  # MUST NOT kill long-running scripts a developer has launched via `docker exec`.
+  BE_LIVE_DIFF="$(echo "$BE_DIFF" | grep -E '^backend/' | grep -vE '^backend/(scripts|tests|eval|alembic)/' || true)"
+  if [ -n "$BE_LIVE_DIFF" ]; then
+    log "backend/ live-API 路径自 ${BE_BASE:0:7} 起有变更 — 触发 restart。"
+    echo "$BE_LIVE_DIFF" | sed 's/^/    /'
     backend_changed=true
-    if echo "$BE_DIFF" | grep -qE '^backend/(Dockerfile|requirements[^/]*\.txt|pyproject\.toml)$'; then
+    if echo "$BE_LIVE_DIFF" | grep -qE '^backend/(Dockerfile|requirements[^/]*\.txt|pyproject\.toml)$'; then
       log "backend 依赖/Dockerfile 改动 — 升级为 rebuild image。"
       backend_image_changed=true
     fi
+  elif echo "$BE_DIFF" | grep -q '^backend/'; then
+    # Pure scripts/tests/eval/alembic change — log but don't restart.
+    log "backend/ 仅有 scripts/tests/eval/alembic 改动 — 跳过 restart（不影响 uvicorn，也不杀正在跑的脚本）。"
+    echo "$BE_DIFF" | grep '^backend/' | sed 's/^/    /'
+    # Still bump the marker so we don't keep re-evaluating the same untouched
+    # diff every cron tick — otherwise the next deploy.sh run will see the same
+    # `BE_DIFF` and re-log this skip message indefinitely.
+    echo "$NEW_REV" > "$BACKEND_RESTART_MARKER"
   fi
 fi
 


### PR DESCRIPTION
## Problem

\`deploy.sh\` triggers \`docker compose up -d --force-recreate backend\` whenever ANY file under \`backend/\` differs between the marker commit and HEAD. That includes \`backend/scripts/\`, which holds CLI tools that don't run inside the uvicorn process at all.

**Concrete prod incident 2026-06-09**: PR #661 added a new pair to \`backend/scripts/build_alignments.py\`. The very next cron tick of \`deploy.sh\` saw the script touched \`backend/\`, recreated the backend container, and killed the \`prajna_8k_zh_bo\` alignment run that had been started ~2.5h earlier via \`docker exec\`. 82 already-committed pairs survived (uq index + \`--commit-every 10\` from #659), but ~\$1 of LLM verification work for the final 53 chunks was lost and had to be re-paid on restart.

## Fix

Filter the diff to the live-API subset of \`backend/\` before deciding to restart:

| path | reason for excluding |
|--|--|
| \`backend/scripts/\` | CLI tools run via \`docker exec\`, not inside uvicorn |
| \`backend/tests/\` | pytest — never live in prod |
| \`backend/eval/\` | RAG eval harness — invoked manually |
| \`backend/alembic/\` | migrations apply via \`alembic upgrade\`, not via restart |

If any **remaining** file under \`backend/\` changed (e.g. \`backend/app/\`, \`backend/Dockerfile\`, \`backend/requirements.txt\`, \`backend/pyproject.toml\`) → restart as before. The Dockerfile/requirements → rebuild-image escalation still works.

If **only** scripts/tests/eval/alembic changed → log it, bump the marker (so next cron tick doesn't re-log the same skip forever), and continue.

## Test plan

- [x] \`bash -n deploy.sh\` passes
- [ ] Merge
- [ ] On prod next cron tick: \`deploy.sh\` sees this PR's own \`deploy.sh\` change as a live-API change (correct), restarts backend ONCE, then on subsequent ticks goes quiet
- [ ] Verify by touching \`backend/scripts/foo.txt\` (or merging an alignment PR like #661): next cron tick logs the new skip message and does NOT recreate backend
- [ ] No frontend / .env behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)