### PR TITLE
feat(sources): add license/rights metadata fields

### DIFF
--- a/backend/alembic/versions/0148_add_source_license_fields.py
+++ b/backend/alembic/versions/0148_add_source_license_fields.py
@@ -1,0 +1,46 @@
+"""add license fields to data_sources
+
+Revision ID: 0148
+Revises: 0147
+Create Date: 2026-06-10
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0148"
+down_revision: Union[str, None] = "0147"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+LICENSE_COLUMNS = [
+    "license_spdx",
+    "license_url",
+    "license_notes",
+    "attribution_required",
+    "commercial_allowed",
+    "redistribution_allowed",
+    "embedding_allowed",
+    "license_verified_at",
+]
+
+
+def upgrade() -> None:
+    op.add_column("data_sources", sa.Column("license_spdx", sa.String(50), nullable=True))
+    op.add_column("data_sources", sa.Column("license_url", sa.String(500), nullable=True))
+    op.add_column("data_sources", sa.Column("license_notes", sa.Text(), nullable=True))
+    op.add_column("data_sources", sa.Column("attribution_required", sa.Boolean(), nullable=True))
+    op.add_column("data_sources", sa.Column("commercial_allowed", sa.Boolean(), nullable=True))
+    op.add_column("data_sources", sa.Column("redistribution_allowed", sa.Boolean(), nullable=True))
+    op.add_column("data_sources", sa.Column("embedding_allowed", sa.Boolean(), nullable=True))
+    op.add_column(
+        "data_sources",
+        sa.Column("license_verified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    for col in reversed(LICENSE_COLUMNS):
+        op.drop_column("data_sources", col)

--- a/backend/app/models/source.py
+++ b/backend/app/models/source.py
@@ -38,6 +38,20 @@ class DataSource(Base):
     # When the source first entered its current continuous unreachable streak;
     # NULL when not unreachable. now() - unreachable_since is the streak length.
     unreachable_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # License / rights metadata. NULL = unknown (not yet audited).
+    # license_spdx prefers SPDX identifier (CC-BY-4.0, CC0-1.0, CC-BY-NC-SA-3.0)
+    # or "proprietary" / "public-domain" / "unknown" when SPDX does not apply.
+    license_spdx: Mapped[str | None] = mapped_column(String(50))
+    license_url: Mapped[str | None] = mapped_column(String(500))
+    license_notes: Mapped[str | None] = mapped_column(Text)
+    attribution_required: Mapped[bool | None] = mapped_column(Boolean)
+    commercial_allowed: Mapped[bool | None] = mapped_column(Boolean)
+    redistribution_allowed: Mapped[bool | None] = mapped_column(Boolean)
+    # Specifically governs whether full-text may be embedded for AI/RAG indexing.
+    # Decoupled from redistribution_allowed: some sources permit linking but not
+    # embedding, or permit embedding for research but not commercial.
+    embedding_allowed: Mapped[bool | None] = mapped_column(Boolean)
+    license_verified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     # embedding column is vector(1024), managed via raw SQL; not mapped here
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/app/schemas/source.py
+++ b/backend/app/schemas/source.py
@@ -48,6 +48,14 @@ class DataSourceResponse(BaseModel):
     health_status: str = "ok"
     health_checked_at: datetime | None = None
     health_detail: str | None = None
+    license_spdx: str | None = None
+    license_url: str | None = None
+    license_notes: str | None = None
+    attribution_required: bool | None = None
+    commercial_allowed: bool | None = None
+    redistribution_allowed: bool | None = None
+    embedding_allowed: bool | None = None
+    license_verified_at: datetime | None = None
     created_at: datetime
     distributions: list[SourceDistributionResponse] = Field(default_factory=list)
 


### PR DESCRIPTION
## Summary

Wave 1.2 (P0): adds 8 nullable license/rights columns to `data_sources` to track per-source licensing for the 547 aggregated sources. Schema only — data backfill for the 5 primary sources (CBETA / 84000 / SuttaCentral / GRETIL / BDRC) follows in a separate PR after per-source ToS verification.

### Why now

fojin aggregates 547 sources and runs RAG embeddings across them, but has no per-source license tracking. This is a legal posture gap: there's currently no way to answer "is it OK to embed source X for AI indexing?" or "does source Y require attribution in citations?". The 8 fields make these questions answerable.

### Schema additions (all nullable; NULL = not yet audited)

| Field | Type | Purpose |
|---|---|---|
| `license_spdx` | `String(50)` | SPDX identifier preferred (`CC-BY-4.0`, `CC0-1.0`), fallback `proprietary` / `public-domain` / `unknown` |
| `license_url` | `String(500)` | Canonical license text URL |
| `license_notes` | `Text` | Free-text caveats, exceptions, special terms |
| `attribution_required` | `Boolean` | Citation/attribution required |
| `commercial_allowed` | `Boolean` | Commercial use allowed |
| `redistribution_allowed` | `Boolean` | Verbatim redistribution allowed |
| `embedding_allowed` | `Boolean` | **Specifically governs AI/RAG embedding** — decoupled from redistribution because some sources permit linking but not embedding |
| `license_verified_at` | `DateTime(tz=True)` | Audit timestamp |

### Migration

- `0148_add_source_license_fields.py`, chained from `0147`
- All `add_column` ops, no data movement
- Downgrade reverses by `drop_column`

### Out of scope (follow-up PRs)

1. **PR-2**: Backfill 5 primary sources after per-source license verification (CBETA terms, 84000 CC-BY-NC-ND-4.0, SuttaCentral, GRETIL per-text licenses, BDRC)
2. **UI exposure**: Display license badge in citation sidebar / source detail page
3. **Audit tooling**: Endpoint/script to flag sources with `license_spdx IS NULL` for backlog tracking

### Test plan

- [ ] CI green (mypy, ruff, pytest)
- [ ] alembic upgrade head dry-run on dev DB
- [ ] DataSourceResponse serializes new fields when NULL (sanity check on `/api/sources/`)

### Deploy notes

- **Prod alembic_version check required before deploy** ([feedback_fojin_alembic_chain_check.md] — 0130 incident teaches us prod can lag behind file chain). Verify prod is at `0147` before applying.
- Pure additive migration, no lock concerns, safe to roll forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)