### PR TITLE
feat(gaiji): add gaiji table for CBETA rare-character normalization

### DIFF
--- a/backend/alembic/versions/0150_add_gaiji_table.py
+++ b/backend/alembic/versions/0150_add_gaiji_table.py
@@ -1,0 +1,57 @@
+"""add gaiji table for CBETA rare-character normalization
+
+Revision ID: 0150
+Revises: 0149
+Create Date: 2026-06-10
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0150"
+down_revision: Union[str, None] = "0149"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "gaiji",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("cb_code", sa.String(length=20), nullable=False),
+        sa.Column("composition", sa.String(length=200), nullable=True),
+        sa.Column("unicode_char", sa.String(length=8), nullable=True),
+        sa.Column("unicode_codepoint", sa.String(length=20), nullable=True),
+        sa.Column("norm_unicode_char", sa.String(length=8), nullable=True),
+        sa.Column("norm_big5_char", sa.String(length=8), nullable=True),
+        sa.Column("pua_codepoint", sa.String(length=20), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("image_url", sa.String(length=500), nullable=True),
+        sa.Column("moe_variant_id", sa.String(length=50), nullable=True),
+        sa.Column("source", sa.String(length=20), nullable=False, server_default="cbeta"),
+        sa.Column("upstream_version", sa.String(length=50), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("cb_code", name="uq_gaiji_cb_code"),
+    )
+    op.create_index("ix_gaiji_cb_code", "gaiji", ["cb_code"])
+    op.create_index("ix_gaiji_composition", "gaiji", ["composition"])
+    op.create_index("ix_gaiji_norm_unicode_char", "gaiji", ["norm_unicode_char"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_gaiji_norm_unicode_char", table_name="gaiji")
+    op.drop_index("ix_gaiji_composition", table_name="gaiji")
+    op.drop_index("ix_gaiji_cb_code", table_name="gaiji")
+    op.drop_table("gaiji")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.audit import AdminAuditLog
 from app.models.chat import ChatAttachment, ChatMessage, ChatSession, TextEmbedding
 from app.models.dictionary import DictionaryEntry
 from app.models.feed import AcademicFeed, SourceUpdate
+from app.models.gaiji import Gaiji
 from app.models.hot_question import HotQuestion
 from app.models.iiif import IIIFManifest
 from app.models.knowledge_graph import KGEntity, KGRelation
@@ -26,6 +27,7 @@ __all__ = [
     "ChatSession",
     "DataSource",
     "DictionaryEntry",
+    "Gaiji",
     "HotQuestion",
     "IIIFManifest",
     "KGEntity",

--- a/backend/app/models/gaiji.py
+++ b/backend/app/models/gaiji.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Gaiji(Base):
+    """CBETA-style rare-character (缺字/gaiji) entries.
+
+    A gaiji is a Chinese character that lacks a standard Unicode code point
+    at the time the source text was digitized. CBETA encodes these as
+    composition expressions like "[木*奈]" (tree radical combined with 奈).
+    To keep search recall correct across passages containing gaiji, we
+    normalize on both index and query paths: composition / PUA / Big5
+    variants all collapse to norm_unicode_char when present, otherwise
+    the composition string is retained verbatim.
+
+    Upstream: github.com/cbeta-org/cbeta_gaiji (XML/JSON/CSV releases).
+    """
+
+    __tablename__ = "gaiji"
+    __table_args__ = (
+        # Speed up the search-side normalization scan: query text is
+        # decomposed into tokens, each looked up by composition or pua.
+        Index("ix_gaiji_norm_unicode_char", "norm_unicode_char"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # CBETA stable identifier, e.g. "CB00001". Unique across the corpus.
+    cb_code: Mapped[str] = mapped_column(String(20), unique=True, nullable=False, index=True)
+    # Composition expression as used inline in CBETA texts, e.g. "[木*奈]".
+    # Indexed because the search-time normalizer scans incoming queries
+    # for these literal patterns.
+    composition: Mapped[str | None] = mapped_column(String(200), index=True)
+    # The glyph itself if a real Unicode codepoint was eventually assigned.
+    # NULL when the character is still gaiji-only.
+    unicode_char: Mapped[str | None] = mapped_column(String(8))
+    unicode_codepoint: Mapped[str | None] = mapped_column(String(20))  # "U+2A6B2"
+    # The normalized Unicode the *search index* should fold this gaiji to.
+    # Often identical to unicode_char; differs when the gaiji has a
+    # commonly-used variant character (e.g. CBETA assigns norm_unicode
+    # to the simplified or BMP-range fallback for retrieval purposes).
+    norm_unicode_char: Mapped[str | None] = mapped_column(String(8))
+    norm_big5_char: Mapped[str | None] = mapped_column(String(8))
+    # CBETA Private Use Area assignment, "U+F0000" + numeric ID.
+    # Some older corpus files still encode gaiji this way.
+    pua_codepoint: Mapped[str | None] = mapped_column(String(20))
+    description: Mapped[str | None] = mapped_column(Text)
+    # Optional CBETA-hosted glyph image used as last-resort fallback in UI
+    # when no Unicode form is available.
+    image_url: Mapped[str | None] = mapped_column(String(500))
+    # Reference to the MoE 異體字字典 variant_id when CBETA links one.
+    moe_variant_id: Mapped[str | None] = mapped_column(String(50))
+    # Provenance — which upstream produced this row, frozen at ingest time
+    # so re-imports can detect upstream changes via cb_code + upstream_version.
+    source: Mapped[str] = mapped_column(String(20), server_default="cbeta", nullable=False)
+    upstream_version: Mapped[str | None] = mapped_column(String(50))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/schemas/gaiji.py
+++ b/backend/app/schemas/gaiji.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class GaijiResponse(BaseModel):
+    id: int
+    cb_code: str
+    composition: str | None = None
+    unicode_char: str | None = None
+    unicode_codepoint: str | None = None
+    norm_unicode_char: str | None = None
+    norm_big5_char: str | None = None
+    pua_codepoint: str | None = None
+    description: str | None = None
+    image_url: str | None = None
+    moe_variant_id: str | None = None
+    source: str = "cbeta"
+    upstream_version: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary

Wave 1.3a — schema-only PR that creates the `gaiji` table. No data yet; the importer (1.3b) and the search-time normalizer (1.3c) are deliberately separate so each can be reviewed on its own merits.

## Why this matters

For an aggregator platform spanning 547 sources, every CBETA-derived passage containing a gaiji (composition expressions like `[木*奈]`) is currently invisible to full-text searches against the underlying character. This is the "聚合平台特有的脏活" the architect-review pass flagged: a quality dividing line between fojin and a casual aggregator.

## Schema decisions

| Column | Why |
|---|---|
| `cb_code` (unique, indexed) | Upstream stable identifier — re-ingest pivot |
| `composition` (indexed) | Search-time normalizer scans incoming query strings for `[...]` patterns |
| `unicode_char`, `unicode_codepoint` | Set when a formal Unicode codepoint exists (often Ext-B/C/D) |
| `norm_unicode_char` (indexed) | What the ES index actually folds to; sometimes a BMP-range fallback distinct from the formal Unicode when the latter lacks font coverage |
| `norm_big5_char` | Legacy Big5 equivalent if any |
| `pua_codepoint` | Older PUA-based encoding still present in some legacy files |
| `image_url` | UI last-resort fallback when no Unicode form is available |
| `moe_variant_id` | Cross-reference to MoE 異體字字典 |
| `(source, upstream_version)` | Provenance pair so re-ingests can detect upstream-changed rows |

## Out of scope (follow-up PRs)

- **1.3b**: importer that pulls JSON from `github.com/cbeta-org/cbeta_gaiji`, pinned to a release tag for `upstream_version`
- **1.3c**: `normalize_gaiji()` service + ES indexer hook + query analyzer hook

## Test plan

- [ ] CI green (Alembic dry-run, smoke)
- [ ] Post-deploy: `\dt gaiji` shows the table with 3 indexes; `SELECT COUNT(*) FROM gaiji` returns 0

## Deploy notes

- Pure additive `create_table`, no lock concerns
- Empty table after migration — no behavioral change to existing queries until 1.3c integrates the normalizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)