### PR TITLE
fix(gaiji): widen moe_variant_id varchar(50) → varchar(100)

### DIFF
--- a/backend/alembic/versions/0151_widen_gaiji_moe_variant_id.py
+++ b/backend/alembic/versions/0151_widen_gaiji_moe_variant_id.py
@@ -1,0 +1,42 @@
+"""widen gaiji.moe_variant_id to accommodate comma-joined IDs
+
+Revision ID: 0151
+Revises: 0150
+Create Date: 2026-06-10
+
+CBETA encodes multi-MoE-variant references as comma-joined strings,
+e.g. "b00914-004_2, a00010-021,b01510-001,a03464-002, c00956-001_1".
+Empirically the longest such value is 60 chars (n=31,653 entries
+from upstream 4f0a8c31). The original column was sized for a single
+ID at varchar(50); widening to varchar(100) gives headroom without
+committing to JSON storage.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0151"
+down_revision: Union[str, None] = "0150"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "gaiji",
+        "moe_variant_id",
+        existing_type=sa.String(length=50),
+        type_=sa.String(length=100),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "gaiji",
+        "moe_variant_id",
+        existing_type=sa.String(length=100),
+        type_=sa.String(length=50),
+        existing_nullable=True,
+    )

--- a/backend/app/models/gaiji.py
+++ b/backend/app/models/gaiji.py
@@ -52,7 +52,8 @@ class Gaiji(Base):
     # when no Unicode form is available.
     image_url: Mapped[str | None] = mapped_column(String(500))
     # Reference to the MoE 異體字字典 variant_id when CBETA links one.
-    moe_variant_id: Mapped[str | None] = mapped_column(String(50))
+    # Empirically up to 60 chars (comma-joined multi-IDs); widened in 0151.
+    moe_variant_id: Mapped[str | None] = mapped_column(String(100))
     # Provenance — which upstream produced this row, frozen at ingest time
     # so re-imports can detect upstream changes via cb_code + upstream_version.
     source: Mapped[str] = mapped_column(String(20), server_default="cbeta", nullable=False)


### PR DESCRIPTION
## Summary

Fast-follow fix for #669 — the gaiji importer failed on first prod run with `StringDataRightTruncationError` because `moe_variant_id` was sized for single IDs (varchar(50)) but CBETA encodes multi-MoE-variant cross-references as comma-joined strings up to 60 chars.

## Evidence

Sample failing value (one of many):
```
b00914-004_2, a00010-021,b01510-001,a03464-002, c00956-001_1
```
Length: 60 chars > varchar(50) → INSERT rejected by PostgreSQL.

## Full corpus audit (against upstream 4f0a8c31, n=31,653)

| Column | Max observed | Column size | Status |
|---|---:|---:|:---:|
| cb_code | 7 | 20 | ✓ |
| composition | 37 | 200 | ✓ |
| pua | 7 | 20 | ✓ |
| unicode (codepoint) | 5 | 20 | ✓ |
| uni_char / norm_big5_char / norm_uni_char | 1 | 8 | ✓ |
| **moe_variant_id** | **60** | **50 → 100** | fixed here |

`moe_variant_id` was the only undersized column. Widening to varchar(100) gives ~40 chars headroom (≈ 3 additional comma-joined entries) without committing to JSON storage.

## Why this got past PR #668

The schema was built from the WebFetch-summarized field shape, not from a per-column histogram of the real corpus. Lesson: when adding a typed column for upstream data, audit max-lengths against the live dataset before sizing. Added this principle implicitly here; will pick it up in 1.3c's design pass.

## Test plan

- [ ] CI green
- [ ] Post-deploy: re-run `docker compose exec -T backend python scripts/import_gaiji.py` → expect 31,653 rows imported with no truncation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)