### PR TITLE
feat(gaiji): normalization service (pure-logic, no integration yet)

### DIFF
--- a/backend/app/services/gaiji.py
+++ b/backend/app/services/gaiji.py
@@ -1,0 +1,164 @@
+"""CBETA gaiji (rare-character) normalization service.
+
+A gaiji is a Chinese character that lacks a standard Unicode code point
+at digitization time. CBETA encodes them inline as composition
+expressions like ``[木*奈]`` or PUA codepoints like ``U+F0001``. Without
+normalization, full-text search systematically under-recalls passages
+containing such characters: a user searching for "款" never matches a
+passage encoded as ``[肄-聿+欠]``.
+
+This service exposes two operations:
+
+1. :func:`normalize_for_index` — used at ES index time. Returns a copy
+   of the text with all composition expressions and PUA codepoints
+   replaced by their best Unicode equivalent. Unmatched compositions
+   are preserved verbatim (they may be valid bracket text for
+   non-gaiji reasons, or a gaiji not yet in the upstream table).
+
+2. :func:`expand_for_query` — used at query analysis time. Given a
+   single plain character, returns the set of alternate spellings
+   under which the same gaiji might appear in source text (composition
+   plus PUA codepoint), for ES OR-expansion.
+
+Both operations are sync and pure (given a built normalizer). The
+normalizer itself is built once at backend startup from the
+``gaiji`` table (~31k entries, ~10MB in-memory). If upstream gaiji
+changes, rebuild and replace the snapshot rather than mutating it.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gaiji import Gaiji
+
+logger = logging.getLogger(__name__)
+
+
+# CBETA composition expressions: ``[...]`` where the inner content has
+# no closing bracket. Nesting is via parentheses, never square brackets,
+# so a flat regex is sufficient. The ``+`` is intentional — empty ``[]``
+# is never valid gaiji syntax and we don't want to match stray brackets.
+_COMPOSITION_RE = re.compile(r"\[[^\]]+\]")
+
+# CBETA PUA codepoints written textually, ``U+F0001`` through ``U+FFFFF``.
+# Some legacy CBETA files embed these as ASCII rather than as the
+# corresponding PUA glyph, hence textual matching.
+_PUA_TEXT_RE = re.compile(r"U\+F[0-9A-F]{4}")
+
+
+@dataclass(frozen=True, slots=True)
+class GaijiNormalizer:
+    """Immutable snapshot of the gaiji table for sync lookup.
+
+    Three reverse-index dictionaries are precomputed at build time so
+    ``normalize_for_index`` and ``expand_for_query`` run in O(text)
+    rather than per-character DB lookups.
+    """
+
+    # composition string → best Unicode equivalent (norm_uni_char fallback unicode_char)
+    composition_to_norm: dict[str, str]
+    # PUA textual codepoint → best Unicode equivalent
+    pua_to_norm: dict[str, str]
+    # Any Unicode form of a gaiji → set of alternate spellings (composition + PUA)
+    glyph_to_alternates: dict[str, frozenset[str]]
+
+    def size(self) -> int:
+        """Total number of distinct entries indexed (for diagnostics)."""
+        return len(self.composition_to_norm) + len(self.pua_to_norm)
+
+
+async def build_normalizer(db: AsyncSession) -> GaijiNormalizer:
+    """Load the full gaiji table and build the in-memory normalizer.
+
+    Should be called once at backend startup. The resulting snapshot
+    is safe to share across requests; do not mutate.
+    """
+    rs = await db.execute(
+        select(
+            Gaiji.composition,
+            Gaiji.unicode_char,
+            Gaiji.norm_unicode_char,
+            Gaiji.norm_big5_char,
+            Gaiji.pua_codepoint,
+        )
+    )
+
+    composition_to_norm: dict[str, str] = {}
+    pua_to_norm: dict[str, str] = {}
+    glyph_to_alternates_mut: dict[str, set[str]] = {}
+
+    for comp, uni, norm_uni, norm_big5, pua in rs.all():
+        # Best Unicode equivalent: norm_uni_char is CBETA's canonical
+        # search target when assigned (BMP-range, font-safe); otherwise
+        # fall back to unicode_char (formal Unicode if any).
+        best = norm_uni or uni
+
+        if comp and best:
+            composition_to_norm[comp] = best
+        if pua and best:
+            pua_to_norm[pua] = best
+
+        # Reverse index for query expansion. Any Unicode form a user
+        # might type maps back to all gaiji spellings.
+        for glyph in (uni, norm_uni, norm_big5):
+            if not glyph:
+                continue
+            alts = glyph_to_alternates_mut.setdefault(glyph, set())
+            if comp:
+                alts.add(comp)
+            if pua:
+                alts.add(pua)
+
+    normalizer = GaijiNormalizer(
+        composition_to_norm=composition_to_norm,
+        pua_to_norm=pua_to_norm,
+        glyph_to_alternates={k: frozenset(v) for k, v in glyph_to_alternates_mut.items()},
+    )
+    logger.info(
+        "gaiji normalizer built: %d compositions, %d pua, %d glyphs reverse-indexed",
+        len(composition_to_norm),
+        len(pua_to_norm),
+        len(glyph_to_alternates_mut),
+    )
+    return normalizer
+
+
+def normalize_for_index(text: str, normalizer: GaijiNormalizer) -> str:
+    """Replace gaiji compositions and PUA codepoints with Unicode equivalents.
+
+    Two passes: composition expressions first, then PUA codepoints.
+    Unmatched compositions are preserved verbatim.
+    """
+    if not text:
+        return text
+
+    def _comp_repl(match: re.Match[str]) -> str:
+        comp = match.group(0)
+        return normalizer.composition_to_norm.get(comp, comp)
+
+    text = _COMPOSITION_RE.sub(_comp_repl, text)
+
+    def _pua_repl(match: re.Match[str]) -> str:
+        pua = match.group(0)
+        return normalizer.pua_to_norm.get(pua, pua)
+
+    return _PUA_TEXT_RE.sub(_pua_repl, text)
+
+
+def expand_for_query(token: str, normalizer: GaijiNormalizer) -> frozenset[str]:
+    """Return alternate spellings the token might appear under in source text.
+
+    For multi-character tokens, only the first character is considered:
+    gaiji is a per-character phenomenon and multi-char tokens should be
+    expanded char-by-char by the caller. Returns an empty frozenset
+    when no alternates are known — caller may use the original token
+    unchanged.
+    """
+    if not token:
+        return frozenset()
+    return normalizer.glyph_to_alternates.get(token[0], frozenset())

--- a/backend/tests/test_gaiji_service.py
+++ b/backend/tests/test_gaiji_service.py
@@ -1,0 +1,158 @@
+"""Unit tests for app.services.gaiji.
+
+Tests use a hand-built ``GaijiNormalizer`` fixture rather than going
+through ``build_normalizer`` and the DB — this PR is service-only,
+DB integration is exercised in subsequent PRs.
+
+Coverage:
+- normalize_for_index: known composition / known PUA / unknown
+  composition (preserved verbatim) / mixed text / nested-parens
+  composition / empty text.
+- expand_for_query: known glyph / multi-char (first char only) /
+  unknown char / empty.
+- Real-data smoke: the three CB00001-3 entries used as deploy
+  sanity checks should round-trip through the small fixture.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.gaiji import (
+    GaijiNormalizer,
+    _COMPOSITION_RE,
+    _PUA_TEXT_RE,
+    expand_for_query,
+    normalize_for_index,
+)
+
+
+@pytest.fixture
+def normalizer() -> GaijiNormalizer:
+    """Three real CBETA entries + one synthetic for unknown-comp coverage.
+
+    CB00001: composition "[肄-聿+欠]", norm_big5 "款", PUA "U+F0001"
+    CB00002: composition "[(匕/示)*頁]", norm_big5 "穎", PUA "U+F0002"
+    CB00003: composition "[(工*刀)/言]", norm_big5 "辯", PUA "U+F0003"
+    """
+    return GaijiNormalizer(
+        composition_to_norm={
+            "[肄-聿+欠]": "款",
+            "[(匕/示)*頁]": "穎",
+            "[(工*刀)/言]": "辯",
+        },
+        pua_to_norm={
+            "U+F0001": "款",
+            "U+F0002": "穎",
+            "U+F0003": "辯",
+        },
+        glyph_to_alternates={
+            "款": frozenset({"[肄-聿+欠]", "U+F0001"}),
+            "穎": frozenset({"[(匕/示)*頁]", "U+F0002"}),
+            "辯": frozenset({"[(工*刀)/言]", "U+F0003"}),
+        },
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Regex shape
+
+
+def test_composition_regex_matches_flat() -> None:
+    assert _COMPOSITION_RE.findall("foo [木*奈] bar") == ["[木*奈]"]
+
+
+def test_composition_regex_matches_nested_parens() -> None:
+    """The hard case from CBETA: parentheses nest, but brackets don't."""
+    sample = "[丮-(舉-與)+((乏-之+虫)/((乏-之+虫)*(乏-之+虫)))]"
+    assert _COMPOSITION_RE.findall(sample) == [sample]
+
+
+def test_composition_regex_does_not_match_empty_brackets() -> None:
+    assert _COMPOSITION_RE.findall("text [] more") == []
+
+
+def test_pua_regex_matches_textual_codepoint() -> None:
+    assert _PUA_TEXT_RE.findall("see U+F0001 here") == ["U+F0001"]
+
+
+def test_pua_regex_does_not_match_normal_unicode_codepoint() -> None:
+    """U+4E2D (中) is BMP, not PUA — must not match."""
+    assert _PUA_TEXT_RE.findall("char U+4E2D") == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# normalize_for_index
+
+
+def test_normalize_replaces_known_composition(normalizer: GaijiNormalizer) -> None:
+    assert normalize_for_index("佛说[肄-聿+欠]经", normalizer) == "佛说款经"
+
+
+def test_normalize_replaces_known_pua(normalizer: GaijiNormalizer) -> None:
+    assert normalize_for_index("see U+F0002 here", normalizer) == "see 穎 here"
+
+
+def test_normalize_preserves_unknown_composition(normalizer: GaijiNormalizer) -> None:
+    """A composition not in the table must round-trip unchanged."""
+    text = "未知 [未*录] 字符"
+    assert normalize_for_index(text, normalizer) == text
+
+
+def test_normalize_handles_mixed_composition_and_pua(normalizer: GaijiNormalizer) -> None:
+    assert (
+        normalize_for_index("[肄-聿+欠]和U+F0003字符", normalizer)
+        == "款和辯字符"
+    )
+
+
+def test_normalize_handles_multiple_compositions_in_one_line(
+    normalizer: GaijiNormalizer,
+) -> None:
+    assert (
+        normalize_for_index("[肄-聿+欠][(匕/示)*頁][(工*刀)/言]", normalizer)
+        == "款穎辯"
+    )
+
+
+def test_normalize_passes_through_normal_text(normalizer: GaijiNormalizer) -> None:
+    assert normalize_for_index("普通文本无缺字", normalizer) == "普通文本无缺字"
+
+
+def test_normalize_empty_text(normalizer: GaijiNormalizer) -> None:
+    assert normalize_for_index("", normalizer) == ""
+
+
+# ──────────────────────────────────────────────────────────────────────
+# expand_for_query
+
+
+def test_expand_returns_known_alternates(normalizer: GaijiNormalizer) -> None:
+    assert expand_for_query("款", normalizer) == frozenset(
+        {"[肄-聿+欠]", "U+F0001"}
+    )
+
+
+def test_expand_unknown_glyph_returns_empty(normalizer: GaijiNormalizer) -> None:
+    assert expand_for_query("佛", normalizer) == frozenset()
+
+
+def test_expand_empty_token_returns_empty(normalizer: GaijiNormalizer) -> None:
+    assert expand_for_query("", normalizer) == frozenset()
+
+
+def test_expand_multi_char_uses_first_char_only(
+    normalizer: GaijiNormalizer,
+) -> None:
+    """Multi-char tokens are gaiji-expanded char-by-char by the caller."""
+    assert expand_for_query("款诉", normalizer) == frozenset(
+        {"[肄-聿+欠]", "U+F0001"}
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Diagnostics
+
+
+def test_size_reports_total_distinct_entries(normalizer: GaijiNormalizer) -> None:
+    # 3 compositions + 3 PUAs
+    assert normalizer.size() == 6


### PR DESCRIPTION
## Summary

Wave 1.3c1 — `app.services.gaiji` exposes the building block used by 1.3c2 (ES integration) and 1.3c3 (reindex). Pure logic, 17 unit tests, no DB/ES wiring yet.

## API

```python
async def build_normalizer(db) -> GaijiNormalizer
def normalize_for_index(text: str, normalizer) -> str
def expand_for_query(token: str, normalizer) -> frozenset[str]
```

- `build_normalizer` loads the full 31k gaiji table once at startup.
- `normalize_for_index` replaces `[木*奈]`-style compositions and `U+F0001`-style PUA codepoints with the best Unicode equivalent.
- `expand_for_query` returns the alternate spellings a glyph might appear under, for ES OR-expansion.

## Design notes

- **Sync + immutable snapshot**: precomputed reverse-index dicts so operations run in O(text) without per-character DB lookups.
- **norm_uni_char > unicode_char**: CBETA assigns norm_uni_char as the BMP-range font-safe search target; we prefer it when present.
- **Unknown compositions preserved verbatim**: safer than aggressive replacement — `[...]` may be valid bracket text for non-gaiji reasons.
- **PUA regex bounded to U+F0000-U+FFFFF**: BMP textual codepoints stay untouched.
- **Empty `[]` does not match**: prevents stray brackets in user text from being absorbed.

## Tests (17 cases, mock-fixture normalizer)

- Regex shape: flat composition, nested-parens composition (worst real case from corpus), empty-bracket exclusion, PUA in-range / out-of-range
- `normalize_for_index`: known composition, known PUA, unknown composition preserved, mixed text, multiple compositions in one line, normal text passthrough, empty
- `expand_for_query`: known glyph, unknown, empty, multi-char (first-char-only)
- Diagnostics: `size()` reports total entries

All pass locally in 0.39s.

## Out of scope (follow-ups)

- **1.3c2** wires the normalizer into the actual ES indexer (`app.services.search` + chunk content pipeline) and query analyzer. Adds startup hook to build + cache.
- **1.3c3** decides whether prod ES needs a full reindex on the normalized path, or whether incremental indexing on new content is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)