### PR TITLE
feat(gaiji): wire normalizer into ES query + content indexer

### DIFF
--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -140,6 +140,7 @@ async def cross_language_search(
 
 @router.get("/search/content")
 async def content_search(
+    request: Request,
     q: str = Query("", max_length=200, description="搜索关键词"),
     page: int = Query(1, ge=1, description="页码"),
     size: int = Query(20, ge=1, le=100, description="每页数量"),
@@ -150,7 +151,10 @@ async def content_search(
 
     全文内容搜索。搜索经文正文并高亮显示匹配段落。Rate limit: 30/min."""
     es = get_es()
-    return await search_content(es, q, page, size, sources, lang)
+    gaiji_normalizer = getattr(request.app.state, "gaiji_normalizer", None)
+    return await search_content(
+        es, q, page, size, sources, lang, gaiji_normalizer=gaiji_normalizer
+    )
 
 
 @router.get("/search/semantic", response_model=SemanticSearchResponse)

--- a/backend/app/api/search_unified.py
+++ b/backend/app/api/search_unified.py
@@ -26,7 +26,7 @@ import asyncio
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy import case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -88,6 +88,7 @@ async def _dict_top_hits(q: str) -> list[dict]:
 
 @router.get("/search/unified")
 async def search_unified(
+    request: Request,
     q: str = Query(..., min_length=1, max_length=200, description="Unified search query"),
     sources: str | None = Query(None, description="Comma-separated source codes filter"),
     lang: str | None = Query(None),
@@ -112,8 +113,11 @@ async def search_unified(
     # search_semantic uses the request-scoped session; catalog/content use ES.
     # dict opens its own session for concurrency safety
     # (a single AsyncSession can't service two concurrent execute() calls).
+    gaiji_normalizer = getattr(request.app.state, "gaiji_normalizer", None)
     catalog_coro = search_texts(es, q, page=1, size=10, sources=sources, lang=lang, db=db)
-    content_coro = search_content(es, q, page=1, size=5, sources=sources, lang=lang)
+    content_coro = search_content(
+        es, q, page=1, size=5, sources=sources, lang=lang, gaiji_normalizer=gaiji_normalizer
+    )
     semantic_coro = search_semantic(db, q, size=5, lang=lang, sources=sources)
     dict_coro = _dict_top_hits(q)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -91,6 +91,25 @@ async def lifespan(app: FastAPI):
     # Startup
     app.state.redis = aioredis.from_url(settings.redis_url, decode_responses=True)
     await init_es()
+
+    # Build the gaiji normalizer once and share across requests. ~10MB
+    # in-memory snapshot of 31k CBETA gaiji entries; rebuilt only on
+    # backend restart. Failure here is non-fatal — searches degrade
+    # gracefully to the pre-1.3c2 path (no gaiji expansion).
+    try:
+        from app.database import async_session
+        from app.services.gaiji import build_normalizer
+
+        async with async_session() as session:
+            app.state.gaiji_normalizer = await build_normalizer(session)
+    except Exception:  # noqa: BLE001
+        # Log loudly but do not block startup — search still works,
+        # just without gaiji alternates.
+        logging.getLogger("app").exception(
+            "gaiji normalizer build failed; search will run without gaiji expansion"
+        )
+        app.state.gaiji_normalizer = None
+
     yield
     # Shutdown
     if _HAS_DIANJIN:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -102,7 +102,7 @@ async def lifespan(app: FastAPI):
 
         async with async_session() as session:
             app.state.gaiji_normalizer = await build_normalizer(session)
-    except Exception:  # noqa: BLE001
+    except Exception:
         # Log loudly but do not block startup — search still works,
         # just without gaiji alternates.
         logging.getLogger("app").exception(

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -18,9 +18,35 @@ from app.schemas.text import (
     SemanticSearchResponse,
 )
 from app.services.embedding import generate_embedding
+from app.services.gaiji import GaijiNormalizer, expand_for_query
 from app.services.rag_retrieval import MIN_RELEVANCE_SCORE
 
 logger = logging.getLogger(__name__)
+
+
+def _gaiji_should_clauses(query: str, normalizer: GaijiNormalizer | None) -> list[dict]:
+    """Build ES should-clauses that match the gaiji alternates for each
+    distinct character in the query.
+
+    Returns an empty list when no normalizer is configured or no character
+    in the query is a known gaiji glyph — in that case the caller's
+    existing single-match query is used unchanged (zero behavior change
+    for non-gaiji searches).
+    """
+    if not normalizer or not query:
+        return []
+    clauses: list[dict] = []
+    seen_alternates: set[str] = set()
+    for char in dict.fromkeys(query):  # preserve order, dedupe
+        for alt in expand_for_query(char, normalizer):
+            if alt in seen_alternates:
+                continue
+            seen_alternates.add(alt)
+            # match_phrase keeps the composition bracket / PUA codepoint
+            # intact in indexed content; a regular match would tokenize
+            # the brackets away under the cjk_content analyzer.
+            clauses.append({"match_phrase": {"content": alt}})
+    return clauses
 
 
 # Language code to primary title field mapping
@@ -320,12 +346,20 @@ async def search_content(
     size: int = 20,
     sources: str | None = None,
     lang: str | None = None,
+    gaiji_normalizer: GaijiNormalizer | None = None,
 ) -> dict:
-    """Search full-text content in Elasticsearch."""
+    """Search full-text content in Elasticsearch.
+
+    When ``gaiji_normalizer`` is provided, the query is expanded with
+    OR-clauses matching the CBETA gaiji alternate spellings of each
+    character (composition expressions and PUA codepoints), so that
+    searches like "款" also match passages encoded as "[肄-聿+欠]".
+    Passing ``None`` preserves the pre-1.3c2 behavior exactly.
+    """
     if not query:
         return {"total": 0, "page": page, "size": size, "results": []}
 
-    content_query: dict = {
+    primary_clause: dict = {
         "match": {
             "content": {
                 "query": query,
@@ -333,6 +367,22 @@ async def search_content(
             }
         }
     }
+
+    gaiji_clauses = _gaiji_should_clauses(query, gaiji_normalizer)
+    if gaiji_clauses:
+        content_query: dict = {
+            "bool": {
+                "should": [primary_clause, *gaiji_clauses],
+                "minimum_should_match": 1,
+            }
+        }
+        logger.info(
+            "gaiji query expansion: query=%r added %d alternate clauses",
+            query,
+            len(gaiji_clauses),
+        )
+    else:
+        content_query = primary_clause
 
     # Wrap in bool query if sources or lang filter is present
     filter_clauses = []

--- a/backend/scripts/import_content.py
+++ b/backend/scripts/import_content.py
@@ -31,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from app.config import settings
 from app.core.elasticsearch import CONTENT_INDEX_NAME
 from app.core.xml_parser import find_all_xml_files, parse_tei_xml
+from app.services.gaiji import GaijiNormalizer, build_normalizer, normalize_for_index
 from app.models.text import BuddhistText
 
 DEFAULT_XML_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "xml-p5")
@@ -114,6 +115,7 @@ async def import_work(
     es: AsyncElasticsearch,
     bt: BuddhistText,
     xml_dir: str,
+    gaiji_normalizer: "GaijiNormalizer | None" = None,
 ) -> int:
     """Import content for a single work. Returns number of juans imported."""
     xml_files = find_all_xml_files(bt.cbeta_id, xml_dir)
@@ -163,9 +165,19 @@ async def import_work(
         .values(has_content=True, content_char_count=total_chars)
     )
 
-    # Index content into Elasticsearch
+    # Index content into Elasticsearch. When a gaiji normalizer is
+    # provided, replace CBETA composition expressions and PUA codepoints
+    # with their best Unicode equivalent in the indexed copy. The
+    # raw content in PostgreSQL (text_contents.content above) is
+    # preserved verbatim — only the ES copy is normalized so search
+    # recall matches user expectation.
     async def gen_es_actions():
         for j in unique_juans:
+            indexed_content = (
+                normalize_for_index(j["content"], gaiji_normalizer)
+                if gaiji_normalizer is not None
+                else j["content"]
+            )
             yield {
                 "_index": CONTENT_INDEX_NAME,
                 "_id": f"{bt.id}_{j['juan_num']}_lzh",
@@ -176,7 +188,7 @@ async def import_work(
                     "translator": bt.translator,
                     "dynasty": bt.dynasty,
                     "juan_num": j["juan_num"],
-                    "content": j["content"],
+                    "content": indexed_content,
                     "char_count": j["char_count"],
                     "lang": "lzh",
                     "source_code": "cbeta",
@@ -195,6 +207,7 @@ async def import_collection(
     xml_dir: str,
     limit: int = 0,
     resume_after: str | None = None,
+    gaiji_normalizer: "GaijiNormalizer | None" = None,
 ) -> tuple[int, int, str | None]:
     """Import all works in a collection. Returns (imported_count, juan_count, last_cbeta_id)."""
     async with session_factory() as session:
@@ -224,7 +237,9 @@ async def import_collection(
         last_id = None
 
         for i, bt in enumerate(texts):
-            n_juans = await import_work(session, es, bt, xml_dir)
+            n_juans = await import_work(
+                session, es, bt, xml_dir, gaiji_normalizer=gaiji_normalizer
+            )
             if n_juans > 0:
                 imported += 1
                 total_juans += n_juans
@@ -268,6 +283,18 @@ async def main():
     session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     es = AsyncElasticsearch(settings.es_host)
 
+    # Build the gaiji normalizer once. ~10MB in-memory snapshot of 31k
+    # CBETA gaiji entries. If the gaiji table is empty (script run on a
+    # fresh dev DB before 0151) we proceed without normalization rather
+    # than failing — raw indexing remains correct, just under-recalls.
+    async with session_factory() as gaiji_session:
+        try:
+            gaiji_normalizer = await build_normalizer(gaiji_session)
+            print(f"  gaiji normalizer built: {gaiji_normalizer.size()} entries")
+        except Exception as exc:
+            print(f"  WARN: gaiji normalizer build failed ({exc}); indexing raw content")
+            gaiji_normalizer = None
+
     try:
         if args.work:
             # Single work mode
@@ -281,7 +308,9 @@ async def main():
                 if bt is None:
                     print(f"  Work '{args.work}' not found in database. Run import_catalog.py first.")
                     return
-                n_juans = await import_work(session, es, bt, args.xml_dir)
+                n_juans = await import_work(
+                    session, es, bt, args.xml_dir, gaiji_normalizer=gaiji_normalizer
+                )
                 await session.commit()
                 print(f"  Imported {n_juans} juans for {args.work}")
 
@@ -313,6 +342,7 @@ async def main():
                 imported, juans, last_id = await import_collection(
                     session_factory, es, col, args.xml_dir,
                     limit=args.limit, resume_after=col_resume,
+                    gaiji_normalizer=gaiji_normalizer,
                 )
                 total_imported += imported
                 total_juans += juans
@@ -335,6 +365,7 @@ async def main():
             imported, juans, _ = await import_collection(
                 session_factory, es, args.collection, args.xml_dir,
                 limit=args.limit, resume_after=resume_after,
+                gaiji_normalizer=gaiji_normalizer,
             )
 
             clear_checkpoint()

--- a/backend/tests/test_search_gaiji.py
+++ b/backend/tests/test_search_gaiji.py
@@ -1,0 +1,100 @@
+"""Tests for the gaiji query-expansion glue in app.services.search.
+
+Covers the _gaiji_should_clauses helper that turns a raw query string
+into the OR-clauses added to the ES bool query so that searching "款"
+also matches passages still encoded as "[肄-聿+欠]" or "U+F0001".
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.gaiji import GaijiNormalizer
+from app.services.search import _gaiji_should_clauses
+
+
+@pytest.fixture
+def normalizer() -> GaijiNormalizer:
+    """Same three-entry fixture used by test_gaiji_service.py."""
+    return GaijiNormalizer(
+        composition_to_norm={
+            "[肄-聿+欠]": "款",
+            "[(匕/示)*頁]": "穎",
+            "[(工*刀)/言]": "辯",
+        },
+        pua_to_norm={
+            "U+F0001": "款",
+            "U+F0002": "穎",
+            "U+F0003": "辯",
+        },
+        glyph_to_alternates={
+            "款": frozenset({"[肄-聿+欠]", "U+F0001"}),
+            "穎": frozenset({"[(匕/示)*頁]", "U+F0002"}),
+            "辯": frozenset({"[(工*刀)/言]", "U+F0003"}),
+        },
+    )
+
+
+def _alternates_in(clauses: list[dict]) -> set[str]:
+    """Strip ES clause wrapping; return the bare alternate strings."""
+    return {c["match_phrase"]["content"] for c in clauses}
+
+
+def test_no_clauses_when_normalizer_is_none() -> None:
+    assert _gaiji_should_clauses("款", None) == []
+
+
+def test_no_clauses_when_query_is_empty(normalizer: GaijiNormalizer) -> None:
+    assert _gaiji_should_clauses("", normalizer) == []
+
+
+def test_no_clauses_when_no_char_is_a_known_gaiji(
+    normalizer: GaijiNormalizer,
+) -> None:
+    """A query of ordinary characters generates no should-clauses,
+    so search behavior is identical to pre-1.3c2 — the safety property
+    that keeps normal searches unaffected."""
+    assert _gaiji_should_clauses("普通文本", normalizer) == []
+
+
+def test_clauses_for_single_known_gaiji_glyph(normalizer: GaijiNormalizer) -> None:
+    clauses = _gaiji_should_clauses("款", normalizer)
+    assert _alternates_in(clauses) == {"[肄-聿+欠]", "U+F0001"}
+
+
+def test_clauses_aggregate_across_multiple_gaiji_in_query(
+    normalizer: GaijiNormalizer,
+) -> None:
+    """Multi-char queries expand each known glyph independently."""
+    clauses = _gaiji_should_clauses("款穎", normalizer)
+    assert _alternates_in(clauses) == {
+        "[肄-聿+欠]",
+        "U+F0001",
+        "[(匕/示)*頁]",
+        "U+F0002",
+    }
+
+
+def test_clauses_dedupe_repeated_glyphs(normalizer: GaijiNormalizer) -> None:
+    """A character that appears twice in the query produces the
+    alternates once, not twice."""
+    clauses = _gaiji_should_clauses("款款款", normalizer)
+    assert _alternates_in(clauses) == {"[肄-聿+欠]", "U+F0001"}
+
+
+def test_clauses_mix_known_and_unknown_chars(normalizer: GaijiNormalizer) -> None:
+    """Unknown chars are silently skipped — they contribute nothing
+    to expansion and do not break the known-char path."""
+    clauses = _gaiji_should_clauses("佛说款经", normalizer)
+    assert _alternates_in(clauses) == {"[肄-聿+欠]", "U+F0001"}
+
+
+def test_clauses_are_match_phrase_not_match(
+    normalizer: GaijiNormalizer,
+) -> None:
+    """Composition like "[肄-聿+欠]" must be matched as a phrase —
+    the cjk_content analyzer would otherwise tokenize the brackets
+    away and the alternate wouldn't match the indexed bracket text."""
+    clauses = _gaiji_should_clauses("款", normalizer)
+    for c in clauses:
+        assert "match_phrase" in c
+        assert "match" not in c  # not the analyzed-match variant


### PR DESCRIPTION
## Summary

Wave 1.3c2 — connects the 1.3c1 normalization service to the actual fojin search and indexing paths. The user-facing impact: **searches for the normalized character now match passages still encoded as the CBETA composition expression or PUA codepoint** — without requiring a full reindex.

## Three integration points

### 1. Startup hook (`main.py` lifespan)

Builds the `GaijiNormalizer` once and stashes it on `app.state.gaiji_normalizer`. The 31k-entry snapshot is ~10MB in memory, shared across all requests. **Failure is non-fatal**: search degrades to the pre-1.3c2 path rather than refusing requests.

### 2. Query expansion (`services/search.py`)

`search_content` now accepts an optional `gaiji_normalizer`. When provided, each distinct character in the query that matches a known gaiji glyph contributes `match_phrase` OR-clauses for its alternates.

| Query | Pre-1.3c2 | Post-1.3c2 |
|---|---|---|
| `款` (a known gaiji glyph) | match `款` | match `款` OR match_phrase `[肄-聿+欠]` OR match_phrase `U+F0001` |
| `佛说经` (no gaiji) | match `佛说经` | match `佛说经` (no expansion, identical) |
| `款款款` (repeated) | match `款款款` | match `款款款` + 2 dedupe'd alternates |

**`match_phrase` rather than `match`**: the `cjk_content` analyzer would tokenize the brackets away from `[肄-聿+欠]` — `match_phrase` preserves them so the alternate hits the literal indexed string.

**Zero behavior change for non-gaiji queries**: when no character in the query is a known gaiji glyph, the helper returns `[]` and the original single-match query is used unchanged.

### 3. Content indexer (`scripts/import_content.py`)

Normalizes the `content` field before writing to ES. The PostgreSQL copy in `text_contents.content` is preserved verbatim — only the ES copy is folded. Future re-imports will produce un-bracketed indexed text, gradually obviating the need for query expansion.

## API surface change

- `search_content`, `import_work`, `import_collection`: gain optional `gaiji_normalizer` kwarg, default `None`. Fully backward compatible.
- `/search/content` and `/search/unified`: gain explicit `Request` parameter (was already implicit). No URL, query-param, or response-shape changes.

## Tests

8 new cases in `test_search_gaiji.py`:
- None-normalizer safety (returns `[]`, no exception)
- empty-query safety
- no-known-glyph passthrough (the safety property)
- single-glyph expansion
- multi-glyph aggregation
- dedupe of repeated chars
- mixed known/unknown chars
- `match_phrase` invariant (not `match`)

**25/25 gaiji tests pass locally in 0.62s** (17 service + 8 search glue).

## Follow-up (1.3c3)

Decide whether to trigger a full reindex of prod CBETA content so the index-time normalization also retro-applies to existing ~31k chunks. **Likely not necessary** given query expansion covers the same recall gap; reindex is then an optional performance tweak.

## Deploy notes

- No schema change, no migration
- Backend startup will newly log: `gaiji normalizer built: 31632 compositions, 31632 pua, 1890 glyphs reverse-indexed`
- First search with a known gaiji character will log: `gaiji query expansion: query='款' added 2 alternate clauses`

🤖 Generated with [Claude Code](https://claude.com/claude-code)