### PR TITLE
feat(texts): expose canon (底本) in TextResponse + JuanContentResponse

### DIFF
--- a/backend/app/api/texts.py
+++ b/backend/app/api/texts.py
@@ -108,7 +108,12 @@ async def get_text(text_id: int, db: AsyncSession = Depends(get_db)):
     text = await get_text_by_id(db, text_id)
     if not text:
         raise TextNotFoundError(text_id=text_id)
-    return text
+    from app.services.text import canon_from_cbeta_id, canon_label_zh
+
+    response = TextResponseBase.model_validate(text)
+    response.canon = canon_from_cbeta_id(text.cbeta_id)
+    response.canon_label = canon_label_zh(response.canon)
+    return response
 
 
 @router.get("/texts/{text_id}/juans", response_model=JuanListResponse)

--- a/backend/app/schemas/text.py
+++ b/backend/app/schemas/text.py
@@ -32,6 +32,12 @@ class TextResponseBase(TextBase):
     content_char_count: int = 0
     lang: str = "lzh"
     created_at: datetime
+    # Canon (底本) derived from cbeta_id prefix at serialization time.
+    # canon is the machine code (taisho/xuzang/pali/kangyur/gretil);
+    # canon_label is the Chinese display string (大正藏 / 卍续藏 / …).
+    # Both NULL when the cbeta_id prefix is unrecognized.
+    canon: str | None = None
+    canon_label: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -72,6 +78,10 @@ class JuanContentResponse(BaseModel):
     lang: str = "lzh"
     prev_juan: int | None = None
     next_juan: int | None = None
+    # Reader-side base-edition (底本) declaration. Same provenance as
+    # TextResponseBase.canon — derived from cbeta_id prefix.
+    canon: str | None = None
+    canon_label: str | None = None
 
 
 class RelatedTranslation(BaseModel):

--- a/backend/app/services/content.py
+++ b/backend/app/services/content.py
@@ -101,6 +101,9 @@ async def get_juan_content(
     prev_juan = all_juans[idx - 1] if idx > 0 else None
     next_juan = all_juans[idx + 1] if idx < len(all_juans) - 1 else None
 
+    from app.services.text import canon_from_cbeta_id, canon_label_zh
+
+    canon = canon_from_cbeta_id(bt.cbeta_id)
     return JuanContentResponse(
         text_id=text_id,
         cbeta_id=bt.cbeta_id,
@@ -112,4 +115,6 @@ async def get_juan_content(
         lang=tc.lang,
         prev_juan=prev_juan,
         next_juan=next_juan,
+        canon=canon,
+        canon_label=canon_label_zh(canon),
     )

--- a/backend/app/services/text.py
+++ b/backend/app/services/text.py
@@ -3,7 +3,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.text import BuddhistText
 
-
 # ── Canon (底本) derivation ────────────────────────────────────────
 # Logic mirrors scripts/build_works.py:canon_from_cbeta_id so that
 # the runtime API surface and the offline FRBR Work-spine builder

--- a/backend/app/services/text.py
+++ b/backend/app/services/text.py
@@ -4,6 +4,51 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.text import BuddhistText
 
 
+# ── Canon (底本) derivation ────────────────────────────────────────
+# Logic mirrors scripts/build_works.py:canon_from_cbeta_id so that
+# the runtime API surface and the offline FRBR Work-spine builder
+# agree on which canon a given cbeta_id maps to. Keep both in sync
+# when adding a new prefix.
+
+_CANON_LABELS_ZH: dict[str, str] = {
+    "taisho": "大正藏",
+    "xuzang": "卍续藏",
+    "pali": "巴利三藏",
+    "kangyur": "甘珠尔",
+    "gretil": "梵文 GRETIL",
+}
+
+
+def canon_from_cbeta_id(cbeta_id: str | None) -> str | None:
+    """Map a cbeta_id prefix to its canon code.
+
+    T... → taisho, X... → xuzang, SC-... → pali, 84K-toh... → kangyur,
+    GRETIL-... → gretil, VRI-... → pali. Unknown prefix → None.
+    """
+    if not cbeta_id:
+        return None
+    if cbeta_id.startswith("SC-"):
+        return "pali"
+    if cbeta_id.startswith("84K-toh"):
+        return "kangyur"
+    if cbeta_id.startswith("GRETIL-"):
+        return "gretil"
+    if cbeta_id.startswith("VRI-"):
+        return "pali"
+    if cbeta_id.startswith("T"):
+        return "taisho"
+    if cbeta_id.startswith("X"):
+        return "xuzang"
+    return None
+
+
+def canon_label_zh(canon: str | None) -> str | None:
+    """Return the Chinese display label for a canon code, or None."""
+    if not canon:
+        return None
+    return _CANON_LABELS_ZH.get(canon)
+
+
 async def get_text_by_id(session: AsyncSession, text_id: int) -> BuddhistText | None:
     result = await session.execute(
         select(BuddhistText).where(BuddhistText.id == text_id)

--- a/backend/tests/test_text_canon.py
+++ b/backend/tests/test_text_canon.py
@@ -1,0 +1,45 @@
+"""Unit tests for canon (底本) derivation in app.services.text.
+
+The runtime helper must stay in lockstep with the offline equivalent
+in scripts/build_works.py — when adding a prefix here, sync there
+too, and vice versa.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.text import canon_from_cbeta_id, canon_label_zh
+
+
+@pytest.mark.parametrize(
+    "cbeta_id,expected_code,expected_label",
+    [
+        ("T0251", "taisho", "大正藏"),
+        ("T1579", "taisho", "大正藏"),
+        ("X0123", "xuzang", "卍续藏"),
+        ("SC-mn10", "pali", "巴利三藏"),
+        ("VRI-an1", "pali", "巴利三藏"),
+        ("84K-toh11", "kangyur", "甘珠尔"),
+        ("GRETIL-rama", "gretil", "梵文 GRETIL"),
+    ],
+)
+def test_canon_from_known_prefix(
+    cbeta_id: str, expected_code: str, expected_label: str
+) -> None:
+    code = canon_from_cbeta_id(cbeta_id)
+    assert code == expected_code
+    assert canon_label_zh(code) == expected_label
+
+
+@pytest.mark.parametrize("cbeta_id", [None, "", "UNKNOWN-001", "FOO0001"])
+def test_canon_unknown_prefix_returns_none(cbeta_id: str | None) -> None:
+    code = canon_from_cbeta_id(cbeta_id)
+    assert code is None
+    assert canon_label_zh(code) is None
+
+
+def test_canon_label_for_unknown_code_returns_none() -> None:
+    """An out-of-vocabulary code (e.g. canon='other') yields no label
+    rather than raising — schema returns canon=None on bad data."""
+    assert canon_label_zh("other") is None
+    assert canon_label_zh(None) is None


### PR DESCRIPTION
Wave 2.3 Phase 1 — derives canon from cbeta_id prefix and surfaces `canon` (machine code) + `canon_label` (Chinese display) on TextResponseBase and JuanContentResponse. NULL when prefix unknown. Phase 2 will add reader-side rendering + version switcher. 12 unit tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)