### PR TITLE
feat(urn): add fojin URN parser + /api/urn/resolve endpoint

### DIFF
--- a/backend/app/api/urn.py
+++ b/backend/app/api/urn.py
@@ -1,0 +1,64 @@
+"""HTTP endpoint that turns a fojin URN into a reader URL.
+
+This is the public face of app.services.urn — the contract that
+external citers (papers, datasets, third-party tools) can rely on.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.services.urn import URNParseError, parse_urn, resolve_urn
+
+router = APIRouter(tags=["urn"])
+
+
+class URNResolveResponse(BaseModel):
+    urn: str
+    scheme: str
+    work_id: str
+    juan: int | None = None
+    anchor: str | None = None
+    text_id: int | None = None
+    reader_url: str | None = None
+    # True iff the work was found in the database.
+    exists: bool
+
+
+@router.get("/urn/resolve", response_model=URNResolveResponse)
+async def urn_resolve(
+    urn: str = Query(
+        ...,
+        min_length=8,
+        max_length=300,
+        description="fojin URN, e.g. fojin:cbeta/T0001.1#p0001a01",
+    ),
+    db: AsyncSession = Depends(get_db),
+):
+    """Parse a fojin URN and return its resolution target.
+
+    Returns 422 if the URN is syntactically invalid (parse error),
+    so clients distinguish "you sent bad input" from "I can't find
+    the referenced work". A valid-but-unknown URN returns 200 with
+    exists=false rather than 404 so external tools can detect the
+    miss without parsing an error body.
+    """
+    try:
+        parsed = parse_urn(urn)
+    except URNParseError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    text_id, reader_url = await resolve_urn(db, parsed)
+
+    return URNResolveResponse(
+        urn=parsed.raw,
+        scheme=parsed.scheme,
+        work_id=parsed.work_id,
+        juan=parsed.juan,
+        anchor=parsed.anchor,
+        text_id=text_id,
+        reader_url=reader_url,
+        exists=text_id is not None,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,6 +77,7 @@ from app.api import (
     sources,
     stats,
     texts,
+    urn,
     works,
 )
 
@@ -449,6 +450,9 @@ app.include_router(works.router, prefix="/api")
 
 # Citations
 app.include_router(citations.router, prefix="/api")
+
+# URN resolver — stable text references
+app.include_router(urn.router, prefix="/api")
 
 # Phase 4 routers
 app.include_router(exports.router, prefix="/api")

--- a/backend/app/services/urn.py
+++ b/backend/app/services/urn.py
@@ -1,0 +1,164 @@
+"""URN parser and resolver for fojin's stable text references.
+
+fojin does not invent its own canonical identifier scheme — CBETA's
+``T0001`` style is the de-facto standard in Chinese Buddhist
+philology. The URN form below is a thin wrap that gives external
+citations a single grammatical shape they can paste into a paper or
+embed in an external dataset, with deterministic resolution to a
+reader URL.
+
+URN grammar (BNF-ish):
+
+    URN       := "fojin:" SCHEME "/" PATH ["#" ANCHOR]
+    SCHEME    := "cbeta"                       # extensible; only CBETA today
+    PATH      := WORK ["." JUAN]
+    WORK      := <cbeta_id as stored, e.g. T0001, X0123, SC-mn10>
+    JUAN      := <positive integer>
+    ANCHOR    := <opaque token passed to reader as ?anchor=>
+
+Examples:
+
+    fojin:cbeta/T0001                  → text-level: redirect to /text/{id}
+    fojin:cbeta/T0001.1                → juan-level: redirect to /reader?text=&juan=1
+    fojin:cbeta/T0001.1#p0001a01       → line-level: same + ?anchor=p0001a01
+
+The ANCHOR is intentionally opaque: this PR does not index CBETA's
+``<lb n="...">`` line numbers; instead anchors flow through to the
+reader as a fragment hint that future PRs (or external tools) can
+consume. Treating the anchor as opaque means the URN scheme survives
+the eventual index-time work without a URI version bump.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.text import get_text_id_by_cbeta
+
+logger = logging.getLogger(__name__)
+
+
+# Restrict to the schemes we currently understand. Unknown schemes
+# are an error, not a silent fall-through — we'd rather break loudly
+# than redirect to a wrong place.
+_KNOWN_SCHEMES = frozenset({"cbeta"})
+
+# The path body before # / before the optional ".juan" suffix. CBETA
+# IDs in the wild use [A-Za-z0-9-]; we allow that plus underscore for
+# future-proofing without opening the door to path traversal.
+_WORK_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_ANCHOR_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedURN:
+    """Structured form of a fojin URN.
+
+    juan and anchor are None when the URN does not specify them; a
+    text-level URN is fully valid and resolves to the text detail page.
+    """
+
+    raw: str
+    scheme: str
+    work_id: str
+    juan: int | None
+    anchor: str | None
+
+
+class URNParseError(ValueError):
+    """The input string is not a syntactically valid fojin URN."""
+
+
+def parse_urn(urn: str) -> ParsedURN:
+    """Parse a fojin URN string into its structured components.
+
+    Raises URNParseError on malformed input. Does not touch the
+    database; resolution to a text id is a separate step.
+    """
+    if not isinstance(urn, str) or not urn:
+        raise URNParseError("urn must be a non-empty string")
+
+    if not urn.startswith("fojin:"):
+        raise URNParseError("urn must start with 'fojin:'")
+
+    body = urn[len("fojin:"):]
+
+    # Split off optional #anchor first so a "/" inside the anchor (we
+    # don't expect any, but be defensive) doesn't confuse the scheme
+    # split.
+    if "#" in body:
+        body, anchor = body.split("#", 1)
+        if not _ANCHOR_RE.match(anchor):
+            raise URNParseError(f"invalid anchor: {anchor!r}")
+    else:
+        anchor = None
+
+    if "/" not in body:
+        raise URNParseError("urn must contain 'scheme/path'")
+    scheme, path = body.split("/", 1)
+    if scheme not in _KNOWN_SCHEMES:
+        raise URNParseError(f"unknown scheme: {scheme!r}")
+
+    if "." in path:
+        work_id, juan_str = path.split(".", 1)
+        try:
+            juan = int(juan_str)
+            if juan < 1:
+                raise ValueError
+        except ValueError as exc:
+            raise URNParseError(f"invalid juan number: {juan_str!r}") from exc
+    else:
+        work_id = path
+        juan = None
+
+    if not _WORK_ID_RE.match(work_id):
+        raise URNParseError(f"invalid work id: {work_id!r}")
+
+    return ParsedURN(
+        raw=urn,
+        scheme=scheme,
+        work_id=work_id,
+        juan=juan,
+        anchor=anchor,
+    )
+
+
+def build_reader_url(parsed: ParsedURN, *, text_id: int) -> str:
+    """Produce the in-app reader URL a resolver should redirect to.
+
+    URLs are relative paths so that they work for both local dev and
+    prod fojin.app. The caller (the API endpoint) decides whether to
+    return them as-is or compose an absolute URL.
+    """
+    if parsed.juan is None:
+        # Text-level: jump to the detail page so the user picks a juan.
+        return f"/texts/{text_id}"
+    base = f"/reader?text={text_id}&juan={parsed.juan}"
+    if parsed.anchor:
+        base += f"&anchor={parsed.anchor}"
+    return base
+
+
+async def resolve_urn(
+    db: AsyncSession, parsed: ParsedURN
+) -> tuple[int | None, str | None]:
+    """Resolve a parsed URN to (text_id, reader_url) or (None, None).
+
+    Returns (None, None) when the referenced work is not in the
+    database — letting the API layer respond with 404 instead of
+    redirecting to a nonexistent page.
+    """
+    if parsed.scheme != "cbeta":
+        # Future schemes route here; today's URN parser already
+        # rejects them, so this branch is defense-in-depth.
+        return None, None
+
+    text_id = await get_text_id_by_cbeta(db, parsed.work_id)
+    if text_id is None:
+        logger.info("urn resolve miss: scheme=%s work=%s", parsed.scheme, parsed.work_id)
+        return None, None
+
+    return text_id, build_reader_url(parsed, text_id=text_id)

--- a/backend/tests/test_urn.py
+++ b/backend/tests/test_urn.py
@@ -1,0 +1,120 @@
+"""Unit tests for app.services.urn parse_urn + build_reader_url.
+
+Resolution against the database is integration-shaped and lives in
+test_urn_endpoint.py; the parser and URL builder are pure functions
+and warrant their own focused coverage.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.urn import (
+    ParsedURN,
+    URNParseError,
+    build_reader_url,
+    parse_urn,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# parse_urn — happy path
+
+
+def test_parse_text_level_urn() -> None:
+    p = parse_urn("fojin:cbeta/T0001")
+    assert p.scheme == "cbeta"
+    assert p.work_id == "T0001"
+    assert p.juan is None
+    assert p.anchor is None
+
+
+def test_parse_juan_level_urn() -> None:
+    p = parse_urn("fojin:cbeta/T0001.5")
+    assert p.work_id == "T0001"
+    assert p.juan == 5
+    assert p.anchor is None
+
+
+def test_parse_line_level_urn() -> None:
+    p = parse_urn("fojin:cbeta/T0001.5#p0001a01")
+    assert p.juan == 5
+    assert p.anchor == "p0001a01"
+
+
+def test_parse_work_id_with_hyphen() -> None:
+    """SC-mn10 / 84K-toh11 are real cbeta_id shapes."""
+    p = parse_urn("fojin:cbeta/SC-mn10")
+    assert p.work_id == "SC-mn10"
+
+    q = parse_urn("fojin:cbeta/84K-toh11.2")
+    assert q.work_id == "84K-toh11"
+    assert q.juan == 2
+
+
+# ──────────────────────────────────────────────────────────────────────
+# parse_urn — error paths
+
+
+def test_parse_rejects_empty() -> None:
+    with pytest.raises(URNParseError):
+        parse_urn("")
+
+
+@pytest.mark.parametrize("urn", [
+    "T0001",                            # no fojin: prefix
+    "fojin:T0001",                      # no scheme/path slash
+    "fojin:unknown/T0001",              # unknown scheme
+    "fojin:cbeta/T0001.0",              # juan < 1
+    "fojin:cbeta/T0001.abc",            # non-numeric juan
+    "fojin:cbeta/../etc/passwd",        # path traversal attempt
+    "fojin:cbeta/T0001#has spaces",     # invalid anchor char
+])
+def test_parse_rejects_malformed(urn: str) -> None:
+    with pytest.raises(URNParseError):
+        parse_urn(urn)
+
+
+def test_parse_rejects_non_string() -> None:
+    """The endpoint passes through whatever pydantic validates, but
+    the parser itself should not crash on degenerate input."""
+    with pytest.raises(URNParseError):
+        parse_urn(None)  # type: ignore[arg-type]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# build_reader_url
+
+
+def _p(scheme: str, work: str, juan: int | None = None, anchor: str | None = None) -> ParsedURN:
+    return ParsedURN(
+        raw=f"fojin:{scheme}/{work}" + (f".{juan}" if juan else "") + (f"#{anchor}" if anchor else ""),
+        scheme=scheme,
+        work_id=work,
+        juan=juan,
+        anchor=anchor,
+    )
+
+
+def test_build_url_text_level_goes_to_detail_page() -> None:
+    assert build_reader_url(_p("cbeta", "T0001"), text_id=42) == "/texts/42"
+
+
+def test_build_url_juan_level_goes_to_reader() -> None:
+    assert (
+        build_reader_url(_p("cbeta", "T0001", juan=3), text_id=42)
+        == "/reader?text=42&juan=3"
+    )
+
+
+def test_build_url_with_anchor_appends_anchor_param() -> None:
+    assert (
+        build_reader_url(_p("cbeta", "T0001", juan=3, anchor="p0001a01"), text_id=42)
+        == "/reader?text=42&juan=3&anchor=p0001a01"
+    )
+
+
+def test_build_url_anchor_without_juan_is_dropped() -> None:
+    """Pathological input — the parser rejects this, but defend the
+    URL builder against degenerate ParsedURN literals."""
+    p = _p("cbeta", "T0001", juan=None, anchor="p0001a01")
+    assert build_reader_url(p, text_id=42) == "/texts/42"


### PR DESCRIPTION
## Summary

Wave 2.1 — a stable, citable reference scheme that wraps CBETA's de-facto IDs. External citers paste a URN, the platform resolves it to a reader URL.

## URN grammar

| Form | Meaning | Resolves to |
|---|---|---|
| \`fojin:cbeta/T0001\` | text-level | \`/texts/{id}\` |
| \`fojin:cbeta/T0001.1\` | juan-level | \`/reader?text={id}&juan=1\` |
| \`fojin:cbeta/T0001.1#p0001a01\` | line-level | \`/reader?...&anchor=p0001a01\` |

## Why this is lightweight

- **Wraps CBETA, doesn't invent**: \`fojin:\` is just the namespace; the payload (\`T0001\`) is what scholars already cite.
- **Anchor is opaque**: this PR doesn't index \`<lb n=\"...\"/>\` line markers — the anchor flows through to the reader as a hint. Future xml_parser work can light up real line-level deep linking without a URI version bump.
- **No schema change, no re-import, no UI change**.

## API behavior

| Input | Response |
|---|---|
| valid URN, work exists | 200 + reader_url + exists=true |
| valid URN, work missing | 200 + exists=false (tools can detect miss without parsing error bodies) |
| malformed URN | 422 + detail |

## Security

Strict character classes prevent path traversal — the \`../etc/passwd\` test case is in the suite.

## Tests

17 unit cases (0.39s local):
- Parse: text/juan/line levels, hyphenated work_ids (\`SC-mn10\`, \`84K-toh11\`)
- Reject: missing prefix, missing slash, unknown scheme, juan<1, non-numeric juan, path traversal, invalid anchor char, empty/None
- Build URL: all three levels + degenerate ParsedURN with anchor-but-no-juan

## Out of scope

- Indexing CBETA \`<lb>\` line markers (anchor stays opaque)
- Reader-side fragment scroll (future PR can consume the \`?anchor=\` param)
- Python SDK / OpenSearch advertisement (when external uptake validates demand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)