### PR TITLE
feat(reader,urn): canon chip in reader header + URN anchor doc

### DIFF
--- a/backend/app/api/urn.py
+++ b/backend/app/api/urn.py
@@ -33,7 +33,16 @@ async def urn_resolve(
         ...,
         min_length=8,
         max_length=300,
-        description="fojin URN, e.g. fojin:cbeta/T0001.1#p0001a01",
+        description=(
+            "fojin URN, e.g. `fojin:cbeta/T0001.1#p0001a01`.\n\n"
+            "**Anchor (the part after `#`) must be URL-encoded as `%23` in "
+            "HTTP clients**, otherwise the browser or curl will treat `#` "
+            "as a fragment delimiter and strip everything after it before "
+            "sending the request — the server then sees an anchor-less URN "
+            "and silently returns `anchor: null`.\n\n"
+            "Example (anchor preserved):\n"
+            "`/api/urn/resolve?urn=fojin:cbeta/T0001.1%23p0001a01`"
+        ),
     ),
     db: AsyncSession = Depends(get_db),
 ):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -152,6 +152,11 @@ export interface JuanContentResponse {
   char_count: number;
   prev_juan: number | null;
   next_juan: number | null;
+  // Base-edition (底本) — derived from cbeta_id prefix by the backend.
+  // canon is the machine code (taisho / xuzang / pali / kangyur / gretil);
+  // canon_label is the Chinese display string (大正藏 / 卍续藏 / …).
+  canon?: string | null;
+  canon_label?: string | null;
 }
 
 export interface MatchedJuan {

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Typography, Spin, Button, Select, Breadcrumb, Row, Col, message, Tooltip } from "antd";
+import { Typography, Spin, Button, Select, Breadcrumb, Row, Col, message, Tooltip, Tag } from "antd";
 import {
   HomeOutlined,
   LeftOutlined,
@@ -551,8 +551,26 @@ export default function TextReaderPage() {
 
       {/* Header */}
       <div className="reader-header">
-        <Typography.Title level={3}>
+        <Typography.Title level={3} style={{ marginBottom: 4 }}>
           {content?.title_zh || juanList?.title_zh || "加载中..."}
+          {content?.canon_label && (
+            <Tooltip
+              title="本经所属藏经（底本）— 据 CBETA 编号推导"
+              placement="right"
+            >
+              <Tag
+                color="geekblue"
+                style={{
+                  marginLeft: 12,
+                  verticalAlign: "middle",
+                  fontSize: 13,
+                  fontWeight: "normal",
+                }}
+              >
+                {content.canon_label}
+              </Tag>
+            </Tooltip>
+          )}
         </Typography.Title>
 
         <div className="reader-nav">


### PR DESCRIPTION
**G3-simple**: PR #675 added canon/canon_label fields but frontend reader didn't consume them. Adds antd Tag next to title (《长阿含经》卷一 [大正藏]) wrapped in Tooltip explaining derivation. Also syncs JuanContentResponse TS type.

**G1**: OpenAPI URN endpoint description now warns that anchor (after #) must be URL-encoded as %23 in HTTP clients, with correctly-encoded example.

Both close the user-facing reflection of Wave 2.1 / 2.3 work that previously stopped at the API boundary. tsc + ruff pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)