### PR TITLE
fix(pwa): SW update script was CSP-blocked — move inline to external file

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -102,14 +102,8 @@
         </ul>
       </div>
     </noscript>
-    <script>
-      // Force refresh stale service workers (one-time cleanup for cached old versions)
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.getRegistrations().then(function(regs) {
-          regs.forEach(function(reg) { reg.update(); });
-        });
-      }
-    </script>
+    <!-- External file: inline scripts are blocked by the CSP (script-src 'self') -->
+    <script src="/sw-update.js" defer></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -200,6 +200,20 @@ server {
         add_header Expires "0";
     }
 
+    # SW registration/update helpers — Cloudflare caches bare .js for hours
+    # by default, which delays SW updates for returning visitors
+    location = /registerSW.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    location = /sw-update.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
     # index.html must not be cached (references hashed assets)
     location = /index.html {
         add_header Cache-Control "no-cache, no-store, must-revalidate";

--- a/frontend/public/sw-update.js
+++ b/frontend/public/sw-update.js
@@ -1,0 +1,32 @@
+// Service worker freshness for returning visitors.
+//
+// External file on purpose: the previous inline version of this script was
+// silently blocked by the CSP (`script-src 'self'` — no 'unsafe-inline'),
+// which meant stale service workers were never told to update (#657).
+(function () {
+  if (!("serviceWorker" in navigator)) return;
+
+  // Restore the #185 behavior: proactively check for a newer sw.js.
+  navigator.serviceWorker.getRegistrations().then(function (regs) {
+    regs.forEach(function (reg) {
+      reg.update().catch(function () {});
+    });
+  });
+
+  // With skipWaiting + clientsClaim, a new SW can take over mid-session.
+  // The running page then no longer matches the active precache (old lazy
+  // chunks 404 after a redeploy). Reload once so page and SW stay in sync.
+  // Guard: on the very first install clientsClaim also fires
+  // controllerchange (null -> SW); don't reload first-time visitors.
+  var hadController = !!navigator.serviceWorker.controller;
+  var reloaded = false;
+  navigator.serviceWorker.addEventListener("controllerchange", function () {
+    if (!hadController) {
+      hadController = true;
+      return;
+    }
+    if (reloaded) return;
+    reloaded = true;
+    window.location.reload();
+  });
+})();


### PR DESCRIPTION
## 问题 (#657)

用户报告顶栏语言切换/通知铃/用户名菜单全部点击无响应（macOS Chrome + Safari，两个浏览器同时坏 = 共享的本地缓存状态问题）。

## 根因调查

1. 线上每次页面加载 console 都有 CSP violation：被拦截的 inline script hash `sha256-oMuOAHWIMGAv5Ss7Nrc5096yfEjVYYlrVI4qXjKyRaQ=` **与 index.html 里 #185 加的 SW 强刷脚本完全吻合**（已逐字节验证）
2. 即 #185 的 stale-SW 修复自 CSP 加固后**从未执行过**
3. PWA 配置 `skipWaiting + clientsClaim` + navigateFallback 全量 precache：回访用户可被钉死在旧 bundle 上；当天多次部署时新 SW 接管后旧页面的 lazy chunk 404
4. 新浏览器（无 SW 历史）端到端验证当前版本完全正常：语言菜单弹出 → 点 English → htmlLang=en ✓

## 修复

- inline 脚本移到 `public/sw-update.js`（CSP `script-src 'self'` 放行）
- 新增 controllerchange 一次性 reload（首次安装有 guard 不会 reload 新访客）
- nginx 给 `/registerSW.js` `/sw-update.js` 加 no-cache（CF 默认对裸 .js 边缘缓存 4h，实测 cf-cache-status: HIT age 437）

## 验证

- `npm run build`：sw-update.js 进 dist 且被 index.html 引用 ✓
- 部署后将验证：console 无 CSP violation、/sw-update.js 200 no-cache、并请 #657 报告者复测

🤖 Generated with [Claude Code](https://claude.com/claude-code)