### PR TITLE
chore(deps): bump uvicorn 0.42.0 + asyncpg 0.31.0 (supersedes #163, #99)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.136.3
-uvicorn[standard]==0.34.0
-asyncpg==0.30.0
+uvicorn[standard]==0.42.0
+asyncpg==0.31.0
 sqlalchemy[asyncio]==2.0.36
 alembic==1.18.4
 pydantic-settings==2.13.1


### PR DESCRIPTION
取代 3 月积压的 dependabot #163（uvicorn 0.34→0.42）和 #99（asyncpg 0.30→0.31），两个都是 minor/patch 级别。CI smoke + 部署后容器健康检查验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)