### PR TITLE
feat(alignment): --juans flag — slice huge pairs into multi-day sessions

### DIFF
--- a/backend/scripts/build_alignments.py
+++ b/backend/scripts/build_alignments.py
@@ -750,7 +750,38 @@ async def process_pair(
     return stats
 
 
-async def main_async(pair_key: str, dry_run: bool, limit_chunks: int | None, threshold: float, max_spend_usd: float, force_reasoning_model: bool, commit_every: int) -> None:
+def parse_juans(spec: str) -> list[int]:
+    """Parse a --juans CLI spec into a sorted, deduplicated juan list.
+
+    Accepts comma-separated items; each item is a single juan number ("5")
+    or an inclusive range ("1-3"):
+        "1,2,3"  -> [1, 2, 3]
+        "1-3"    -> [1, 2, 3]
+        "1-3,7"  -> [1, 2, 3, 7]
+    Raises ValueError on empty items, non-numeric input, reversed ranges,
+    or juan numbers < 1.
+    """
+    juans: set[int] = set()
+    for raw_item in spec.split(","):
+        item = raw_item.strip()
+        if not item:
+            raise ValueError(f"empty item in --juans spec: {spec!r}")
+        if "-" in item:
+            start_s, _, end_s = item.partition("-")
+            if not start_s.strip() or not end_s.strip():
+                raise ValueError(f"malformed range {item!r} in --juans spec")
+            start, end = int(start_s), int(end_s)
+            if start > end:
+                raise ValueError(f"reversed range {item!r} in --juans spec")
+            juans.update(range(start, end + 1))
+        else:
+            juans.add(int(item))
+    if any(j < 1 for j in juans):
+        raise ValueError(f"juan numbers must be >= 1: {spec!r}")
+    return sorted(juans)
+
+
+async def main_async(pair_key: str, dry_run: bool, limit_chunks: int | None, threshold: float, max_spend_usd: float, force_reasoning_model: bool, commit_every: int, juans: list[int] | None = None) -> None:
     pairs_to_run = (
         MVP_PAIRS if pair_key == "all"
         else [p for p in MVP_PAIRS if p.key == pair_key]
@@ -759,6 +790,16 @@ async def main_async(pair_key: str, dry_run: bool, limit_chunks: int | None, thr
         logger.error("❌ No MVP pair with key=%s (available: %s)",
                      pair_key, [p.key for p in MVP_PAIRS])
         sys.exit(1)
+
+    if juans:
+        if len(pairs_to_run) != 1:
+            logger.error("❌ --juans requires a single --pair, not 'all'")
+            sys.exit(1)
+        # Runtime override of the pair's static juan filter: lets a huge
+        # single-text_a pair (e.g. 25k-Prajñā, 815 chunks ≈ 11h) be split
+        # into separate 2-3h sessions per juan slice across multiple days.
+        pairs_to_run[0].text_a_juan_filter = juans
+        logger.info("Juan slice override: text_a restricted to juans %s", juans)
 
     effective_model = VERIFY_LLM_MODEL or settings.llm_model
     if effective_model in REASONING_MODELS_DENYLIST and not dry_run and not force_reasoning_model:
@@ -824,9 +865,20 @@ if __name__ == "__main__":
              "on single-text_a pairs (e.g. lotus_zh_bo: 182 chunks otherwise "
              "held one transaction open ~3h). Set higher for faster pairs.",
     )
+    parser.add_argument(
+        "--juans",
+        type=parse_juans,
+        default=None,
+        metavar="SPEC",
+        help="Restrict text_a to a juan slice, e.g. '1-3' or '1,2,5' or '1-3,7'. "
+             "Only valid with a single --pair. Lets a huge pair (25k-Prajñā: "
+             "815 chunks ≈ 11h) run as separate 2-3h sessions per slice; "
+             "each slice ships partial coverage immediately.",
+    )
     args = parser.parse_args()
 
     asyncio.run(main_async(
         args.pair, args.dry_run, args.limit_chunks, args.threshold,
         args.max_spend_usd, args.force_reasoning_model, args.commit_every,
+        args.juans,
     ))

--- a/backend/scripts/build_alignments.py
+++ b/backend/scripts/build_alignments.py
@@ -34,6 +34,7 @@ Guards:
 
 import argparse
 import asyncio
+import dataclasses
 import json
 import logging
 import os
@@ -493,7 +494,7 @@ async def fetch_chunks(
             "SELECT juan_num, chunk_index, chunk_text "
             "FROM text_embeddings WHERE text_id = :tid "
             "AND embedding IS NOT NULL "
-            f"AND juan_num IN ({placeholders}) "  # nosec B608 — juans from hardcoded MVP_PAIRS
+            f"AND juan_num IN ({placeholders}) "  # nosec B608 — juan_filter is list[int]: parse_juans/MVP_PAIRS guarantee ints >= 1
             "ORDER BY juan_num, chunk_index"
         )
     else:
@@ -759,8 +760,11 @@ def parse_juans(spec: str) -> list[int]:
         "1-3"    -> [1, 2, 3]
         "1-3,7"  -> [1, 2, 3, 7]
     Raises ValueError on empty items, non-numeric input, reversed ranges,
-    or juan numbers < 1.
+    oversized ranges, or juan numbers < 1.
     """
+    # No real canon exceeds ~600 juans (大般若 T0220); anything bigger is a
+    # typo, and materializing it would OOM the VPS before the >= 1 check.
+    max_range_size = 1000
     juans: set[int] = set()
     for raw_item in spec.split(","):
         item = raw_item.strip()
@@ -773,12 +777,24 @@ def parse_juans(spec: str) -> list[int]:
             start, end = int(start_s), int(end_s)
             if start > end:
                 raise ValueError(f"reversed range {item!r} in --juans spec")
+            if end - start + 1 > max_range_size:
+                raise ValueError(f"range {item!r} too large (max {max_range_size} juans)")
             juans.update(range(start, end + 1))
         else:
             juans.add(int(item))
     if any(j < 1 for j in juans):
         raise ValueError(f"juan numbers must be >= 1: {spec!r}")
     return sorted(juans)
+
+
+def _parse_juans_argtype(spec: str) -> list[int]:
+    """argparse `type=` wrapper: argparse only surfaces messages from
+    ArgumentTypeError; plain ValueError collapses to an unhelpful
+    'invalid value' line."""
+    try:
+        return parse_juans(spec)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(str(e)) from e
 
 
 async def main_async(pair_key: str, dry_run: bool, limit_chunks: int | None, threshold: float, max_spend_usd: float, force_reasoning_model: bool, commit_every: int, juans: list[int] | None = None) -> None:
@@ -795,10 +811,18 @@ async def main_async(pair_key: str, dry_run: bool, limit_chunks: int | None, thr
         if len(pairs_to_run) != 1:
             logger.error("❌ --juans requires a single --pair, not 'all'")
             sys.exit(1)
+        if pairs_to_run[0].text_a.resolve_all:
+            # Multi-target text_a (e.g. SC suttas, mostly single-juan rows):
+            # the filter would apply to every resolved text and silently
+            # fetch 0 chunks — a wasted multi-hour session.
+            logger.error("❌ --juans only makes sense for single-text_a pairs; "
+                         "pair %r resolves multiple text_a targets", pairs_to_run[0].key)
+            sys.exit(1)
         # Runtime override of the pair's static juan filter: lets a huge
         # single-text_a pair (e.g. 25k-Prajñā, 815 chunks ≈ 11h) be split
         # into separate 2-3h sessions per juan slice across multiple days.
-        pairs_to_run[0].text_a_juan_filter = juans
+        # replace() not in-place mutation: MVP_PAIRS is module-global.
+        pairs_to_run[0] = dataclasses.replace(pairs_to_run[0], text_a_juan_filter=juans)
         logger.info("Juan slice override: text_a restricted to juans %s", juans)
 
     effective_model = VERIFY_LLM_MODEL or settings.llm_model
@@ -867,7 +891,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--juans",
-        type=parse_juans,
+        type=_parse_juans_argtype,
         default=None,
         metavar="SPEC",
         help="Restrict text_a to a juan slice, e.g. '1-3' or '1,2,5' or '1-3,7'. "

--- a/backend/tests/test_alignment_juans_flag.py
+++ b/backend/tests/test_alignment_juans_flag.py
@@ -1,0 +1,72 @@
+"""Tests for the --juans CLI spec parser in scripts/build_alignments.py.
+
+Pure-logic tests (no DB / LLM): parse_juans turns a CLI slice spec into a
+sorted, deduplicated juan list used to override pair.text_a_juan_filter.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_alignments.py"
+_spec = importlib.util.spec_from_file_location("build_alignments", _SCRIPT_PATH)
+ba = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ba)
+
+
+class TestParseJuans:
+    def test_comma_list(self):
+        assert ba.parse_juans("1,2,3") == [1, 2, 3]
+
+    def test_single_value(self):
+        assert ba.parse_juans("7") == [7]
+
+    def test_range(self):
+        assert ba.parse_juans("1-3") == [1, 2, 3]
+
+    def test_mixed_range_and_list(self):
+        assert ba.parse_juans("1-3,7,9-10") == [1, 2, 3, 7, 9, 10]
+
+    def test_dedup_and_sort(self):
+        assert ba.parse_juans("3,1,2-3,1") == [1, 2, 3]
+
+    def test_whitespace_tolerated(self):
+        assert ba.parse_juans(" 1 , 2 - 4 ") == [1, 2, 3, 4]
+
+    def test_single_element_range_allowed(self):
+        assert ba.parse_juans("5-5") == [5]
+
+    def test_reversed_range_rejected(self):
+        with pytest.raises(ValueError, match="reversed range"):
+            ba.parse_juans("3-1")
+
+    def test_empty_item_rejected(self):
+        with pytest.raises(ValueError, match="empty item"):
+            ba.parse_juans("1,,3")
+
+    def test_non_numeric_rejected(self):
+        with pytest.raises(ValueError):
+            ba.parse_juans("1,foo")
+
+    def test_zero_rejected(self):
+        with pytest.raises(ValueError, match=">= 1"):
+            ba.parse_juans("0,1")
+
+    def test_open_ended_range_rejected(self):
+        with pytest.raises(ValueError, match="malformed range"):
+            ba.parse_juans("1-")
+
+
+class TestJuansPairGuard:
+    def test_juans_with_all_pairs_exits(self):
+        import asyncio
+
+        # Guard fires before any DB / LLM access, so this is a pure-logic test.
+        with pytest.raises(SystemExit) as exc_info:
+            asyncio.run(
+                ba.main_async(
+                    "all", True, None, 0.5, 1.0, False, 10, juans=[1, 2]
+                )
+            )
+        assert exc_info.value.code == 1

--- a/backend/tests/test_alignment_juans_flag.py
+++ b/backend/tests/test_alignment_juans_flag.py
@@ -57,6 +57,28 @@ class TestParseJuans:
         with pytest.raises(ValueError, match="malformed range"):
             ba.parse_juans("1-")
 
+    def test_negative_single_item_rejected(self):
+        # "-3" partitions into ("", "-", "3") -> malformed range; pin it so a
+        # refactor to split("-")/regex can't silently start accepting it.
+        with pytest.raises(ValueError, match="malformed range"):
+            ba.parse_juans("-3")
+
+    def test_double_dash_rejected(self):
+        with pytest.raises(ValueError):
+            ba.parse_juans("1--3")
+
+    def test_oversized_range_rejected(self):
+        # Must raise BEFORE materializing the range (OOM guard on the VPS).
+        with pytest.raises(ValueError, match="too large"):
+            ba.parse_juans("1-99999999")
+
+    def test_argtype_wrapper_raises_argument_type_error(self):
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="reversed range"):
+            ba._parse_juans_argtype("3-1")
+        assert ba._parse_juans_argtype("1-3") == [1, 2, 3]
+
 
 class TestJuansPairGuard:
     def test_juans_with_all_pairs_exits(self):


### PR DESCRIPTION
Batch 2 roadmap (docs/superpowers/specs/2026-06-09-batch2-cross-canon-roadmap.md) Option A 落地：

- `--juans '1-3'` / `'1,2,5'` / `'1-3,7'` 运行时覆盖 pair.text_a_juan_filter（管道 fetch_chunks 已支持，只补 CLI）
- `--juans` + `--pair all` 直接拒绝
- 13 个纯逻辑测试

为 25k 般若 (T0223↔Toh 9, 815 chunks ≈ 11h) 分 3-4 个 2-3h 会话跑铺路；每卷跑完即在 reader 可查。pair 定义在 prod text_id 核实后随本 PR 或 follow-up 加入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)