### PR TITLE
chore(nav): 佛学动态菜单按 owner 决定暂不上线

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,7 +15,7 @@ import {
   RobotOutlined,
   GithubOutlined,
   GlobalOutlined,
-  NotificationOutlined,
+  // NotificationOutlined,
   // FieldTimeOutlined,
   // BarChartOutlined,
 } from "@ant-design/icons";
@@ -78,9 +78,10 @@ export default function Layout() {
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
     { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
-    // 佛学动态 2026-06-11 重新上线：feed cron 自 #211 时代已每日运行，源清单
-    // 同日已审计换血（见 backend/scripts/fetch_academic_feeds.py 注释）
-    { icon: <NotificationOutlined />, label: t("nav.activity"), path: "/activity" },
+    // 佛学动态按 owner 决定暂不上线（2026-06-11）。数据管道是健康的：feed cron
+    // 每日运行，源清单已审计换血（见 backend/scripts/fetch_academic_feeds.py），
+    // /activity 路由可直达——只是不放导航入口。
+    // { icon: <NotificationOutlined />, label: t("nav.activity"), path: "/activity" },
     // TODO: 时间线和数据总览暂时隐藏，待优化后重新上线
     // { icon: <FieldTimeOutlined />, label: t("nav.timeline"), path: "/timeline" },
     // { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },


### PR DESCRIPTION
撤回 #688 中恢复的导航入口（owner 决定暂不上这个功能）。feed 源修复保留（死链清理是纯收益），/activity 路由仍可直达，只是不进导航。

🤖 Generated with [Claude Code](https://claude.com/claude-code)