### PR TITLE
feat(reader): 阅读续读 + 最近阅读（高 ROI 功能 #1）

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -58,6 +58,8 @@
   "home.selected_sources": "{{count}} selected",
   "home.select_source": "Select source",
   "home.hot_label": "Popular",
+  "home.continue_reading": "Continue reading",
+  "home.juan_n": "Fascicle {{n}}",
   "home.hot_tags": [
     "Diamond Sutra",
     "Heart Sutra",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -58,6 +58,8 @@
   "home.selected_sources": "已選 {{count}} 源",
   "home.select_source": "選擇資料來源",
   "home.hot_label": "熱門檢索",
+  "home.continue_reading": "繼續閱讀",
+  "home.juan_n": "第{{n}}卷",
   "home.hot_tags": [
     "金剛經",
     "心經",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -58,6 +58,8 @@
   "home.selected_sources": "已选 {{count}} 源",
   "home.select_source": "选择数据源",
   "home.hot_label": "热门检索",
+  "home.continue_reading": "继续阅读",
+  "home.juan_n": "第{{n}}卷",
   "home.hot_tags": [
     "金刚经",
     "心经",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -22,6 +22,12 @@ import { getReadingHistory } from "../utils/readingHistory";
 import { useAuthStore } from "../stores/authStore";
 import "../styles/home.css"; // mobile-responsive v2.1
 
+/** 代码点级截断：CBETA 题名偶含扩展 B 区汉字，String.slice 会撕裂代理对。 */
+function truncateTitle(title: string, max = 12): string {
+  const chars = Array.from(title);
+  return chars.length > max ? `${chars.slice(0, max).join("")}…` : title;
+}
+
 export default function HomePage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -140,7 +146,7 @@ export default function HomePage() {
                 onClick={() => navigate(`/texts/${e.textId}/read?juan=${e.juan}`)}
                 title={e.title}
               >
-                《{e.title.length > 12 ? `${e.title.slice(0, 12)}…` : e.title}》{t("home.juan_n", { n: e.juan })}
+                《{truncateTitle(e.title)}》{t("home.juan_n", { n: e.juan })}
               </button>
             ))}
           </div>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -18,6 +18,7 @@ import { InfoCircleOutlined, CloseOutlined } from "@ant-design/icons";
 import SourceSelector from "../components/SourceSelector";
 import { getStats, getSources, getFilters } from "../api/client";
 import { getLangName } from "../utils/sourceUrls";
+import { getReadingHistory } from "../utils/readingHistory";
 import { useAuthStore } from "../stores/authStore";
 import "../styles/home.css"; // mobile-responsive v2.1
 
@@ -30,6 +31,8 @@ export default function HomePage() {
   const [query, setQuery] = useState("");
   const [tipDismissed, setTipDismissed] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  // 一次性读取，避免每次 render 触碰 localStorage
+  const [recentReading] = useState(() => getReadingHistory().slice(0, 3));
 
   const { data: stats } = useQuery({ queryKey: ["stats"], queryFn: getStats });
   const { data: sources } = useQuery({ queryKey: ["sources"], queryFn: getSources, enabled: sourceOpen });
@@ -125,6 +128,23 @@ export default function HomePage() {
             </button>
           ))}
         </div>
+
+        {/* 续读入口：有本地阅读记录才出现，复用热门检索的样式 */}
+        {recentReading.length > 0 && (
+          <div className="home-hot-tags">
+            <span className="home-hot-label">{t("home.continue_reading")}</span>
+            {recentReading.map((e) => (
+              <button
+                key={e.textId}
+                className="home-hot-tag"
+                onClick={() => navigate(`/texts/${e.textId}/read?juan=${e.juan}`)}
+                title={e.title}
+              >
+                《{e.title.length > 12 ? `${e.title.slice(0, 12)}…` : e.title}》{t("home.juan_n", { n: e.juan })}
+              </button>
+            ))}
+          </div>
+        )}
 
         {!user && !tipDismissed && (
           <div className="home-tip">

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
@@ -33,8 +33,9 @@ export default function TextDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [citationOpen, setCitationOpen] = useState(false);
-  // 续读：有本地阅读记录时，主按钮变为"继续阅读·第N卷"
-  const [lastRead] = useState(() => getLastPosition(Number(id)));
+  // 续读：有本地阅读记录时，主按钮变为"继续阅读·第N卷"。
+  // useMemo 按 id 重算：相关经典跳转复用同一路由实例，useState 初始化会 stale。
+  const lastRead = useMemo(() => getLastPosition(Number(id)), [id]);
 
   const { data: text, isLoading } = useQuery({
     queryKey: ["text", id],

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "@ant-design/icons";
 import { getTextDetail } from "../api/client";
 import { buildCbetaReadUrl } from "../utils/sourceUrls";
+import { getLastPosition } from "../utils/readingHistory";
 import BookmarkButton from "../components/BookmarkButton";
 import { RelatedTextsStandalone as RelatedTexts } from "../components/RelatedTexts";
 import OtherVersions from "../components/OtherVersions";
@@ -32,6 +33,8 @@ export default function TextDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [citationOpen, setCitationOpen] = useState(false);
+  // 续读：有本地阅读记录时，主按钮变为"继续阅读·第N卷"
+  const [lastRead] = useState(() => getLastPosition(Number(id)));
 
   const { data: text, isLoading } = useQuery({
     queryKey: ["text", id],
@@ -176,9 +179,15 @@ export default function TextDetailPage() {
               type="primary"
               size="large"
               icon={<BookOutlined />}
-              onClick={() => navigate(`/texts/${text.id}/read`)}
+              onClick={() =>
+                navigate(
+                  lastRead
+                    ? `/texts/${text.id}/read?juan=${lastRead.juan}`
+                    : `/texts/${text.id}/read`,
+                )
+              }
             >
-              在线阅读
+              {lastRead ? `继续阅读 · 第${lastRead.juan}卷` : "在线阅读"}
             </Button>
           )}
           {cbetaUrl && (

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -246,6 +246,23 @@ function getInitialFontSize(): number {
   return 18;
 }
 
+/**
+ * 找到 el 实际所在的滚动容器。AI 面板打开时（默认即打开）reader.css 把
+ * .reader-with-sidebar 锁高、滚动权交给 .reader-container；面板关闭时滚动
+ * 的是 document（返回 null）。续读与 highlight 深链都必须按真实 scroller 操作。
+ */
+function findScrollContainer(el: HTMLElement): HTMLElement | null {
+  let p = el.parentElement;
+  while (p) {
+    const style = getComputedStyle(p);
+    if ((style.overflowY === "auto" || style.overflowY === "scroll") && p.scrollHeight > p.clientHeight) {
+      return p;
+    }
+    p = p.parentElement;
+  }
+  return null;
+}
+
 /** 划词查辞典浮层状态 */
 export default function TextReaderPage() {
   const { id } = useParams<{ id: string }>();
@@ -483,29 +500,36 @@ export default function TextReaderPage() {
     }
   }, [textId, textDetail]);
 
-  // 续读 · 恢复滚动位置。与 highlight_chunk 同一套坐标系：阅读锚点取
-  // 视口上 1/3 处（scrollTo 公式的逆运算），所以记录与恢复互为逆变换。
+  // 续读 · 恢复滚动位置。坐标系说明：阅读锚点取视口上 1/3 处。测量公式
+  // (innerHeight/3 - rect.top) / rect.height 只依赖 viewport 坐标，对
+  // document 滚动和 .reader-container 元素滚动（AI 面板打开时 reader.css
+  // 把滚动权交给容器）都成立；恢复用 scrollBy 增量同理对两种 scroller 通用。
   useEffect(() => {
     const resume = resumeRef.current;
     if (!resume || resume.juan !== juanNum) return;
     if (!content?.content) return;
-    resumeRef.current = null; // 一次性消费，卷间切换不再触发
     const raf = requestAnimationFrame(() => {
+      // 消费 ref 放在 rAF 内：StrictMode 下 effect 第一轮的 cleanup 会取消
+      // rAF，此时 ref 未消费，第二轮才能重试（否则暖缓存时续读静默失效）。
+      if (!resumeRef.current) return;
+      resumeRef.current = null;
       const el = readerContentRef.current;
       if (!el) return;
       if (resume.ratio > 0.03) {
         const rect = el.getBoundingClientRect();
-        const divTopAbs = rect.top + window.scrollY;
-        const target = Math.max(divTopAbs + rect.height * resume.ratio - window.innerHeight / 3, 0);
-        window.scrollTo({ top: target });
+        const delta = rect.top + rect.height * resume.ratio - window.innerHeight / 3;
+        const scroller = findScrollContainer(el);
+        if (scroller) scroller.scrollTop += delta;
+        else window.scrollBy({ top: delta });
       }
       message.info(`已定位到上次阅读位置 · 第${resume.juan}卷`, 2.5);
     });
     return () => cancelAnimationFrame(raf);
   }, [content, juanNum]);
 
-  // 续读 · 记录阅读位置。trailing-throttle 1.5s；进卷时也记录一次，
-  // 这样未滚动就离开的卷切换也会留下记录。
+  // 续读 · 记录阅读位置。trailing-throttle 1.5s；进卷时也记录一次；卸载时
+  // flush 未落盘的最后位置。capture: true 是关键 —— AI 面板打开时滚动发生在
+  // .reader-container 上，scroll 事件不冒泡，只有捕获阶段能在 window 收到。
   useEffect(() => {
     if (!content?.content) return;
     let timer: number | undefined;
@@ -515,13 +539,11 @@ export default function TextReaderPage() {
       if (!el) return;
       const rect = el.getBoundingClientRect();
       if (rect.height <= 0) return;
-      const divTopAbs = rect.top + window.scrollY;
-      const anchorY = window.scrollY + window.innerHeight / 3;
       recordReading({
         textId,
         title: content.title_zh || `文本 ${textId}`,
         juan: juanNum,
-        ratio: (anchorY - divTopAbs) / rect.height,
+        ratio: (window.innerHeight / 3 - rect.top) / rect.height,
       });
     };
     const onScroll = () => {
@@ -529,10 +551,13 @@ export default function TextReaderPage() {
       timer = window.setTimeout(record, 1500);
     };
     onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("scroll", onScroll, { passive: true, capture: true });
     return () => {
-      window.removeEventListener("scroll", onScroll);
-      if (timer !== undefined) window.clearTimeout(timer);
+      window.removeEventListener("scroll", onScroll, { capture: true });
+      if (timer !== undefined) {
+        window.clearTimeout(timer);
+        record(); // flush：离开页面/换卷前把最后 1.5s 内的滚动落盘
+      }
     };
   }, [content, textId, juanNum]);
 
@@ -556,15 +581,16 @@ export default function TextReaderPage() {
     const ratio = Math.min(chunkCharOffset / totalChars, 0.95);
 
     // Wait for paint so the DOM reflects the juan's full rendered height.
-    // The reader content div is not itself scrollable — the document is —
-    // so compute an absolute page-level y offset from the div's bounding rect.
+    // Scroll the REAL scroller: with the AI panel open (the default) reader.css
+    // hands scrolling to .reader-container, where window.scrollTo is a no-op.
     const raf = requestAnimationFrame(() => {
       const el = readerContentRef.current;
       if (!el) return;
       const rect = el.getBoundingClientRect();
-      const divTopAbs = rect.top + window.scrollY;
-      const target = Math.max(divTopAbs + rect.height * ratio - window.innerHeight / 3, 0);
-      window.scrollTo({ top: target, behavior: "smooth" });
+      const delta = rect.top + rect.height * ratio - window.innerHeight / 3;
+      const scroller = findScrollContainer(el);
+      if (scroller) scroller.scrollTo({ top: scroller.scrollTop + delta, behavior: "smooth" });
+      else window.scrollBy({ top: delta, behavior: "smooth" });
     });
     return () => cancelAnimationFrame(raf);
   }, [highlightChunkIndex, content, textId, juanNum]);

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Typography, Spin, Button, Select, Breadcrumb, Row, Col, message, Tooltip, Tag } from "antd";
+import { getLastPosition, recordReading } from "../utils/readingHistory";
 import {
   HomeOutlined,
   LeftOutlined,
@@ -255,7 +256,24 @@ export default function TextReaderPage() {
   const initialJuan = initialJuanParam ? parseInt(initialJuanParam, 10) : 1;
   const highlightChunkParam = searchParams.get("highlight_chunk");
   const highlightChunkIndex = highlightChunkParam ? parseInt(highlightChunkParam, 10) : null;
-  const [juanNum, setJuanNum] = useState(Number.isFinite(initialJuan) && initialJuan > 0 ? initialJuan : 1);
+  // 续读：URL 显式指定卷或深链高亮时尊重 URL；否则恢复上次阅读位置。
+  // resumeRef 在首次渲染时一次性决定，供后续滚动恢复 effect 消费。
+  const resumeRef = useRef<{ juan: number; ratio: number } | null>(null);
+  const [juanNum, setJuanNum] = useState(() => {
+    const last = highlightChunkParam ? null : getLastPosition(Number(id));
+    if (initialJuanParam && Number.isFinite(initialJuan) && initialJuan > 0) {
+      // URL 显式指定卷：尊重 URL；若与记录同卷（如详情页"继续阅读"），仍恢复滚动。
+      if (last && last.juan === initialJuan && last.ratio > 0.03) {
+        resumeRef.current = { juan: initialJuan, ratio: last.ratio };
+      }
+      return initialJuan;
+    }
+    if (last && last.juan > 0 && (last.juan > 1 || last.ratio > 0.03)) {
+      resumeRef.current = { juan: last.juan, ratio: last.ratio };
+      return last.juan;
+    }
+    return 1;
+  });
   const [fontSize, setFontSize] = useState(getInitialFontSize);
   const [citationOpen, setCitationOpen] = useState(false);
   const [annotationOpen, setAnnotationOpen] = useState(false);
@@ -464,6 +482,59 @@ export default function TextReaderPage() {
       umami.track("read", { id: String(textId), title: textDetail.title_zh || "" });
     }
   }, [textId, textDetail]);
+
+  // 续读 · 恢复滚动位置。与 highlight_chunk 同一套坐标系：阅读锚点取
+  // 视口上 1/3 处（scrollTo 公式的逆运算），所以记录与恢复互为逆变换。
+  useEffect(() => {
+    const resume = resumeRef.current;
+    if (!resume || resume.juan !== juanNum) return;
+    if (!content?.content) return;
+    resumeRef.current = null; // 一次性消费，卷间切换不再触发
+    const raf = requestAnimationFrame(() => {
+      const el = readerContentRef.current;
+      if (!el) return;
+      if (resume.ratio > 0.03) {
+        const rect = el.getBoundingClientRect();
+        const divTopAbs = rect.top + window.scrollY;
+        const target = Math.max(divTopAbs + rect.height * resume.ratio - window.innerHeight / 3, 0);
+        window.scrollTo({ top: target });
+      }
+      message.info(`已定位到上次阅读位置 · 第${resume.juan}卷`, 2.5);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [content, juanNum]);
+
+  // 续读 · 记录阅读位置。trailing-throttle 1.5s；进卷时也记录一次，
+  // 这样未滚动就离开的卷切换也会留下记录。
+  useEffect(() => {
+    if (!content?.content) return;
+    let timer: number | undefined;
+    const record = () => {
+      timer = undefined;
+      const el = readerContentRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.height <= 0) return;
+      const divTopAbs = rect.top + window.scrollY;
+      const anchorY = window.scrollY + window.innerHeight / 3;
+      recordReading({
+        textId,
+        title: content.title_zh || `文本 ${textId}`,
+        juan: juanNum,
+        ratio: (anchorY - divTopAbs) / rect.height,
+      });
+    };
+    const onScroll = () => {
+      if (timer !== undefined) return;
+      timer = window.setTimeout(record, 1500);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [content, textId, juanNum]);
 
   // Deep-link from the chat citation drawer: ?highlight_chunk=N
   // Chunks are 500 chars wide with 50-char overlap (see scripts/archive/misc/generate_embeddings.py),

--- a/frontend/src/utils/readingHistory.ts
+++ b/frontend/src/utils/readingHistory.ts
@@ -1,0 +1,69 @@
+/**
+ * 阅读续读历史 — localStorage 实现。
+ *
+ * 对所有访客生效（含未登录）：记录最近阅读的 (text, 卷, 滚动位置)，
+ * 供阅读器恢复位置、详情页"继续阅读"、首页"最近阅读"入口使用。
+ * 设备本地存储；跨设备同步留给将来的服务端版本（登录权益）。
+ */
+
+export interface ReadingEntry {
+  textId: number;
+  title: string;
+  juan: number;
+  /** 0..1 — 阅读视口锚点在正文渲染高度中的比例 */
+  ratio: number;
+  ts: number;
+}
+
+const STORAGE_KEY = "fojin-reading-history";
+const MAX_ENTRIES = 10;
+
+function readAll(): ReadingEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is ReadingEntry =>
+        e &&
+        typeof e.textId === "number" &&
+        typeof e.juan === "number" &&
+        typeof e.ratio === "number" &&
+        typeof e.ts === "number",
+    );
+  } catch {
+    // localStorage 不可用（隐私模式）或损坏数据 — 静默降级为"无历史"
+    return [];
+  }
+}
+
+function writeAll(entries: ReadingEntry[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries.slice(0, MAX_ENTRIES)));
+  } catch {
+    /* quota / 隐私模式 — 丢弃即可 */
+  }
+}
+
+/** 记录（或更新）一条阅读位置；同一 text 只保留最新一条，列表按时间倒序。 */
+export function recordReading(entry: Omit<ReadingEntry, "ts">): void {
+  if (!Number.isFinite(entry.textId) || entry.textId <= 0) return;
+  const rest = readAll().filter((e) => e.textId !== entry.textId);
+  writeAll([{ ...entry, ratio: clamp01(entry.ratio), ts: Date.now() }, ...rest]);
+}
+
+/** 最近阅读列表（时间倒序，最多 MAX_ENTRIES 条）。 */
+export function getReadingHistory(): ReadingEntry[] {
+  return readAll();
+}
+
+/** 某部经的上次阅读位置；无记录返回 null。 */
+export function getLastPosition(textId: number): ReadingEntry | null {
+  return readAll().find((e) => e.textId === textId) ?? null;
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(Math.max(n, 0), 1);
+}

--- a/frontend/src/utils/readingHistory.ts
+++ b/frontend/src/utils/readingHistory.ts
@@ -28,6 +28,7 @@ function readAll(): ReadingEntry[] {
       (e): e is ReadingEntry =>
         e &&
         typeof e.textId === "number" &&
+        typeof e.title === "string" &&
         typeof e.juan === "number" &&
         typeof e.ratio === "number" &&
         typeof e.ts === "number",
@@ -49,6 +50,7 @@ function writeAll(entries: ReadingEntry[]): void {
 /** 记录（或更新）一条阅读位置；同一 text 只保留最新一条，列表按时间倒序。 */
 export function recordReading(entry: Omit<ReadingEntry, "ts">): void {
   if (!Number.isFinite(entry.textId) || entry.textId <= 0) return;
+  if (!Number.isFinite(entry.juan) || entry.juan < 1) return;
   const rest = readAll().filter((e) => e.textId !== entry.textId);
   writeAll([{ ...entry, ratio: clamp01(entry.ratio), ts: Date.now() }, ...rest]);
 }


### PR DESCRIPTION
30 天真实数据驱动（read 624 次/月、金刚经单本 92 访客/月）：回访读者每次都要重新找经找卷找位置，续读完全缺失。

- **阅读器**：滚动节流记录 (卷, 位置)；回访自动恢复卷+滚动+轻提示；与 highlight_chunk 深链同坐标系且深链优先
- **详情页**：主按钮智能变「继续阅读 · 第N卷」
- **首页**：「继续阅读」chips 入口（复用热门检索样式，零新 CSS，无记录不渲染）
- localStorage 实现，所有访客可用；隐私模式静默降级；跨设备同步留作将来登录权益

纯前端，不触碰 backend（对齐链安全）。部署后将 headless 全链路验证（写入→恢复→入口）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)