### PR TITLE
feat(chat): 游客转化钩子 — 首条回复后提示登录保存历史（高 ROI #2）

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -192,6 +192,8 @@
   "chat.unlimited_usage": "for unlimited usage.",
   "chat.login": "Log in",
   "chat.login_quota_hint": " to enjoy the AI Buddhist assistant. Configure your own API Key for unlimited usage.",
+  "chat.guest_save_hint": "This conversation won't be saved — it's gone after refresh. Sign in to keep your chat history.",
+  "chat.guest_save_hint_cta": "Sign in to save",
   "chat.hot_questions": [
     "What does 'form is emptiness' mean in the Heart Sutra?",
     "How do Kumārajīva and Xuanzang's translation styles differ?",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -192,6 +192,8 @@
   "chat.unlimited_usage": "可無限使用。",
   "chat.login": "登入",
   "chat.login_quota_hint": "後即可暢享 AI 佛典問答。配置自己的 API Key 可無限使用。",
+  "chat.guest_save_hint": "當前對話不會被保存，刷新或離開後即丟失。登入後會話自動保存，可隨時回看。",
+  "chat.guest_save_hint_cta": "登入保存",
   "chat.hot_questions": [
     "《心經》中「色不異空」的含義是什麼？",
     "鳩摩羅什與玄奘的翻譯風格有何不同？",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -192,6 +192,8 @@
   "chat.unlimited_usage": "可无限使用。",
   "chat.login": "登录",
   "chat.login_quota_hint": "后即可畅享 AI 佛典问答。配置自己的 API Key 可无限使用。",
+  "chat.guest_save_hint": "当前对话不会被保存，刷新或离开后即丢失。登录后会话自动保存，可随时回看。",
+  "chat.guest_save_hint_cta": "登录保存",
   "chat.hot_questions": [
     "《心经》中「色不异空」的含义是什么？",
     "鸠摩罗什与玄奘的翻译风格有何不同？",

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -303,6 +303,28 @@ export default function ChatPage() {
     setSaveHintDismissed(true);
     try { window.localStorage.setItem(SAVE_HINT_KEY, String(Date.now())); } catch { /* ignore */ }
   }, []);
+  // CTA：先暂存游客对话再去登录——navigate 卸载本组件，不存就把用户
+  // 想保存的对话当场销毁。LoginPage 读 returnTo 回跳，本组件 mount 恢复。
+  const goLoginKeepingTranscript = useCallback(() => {
+    try {
+      sessionStorage.setItem("fojin.chat.guestTranscript", JSON.stringify(messages));
+      sessionStorage.setItem("fojin.login.returnTo", "/chat");
+    } catch { /* ignore */ }
+    navigate("/login");
+  }, [messages, navigate]);
+  // 登录归来恢复暂存对话（无论登录成功与否，回到 /chat 都不该丢对话）
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem("fojin.chat.guestTranscript");
+      if (!raw) return;
+      sessionStorage.removeItem("fojin.chat.guestTranscript");
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        setMessages((prev) => (prev.length === 0 ? parsed : prev));
+      }
+    } catch { /* ignore */ }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [attachments, setAttachments] = useState<ChatAttachmentMeta[]>([]);
   const [uploadingAttachment, setUploadingAttachment] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -1252,30 +1274,34 @@ export default function ChatPage() {
                 </div>
               </div>
             ))}
-            {/* 游客转化钩子：拿到第一条完整回复后提示保存历史（可关闭，14 天静默） */}
-            {!user && !sending && !saveHintDismissed && messages.some((m) => m.role === "assistant") && (
-              <Alert
-                type="info"
-                showIcon
-                closable
-                onClose={dismissSaveHint}
-                style={{ margin: "4px 0 8px", fontSize: 12 }}
-                message={
-                  <span>
-                    {t("chat.guest_save_hint")}
-                    <a onClick={() => navigate("/login")} style={{ marginLeft: 4 }}>
-                      {t("chat.guest_save_hint_cta")}
-                    </a>
-                  </span>
-                }
-              />
-            )}
             {/* Streaming cursor is shown inline via ▌ in the message bubble */}
             <div ref={bottomRef} />
           </div>
 
           {/* Input */}
           <div style={{ padding: "12px 0", borderTop: "1px solid rgba(217,208,193,0.5)" }}>
+            {/* 游客转化钩子：拿到第一条成功回复后提示保存历史（可关闭，14 天
+                静默）。固定在输入区上方而非消息流末尾：消息流尾部的 mount 受
+                scrollToBottom 时序影响可能落在视口外，用户永远看不到。
+                排除失败哨兵回复——在报错下面劝人"保存这段对话"很荒谬。 */}
+            {!user && !sending && !saveHintDismissed
+              && messages.some((m) => m.role === "assistant" && m.content !== "请求失败，请重试") && (
+              <Alert
+                type="info"
+                showIcon
+                closable
+                onClose={dismissSaveHint}
+                style={{ marginBottom: 8, fontSize: 12 }}
+                message={
+                  <span>
+                    {t("chat.guest_save_hint")}
+                    <a onClick={goLoginKeepingTranscript} style={{ marginLeft: 4 }}>
+                      {t("chat.guest_save_hint_cta")}
+                    </a>
+                  </span>
+                }
+              />
+            )}
             <div style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 8 }}>
               <span style={{ fontSize: 13, color: "#8b7355", whiteSpace: "nowrap" }}>{t("chat.master_mode")}</span>
               <Select

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -289,6 +289,20 @@ export default function ChatPage() {
   const [sessionId, setSessionId] = useState<number | undefined>();
   const [messages, setMessages] = useState<ChatMessageItem[]>([]);
   const [sending, setSending] = useState(false);
+  // 游客转化钩子：游客拿到第一条 AI 回复后提示"登录可保存历史"。
+  // 数据背景：月 730 chat 用户 vs 65 注册——多数游客不知道对话会丢。
+  // 关闭后 14 天静默（localStorage）。
+  const SAVE_HINT_KEY = "fojin.chat.saveHintDismissedAt";
+  const [saveHintDismissed, setSaveHintDismissed] = useState(() => {
+    try {
+      const ts = Number(window.localStorage.getItem(SAVE_HINT_KEY));
+      return Number.isFinite(ts) && Date.now() - ts < 14 * 86400_000;
+    } catch { return false; }
+  });
+  const dismissSaveHint = useCallback(() => {
+    setSaveHintDismissed(true);
+    try { window.localStorage.setItem(SAVE_HINT_KEY, String(Date.now())); } catch { /* ignore */ }
+  }, []);
   const [attachments, setAttachments] = useState<ChatAttachmentMeta[]>([]);
   const [uploadingAttachment, setUploadingAttachment] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -1238,6 +1252,24 @@ export default function ChatPage() {
                 </div>
               </div>
             ))}
+            {/* 游客转化钩子：拿到第一条完整回复后提示保存历史（可关闭，14 天静默） */}
+            {!user && !sending && !saveHintDismissed && messages.some((m) => m.role === "assistant") && (
+              <Alert
+                type="info"
+                showIcon
+                closable
+                onClose={dismissSaveHint}
+                style={{ margin: "4px 0 8px", fontSize: 12 }}
+                message={
+                  <span>
+                    {t("chat.guest_save_hint")}
+                    <a onClick={() => navigate("/login")} style={{ marginLeft: 4 }}>
+                      {t("chat.guest_save_hint_cta")}
+                    </a>
+                  </span>
+                }
+              />
+            )}
             {/* Streaming cursor is shown inline via ▌ in the message bubble */}
             <div ref={bottomRef} />
           </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -8,6 +8,20 @@ import api from "../api/client";
 
 const { Title, Text } = Typography;
 
+/**
+ * 登录成功后的回跳目标。用 sessionStorage 而非 location.state：OAuth 流程
+ * 经第三方往返后 state 必然丢失，sessionStorage 两条路径通吃。
+ * 只接受站内相对路径，防 open-redirect。
+ */
+function consumeReturnTo(): string {
+  try {
+    const v = sessionStorage.getItem("fojin.login.returnTo");
+    sessionStorage.removeItem("fojin.login.returnTo");
+    if (v && v.startsWith("/") && !v.startsWith("//")) return v;
+  } catch { /* ignore */ }
+  return "/";
+}
+
 export default function LoginPage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -39,7 +53,7 @@ export default function LoginPage() {
           });
           setAuth(token, user);
           message.success(`${provider === "github" ? "GitHub" : "Google"} 登录成功`);
-          navigate("/", { replace: true });
+          navigate(consumeReturnTo(), { replace: true });
         } catch {
           message.error("第三方登录失败，请重试");
           navigate("/login", { replace: true });
@@ -57,7 +71,7 @@ export default function LoginPage() {
       });
       setAuth(tokenData.access_token, user);
       message.success(t("auth.login_success"));
-      navigate("/");
+      navigate(consumeReturnTo());
     } catch (err: any) {
       message.error(err.response?.data?.detail || t("auth.login_fail"));
     } finally {


### PR DESCRIPTION
月数据：730 chat 用户 vs 65 注册（~12% 转化）。游客对话聊完即丢但界面从未告知——quota banner 只讲次数不讲保存。

- 游客收到第一条完整回复后，消息流末尾出现可关闭 info 提示 + 登录链接
- 时机设计：价值先行（拿到答案后才提示），不打断首问
- 关闭后 14 天静默；三语 i18n
- 纯前端，对齐链安全

🤖 Generated with [Claude Code](https://claude.com/claude-code)