### PR TITLE
feat(alignment): 跨藏对照目录 — catalog 端点 + 专区入口（高 ROI #4）

### DIFF
--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -419,9 +419,12 @@ class CatalogEntry(BaseModel):
     pair_count: int              # total aligned chunk pairs
     partner_count: int           # distinct counterpart texts (e.g. SC suttas)
     avg_confidence: float
-    # A representative counterpart for building a /parallel deep link.
-    # For multi-partner rows (阿含 ↔ dozens of suttas) the reader's relation
-    # panel lists the rest once the user lands there.
+    # Deep-link target: the reader page at the lzh juan with the most
+    # anchors. (NOT the /parallel page: 3 of 10 texts have zero anchors at
+    # juan 1, and counterpart texts store their whole content as juan 1, so
+    # /parallel?juan=N>1 renders a blank partner column.) The reader's
+    # per-chunk alignment panel works on any juan that has anchors.
+    sample_juan: int
     sample_partner_id: int
     sample_partner_title: str
 
@@ -445,12 +448,18 @@ async def get_alignment_catalog(db: AsyncSession = Depends(get_db)):
             sql_text(
                 """
                 WITH normalized AS (
-                    SELECT text_a_id AS lzh_id, text_b_id AS other_id,
+                    -- NULL-lang rows are deliberately dropped by both
+                    -- branches ('!=' is NULL-hostile); langs come from
+                    -- buddhist_texts.lang (non-nullable) in practice.
+                    SELECT text_a_id AS lzh_id, text_a_juan_num AS lzh_juan,
+                           text_b_id AS other_id,
                            text_b_lang AS other_lang, confidence
                     FROM alignment_pairs
-                    WHERE text_a_lang = 'lzh' AND text_b_id IS NOT NULL
+                    WHERE text_a_lang = 'lzh' AND text_b_lang != 'lzh'
+                          AND text_b_id IS NOT NULL
                     UNION ALL
-                    SELECT text_b_id AS lzh_id, text_a_id AS other_id,
+                    SELECT text_b_id AS lzh_id, text_b_juan_num AS lzh_juan,
+                           text_a_id AS other_id,
                            text_a_lang AS other_lang, confidence
                     FROM alignment_pairs
                     WHERE text_b_lang = 'lzh' AND text_a_lang != 'lzh'
@@ -463,7 +472,9 @@ async def get_alignment_catalog(db: AsyncSession = Depends(get_db)):
                        count(*) AS pair_count,
                        count(DISTINCT n.other_id) AS partner_count,
                        round(avg(n.confidence)::numeric, 2) AS avg_confidence,
-                       -- counterpart with the most pairs = best deep-link target
+                       -- juan with the most anchors = best reader landing
+                       mode() WITHIN GROUP (ORDER BY n.lzh_juan) AS sample_juan,
+                       -- counterpart with the most pairs (panel shows the rest)
                        mode() WITHIN GROUP (ORDER BY n.other_id) AS sample_partner_id
                 FROM normalized n
                 JOIN buddhist_texts bt ON bt.id = n.lzh_id
@@ -474,7 +485,7 @@ async def get_alignment_catalog(db: AsyncSession = Depends(get_db)):
         )
     ).fetchall()
 
-    partner_ids = {r[7] for r in rows}
+    partner_ids = {r[8] for r in rows}
     partner_titles: dict[int, str] = {}
     if partner_ids:
         for pid, title in (
@@ -497,8 +508,9 @@ async def get_alignment_catalog(db: AsyncSession = Depends(get_db)):
             pair_count=r[4],
             partner_count=r[5],
             avg_confidence=float(r[6] or 0),
-            sample_partner_id=r[7],
-            sample_partner_title=partner_titles.get(r[7], ""),
+            sample_juan=r[7] or 1,
+            sample_partner_id=r[8],
+            sample_partner_title=partner_titles.get(r[8], ""),
         )
         for r in rows
     ]

--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -404,3 +404,105 @@ async def ai_diff(
         model=model,
         analysis=analysis,
     )
+
+
+# ---------------------------------------------------------------------------
+# Catalog: which texts have cross-canon alignments at all (discoverability)
+# ---------------------------------------------------------------------------
+
+class CatalogEntry(BaseModel):
+    """One lzh text's cross-canon alignment coverage, aggregated per language."""
+    text_id: int                 # the lzh (Chinese) side
+    cbeta_id: str
+    title_zh: str
+    other_lang: str              # pi / bo / sa
+    pair_count: int              # total aligned chunk pairs
+    partner_count: int           # distinct counterpart texts (e.g. SC suttas)
+    avg_confidence: float
+    # A representative counterpart for building a /parallel deep link.
+    # For multi-partner rows (阿含 ↔ dozens of suttas) the reader's relation
+    # panel lists the rest once the user lands there.
+    sample_partner_id: int
+    sample_partner_title: str
+
+
+class AlignmentCatalogResponse(BaseModel):
+    entries: list[CatalogEntry]
+    total_pairs: int
+
+
+@router.get("/catalog", response_model=AlignmentCatalogResponse)
+async def get_alignment_catalog(db: AsyncSession = Depends(get_db)):
+    """All texts with cross-canon alignment coverage, lzh-side normalized.
+
+    alignment_pairs stores direction by pipeline cost (smaller text = text_a),
+    so the Chinese text can sit on either side. UNION both orientations into
+    (lzh_text, other_lang) rows, then aggregate. Small table (thousands of
+    rows), no pagination needed.
+    """
+    rows = (
+        await db.execute(
+            sql_text(
+                """
+                WITH normalized AS (
+                    SELECT text_a_id AS lzh_id, text_b_id AS other_id,
+                           text_b_lang AS other_lang, confidence
+                    FROM alignment_pairs
+                    WHERE text_a_lang = 'lzh' AND text_b_id IS NOT NULL
+                    UNION ALL
+                    SELECT text_b_id AS lzh_id, text_a_id AS other_id,
+                           text_a_lang AS other_lang, confidence
+                    FROM alignment_pairs
+                    WHERE text_b_lang = 'lzh' AND text_a_lang != 'lzh'
+                          AND text_a_id IS NOT NULL
+                )
+                SELECT n.lzh_id,
+                       bt.cbeta_id,
+                       bt.title_zh,
+                       n.other_lang,
+                       count(*) AS pair_count,
+                       count(DISTINCT n.other_id) AS partner_count,
+                       round(avg(n.confidence)::numeric, 2) AS avg_confidence,
+                       -- counterpart with the most pairs = best deep-link target
+                       mode() WITHIN GROUP (ORDER BY n.other_id) AS sample_partner_id
+                FROM normalized n
+                JOIN buddhist_texts bt ON bt.id = n.lzh_id
+                GROUP BY n.lzh_id, bt.cbeta_id, bt.title_zh, n.other_lang
+                ORDER BY pair_count DESC
+                """
+            )
+        )
+    ).fetchall()
+
+    partner_ids = {r[7] for r in rows}
+    partner_titles: dict[int, str] = {}
+    if partner_ids:
+        for pid, title in (
+            await db.execute(
+                sql_text(
+                    "SELECT id, COALESCE(NULLIF(title_zh, ''), title_en, cbeta_id) "
+                    "FROM buddhist_texts WHERE id = ANY(:ids)"
+                ),
+                {"ids": list(partner_ids)},
+            )
+        ).fetchall():
+            partner_titles[pid] = title or ""
+
+    entries = [
+        CatalogEntry(
+            text_id=r[0],
+            cbeta_id=r[1] or "",
+            title_zh=r[2] or "",
+            other_lang=r[3] or "",
+            pair_count=r[4],
+            partner_count=r[5],
+            avg_confidence=float(r[6] or 0),
+            sample_partner_id=r[7],
+            sample_partner_title=partner_titles.get(r[7], ""),
+        )
+        for r in rows
+    ]
+    return AlignmentCatalogResponse(
+        entries=entries,
+        total_pairs=sum(e.pair_count for e in entries),
+    )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1285,6 +1285,28 @@ export async function getJuanAlignment(
   return data;
 }
 
+export interface AlignmentCatalogEntry {
+  text_id: number;
+  cbeta_id: string;
+  title_zh: string;
+  other_lang: string;
+  pair_count: number;
+  partner_count: number;
+  avg_confidence: number;
+  sample_partner_id: number;
+  sample_partner_title: string;
+}
+
+export interface AlignmentCatalogResponse {
+  entries: AlignmentCatalogEntry[];
+  total_pairs: number;
+}
+
+export async function getAlignmentCatalog(): Promise<AlignmentCatalogResponse> {
+  const { data } = await api.get<AlignmentCatalogResponse>("/alignment/catalog");
+  return data;
+}
+
 export interface CanonicalParallel {
   related_text_id: number;
   related_cbeta_id: string;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1293,6 +1293,7 @@ export interface AlignmentCatalogEntry {
   pair_count: number;
   partner_count: number;
   avg_confidence: number;
+  sample_juan: number;
   sample_partner_id: number;
   sample_partner_title: string;
 }

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -209,10 +209,10 @@ function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useN
     <div className="coll-card" style={{ marginBottom: 24 }}>
       <div className="coll-section" style={{ padding: "16px 20px" }}>
         <div className="coll-section-title">
-          <TranslationOutlined /> 跨藏对照（{data.entries.length} 部经 · {data.total_pairs.toLocaleString()} 组对齐段落）
+          <TranslationOutlined /> 跨藏对照（{new Set(data.entries.map((e) => e.text_id)).size} 部经 · {data.total_pairs.toLocaleString()} 组对齐段落）
         </div>
         <p style={{ fontSize: 12, color: "var(--fj-ink-muted)", margin: "4px 0 12px" }}>
-          以下经典已建立逐段跨语对照（AI 对齐 + 置信度过滤），点击进入双栏对读。
+          以下经典已建立逐段跨语对照（AI 对齐 + 置信度过滤），点击进入阅读器，正文旁即可逐段查看对照。
         </p>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
           {data.entries.map((e) => {
@@ -223,7 +223,10 @@ function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useN
                 className="source-btn"
                 style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
                 onClick={() =>
-                  navigate(`/parallel/${e.text_id}?compare=${e.sample_partner_id}&juan=1`)
+                  // 阅读器而非 /parallel：sample_juan 保证该卷有锚点；reader 的
+                  // 按段对照面板不依赖对本侧 text_contents 的卷结构（对本整本
+                  // 存为 juan 1，/parallel 在 juan>1 时对本栏全空）。
+                  navigate(`/texts/${e.text_id}/read?juan=${e.sample_juan}`)
                 }
               >
                 <span>{e.title_zh}</span>

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { Input, Tag, Empty } from "antd";
@@ -20,6 +21,7 @@ import collections, {
   type CollectionLink,
   type ResourceCategory,
 } from "../data/collections";
+import { getAlignmentCatalog } from "../api/client";
 import "../styles/sources.css";
 import "../styles/collections.css";
 
@@ -187,7 +189,61 @@ function CollectionCard({ coll, cbetaMap }: { coll: Collection; cbetaMap: Record
   );
 }
 
+const LANG_LABELS: Record<string, { label: string; color: string }> = {
+  pi: { label: "巴利", color: "green" },
+  bo: { label: "藏文", color: "purple" },
+  sa: { label: "梵文", color: "orange" },
+};
+
+/** 跨藏对照专区：哪些经有逐段对照语料（可发现性入口）。
+    API 失败/空数据时整块隐身，可与 backend 端点解耦部署。 */
+function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useNavigate> }) {
+  const { data } = useQuery({
+    queryKey: ["alignmentCatalog"],
+    queryFn: getAlignmentCatalog,
+    staleTime: 3600_000,
+    retry: 1,
+  });
+  if (!data || data.entries.length === 0) return null;
+  return (
+    <div className="coll-card" style={{ marginBottom: 24 }}>
+      <div className="coll-section" style={{ padding: "16px 20px" }}>
+        <div className="coll-section-title">
+          <TranslationOutlined /> 跨藏对照（{data.entries.length} 部经 · {data.total_pairs.toLocaleString()} 组对齐段落）
+        </div>
+        <p style={{ fontSize: 12, color: "var(--fj-ink-muted)", margin: "4px 0 12px" }}>
+          以下经典已建立逐段跨语对照（AI 对齐 + 置信度过滤），点击进入双栏对读。
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          {data.entries.map((e) => {
+            const lang = LANG_LABELS[e.other_lang] ?? { label: e.other_lang, color: "default" };
+            return (
+              <button
+                key={`${e.text_id}-${e.other_lang}`}
+                className="source-btn"
+                style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+                onClick={() =>
+                  navigate(`/parallel/${e.text_id}?compare=${e.sample_partner_id}&juan=1`)
+                }
+              >
+                <span>{e.title_zh}</span>
+                <Tag color={lang.color} style={{ margin: 0, fontSize: 10, lineHeight: "16px", padding: "0 4px" }}>
+                  {lang.label}
+                </Tag>
+                <span style={{ fontSize: 11, color: "var(--fj-ink-muted)" }}>
+                  {e.pair_count} 段{e.partner_count > 1 ? ` · ${e.partner_count} 部对本` : ""}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function CollectionsPage() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const [showTop, setShowTop] = useState(false);
   const [cbetaMap, setCbetaMap] = useState<Record<string, number>>({});
@@ -256,6 +312,8 @@ export default function CollectionsPage() {
           style={{ width: 320 }}
         />
       </div>
+
+      <ParallelCatalogSection navigate={navigate} />
 
       <div className="sources-stats-bar">
         当前显示 <strong>{filtered.length}</strong> / {collections.length} 个专题


### PR DESCRIPTION
## 缺口

跨藏对照（V1 #642/V2 #643）只能从已打开的阅读器内部进入——全站没有任何地方告诉用户**哪些经有对照**，旗舰差异化功能不可见。prod 现状：10 部汉文经、3,888 组对齐（Batch 2a 跑完会继续涨）。

## 实现

- `GET /alignment/catalog`：按汉文侧归一聚合（存储方向跟随管道成本，汉文可在任一侧，UNION 两向）；`mode()` 取配对最多的对本作为深链目标；SQL 已对 prod 原型验证
- /collections 顶部「跨藏对照」专区：每经一个 chip（语言 tag + 段数 + 多对本计数），点击直达 `/parallel/{lzh}?compare={partner}&juan=1`
- **解耦部署**：API 404/空时整块隐身——前端可先上，backend 随 Batch 2a 结束后与 #687 一起部署

## 部署计划

frontend 先部署（专区隐身）→ 对齐链跑完 → backend 与 #687 一起部署 → 专区自动浮现 → prod 验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)