### PR TITLE
fix(search): 统一搜索「经文标题」区块死于 session 竞态（楞严经检索不出本经）

### DIFF
--- a/backend/app/api/search_unified.py
+++ b/backend/app/api/search_unified.py
@@ -26,13 +26,12 @@ import asyncio
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Query, Request
 from sqlalchemy import case, func, or_, select
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.elasticsearch import get_es
-from app.database import async_session, get_db
+from app.database import async_session
 from app.models.dictionary import DictionaryEntry
 from app.services.search import (
     search_content,
@@ -92,7 +91,6 @@ async def search_unified(
     q: str = Query(..., min_length=1, max_length=200, description="Unified search query"),
     sources: str | None = Query(None, description="Comma-separated source codes filter"),
     lang: str | None = Query(None),
-    db: AsyncSession = Depends(get_db),
 ):
     """Run all search backends in parallel and return sectioned results.
 
@@ -110,21 +108,36 @@ async def search_unified(
     """
     es = get_es()
 
-    # search_semantic uses the request-scoped session; catalog/content use ES.
-    # dict opens its own session for concurrency safety
-    # (a single AsyncSession can't service two concurrent execute() calls).
+    # EVERY db-touching section opens its own session: a single AsyncSession
+    # cannot service two concurrent execute() calls, and under gather() the
+    # loser dies with "session is provisioning a new connection; concurrent
+    # operations are not permitted" — which _attach silently swallowed,
+    # rendering the catalog section (with the base-text top hit) as null
+    # while commentaries from the content section still displayed. catalog
+    # only needs db for the related-translations enrich; semantic needs it
+    # for pgvector. The request-scoped Depends(get_db) is gone entirely so
+    # this endpoint no longer pins a pool connection for its whole lifetime.
     gaiji_normalizer = getattr(request.app.state, "gaiji_normalizer", None)
-    catalog_coro = search_texts(es, q, page=1, size=10, sources=sources, lang=lang, db=db)
+
+    async def catalog_coro():
+        async with async_session() as session:
+            return await search_texts(
+                es, q, page=1, size=10, sources=sources, lang=lang, db=session
+            )
+
+    async def semantic_coro():
+        async with async_session() as session:
+            return await search_semantic(session, q, size=5, lang=lang, sources=sources)
+
     content_coro = search_content(
         es, q, page=1, size=5, sources=sources, lang=lang, gaiji_normalizer=gaiji_normalizer
     )
-    semantic_coro = search_semantic(db, q, size=5, lang=lang, sources=sources)
     dict_coro = _dict_top_hits(q)
 
     catalog_r, content_r, semantic_r, dict_r = await asyncio.gather(
-        catalog_coro,
+        catalog_coro(),
         content_coro,
-        semantic_coro,
+        semantic_coro(),
         dict_coro,
         return_exceptions=True,
     )


### PR DESCRIPTION
## 用户报告

搜「楞严经」只看到注疏（楞嚴經疏解蒙鈔等），本经 T0945 完全不出现。

## 根因

`/search/unified` 用 asyncio.gather 并发跑四个 section，但 **catalog 和 semantic 共享同一个请求级 AsyncSession**——SQLAlchemy 禁止单 session 并发操作，输掉竞态的 section 抛 `concurrent operations are not permitted`，被 `_attach` 静默吞成 `sections.catalog = null`。于是页面只剩 content 区块（纯 ES 不受影响）的注疏，而独立 `/search` 同查询里 T0945 以 1796 分断层第一。

讽刺的是文件注释自己写了规则（'a single AsyncSession can't service two concurrent execute() calls'）、dict 段也已独立开 session——catalog 被以为是纯 ES（它的 db 实为可选的译本 enrich）。

## 修复

- catalog/semantic 各自 `async with async_session()`（与 dict 段同 pattern）
- 移除请求级 `Depends(get_db)`：端点不再整个生命周期占用一个 pool 连接（呼应 06-04 pool 耗尽事故）

## 验证计划

部署后（随对齐链结束的 backend 窗口）：`curl /api/search/unified?q=楞严经` 应 sections.catalog.results[0] = T0945 且 errors 空；前端搜索页「经文标题」区块复现。

⚠️ backend live-API 改动：webhook CD 已停，merge 不会自动部署，与 #687/#693 同窗口上线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)