### PR TITLE
fix(nginx): no-cache for /locales/ — stale heuristic caching hid new translations

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -46,6 +46,15 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # i18n resource files — un-hashed URLs, so they must revalidate on every
+    # load. Without an explicit Cache-Control, browsers heuristically cache
+    # them for days (10% of last-modified age) and keep serving a stale
+    # translation file after deploys: every new key silently falls back to
+    # the bundled zh and English users see mixed-language UI.
+    location /locales/ {
+        add_header Cache-Control "no-cache";
+    }
+
     # Use Docker DNS resolver so backend can be re-resolved after restarts
     resolver 127.0.0.11 valid=30s;
     set $upstream_backend http://backend:8000;


### PR DESCRIPTION
## Problem

`/locales/{lng}/translation.json` is fetched at runtime by i18next-http-backend at a stable, un-hashed URL. nginx served it with no `Cache-Control`, so browsers fell back to heuristic caching (≈10% of the file's age since `last-modified` — days, for a file that rarely changed). After deploying #706 (+111 keys), any browser that had visited before kept reading the stale 194-key English file: every new key fell back to the inline zh bundle and English users saw a mixed Chinese/English page. Verified on production while QA-ing #706 — `fetch('/locales/en/translation.json')` from page context returned 194 keys while the server was serving 305.

## Fix

`Cache-Control: no-cache` for `location /locales/` — forces revalidation on every load; nginx already emits an ETag so the common case is a 304, not a re-download. Follows the existing `/assets/`–`/fonts/` location-block pattern.

Config validated with `nginx -t` in a clean nginx:alpine container.

Note: SW-installed clients were already safe (workbox precache cache-busts), this fixes the plain-HTTP path (first visits, cleared-SW browsers — including the #657 reporter's situation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)