### PR TITLE
fix(i18n): decouple text-language filters from the UI ?lang= param

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -5,13 +5,18 @@ import LanguageDetector from "i18next-browser-languagedetector";
 // Inline zh so the default language is available synchronously (no FOUT)
 import zhTranslation from "../public/locales/zh/translation.json";
 
+// UI locale codes — these own the `?lang=` query param (detector below).
+// Text/source language FILTERS must use a different param (`tl`, see #709)
+// and treat these codes as not-a-filter when reading legacy links.
+export const SUPPORTED_UI_LANGS = ["zh", "zh-Hant", "en"] as const;
+
 i18n
   .use(HttpBackend)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     fallbackLng: "zh",
-    supportedLngs: ["zh", "zh-Hant", "en"],
+    supportedLngs: [...SUPPORTED_UI_LANGS],
     load: "currentOnly",
     keySeparator: false,
     nsSeparator: false,

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { useSearchParams, useNavigate, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
+import { SUPPORTED_UI_LANGS } from "../i18n";
 import { useQuery } from "@tanstack/react-query";
 import {
   Pagination, Empty, Checkbox, Input, Tag, Button, Tabs, Result, Select, Typography, Skeleton, AutoComplete, Alert,
@@ -88,7 +89,15 @@ export default function SearchPage() {
     return () => { cancelled = true; };
   }, [query, navigate]);
 
-  const langFilter = searchParams.get("lang") || "";
+  // #709: the text-language filter param was renamed `lang` → `tl`. The old
+  // name collided with i18next's querystring detector — selecting the
+  // "English" filter and refreshing flipped (and persisted via localStorage)
+  // the entire UI language. Legacy ?lang= links still resolve as filters for
+  // unambiguous codes; UI locale codes (zh/zh-Hant/en) belong to i18n.
+  const legacyLangParam = searchParams.get("lang") || "";
+  const legacyLangIsFilter =
+    legacyLangParam !== "" && !(SUPPORTED_UI_LANGS as readonly string[]).includes(legacyLangParam);
+  const langFilter = searchParams.get("tl") || (legacyLangIsFilter ? legacyLangParam : "");
   const dictLang = searchParams.get("dict_lang") || "";
   const [dictPage, setDictPage] = useState(1);
   const [dynasty] = useState<string>();
@@ -291,6 +300,8 @@ export default function SearchPage() {
         <link rel="canonical" href={`https://fojin.app/search${(() => { const p = new URLSearchParams(); if (query) p.set("q", query); if (page > 1) p.set("page", String(page)); return p.toString() ? `?${p.toString()}` : ""; })()}`} />
         <link rel="alternate" hrefLang="x-default" href={`https://fojin.app/search${query ? `?q=${encodeURIComponent(query)}` : ""}`} />
         <link rel="alternate" hrefLang="zh" href={`https://fojin.app/search${query ? `?q=${encodeURIComponent(query)}` : ""}`} />
+        <link rel="alternate" hrefLang="en" href={`https://fojin.app/search?${new URLSearchParams({ ...(query ? { q: query } : {}), lang: "en" }).toString()}`} />
+        <link rel="alternate" hrefLang="zh-Hant" href={`https://fojin.app/search?${new URLSearchParams({ ...(query ? { q: query } : {}), lang: "zh-Hant" }).toString()}`} />
         {query && page > 1 && (
           <link rel="prev" href={`https://fojin.app/search?${new URLSearchParams({ q: query, ...(page > 2 ? { page: String(page - 1) } : {}) }).toString()}`} />
         )}
@@ -453,7 +464,7 @@ export default function SearchPage() {
                   <Select
                     size="small"
                     value={langFilter || "all"}
-                    onChange={(v) => { setPage(1); updateUrl({ lang: v === "all" ? "" : v }); }}
+                    onChange={(v) => { setPage(1); updateUrl({ tl: v === "all" ? "" : v, ...(legacyLangIsFilter ? { lang: "" } : {}) }); }}
                     style={{ width: 110 }}
                     options={[
                       { value: "all", label: t("search.lang_all") },

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -81,8 +81,18 @@ export default function SourcesPage() {
     [updateParam],
   );
   const setLangFilter = useCallback(
-    (v: string) => updateParam("tl", v, "all"),
-    [updateParam],
+    (v: string) => {
+      updateParam("tl", v, "all");
+      // Clean a lingering legacy filter value, or the read fallback springs
+      // it back (e.g. old link ?lang=sa → user picks "All" → still sa).
+      if (
+        legacyLangParam &&
+        !(SUPPORTED_UI_LANGS as readonly string[]).includes(legacyLangParam)
+      ) {
+        updateParam("lang", "", "");
+      }
+    },
+    [updateParam, legacyLangParam],
   );
   const setFieldFilter = useCallback(
     (v: string) => updateParam("field", v, "all"),

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -5,6 +5,7 @@ import { Helmet } from "react-helmet-async";
 import { Empty, Input, Select, Skeleton } from "antd";
 import { SearchOutlined, ThunderboltOutlined, VerticalAlignTopOutlined } from "@ant-design/icons";
 import { getSources, type DataSource } from "../api/client";
+import { SUPPORTED_UI_LANGS } from "../i18n";
 import { getLangName, hasDirectSearchUrl, normalizeLangCode } from "../utils/sourceUrls";
 import SourceCard from "./sources/SourceCard";
 import SuggestSourceForm from "./sources/SuggestSourceForm";
@@ -36,7 +37,14 @@ export default function SourcesPage() {
   // URL params are the source of truth; defaults live here, not in state.
   const search = searchParams.get("q") ?? "";
   const regionFilter = searchParams.get("region") ?? "all";
-  const langFilter = searchParams.get("lang") ?? "all";
+  // #709: filter param renamed `lang` → `tl` (collision with the i18next
+  // querystring detector). Legacy ?lang= links resolve for non-UI codes.
+  const legacyLangParam = searchParams.get("lang") ?? "";
+  const langFilter =
+    searchParams.get("tl") ??
+    (legacyLangParam && !(SUPPORTED_UI_LANGS as readonly string[]).includes(legacyLangParam)
+      ? legacyLangParam
+      : "all");
   const fieldFilter = searchParams.get("field") ?? "all";
   const fulltextOnly = searchParams.get("fulltext") === "1";
   const searchQuery = searchParams.get("try") ?? "";
@@ -73,7 +81,7 @@ export default function SourcesPage() {
     [updateParam],
   );
   const setLangFilter = useCallback(
-    (v: string) => updateParam("lang", v, "all"),
+    (v: string) => updateParam("tl", v, "all"),
     [updateParam],
   );
   const setFieldFilter = useCallback(


### PR DESCRIPTION
Fixes #709 — see commit message for full details.

**The bug**: search/sources text-language filters wrote `?lang=`, which i18next's querystring detector owns. A Chinese user picking the「英文」filter and refreshing got their entire UI flipped to English, persisted via localStorage.

**The fix**: filters move to `?tl=`; `?lang=` now belongs exclusively to UI locale. Legacy filter links (`?lang=lzh` etc.) still resolve; ambiguous `?lang=en` resolves to UI language (that combination was the bug). Also unblocks hreflang en/zh-Hant alternates (added here for SearchPage).

**Verified**: tsc / eslint / vitest 107 pass; browser-tested — `?tl=en` keeps zh UI after refresh, legacy `?lang=lzh` doesn't flip the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)