### PR TITLE
feat(alignments): dataset export pipeline + HF dataset card draft

### DIFF
--- a/backend/scripts/export_alignment_dataset.py
+++ b/backend/scripts/export_alignment_dataset.py
@@ -1,0 +1,154 @@
+"""Export verified cross-canon alignment pairs as a publishable JSONL dataset.
+
+FoJin's chunk-level alignments (Pāli–Classical Chinese, Classical Chinese–
+Tibetan) are the project's most citable asset: parallel segments across
+Buddhist canons barely exist in machine-readable form anywhere. This script
+turns the `alignment_pairs` table into a flat, self-describing JSONL suitable
+for a HuggingFace dataset release (one record per pair, full provenance).
+
+Output schema (one JSON object per line):
+    {
+      "id": 12345,                      # stable alignment_pairs.id
+      "lang_src": "pi", "lang_tgt": "lzh",
+      "src": {"text_id", "canonical_id", "title", "juan", "chunk_index"},
+      "tgt": {...same...},
+      "segment_src": "...", "segment_tgt": "...",
+      "confidence": 0.92,               # LLM verifier confidence at build time
+      "method": "embed_llm",            # alignment pipeline variant
+      "verified": false                 # human-verified flag
+    }
+
+Usage (run inside the backend container or with backend deps):
+    python -m scripts.export_alignment_dataset --out /tmp/fojin_alignments.jsonl
+    python -m scripts.export_alignment_dataset --min-confidence 0.85 --langs pi-lzh
+    python -m scripts.export_alignment_dataset --stats   # distribution only, no file
+
+Notes:
+    - Read-only: single SELECT, no writes, safe against production.
+    - Segments are canonical-source text (CBETA / SuttaCentral / etc. ingests);
+      the underlying scriptures are public domain. The alignment annotations
+      are FoJin's and ship under CC BY-SA 4.0 (see dataset card).
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.database import async_session
+
+EXPORT_SQL = """
+SELECT
+    p.id,
+    p.text_a_lang        AS lang_src,
+    p.text_b_lang        AS lang_tgt,
+    p.text_a_id,
+    ta.cbeta_id          AS src_canonical_id,
+    ta.title_zh          AS src_title,
+    p.text_a_juan_num    AS src_juan,
+    p.text_a_chunk_index AS src_chunk,
+    p.text_b_id,
+    tb.cbeta_id          AS tgt_canonical_id,
+    tb.title_zh          AS tgt_title,
+    p.text_b_juan_num    AS tgt_juan,
+    p.text_b_chunk_index AS tgt_chunk,
+    ea.chunk_text        AS segment_src,
+    eb.chunk_text        AS segment_tgt,
+    p.confidence,
+    p.method,
+    p.is_verified
+FROM alignment_pairs p
+JOIN buddhist_texts ta ON ta.id = p.text_a_id
+JOIN buddhist_texts tb ON tb.id = p.text_b_id
+-- alignment_pairs stores chunk references; the segment text lives in
+-- text_embeddings (chunk_text), addressed by (text_id, juan_num, chunk_index)
+JOIN text_embeddings ea
+  ON ea.text_id = p.text_a_id
+ AND ea.juan_num = p.text_a_juan_num
+ AND ea.chunk_index = p.text_a_chunk_index
+JOIN text_embeddings eb
+  ON eb.text_id = p.text_b_id
+ AND eb.juan_num = p.text_b_juan_num
+ AND eb.chunk_index = p.text_b_chunk_index
+WHERE p.confidence >= :min_confidence
+ORDER BY p.text_a_id, p.text_a_juan_num, p.text_a_chunk_index, p.id
+"""
+
+
+def to_record(row) -> dict:
+    return {
+        "id": row.id,
+        "lang_src": row.lang_src,
+        "lang_tgt": row.lang_tgt,
+        "src": {
+            "text_id": row.text_a_id,
+            "canonical_id": row.src_canonical_id,
+            "title": row.src_title,
+            "juan": row.src_juan,
+            "chunk_index": row.src_chunk,
+        },
+        "tgt": {
+            "text_id": row.text_b_id,
+            "canonical_id": row.tgt_canonical_id,
+            "title": row.tgt_title,
+            "juan": row.tgt_juan,
+            "chunk_index": row.tgt_chunk,
+        },
+        "segment_src": row.segment_src,
+        "segment_tgt": row.segment_tgt,
+        "confidence": row.confidence,
+        "method": row.method,
+        "verified": row.is_verified,
+    }
+
+
+async def run(args: argparse.Namespace) -> None:
+    wanted_langs = set(args.langs.split(",")) if args.langs else None
+
+    async with async_session() as session:
+        result = await session.execute(
+            text(EXPORT_SQL), {"min_confidence": args.min_confidence}
+        )
+        rows = result.fetchall()
+
+    records = [
+        to_record(r)
+        for r in rows
+        if wanted_langs is None or f"{r.lang_src}-{r.lang_tgt}" in wanted_langs
+    ]
+
+    dist = Counter(f"{r['lang_src']}-{r['lang_tgt']}" for r in records)
+    texts = len({(r["src"]["text_id"], r["tgt"]["text_id"]) for r in records})
+    print(f"pairs: {len(records)}  text-pairs: {texts}  min_conf: {args.min_confidence}")
+    for langs, n in dist.most_common():
+        confs = [r["confidence"] for r in records if f"{r['lang_src']}-{r['lang_tgt']}" == langs]
+        print(f"  {langs}: {n} pairs, avg conf {sum(confs) / len(confs):.3f}")
+
+    if args.stats:
+        return
+
+    out = Path(args.out)
+    with out.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    print(f"wrote {out} ({out.stat().st_size / 1024:.0f} KB)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--out", default="/tmp/fojin_alignments.jsonl")
+    parser.add_argument("--min-confidence", type=float, default=0.75)
+    parser.add_argument("--langs", help="comma-separated lang pairs, e.g. pi-lzh,lzh-bo")
+    parser.add_argument("--stats", action="store_true", help="print distribution only")
+    args = parser.parse_args()
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/datasets/alignments/README.md
+++ b/datasets/alignments/README.md
@@ -1,0 +1,106 @@
+# FoJin Buddhist Canon Alignments (草案 / dataset card draft)
+
+> 状态：**发布前草案**。发布到 HuggingFace 前需确认：dataset 名称（建议
+> `fojin/buddhist-canon-alignments`）、license 最终选择、是否等 lzh-bo 批次扩充后再发 v0.1。
+> 发布命令见文末。本文件即 HF dataset card（README.md）的底稿。
+
+---
+
+Chunk-level parallel segments across Buddhist canons: Pāli ↔ Classical
+Chinese (Āgama/Nikāya parallels) and Classical Chinese ↔ Tibetan
+(Kangyur parallels). Machine-aligned via embedding retrieval + LLM
+verification, with per-pair confidence scores.
+
+Parallel data across these canons barely exists in machine-readable,
+segment-granular form. Existing resources (SuttaCentral parallels,
+Bukkyō Dendō Kyōkai concordances) map at sutta/text level; this dataset
+aligns at the passage level, making it usable for cross-lingual retrieval,
+translation-pair mining, and computational philology.
+
+## Current contents (v0.1 candidate, 2026-06-12)
+
+| Direction | Pairs | Text pairs | Avg. confidence |
+|---|---|---|---|
+| Pāli → Classical Chinese (`pi-lzh`) | 3,095 | 211 | 0.892 |
+| Classical Chinese → Tibetan (`lzh-bo`) | 955 | 5 | 0.902 |
+| Classical Chinese → Pāli (`lzh-pi`) | 49 | 1 | 0.845 |
+| **Total** | **4,099** | **236** | |
+
+Sources: CBETA (Classical Chinese), SuttaCentral (Pāli), 84000 / Adarsha
+(Tibetan), as ingested by [fojin.app](https://fojin.app).
+
+## Record schema (JSONL, one object per line)
+
+```json
+{
+  "id": 4144,
+  "lang_src": "lzh", "lang_tgt": "bo",
+  "src": {"text_id": 6, "canonical_id": "T0223", "title": "摩訶般若波羅蜜經",
+           "juan": 1, "chunk_index": 4},
+  "tgt": {"text_id": 5163, "canonical_id": "84K-toh9", "title": "Toh 9 (Kangyur)",
+           "juan": 1, "chunk_index": 105},
+  "segment_src": "…", "segment_tgt": "…",
+  "confidence": 0.92,
+  "method": "embed_llm",
+  "verified": false
+}
+```
+
+- `canonical_id` — CBETA Taishō number (`T…`/`X…`), SuttaCentral id (`SC-…`),
+  or 84000 Tohoku number (`84K-toh…`)
+- `confidence` — LLM verifier score at alignment time (pipeline threshold 0.75)
+- `verified` — human-reviewed flag (currently false for all pairs; the
+  alignment UI exists and verification is ongoing)
+
+## Method
+
+For each chunk of the source text: pgvector cosine top-20 candidates from
+the target text → bilingual LLM verification (is-parallel + confidence) →
+persist pairs ≥ 0.75. Pipeline:
+[`backend/scripts/build_alignments.py`](https://github.com/xr843/fojin/blob/master/backend/scripts/build_alignments.py).
+Export: [`backend/scripts/export_alignment_dataset.py`](https://github.com/xr843/fojin/blob/master/backend/scripts/export_alignment_dataset.py).
+
+## Known limitations
+
+- Machine-aligned; `verified: false` pairs have not been individually
+  human-checked. Confidence scores come from the verifying LLM, not
+  philological review.
+- Chunking is retrieval-oriented (~embedding-window sized), so segment
+  boundaries don't follow traditional textual divisions.
+- `lzh-bo` currently covers only 5 texts (Lotus Sutra batch 1 + Prajñāpāramitā);
+  expansion is ongoing.
+- Source-text editions inherit any OCR/digitization issues from upstream.
+
+## License
+
+The underlying scriptures are public domain. The alignment annotations
+(pairings, confidence, segmentation) are © FoJin contributors, released
+under **CC BY-SA 4.0**.
+
+## Citation
+
+```bibtex
+@misc{fojin-alignments-2026,
+  title   = {FoJin Buddhist Canon Alignments: chunk-level Pāli–Chinese–Tibetan parallel segments},
+  author  = {FoJin contributors},
+  year    = {2026},
+  url     = {https://fojin.app},
+  note    = {Version 0.1}
+}
+```
+
+---
+
+## 发布操作（待确认后执行）
+
+```bash
+# 1. 导出最新数据（生产容器内，只读）
+docker exec fojin-backend python -m scripts.export_alignment_dataset \
+  --out /tmp/fojin_alignments.jsonl
+
+# 2. 上传（需要 HF token，hf CLI）
+hf upload fojin/buddhist-canon-alignments /tmp/fojin_alignments.jsonl data/alignments.jsonl --repo-type dataset
+hf upload fojin/buddhist-canon-alignments datasets/alignments/README.md README.md --repo-type dataset
+```
+
+发布后回填：HF 链接进 fojin README + security-research 聚合页风格的引用入口。


### PR DESCRIPTION
First concrete step of the "alignment corpus as a public dataset" track.

**Export script** (`backend/scripts/export_alignment_dataset.py`): read-only, joins `alignment_pairs` × `text_embeddings` (where segment text actually lives — the `segment_a/b` columns are vestigial NULLs) × `buddhist_texts`. JSONL with full provenance per pair. Filters: `--min-confidence`, `--langs`, `--stats`.

**Dataset card draft** (`datasets/alignments/README.md`): HF-ready card — current stats (4,099 pairs / 236 text pairs: pi-lzh 3,095 @ 0.892, lzh-bo 955 @ 0.902), schema, method, honest limitations (machine-aligned, not philologically verified), CC BY-SA 4.0 annotations over public-domain scriptures, citation block, publish runbook.

**Verified on production**: full export runs clean (4,099 records, 9.3 MB), content spot-checked (T0223 摩訶般若波羅蜜經 ↔ 84K-toh9 parallel passages).

**Not in this PR**: the actual HuggingFace publication — gated on dataset naming and license sign-off (card header lists the open decisions). `backend/scripts/` changes don't trigger a backend restart per deploy.sh path rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)