### PR TITLE
fix(i18n): language button showed 中文 on an English UI for returning visitors

### DIFF
--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -70,6 +70,12 @@ test("english locale file is current and the search page renders in English", as
   await expect(tabs.first()).toBeVisible({ timeout: 20_000 });
   await expect(tabs.first()).toHaveText("All", { timeout: 10_000 });
   await expect(page.locator(".s-mode-bar")).not.toContainText("搜经典");
+  // Returning-visitor path (locale from localStorage, init-time async load):
+  // the header language label must show the active language, not the stale
+  // resolvedLanguage fallback (was「中文」on an all-English page).
+  await expect(page.locator(".header-lang-text")).toHaveText("English", {
+    timeout: 10_000,
+  });
 });
 
 test("reader opens the Heart Sutra via CBETA id redirect", async ({ page, request }) => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -20,6 +20,7 @@ import {
   // BarChartOutlined,
 } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
+import { currentUILang } from "../i18n";
 import { useAuthStore } from "../stores/authStore";
 import { getPendingSuggestionCount, getPendingFeedbackCount } from "../api/client";
 import FeedbackButton from "./FeedbackButton";
@@ -234,7 +235,7 @@ export default function Layout() {
                 { key: "en", label: "English" },
               ],
               onClick: ({ key }) => i18n.changeLanguage(key),
-              selectedKeys: [i18n.resolvedLanguage ?? i18n.language],
+              selectedKeys: [currentUILang(i18n)],
             }}
           >
             <Button
@@ -243,7 +244,7 @@ export default function Layout() {
               style={{ color: inkMuted, fontSize: 13 }}
               aria-label={t("a11y.button.switch_language")}
             >
-              <span className="header-lang-text">{t(`language.${i18n.resolvedLanguage ?? i18n.language}`)}</span>
+              <span className="header-lang-text">{t(`language.${currentUILang(i18n)}`)}</span>
             </Button>
           </Dropdown>
           {user ? (

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -10,6 +10,25 @@ import zhTranslation from "../public/locales/zh/translation.json";
 // and treat these codes as not-a-filter when reading legacy links.
 export const SUPPORTED_UI_LANGS = ["zh", "zh-Hant", "en"] as const;
 
+/**
+ * The UI language to display/select in language pickers.
+ *
+ * Do NOT use i18n.resolvedLanguage for this: with partialBundledLanguages +
+ * HttpBackend, a returning non-zh visitor inits before their locale file
+ * arrives, so resolvedLanguage resolves to the zh fallback — and i18next only
+ * recomputes it on changeLanguage, never on the later "loaded" event. The
+ * header then renders an English UI with a「中文」label. i18n.language always
+ * reflects the target language; we just normalize it onto our supported set.
+ */
+export function currentUILang(instance: typeof i18n = i18n): string {
+  const lng = instance.language ?? "";
+  if ((SUPPORTED_UI_LANGS as readonly string[]).includes(lng)) return lng;
+  if (lng.startsWith("zh-Hant")) return "zh-Hant";
+  const base = lng.split("-")[0];
+  if ((SUPPORTED_UI_LANGS as readonly string[]).includes(base)) return base;
+  return instance.resolvedLanguage ?? "zh";
+}
+
 i18n
   .use(HttpBackend)
   .use(LanguageDetector)


### PR DESCRIPTION
Caught by the user during manual i18n verification (screenshot showed an all-English page with a「中文」language button).

**Root cause**: `i18n.resolvedLanguage` is only recomputed on `changeLanguage`, never on the async `loaded` event. A returning English visitor (locale from localStorage) inits before `en/translation.json` arrives over HTTP, so `resolvedLanguage` settles on the `zh` fallback and stays stale — the post-load rerender interpolates `language.zh` while `t()` resolves in English, rendering "中文". Menu-driven switching recomputes it, which is exactly why the existing E2E language-switcher spec couldn't catch this; only the returning-visitor path triggers it.

**Fix**: `currentUILang()` helper in i18n.ts — prefers `i18n.language` (always the target) normalized onto `SUPPORTED_UI_LANGS` (`zh-CN`→`zh`, `zh-Hant-*`→`zh-Hant`, `en-*`→`en`), falls back to `resolvedLanguage` only for unsupported codes. Layout's label and Dropdown `selectedKeys` both use it.

**Regression net**: the returning-visitor E2E spec (init-script localStorage=en) now also asserts `.header-lang-text` says "English".

Verified locally: en returning visitor → label "English"; zh / zh-Hant unaffected. tsc / eslint / vitest 107 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)