### PR TITLE
feat(i18n): render English source names from name_en

### DIFF
--- a/backend/alembic/versions/0154_fix_source_name_en_quality.py
+++ b/backend/alembic/versions/0154_fix_source_name_en_quality.py
@@ -1,0 +1,56 @@
+"""fix data_sources.name_en quality: 6 underscore slugs + 8 missing
+
+Revision ID: 0154
+Revises: 0153
+Create Date: 2026-06-12
+
+The name_en column has existed since the source-governance backfill and is
+populated for 605/613 active sources, but the frontend never read it (#707).
+Before wiring it up, fix the residue a quality audit found: six values are
+underscore slugs (Fo_Guang_Buddhist_Dictionary) rather than display names,
+and eight rows are NULL/empty. After this migration every active source has
+a display-quality English name.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0154"
+down_revision: str | None = "0153"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# code -> display-quality English name
+FIXES = {
+    # underscore slugs → proper names
+    "fanyi-mingyi": "Fanyi Mingyi Ji (Compendium of Translated Terms)",
+    "foguang": "Fo Guang Dictionary of Buddhism",
+    "sanzang-fashu": "Sanzang Fashu (Numerical Buddhist Terms)",
+    "suyu-foyuan": "Buddhist Origins of Chinese Idioms",
+    "tiantai": "Tiantai Teachings Dictionary",
+    "weishi": "Yogacara Glossary (Vernacular Explanations)",
+    # missing → filled
+    "dict-fo": "Foxue Cidian (Buddhist Dictionary)",
+    "kandianguji": "Kandian Guji (Chinese Classics)",
+    "mugenzo": "Mugenzo Buddhist Library",
+    "pan": "Theravada Chinese Resources",
+    "plumvillage": "Living Gems (Plum Village)",
+    "rushi-guji-tools": "Rushi Guji Toolkit",
+    "shu-fo": "Foshu Buddhist Books",
+    "wx": "Theravada Chinese Resources Collection",
+}
+
+
+def upgrade() -> None:
+    for code, name_en in FIXES.items():
+        op.execute(
+            "UPDATE data_sources SET name_en = '{}' WHERE code = '{}'".format(
+                name_en.replace("'", "''"), code.replace("'", "''")
+            )
+        )
+
+
+def downgrade() -> None:
+    # Data-quality fix; the previous slugs/NULLs are not worth restoring.
+    pass

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -76,6 +76,14 @@ test("english locale file is current and the search page renders in English", as
   await expect(page.locator(".header-lang-text")).toHaveText("English", {
     timeout: 10_000,
   });
+  // Source names are DB data (name_en, #707) — the institution facet and the
+  // external-source launcher rows must render English names, not name_zh.
+  const firstInstitution = page.locator(".s-filter-group").nth(1).locator(".s-filter-name").first();
+  await expect(firstInstitution).toBeVisible({ timeout: 20_000 });
+  await expect(firstInstitution).not.toContainText(/[\u4e00-\u9fff]/);
+  const firstLauncher = page.locator(".s-ext-row-name").first();
+  await expect(firstLauncher).toBeVisible({ timeout: 20_000 });
+  await expect(firstLauncher).not.toContainText(/[\u4e00-\u9fff]/);
 });
 
 test("reader opens the Heart Sutra via CBETA id redirect", async ({ page, request }) => {

--- a/frontend/src/components/SourceSelector.tsx
+++ b/frontend/src/components/SourceSelector.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { Input, Select, Checkbox, Button, Tag } from "antd";
 import { SearchOutlined, LinkOutlined } from "@ant-design/icons";
 import type { DataSource } from "../api/client";
+import { localizedSourceName } from "../utils/sourceName";
 
 interface SourceSelectorProps {
   sources: DataSource[];
@@ -120,7 +121,7 @@ export default function SourceSelector({ sources, selected, onChange }: SourceSe
               }}
             />
             <span className="src-item-name">
-              {s.name_zh}
+              {localizedSourceName(s)}
               {s.access_type === "local" && (
                 <Tag color="green" style={{ marginLeft: 6, fontSize: 10, lineHeight: "16px", padding: "0 4px" }}>
                   本地

--- a/frontend/src/components/search/ExternalCard.tsx
+++ b/frontend/src/components/search/ExternalCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Tag } from "antd";
 import { LinkOutlined, EyeOutlined } from "@ant-design/icons";
 import { buildSearchUrl } from "../../utils/sourceUrls";
+import { localizedSourceName } from "../../utils/sourceName";
 import type { DataSource } from "../../api/client";
 
 /**
@@ -17,7 +18,7 @@ export default function ExternalCard({ source, query }: { source: DataSource; qu
   const url = buildSearchUrl(source.code, query) || "#";
   return (
     <div className="s-ext-row">
-      <span className="s-ext-row-name">{source.name_zh}</span>
+      <span className="s-ext-row-name">{localizedSourceName(source)}</span>
       {source.region && <Tag style={{ fontSize: 11, margin: 0 }}>{t(`region.${source.region}`, source.region)}</Tag>}
       <span className="s-ext-row-spacer" />
       <a
@@ -25,7 +26,7 @@ export default function ExternalCard({ source, query }: { source: DataSource; qu
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={t("search.search_at_source_aria", { name: source.name_zh, query })}
+        aria-label={t("search.search_at_source_aria", { name: localizedSourceName(source), query })}
       >
         <LinkOutlined /> {t("search.search_at_source")}
       </a>
@@ -35,7 +36,7 @@ export default function ExternalCard({ source, query }: { source: DataSource; qu
           href={source.base_url}
           target="_blank"
           rel="noopener noreferrer"
-          aria-label={t("search.visit_homepage_aria", { name: source.name_zh })}
+          aria-label={t("search.visit_homepage_aria", { name: localizedSourceName(source) })}
         >
           <EyeOutlined /> {t("search.visit_homepage")}
         </a>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -14,6 +14,7 @@ import { searchTexts, searchContent, searchDictionary, searchCrossLanguage, sear
 import type { DictGroupedSearchResponse } from "../api/client";
 import { hasDirectSearchUrl } from "../utils/sourceUrls";
 import { addSearchHistory, getSearchHistory, type SearchHistoryItem } from "../utils/history";
+import { localizedSourceName } from "../utils/sourceName";
 import { ResultCard, ExternalSourcesSection, DictCard, ContentCard, CrossLangCard, SemanticCard, UnifiedResults } from "../components/search";
 import "../styles/search.css";
 import "../styles/sources.css";
@@ -237,14 +238,16 @@ export default function SearchPage() {
     return counts;
   }, [extSearchable]);
 
-  /* 馆藏列表：只列出外部可搜索源，带数量 */
+  /* 馆藏列表：只列出外部可搜索源，带数量。filter key 固定用 name_zh，
+     显示名按 locale 走 name_en (#707)。 */
   const institutionList = useMemo(() => {
-    const counts: Record<string, number> = {};
+    const counts = new Map<string, { count: number; nameEn: string | null }>();
     extSearchable.forEach((s) => {
-      counts[s.name_zh] = (counts[s.name_zh] || 0) + 1;
+      const entry = counts.get(s.name_zh) ?? { count: 0, nameEn: s.name_en ?? null };
+      entry.count += 1;
+      counts.set(s.name_zh, entry);
     });
-    return Object.entries(counts)
-      .map(([name, count]) => ({ name, count }))
+    return Array.from(counts, ([name, { count, nameEn }]) => ({ name, nameEn, count }))
       .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "zh"));
   }, [extSearchable]);
 
@@ -398,13 +401,13 @@ export default function SearchPage() {
             <div className="s-filter-group">
               <div className="s-filter-title">🏛 {t("search.filter_institution")}</div>
               <div className="s-filter-scroll">
-                {institutionList.map(({ name, count }) => (
+                {institutionList.map(({ name, nameEn, count }) => (
                   <label key={name} className="s-filter-item">
                     <Checkbox
                       checked={institutionFilter.has(name)}
                       onChange={() => toggleInstitution(name)}
                     />
-                    <span className="s-filter-name">{name}</span>
+                    <span className="s-filter-name">{localizedSourceName({ name_zh: name, name_en: nameEn })}</span>
                     <span className="s-filter-count">{count}</span>
                   </label>
                 ))}

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -9,6 +9,7 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import type { DataSource } from "../../api/client";
+import { localizedSourceName } from "../../utils/sourceName";
 import { buildSearchUrl, getLangName } from "../../utils/sourceUrls";
 import { LANG_ORDER, getChannelLabel, trackSourceClick } from "./constants";
 
@@ -98,7 +99,7 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
           <GlobalOutlined />
         </span>
         <div className="source-card-titles">
-          <span className="source-card-name">{s.name_zh}</span>
+          <span className="source-card-name">{localizedSourceName(s)}</span>
           {s.name_en && <span className="source-card-name-en">{s.name_en}</span>}
         </div>
         <div className="source-card-badges">

--- a/frontend/src/utils/sourceName.ts
+++ b/frontend/src/utils/sourceName.ts
@@ -1,0 +1,14 @@
+import i18n, { currentUILang } from "../i18n";
+
+/**
+ * Display name for a data source. Names are DB data, not translation keys:
+ * name_zh is canonical, name_en covers 613/613 active sources after
+ * migration 0154 (#707). English UI prefers name_en; zh / zh-Hant render
+ * the canonical Chinese name.
+ *
+ * Call from inside a component that uses useTranslation() so a language
+ * change re-renders the caller (this function itself is not reactive).
+ */
+export function localizedSourceName(s: { name_zh: string; name_en?: string | null }): string {
+  return currentUILang(i18n) === "en" && s.name_en ? s.name_en : s.name_zh;
+}


### PR DESCRIPTION
Closes #707 — the last Chinese-on-English-UI item from the user's verification screenshots (institution facet + external-source launcher rows).

**The surprise**: the data was already 98% done. `data_sources.name_en` exists, is populated for 605/613 active sources, the API returns it, and the frontend types declare it — the display layer just never read it.

**This PR**:
- **Migration 0154** (data-only): fixes 6 underscore slugs (`Fo_Guang_Buddhist_Dictionary` → "Fo Guang Dictionary of Buddhism") and fills 8 NULLs → all 613 active sources have display-quality English names. Chain verified: prod `alembic_version` = 0153 = repo head.
- **`localizedSourceName()`** helper: English UI prefers `name_en`, zh/zh-Hant keep canonical `name_zh`
- Wired into all four display sites: ExternalCard launcher rows (+ aria labels), SearchPage institution facet (filter keys stay `name_zh`, only labels localize), SourceCard (catalog page), SourceSelector (home picker)
- **E2E**: English search spec asserts the first institution label and first launcher row contain no CJK

**Verified**: tsc / eslint / ruff / vitest 107 / i18n ratchet all pass.

**Deploy note**: needs `alembic upgrade head` on the VPS before/with the frontend rollout (data migration, no schema change, idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)