### PR TITLE
fix(deploy): P0 deploy resilience — apply migrations on alembic-only deploys, flock guard, PG backup

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -76,6 +76,19 @@ is_known_commit() {
   git rev-parse --verify --quiet "$1^{commit}" >/dev/null 2>&1
 }
 
+# --- 0. 并发锁 ---------------------------------------------------------------
+# 串行化 deploy.sh 的并发运行 (cron 与手动, 或两次手动): 两个并发的
+# `docker compose build` 会在 RAM 受限的 VPS 上把 dockerd 推向 OOM。
+# 注意: 仓外的 webhook CD 若不经由 deploy.sh, 必须自己也取这把同一文件锁
+# ($STATE_DIR/deploy.lock) 才能完全堵住与它的竞争 — 否则只挡住 deploy.sh 自身。
+# 非阻塞获取: 抢不到锁就干净退出 (另一个 deploy 已在处理同一份代码)。
+DEPLOY_LOCK="$STATE_DIR/deploy.lock"
+exec 200>"$DEPLOY_LOCK"
+if ! flock -n 200; then
+  warn "另一个 deploy 正在运行 (lock: $DEPLOY_LOCK) — 退出，避免并发 build 触发 OOM。"
+  exit 0
+fi
+
 # --- 1. 取最新代码 -----------------------------------------------------------
 log "Fetching origin/$BRANCH ..."
 OLD_REV="$(git rev-parse HEAD)"

--- a/deploy.sh
+++ b/deploy.sh
@@ -149,6 +149,17 @@ elif [ "$BE_BASE" != "$NEW_REV" ]; then
     # Pure scripts/tests/eval/alembic change — log but don't restart.
     log "backend/ 仅有 scripts/tests/eval/alembic 改动 — 跳过 restart（不影响 uvicorn，也不杀正在跑的脚本）。"
     echo "$BE_DIFF" | grep '^backend/' | sed 's/^/    /'
+    # Pure-migration changes still need applying: entrypoint.sh only runs
+    # `alembic upgrade head` on container START, and we intentionally do NOT
+    # restart here (would kill long-running `docker exec` scripts). Without
+    # this, a migration-only PR (e.g. a new data source) deploys "successfully"
+    # but the migration stays unapplied until some unrelated app/ change later
+    # triggers a restart. `upgrade head` is idempotent — no-op if already at head.
+    if echo "$BE_DIFF" | grep -q '^backend/alembic/'; then
+      log "检测到 alembic 迁移改动 — 运行 alembic upgrade head（容器不重启）。"
+      docker compose exec -T backend alembic upgrade head \
+        || fail "alembic upgrade head 失败 — 迁移未应用，请人工处理。"
+    fi
     # Still bump the marker so we don't keep re-evaluating the same untouched
     # diff every cron tick — otherwise the next deploy.sh run will see the same
     # `BE_DIFF` and re-log this skip message indefinitely.


### PR DESCRIPTION
来自全面审计的 P0 运维韧性修复（3 个独立 commit）。

### 1. `fix(deploy)`: 纯迁移部署现在真正应用迁移
deploy.sh 的路径感知逻辑对"仅 scripts/tests/eval/alembic 改动"跳过 `restart`（正确——避免杀长跑 docker-exec 脚本）。但 `entrypoint.sh` 只在容器**启动**时跑 `alembic upgrade head`，所以一个**纯迁移 PR**（如通过 migration 加数据源，已是既定模式）会"部署成功"但迁移**一直不应用**，直到将来某次无关的 `app/` 改动触发重启。
→ skip 分支命中 `backend/alembic/` 时跑 `alembic upgrade head`（幂等，已 head 则 no-op），不重启容器。

### 2. `fix(deploy)`: flock 并发锁防双 build OOM
deploy.sh 无锁，两个并发 `docker compose build` 在 RAM 受限 VPS 上是已知的 dockerd-OOM 故障模式。加非阻塞 flock。**注意**：只串行化 deploy.sh 自身；仓外 webhook CD 须取同把锁才能完全堵住与它的竞争（follow-up，host 侧改动）。

### 3. `feat(ops)`: PostgreSQL 备份脚本
单 VPS 是 PG（用户数据、BYOK 密文、KG、人物、对齐）的**唯一副本**，全仓零 pg_dump。`backup_pg.sh`：`pg_dump -Fc` + `pg_restore --list` 完整性自检 + N 天保留 + 可选异地 rsync（`$BACKUP_REMOTE`，如 la-vps）。拟作 nightly host cron。

**验证**：`bash -n` 通过；独立 code review 判定 safe to push（flock 在 `set -euo pipefail` 下正确、alembic-exec 在 marker bump 前、失败即 fail-closed）。

⚠️ 合并后需 host 侧：① 部署新 deploy.sh ② 装 backup cron + 配 `BACKUP_REMOTE` + 跑一次 test-restore。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
