### PR TITLE
perf(reader): memoize reflowText to stop re-parsing the juan on every render

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -602,6 +602,20 @@ export default function TextReaderPage() {
     staleTime: 3600000,
   });
 
+  // reflowText is a full line-by-line parse of the juan body (tens of thousands
+  // of chars). Memoize on the raw content so font-size changes, bookmark toggles,
+  // dict-popover opens, and AI-panel resize-drags don't re-parse the whole text
+  // on every render. Keyed on content only — render-time concerns (font size) are
+  // CSS, not part of the parse.
+  const reflowedContent = useMemo(
+    () => (content?.content ? reflowText(content.content) : []),
+    [content?.content],
+  );
+  const reflowedCompare = useMemo(
+    () => (compareContent?.content ? reflowText(compareContent.content) : []),
+    [compareContent?.content],
+  );
+
   const changeFontSize = (delta: number) => {
     setFontSize((prev) => {
       const next = Math.min(Math.max(prev + delta, FONT_SIZE_MIN), FONT_SIZE_MAX);
@@ -787,7 +801,7 @@ export default function TextReaderPage() {
                   className="reader-body"
                   style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
                 >
-                  {reflowText(content.content).map(renderSegment)}
+                  {reflowedContent.map(renderSegment)}
                 </div>
               </div>
             </Col>
@@ -802,7 +816,7 @@ export default function TextReaderPage() {
                     style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
                   >
                     {compareContent?.content
-                      ? reflowText(compareContent.content).map(renderSegment)
+                      ? reflowedCompare.map(renderSegment)
                       : "暂无内容"}
                   </div>
                 )}
@@ -814,7 +828,7 @@ export default function TextReaderPage() {
             className="reader-body"
             style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
           >
-            {reflowText(content.content).map(renderSegment)}
+            {reflowedContent.map(renderSegment)}
           </div>
         )
       ) : (


### PR DESCRIPTION
来自审计的前端最高性价比性能修复。

`reflowText()` 是对整卷正文（数万字；双语模式两份）的逐行解析，原先在 JSX 里 3 处内联调用——每次调字号、切书签、开词典弹窗、拖 AI 面板都重解析全文，大经卷下任何交互都卡。

→ 两个 `useMemo`（keyed on `content?.content` / `compareContent?.content`），替换 3 个调用点。渲染期关注点（字号）走 CSS，不进解析。**行为完全一致**——同样的 segments，只是每次 content 变化才算一次。

**验证**：`tsc -b --noEmit` clean、`eslint` 0、独立 code review 确认 `content?.content` 与原 `content.content` 在 truthy-guarded 调用点语义等价、useMemo deps 无 stale closure。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
