### PR TITLE
chore(deps): bump pypdf 6.10.2 -> 6.12.0 (fix CVE-2026-48155/48156 DoS)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,6 @@ tiktoken==0.8.0
 opencc-python-reimplemented==0.1.7
 Pillow==12.2.0
 python-multipart==0.0.27
-pypdf==6.10.2
+pypdf==6.12.0
 python-docx==1.1.2
 beautifulsoup4==4.12.3


### PR DESCRIPTION
## What

Bump `pypdf` from `6.10.2` to `6.12.0` in `backend/requirements.txt`.

## Why — two DoS CVEs (both fixed in 6.12.0)

- **CVE-2026-48155**: in layout extraction mode, large character offsets cause excessive memory allocation.
- **CVE-2026-48156**: a `/W [0 0 0]` width array combined with a large `/Size` in a cross-reference stream causes a long-running parse.

CI's `pip-audit` (non-blocking) has been continuously flagging both on the pinned `6.10.2`. Bumping to the patched `6.12.0` release clears the noise.

## API compatibility — verified statically

The only consumer of pypdf is `backend/app/services/attachment_parser.py`. The pypdf APIs it uses, all stable across `6.10 → 6.12`:

- `from pypdf import PdfReader` — import
- `PdfReader(io.BytesIO(file_bytes))` — constructor from a file-like object
- `reader.pages` — page-collection iteration
- `page.extract_text()` — **default** extraction mode, called with no kwargs

`6.12.0` is a within-6.x bump that only patches the two DoS CVEs; it does not change the `PdfReader` / `extract_text` signatures or behavior.

Note: this consumer does **not** pass `extraction_mode="layout"`, so it never exercised the CVE-2026-48155 vector in the first place — the bump is purely to clear pip-audit and harden against the xref-stream path.

## Verification

The worktree venv may not have 6.12.0 installed, so no local run was attempted. **CI will install the new requirements (6.12.0) and run pytest — including the attachment-parser tests — which is the real verification.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)