### PR TITLE
fix(scripts): guard sync_dila against concurrent runs with a file lock

### DIFF
--- a/backend/scripts/sync_dila_combined.py
+++ b/backend/scripts/sync_dila_combined.py
@@ -7,6 +7,7 @@ Usage:
     python scripts/sync_dila_combined.py
 """
 import asyncio
+import fcntl
 import json
 import os
 import re
@@ -282,4 +283,19 @@ async def main():
 
 
 if __name__ == "__main__":
+    # Concurrency guard: an overlapping run (cron firing while a slow run is
+    # still scanning the DILA API, or a manual run alongside cron) would read
+    # the same `existing` snapshot and both INSERT — producing duplicate
+    # person rows (already observed in prod: 21 dila_ids duplicated). Take an
+    # exclusive non-blocking file lock; if another run holds it, exit cleanly.
+    # The lock auto-releases when the process exits. Lives in the container's
+    # /tmp, shared across the `docker compose exec` invocations cron uses.
+    # The handle must outlive a `with` block; closing the file releases the
+    # flock, so we deliberately keep it open for the process lifetime.
+    _lock_fh = open("/tmp/fojin-sync-dila.lock", "w")  # noqa: SIM115
+    try:
+        fcntl.flock(_lock_fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        print("Another sync_dila run is in progress — exiting to avoid duplicate inserts.")
+        sys.exit(0)
     asyncio.run(main())


### PR DESCRIPTION
来自数据管道审计的 P1（并发→重复人物行）。**SSH 核实确认问题已在 prod 发生**。

### 问题
`sync_dila_combined.py` 读 `existing` dila-id 快照后 INSERT 所有不在其中的（无 ON CONFLICT、无 overlap-lock）。两次重叠运行（cron 在慢 DILA-API 扫描未结束时再次触发，或手动+cron 同时跑）读同一快照、各自 insert → 重复人物行。

**prod 实测**：21 个 dila_id 重复、22 个多余行（base64 SQL 经 SSH 查证）。

### 修复
启动时取独占非阻塞 `flock`，拿不到（已有实例在跑）就干净退出。进程退出自动释放。锁在容器 /tmp、跨 cron 的 `docker compose exec` 调用共享。本地双实例模拟验证：实例2 被 `BlockingIOError` 挡住 = 保护生效。

### 范围说明（诚实）
本 PR 只防**未来**重复。**现有 22 个多余行的清理是单独的数据迁移**，不在此 PR：
- 它们是同一 DILA 人物的**异名变体**（如 A001294: 般若斫羯羅 / 般若惹羯羅 / 智慧輪），简单删除会丢异名信息；
- **203 个 kg_relations 引用这些多余行**（全部 43 重复行被 790 个引用），删前必须 re-point + 合并 aliases，且 re-point 后可能产生 relation 自重复；
- 需要 canonical 行选择策略 + 唯一索引——属高风险生产数据迁移，待单独设计 + 维护者确认。

**验证**：ruff（scripts/ 无新增 lint）、py_compile、flock 双实例模拟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
