### PR TITLE
feat(alignment): import MITRA cross-lingual parallels (Skt/Tib ↔ Chinese)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -67,6 +67,17 @@ Usage: Metadata mapping and IIIF manifest links only; no content stored locally.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
+MITRA / Dharmamitra (Sebastian Nehrdich & Kurt Keutzer, UC Berkeley)
+https://github.com/dharmamitra/mitra-parallel — arXiv:2601.06400
+License: CC BY-SA 4.0 (attribution, share-alike)
+Usage: Sentence-level Sanskrit/Tibetan ↔ Buddhist-Chinese parallel passages
+imported into the mitra_alignments table and surfaced in the reader's
+cross-canon parallel panel. The Chinese side is anchored to local CBETA chunks
+by verbatim substring match; the Sanskrit/Tibetan side is stored inline.
+Note: Derived alignment data is share-alike — redistribution must remain CC BY-SA 4.0.
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
 Dictionary Sources
 --------------------------------------------------------------------------------
 - DDB (Digital Dictionary of Buddhism) — CC BY-NC-SA

--- a/backend/alembic/versions/0156_add_mitra_alignments.py
+++ b/backend/alembic/versions/0156_add_mitra_alignments.py
@@ -1,0 +1,78 @@
+"""add mitra_alignments table for MITRA cross-lingual parallel passages
+
+Revision ID: 0156
+Revises: 0155
+Create Date: 2026-06-14
+
+Stores sentence-level Sanskrit/Tibetan ↔ Buddhist-Chinese parallels mined by
+the MITRA project (Nehrdich & Keutzer, arXiv:2601.06400,
+github.com/dharmamitra/mitra-parallel, CC BY-SA 4.0).
+
+Why a separate table instead of alignment_pairs: alignment_pairs is a
+"fojin-chunk ↔ fojin-chunk" model — the reader API resolves the *other* side by
+looking up text_embeddings.chunk_text. MITRA's foreign side is an *inline*
+Sanskrit/Tibetan sentence that has no corresponding fojin text_embeddings row
+(we do not ingest the Skt/Tib source texts as chunks), so it cannot be expressed
+in alignment_pairs. mitra_alignments stores the foreign text inline and anchors
+only the Chinese side to a fojin chunk (text_id, juan_num, chunk_index), located
+by verbatim substring match of the MITRA Chinese sentence inside the juan.
+
+Provenance/license is kept per-row (source, license) so this CC BY-SA 4.0 data
+stays attributable and license-separable from fojin's own alignment_pairs.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0156"
+down_revision: str | None = "0155"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mitra_alignments",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("text_id", sa.Integer(), nullable=False),
+        sa.Column("taisho_id", sa.String(length=20), nullable=False),
+        sa.Column("juan_num", sa.Integer(), nullable=True),
+        sa.Column("chunk_index", sa.Integer(), nullable=True),
+        sa.Column("zh_text", sa.Text(), nullable=False),
+        sa.Column("foreign_lang", sa.String(length=4), nullable=False),
+        sa.Column("foreign_text", sa.Text(), nullable=False),
+        sa.Column("zh_segment", sa.String(length=80), nullable=True),
+        sa.Column("foreign_segment", sa.String(length=80), nullable=True),
+        sa.Column("mitra_file", sa.String(length=160), nullable=True),
+        sa.Column("match_scope", sa.String(length=8), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=False, server_default="1.0"),
+        sa.Column("source", sa.String(length=30), nullable=False, server_default="mitra-parallel"),
+        sa.Column("license", sa.String(length=20), nullable=False, server_default="CC-BY-SA-4.0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["text_id"], ["buddhist_texts.id"], name="fk_mitra_align_text", ondelete="CASCADE"
+        ),
+    )
+    # Reader panel lookup: parallels for one (text_id, juan_num, chunk_index).
+    op.create_index(
+        "ix_mitra_align_chunk",
+        "mitra_alignments",
+        ["text_id", "juan_num", "chunk_index"],
+    )
+    op.create_index("ix_mitra_align_taisho", "mitra_alignments", ["taisho_id"])
+    # Idempotent re-import: an import run wipes its own (text_id) rows first.
+    op.create_index("ix_mitra_align_text", "mitra_alignments", ["text_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mitra_align_text", table_name="mitra_alignments")
+    op.drop_index("ix_mitra_align_taisho", table_name="mitra_alignments")
+    op.drop_index("ix_mitra_align_chunk", table_name="mitra_alignments")
+    op.drop_table("mitra_alignments")

--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -19,9 +19,20 @@ from app.database import get_db
 
 router = APIRouter(prefix="/alignment", tags=["alignment"])
 
+# A fojin chunk (paragraph) can contain many MITRA sentence-level parallels;
+# cap per chunk so the reader panel stays bounded on dense texts.
+MITRA_CHUNK_LIMIT = 50
+
 
 class ParallelPair(BaseModel):
-    """One aligned parallel passage."""
+    """One aligned parallel passage.
+
+    source="fojin": both sides are fojin chunks (from alignment_pairs); text_id/
+    juan_num/chunk_index deep-link to the counterpart in the reader.
+    source="mitra-parallel": the foreign side is an inline Sanskrit/Tibetan
+    sentence from MITRA (CC BY-SA 4.0) with no fojin chunk — chunk_text holds the
+    foreign text and text_id/juan_num/chunk_index are 0 (no deep-link target).
+    """
     text_id: int
     juan_num: int
     chunk_index: int
@@ -31,6 +42,7 @@ class ParallelPair(BaseModel):
     confidence: float = 1.0
     original_preview: str | None = None
     original_lang: str | None = None
+    source: str = "fojin"
 
 
 class ChunkAlignmentResponse(BaseModel):
@@ -166,6 +178,31 @@ async def get_chunk_alignment(
                 original_lang=original_lang,
             ))
 
+    # MITRA cross-lingual parallels (inline Sanskrit/Tibetan, CC BY-SA 4.0).
+    # The foreign side has no fojin chunk, so chunk_text carries the foreign
+    # sentence and the deep-link ids are 0. A fojin chunk (a paragraph) can hold
+    # many MITRA sentence-pairs, so this uses its own larger cap.
+    mitra_rows = (await db.execute(
+        sql_text(
+            "SELECT foreign_text, foreign_lang, confidence "
+            "FROM mitra_alignments "
+            "WHERE text_id = :tid AND juan_num = :juan AND chunk_index = :cidx "
+            "ORDER BY foreign_lang, id LIMIT :limit"
+        ),
+        {"tid": text_id, "juan": juan_num, "cidx": chunk_index, "limit": MITRA_CHUNK_LIMIT},
+    )).fetchall()
+    for foreign_text, foreign_lang, conf in mitra_rows:
+        parallels.append(ParallelPair(
+            text_id=0,
+            juan_num=0,
+            chunk_index=0,
+            chunk_text=foreign_text,
+            lang=foreign_lang or "sa",
+            title="MITRA 平行（藏）" if foreign_lang == "bo" else "MITRA 平行（梵）",
+            confidence=float(conf) if conf is not None else 1.0,
+            source="mitra-parallel",
+        ))
+
     return ChunkAlignmentResponse(
         source_text_id=text_id,
         source_juan_num=juan_num,
@@ -203,13 +240,20 @@ async def get_juan_alignment(
             SELECT DISTINCT te.chunk_index, te.chunk_text
             FROM text_embeddings te
             WHERE te.text_id = :tid AND te.juan_num = :juan
-            AND EXISTS (
-                SELECT 1 FROM alignment_pairs ap
-                WHERE ap.text_a_chunk_index IS NOT NULL
-                AND (
-                    (ap.text_a_id = te.text_id AND ap.text_a_juan_num = te.juan_num AND ap.text_a_chunk_index = te.chunk_index)
-                    OR
-                    (ap.text_b_id = te.text_id AND ap.text_b_juan_num = te.juan_num AND ap.text_b_chunk_index = te.chunk_index)
+            AND (
+                EXISTS (
+                    SELECT 1 FROM alignment_pairs ap
+                    WHERE ap.text_a_chunk_index IS NOT NULL
+                    AND (
+                        (ap.text_a_id = te.text_id AND ap.text_a_juan_num = te.juan_num AND ap.text_a_chunk_index = te.chunk_index)
+                        OR
+                        (ap.text_b_id = te.text_id AND ap.text_b_juan_num = te.juan_num AND ap.text_b_chunk_index = te.chunk_index)
+                    )
+                )
+                OR EXISTS (
+                    SELECT 1 FROM mitra_alignments ma
+                    WHERE ma.text_id = te.text_id AND ma.juan_num = te.juan_num
+                    AND ma.chunk_index = te.chunk_index
                 )
             )
             ORDER BY te.chunk_index

--- a/backend/scripts/import_mitra_alignments.py
+++ b/backend/scripts/import_mitra_alignments.py
@@ -1,0 +1,268 @@
+"""Import MITRA cross-lingual parallels into the mitra_alignments table.
+
+Source: github.com/dharmamitra/mitra-parallel (Nehrdich & Keutzer,
+arXiv:2601.06400), CC BY-SA 4.0. Sentence-level Sanskrit/Tibetan ↔ Buddhist
+Chinese alignments, TSV per source-pair, Chinese side keyed by Taishō line id
+(e.g. T04n0192_002:0010c23_13).
+
+Pipeline (per Taishō text, to bound memory on a small VPS):
+  1. Load that text's fojin chunks (text_embeddings.chunk_text) and build a
+     per-juan normalized concatenation + chunk-offset index.
+  2. Walk the MITRA TSV files that involve this text, take each Chinese
+     sentence, normalize (strip whitespace/punct/latin/digits), and locate it
+     verbatim inside the juan -> the fojin chunk_index that contains it.
+     (Quality gate A: only sentences that localize are imported. Pilot measured
+     ~98% localize; the rest are edition/variant-char mismatches.)
+  3. Wipe this text's existing rows (idempotent re-run) and bulk insert.
+
+The MITRA-E (9B) semantic gate is a separate later enhancement; this importer
+ships the substring gate only.
+
+Usage (inside backend container, DB reachable):
+    python scripts/import_mitra_alignments.py --mitra-dir /tmp/mitra-tsv
+    python scripts/import_mitra_alignments.py --mitra-dir /tmp/mitra-tsv --all
+    python scripts/import_mitra_alignments.py --mitra-dir /tmp/mitra-tsv \
+        --taisho T0262,T0945 --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import bisect
+import glob
+import os
+import re
+import sys
+import time
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import text as sql_text
+
+from app.database import async_session
+
+# The 10 texts validated end-to-end in the pilot (default scope).
+PILOT_TAISHO = [
+    "T0099", "T0310", "T1146", "T1424", "T1509",
+    "T1579", "T1636", "T1736", "T2016", "T2122",
+]
+
+_PUNCT = re.compile(r"[\s　，。、；：！？·「」『』（）()．,0-9A-Za-z\-—…〈〉《》【】\[\]]+")
+# BMP + CJK Ext-A + Ext-B, so all-rare-character / gaiji-heavy Chinese sentences
+# still register as Chinese.
+_CJK = re.compile(r"[㐀-䶿一-鿿\U00020000-\U0002a6df]")
+_TIB = re.compile(r"[ༀ-࿿]")
+_ZH_SEG = re.compile(r"^T\d+n\d+")
+
+INSERT = sql_text(
+    """
+    INSERT INTO mitra_alignments
+        (text_id, taisho_id, juan_num, chunk_index, zh_text, foreign_lang,
+         foreign_text, zh_segment, foreign_segment, mitra_file, match_scope)
+    VALUES
+        (:text_id, :taisho_id, :juan_num, :chunk_index, :zh_text, :foreign_lang,
+         :foreign_text, :zh_segment, :foreign_segment, :mitra_file, :match_scope)
+    """
+)
+
+
+def _norm(s: str) -> str:
+    return _PUNCT.sub("", s)
+
+
+def _taisho_of(seg: str) -> str | None:
+    m = re.match(r"^T\d+n0*(\d+)", seg)
+    return f"T{int(m.group(1)):04d}" if m else None
+
+
+def _juan_of(seg: str) -> int | None:
+    m = re.match(r"^T\d+n\d+[a-zA-Z]*_(\d+)", seg)
+    return int(m.group(1)) if m else None
+
+
+async def _load_chunks(db, taisho: str):
+    """Return (text_id, tj_index, t_index) for one Taishō text, or (None, ...)."""
+    rows = (
+        await db.execute(
+            sql_text(
+                """
+                SELECT te.text_id, te.juan_num, te.chunk_index, te.chunk_text
+                FROM text_embeddings te
+                JOIN buddhist_texts bt ON bt.id = te.text_id
+                WHERE bt.taisho_id = :t
+                ORDER BY te.juan_num, te.chunk_index
+                """
+            ),
+            {"t": taisho},
+        )
+    ).fetchall()
+    if not rows:
+        return None, {}, []
+
+    text_id = rows[0][0]
+    per_juan: dict[int, list[tuple[int, str]]] = defaultdict(list)
+    for _tid, juan, cidx, ctext in rows:
+        per_juan[juan].append((cidx, _norm(ctext or "")))
+
+    tj_index: dict[int, tuple[str, list[int], list[int]]] = {}
+    t_index: list[tuple[int, str, list[int], list[int]]] = []
+    for juan, chunks in per_juan.items():
+        chunks.sort()
+        offs: list[int] = []
+        idxs: list[int] = []
+        parts: list[str] = []
+        cur = 0
+        for cidx, nt in chunks:
+            offs.append(cur)
+            idxs.append(cidx)
+            parts.append(nt)
+            cur += len(nt)
+        concat = "".join(parts)
+        tj_index[juan] = (concat, offs, idxs)
+        t_index.append((juan, concat, offs, idxs))
+    return text_id, tj_index, t_index
+
+
+def _locate(ns: str, juan: int | None, tj_index, t_index):
+    """Find the fojin chunk containing the normalized sentence. Returns
+    (chunk_index, juan, scope) where scope is 'juan' | 'taisho' | 'none'."""
+    hit = tj_index.get(juan) if juan is not None else None
+    if hit:
+        concat, offs, idxs = hit
+        p = concat.find(ns)
+        if p >= 0:
+            return idxs[bisect.bisect_right(offs, p) - 1], juan, "juan"
+    for j, concat, offs, idxs in t_index:
+        if j == juan:
+            continue
+        p = concat.find(ns)
+        if p >= 0:
+            return idxs[bisect.bisect_right(offs, p) - 1], j, "taisho"
+    return None, None, "none"
+
+
+def _pairs_for(tsv_dir: str, taisho: str):
+    """Yield (mitra_file, zh_seg, zh, fo_seg, fo) for one Taishō text."""
+    files = [
+        f
+        for f in glob.glob(os.path.join(tsv_dir, "*.tsv"))
+        if any(_taisho_of(t) == taisho for t in re.findall(r"T\d+n\d+", os.path.basename(f)))
+    ]
+    for fp in files:
+        base = os.path.basename(fp)
+        with open(fp, encoding="utf-8") as fh:
+            for line in fh:
+                c = line.rstrip("\n").split("\t")
+                if len(c) < 4:
+                    continue
+                if _ZH_SEG.match(c[0]):
+                    zh_seg, zh, fo_seg, fo = c[0], c[1], c[2], c[3]
+                elif _ZH_SEG.match(c[2]):
+                    zh_seg, zh, fo_seg, fo = c[2], c[3], c[0], c[1]
+                else:
+                    continue
+                if _taisho_of(zh_seg) != taisho or not _CJK.search(zh):
+                    continue
+                yield base, zh_seg, zh, fo_seg, fo
+
+
+async def _import_one(db, taisho: str, tsv_dir: str, dry: bool) -> tuple[int, int]:
+    text_id, tj_index, t_index = await _load_chunks(db, taisho)
+    if text_id is None:
+        print(f"  {taisho}: not in fojin (skip)")
+        return 0, 0
+
+    if not dry:
+        await db.execute(
+            sql_text("DELETE FROM mitra_alignments WHERE text_id = :tid"), {"tid": text_id}
+        )
+
+    cand = loc = 0
+    batch: list[dict] = []
+    for base, zh_seg, zh, fo_seg, fo in _pairs_for(tsv_dir, taisho):
+        ns = _norm(zh)
+        if len(ns) < 4:
+            continue
+        cand += 1
+        ci, fj, scope = _locate(ns, _juan_of(zh_seg), tj_index, t_index)
+        if ci is None:
+            continue
+        loc += 1
+        # Tibetan text is stored in Tibetan script; Sanskrit in IAST/Devanagari.
+        # Script detection is ground truth here (verified on the pilot corpus:
+        # 119,067 Tibetan rows all carry Tibetan script). Do NOT classify by the
+        # segment id's Derge "D" token — it is embedded mid-id (e.g. K10D0095)
+        # and false-positives on Sanskrit ids.
+        folang = "bo" if _TIB.search(fo) else "sa"
+        batch.append(
+            {
+                "text_id": text_id,
+                "taisho_id": taisho,
+                "juan_num": fj,
+                "chunk_index": ci,
+                "zh_text": zh,
+                "foreign_lang": folang,
+                "foreign_text": fo,
+                "zh_segment": zh_seg[:80],
+                "foreign_segment": fo_seg[:80],
+                "mitra_file": base[:160],
+                "match_scope": scope,
+            }
+        )
+        if not dry and len(batch) >= 5000:
+            await db.execute(INSERT, batch)
+            batch = []
+
+    if not dry:
+        if batch:
+            await db.execute(INSERT, batch)
+        await db.commit()
+
+    pct = loc * 100 // max(cand, 1)
+    print(f"  {taisho} (text_id={text_id}): cand={cand} localized={loc} ({pct}%)")
+    return cand, loc
+
+
+def _resolve_targets(args) -> list[str]:
+    if args.all:
+        seen = {
+            _taisho_of(t)
+            for f in glob.glob(os.path.join(args.mitra_dir, "*.tsv"))
+            for t in re.findall(r"T\d+n\d+", os.path.basename(f))
+        }
+        return sorted(t for t in seen if t)
+    if args.taisho:
+        return [x.strip() for x in args.taisho.split(",") if x.strip()]
+    return PILOT_TAISHO
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--mitra-dir", required=True, help="path to mitra-parallel/tsv")
+    ap.add_argument("--taisho", help="comma-separated Taishō ids (default: pilot 10)")
+    ap.add_argument("--all", action="store_true", help="all Chinese-bearing texts present in fojin")
+    ap.add_argument("--dry-run", action="store_true", help="localize + report, no writes")
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.mitra_dir):
+        print(f"ERROR: --mitra-dir not found: {args.mitra_dir}")
+        return 1
+
+    targets = _resolve_targets(args)
+    print(f"targets: {len(targets)} Taishō text(s); dry_run={args.dry_run}")
+
+    t0 = time.time()
+    tot_c = tot_l = 0
+    async with async_session() as db:
+        for taisho in targets:
+            c, lcount = await _import_one(db, taisho, args.mitra_dir, args.dry_run)
+            tot_c += c
+            tot_l += lcount
+    pct = tot_l * 100 // max(tot_c, 1)
+    print(f"TOTAL: cand={tot_c} localized={tot_l} ({pct}%) in {time.time() - t0:.1f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## What

Adds the **MITRA-parallel** corpus ([github.com/dharmamitra/mitra-parallel](https://github.com/dharmamitra/mitra-parallel), [arXiv:2601.06400](https://arxiv.org/abs/2601.06400), **CC BY-SA 4.0**) as a new cross-canon parallel source in the reader's "多语对读" panel — sentence-level **Sanskrit/Tibetan ↔ Buddhist-Chinese** alignments.

This is the backend half (data + API). Reader badge/styling for `source="mitra-parallel"` is a follow-up PR.

## Why a separate table (`mitra_alignments`, not `alignment_pairs`)

`alignment_pairs` is a **fojin-chunk ↔ fojin-chunk** model — the API resolves the *other* side via `text_embeddings.chunk_text`. MITRA's foreign side is an **inline** Sanskrit/Tibetan sentence with **no fojin chunk** (we don't ingest Skt/Tib source texts as chunks), so it cannot be expressed in `alignment_pairs`. `mitra_alignments` stores the foreign text inline and anchors only the Chinese side to a fojin chunk `(text_id, juan_num, chunk_index)`, located by **verbatim substring match** of the MITRA Chinese sentence inside the juan.

Per-row `source`/`license` keeps the CC BY-SA 4.0 data attributable and license-separable from fojin's own data.

## Changes

- **migration `0156`** — `mitra_alignments` table (FK→buddhist_texts, indexes for the reader lookup, provenance + license columns).
- **`scripts/import_mitra_alignments.py`** — per-Taishō importer (bounded memory for the small VPS), substring-localization quality gate, idempotent re-run (delete-then-insert per text in one tx), runs **inside the backend container against the local DB** (no cross-border data transfer; clone MITRA on the VPS, `docker cp` the TSVs in, run).
- **`api/alignment.py`** — chunk + juan endpoints merge MITRA parallels; `ParallelPair` gains `source` (`"fojin"` default | `"mitra-parallel"`). Fully additive / backward-compatible.
- **`NOTICE`** — MITRA CC BY-SA 4.0 attribution (derived data stays share-alike).

## Validation

Pilot ran end-to-end against the live production DB (read-only + isolated throwaway table, since dropped):
- **10 Taishō texts → 155,352 localized pairs, 98% localization rate, 2.8s**
- **chunk linkage 99.88%** against live `text_embeddings`
- foreign-lang split bo 119,067 / sa 36,285 (classified by script — empirically verified ground truth)

Independent code review: **ready to merge**, no Critical/Important data issues; the two Minor findings (sa/bo heuristic, CJK BMP-only) are fixed in this branch. N+1 in the (pre-existing) juan endpoint noted as a perf follow-up.

## Deploy plan (after merge)

1. Deploy applies migration `0156` (`alembic upgrade head`).
2. On VPS: clone MITRA → `docker cp` TSVs into backend container → `python scripts/import_mitra_alignments.py --mitra-dir <tsv> ` (default = 10 pilot texts).
3. Verify `/api/alignment/chunks/{text_id}/{juan}/{chunk}` returns `source="mitra-parallel"` parallels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)