### PR TITLE
fix(search): GIN trigram index on text_contents.content (prod pool-exhaustion fix)

### DIFF
--- a/backend/alembic/versions/0157_add_text_content_trgm_index.py
+++ b/backend/alembic/versions/0157_add_text_content_trgm_index.py
@@ -1,0 +1,38 @@
+"""add GIN trigram index on text_contents.content for ILIKE content search
+
+Revision ID: 0157
+Revises: 0156
+Create Date: 2026-06-14
+
+api/seo_dict.py._fetch_reverse_index (and other content-substring lookups) run
+`text_contents.content ILIKE '%term%'`. The code comment claimed the column was
+trigram-indexed, but NO such index existed in production — so every call
+seq-scanned the 406MB text_contents table. Under crawler load on /seo dict
+pages these queries (60s+ each) piled up and exhausted the Postgres connection
+pool (2026-06-14 incident). A GIN trigram index makes substring ILIKE
+sub-second, matching the existing pattern in 0039 (kg_entities.name_zh).
+
+The index was built manually on prod ahead of this migration; CREATE INDEX
+IF NOT EXISTS keeps it a no-op there and reproducible on fresh deploys.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0157"
+down_revision: str | None = "0156"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_text_contents_content_trgm "
+        "ON text_contents USING gin (content gin_trgm_ops)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_text_contents_content_trgm")

--- a/backend/app/api/seo_dict.py
+++ b/backend/app/api/seo_dict.py
@@ -92,8 +92,10 @@ async def _fetch_reverse_index(
 ) -> list[dict]:
     """Return up to N sutras containing this headword in their content.
 
-    Uses a vanilla ILIKE — text_contents.content is GiST-trigram-indexed so
-    a single-term substring match is sub-second for the largest sutras.
+    Uses a vanilla ILIKE — text_contents.content has a GIN trigram index
+    (ix_text_contents_content_trgm, migration 0157) so a single-term substring
+    match is sub-second. Without that index this seq-scans the 406MB table and,
+    under crawler load, piles up and exhausts the connection pool.
     """
     if len(headword) > _MAX_HEADWORD_LEN:
         return []


### PR DESCRIPTION
## Incident & root cause

On 2026-06-14 the Postgres connection pool was exhausted (85 stuck queries, 98/100 connections, new connections refused; superuser locked out). Root cause: `api/seo_dict.py._fetch_reverse_index` runs `text_contents.content ILIKE '%headword%'` to list sutras containing a dictionary term. The docstring **claimed** the column was trigram-indexed, but **no such index existed in production** — every call seq-scanned the 406 MB `text_contents` table (~60 s each). Crawler traffic on `/seo` dict pages fired many concurrently; they piled up and starved the pool. (The trigger that exposed it was an unrelated heavy import competing for I/O.)

This is independent of any MITRA work — it's a latent self-DoS on a content-search endpoint.

## Fix

- **migration 0157**: `CREATE INDEX IF NOT EXISTS ix_text_contents_content_trgm ON text_contents USING gin (content gin_trgm_ops)` (+ `CREATE EXTENSION IF NOT EXISTS pg_trgm`). Matches the existing 0039 pattern (kg_entities.name_zh).
- **seo_dict.py**: corrects the stale "GiST-trigram-indexed" docstring (it's now a real GIN index).

## Verification (prod, EXPLAIN ANALYZE)

```
Bitmap Index Scan on ix_text_contents_content_trgm
  Index Cond: (content ~~* '%菩薩摩訶薩%')
Execution Time: 1328 ms   -- worst case: term matches 3,507 sutras
```
vs. 60 s+ (12 min under contention) seq scan before. Typical headwords are sub-second. Fast turnover prevents the cascade.

## Deploy

Index (730 MB) was built **manually on prod ahead of merge** (monitored, no pile-up during build). The migration's `IF NOT EXISTS` makes the deploy a no-op on prod and keeps the schema reproducible for fresh deploys.

## Follow-ups (not in this PR)
- app engine pool `30+90=120` > PG `max_connections=100` (shared with umami) is a misconfiguration — lower pool or raise max_connections.
- Consider routing content search to ES (fojin-es already indexes text_contents) and/or a `statement_timeout` as defence-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)