### PR TITLE
fix(db): statement_timeout + idle_in_transaction guards on app connections

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -19,6 +19,21 @@ engine = create_async_engine(
     max_overflow=90,
     pool_pre_ping=True,
     pool_recycle=3600,
+    # Per-connection guards (asyncpg GUCs). These apply ONLY to the app's
+    # request connections — alembic migrations and admin scripts use their own
+    # engines, so long maintenance (e.g. building a GIN index) is unaffected.
+    # statement_timeout caps any single web query so a slow query can't hold a
+    # pooled connection hostage and exhaust the pool — the failure mode behind
+    # the 2026-06-14 incident, where un-indexed ILIKE content searches ran 60s+
+    # and piled up to max_connections. 30s is far above any legitimate web query
+    # (search is sub-second). idle_in_transaction guards against leaked
+    # transactions. See docs/mitra-alignment-integration.md.
+    connect_args={
+        "server_settings": {
+            "statement_timeout": "30000",
+            "idle_in_transaction_session_timeout": "60000",
+        }
+    },
 )
 async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 


### PR DESCRIPTION
Defense-in-depth follow-up to the 2026-06-14 connection-pool incident (see `docs/mitra-alignment-integration.md`).

## Problem
The app engine had **no `statement_timeout`** (0 = unlimited). A slow query could hold a pooled connection indefinitely; un-indexed ILIKE content searches ran 60s+ and piled up to `max_connections` (98/100), refusing new connections.

## Fix
Set per-connection guards via asyncpg `server_settings` in `connect_args`:
- `statement_timeout = 30s` — caps any single web query (search is sub-second post-#733; 30s is far above anything legitimate)
- `idle_in_transaction_session_timeout = 60s` — guards leaked transactions

These apply **only to the app's request connections**. alembic migrations and admin scripts use their own engines, so long maintenance (e.g. building a GIN index) is unaffected.

## Why not the other levers (measured)
- **Raise `max_connections`**: ❌ PG container is at **81% of its 4GB limit (3.25GB)**; +50 connections (~0.5GB) risks OOM on a VPS with OOM history.
- **Lower the pool (30+90)**: ⚠️ still masks the `/exports/*` streaming-hold; lowering needs that refactor first (`project_fojin_db_pool_streaming`).

`statement_timeout` is the safe, surgical lever — no RAM increase, no capacity reduction, no refactor dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)