### PR TITLE
fix(reader): default 跨藏对照 to 按段对读 when 按经对读 is empty

### DIFF
--- a/frontend/src/components/ReaderParallelPanel.tsx
+++ b/frontend/src/components/ReaderParallelPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Empty, Spin, Alert, Collapse, Tag, Progress, Tabs, Button } from "antd";
 import { LinkOutlined, BookOutlined, ExpandAltOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
@@ -365,13 +365,30 @@ function ChunkView({ textId, juanNum }: Props) {
  * 「对读」= 相关但不同的经文之间的平行关系。
  */
 export default function ReaderParallelPanel({ textId, juanNum }: Props) {
+  // Default-tab selection: most Mahayana texts have no SuttaCentral (按经对读)
+  // parallel but DO have MITRA 段级 parallels, so landing on an empty 按经对读
+  // reads as "no data". When canonical is empty, default to 按段对读. The query
+  // shares CanonicalView's cache key (deduped). activeKey=undefined means
+  // "auto"; a user click pins it. Reset on textId change so auto re-applies.
+  const [activeKey, setActiveKey] = useState<string | undefined>(undefined);
+  useEffect(() => setActiveKey(undefined), [textId]);
+  const { data: canonical } = useQuery({
+    queryKey: ["canonical-parallels", textId],
+    queryFn: () => getCanonicalParallels(textId),
+    enabled: textId > 0,
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+  });
+  const effectiveKey =
+    activeKey ?? (canonical ? (canonical.total > 0 ? "canonical" : "chunk") : "canonical");
   return (
     <div className="reader-parallel-panel">
       <div style={{ padding: "0 12px" }}>
         <OtherVersions textId={textId} />
       </div>
       <Tabs
-        defaultActiveKey="canonical"
+        activeKey={effectiveKey}
+        onChange={setActiveKey}
         size="small"
         style={{ padding: "0 12px" }}
         items={[


### PR DESCRIPTION
Small UX fix surfaced while verifying the MITRA feature.

The 跨藏对照 panel hard-defaulted to the **按经对读** (SuttaCentral, sutta-level) tab. Most Mahayana texts have no SuttaCentral parallel but **do** have MITRA Skt/Tib parallels in **按段对读** — so users landed on an empty "本经暂无 SuttaCentral 学术对应" and read the whole panel as empty (e.g. 維摩詰, whose 按段对读 has 28/29 segments of MITRA parallels).

Now the default tab is chosen from the (already-cached) canonical query: `total === 0` → default to 按段对读, else 按经对读. `activeKey=undefined` = auto; a user click pins it; resets on `textId` change. No extra fetch (shares CanonicalView's queryKey).

Verified data: 維摩詰 按经对读=0, 按段对读 chunk0=43 MITRA parallels; 雜阿含 按经对读=1098, 按段对读 has MITRA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)