### PR TITLE
perf(exports): per-batch sessions for streaming dumps + pool 10+20

### DIFF
--- a/backend/app/api/exports.py
+++ b/backend/app/api/exports.py
@@ -8,11 +8,9 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.deps import get_optional_user
-from app.database import get_db
+from app.database import async_session, get_db
 from app.models.knowledge_graph import KGEntity, KGRelation
 from app.models.text import BuddhistText
-from app.models.user import User
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +18,27 @@ router = APIRouter(prefix="/exports", tags=["exports"])
 
 # Batch size for streaming exports
 BATCH_SIZE = 500
+
+
+async def _fetch_batch(stmt):
+    """Run one keyset-paginated batch in a short-lived session.
+
+    The pooled connection is checked out only for the duration of this single
+    query, then returned to the pool *before* we yield the batch to the client.
+    This is the key to not pinning a connection for the whole streaming
+    response: a slow client downloading 10k+ rows no longer holds a DB
+    connection hostage while bytes trickle over the wire. Keyset pagination is
+    stateless (carried by ``last_id`` in the caller), so each batch is fully
+    independent.
+
+    The returned ORM objects are detached when the session closes, but stay
+    usable: the sessionmaker uses ``expire_on_commit=False`` and every attribute
+    these exporters read is a plain column loaded by the SELECT — no lazy
+    relationship access happens after detach.
+    """
+    async with async_session() as session:
+        result = await session.execute(stmt)
+        return result.scalars().all()
 
 
 @router.get("/stats")
@@ -40,8 +59,6 @@ async def export_metadata_csv(
     dynasty: str | None = Query(None, description="按朝代筛选"),
     category: str | None = Query(None, description="按分类筛选"),
     lang: str | None = Query(None, description="按语言筛选"),
-    user: User | None = Depends(get_optional_user),
-    db: AsyncSession = Depends(get_db),
 ):
     """导出佛典元数据为 CSV 格式，支持分批流式输出。"""
     stmt = select(BuddhistText).order_by(BuddhistText.id)
@@ -66,9 +83,9 @@ async def export_metadata_csv(
         # Stream rows using keyset pagination
         last_id = 0
         while True:
-            batch_stmt = stmt.where(BuddhistText.id > last_id).limit(BATCH_SIZE)
-            result = await db.execute(batch_stmt)
-            texts = result.scalars().all()
+            texts = await _fetch_batch(
+                stmt.where(BuddhistText.id > last_id).limit(BATCH_SIZE)
+            )
             if not texts:
                 break
 
@@ -95,8 +112,6 @@ async def export_metadata_csv(
 @router.get("/kg.json")
 async def export_kg_json(
     entity_type: str | None = Query(None, description="按实体类型筛选"),
-    user: User | None = Depends(get_optional_user),
-    db: AsyncSession = Depends(get_db),
 ):
     """导出知识图谱为 JSON 格式，分批流式输出。"""
     entity_stmt = select(KGEntity).order_by(KGEntity.id)
@@ -111,10 +126,9 @@ async def export_kg_json(
         first = True
         entity_ids: set[int] = set()
         while True:
-            result = await db.execute(
+            entities = await _fetch_batch(
                 entity_stmt.where(KGEntity.id > last_id).limit(BATCH_SIZE)
             )
-            entities = result.scalars().all()
             if not entities:
                 break
             for e in entities:
@@ -155,10 +169,9 @@ async def export_kg_json(
         first = True
         if not skip_relations:
             while True:
-                result = await db.execute(
+                relations = await _fetch_batch(
                     rel_stmt.where(KGRelation.id > last_id).limit(BATCH_SIZE)
                 )
-                relations = result.scalars().all()
                 if not relations:
                     break
                 for r in relations:
@@ -188,8 +201,6 @@ async def export_kg_json(
 @router.get("/kg.jsonld")
 async def export_kg_jsonld(
     entity_type: str | None = Query(None, description="按实体类型筛选"),
-    user: User | None = Depends(get_optional_user),
-    db: AsyncSession = Depends(get_db),
 ):
     """导出知识图谱为 JSON-LD 格式，使用标准语义词汇。"""
     entity_stmt = select(KGEntity).order_by(KGEntity.id)
@@ -222,10 +233,9 @@ async def export_kg_jsonld(
         # Stream entities using keyset pagination
         entity_ids: set[int] = set()
         while True:
-            result = await db.execute(
+            entities = await _fetch_batch(
                 entity_stmt.where(KGEntity.id > last_id).limit(BATCH_SIZE)
             )
-            entities = result.scalars().all()
             if not entities:
                 break
             for e in entities:
@@ -272,10 +282,9 @@ async def export_kg_jsonld(
         last_id = 0
         if not skip_relations:
             while True:
-                result = await db.execute(
+                relations = await _fetch_batch(
                     rel_stmt.where(KGRelation.id > last_id).limit(BATCH_SIZE)
                 )
-                relations = result.scalars().all()
                 if not relations:
                     break
                 for r in relations:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -6,17 +6,20 @@ from app.config import settings
 engine = create_async_engine(
     settings.database_url,
     echo=False,
-    # Pool stays at 30+90 for now. /chat/stream's streaming session-hold is
-    # GONE (it no longer takes get_db/get_optional_user — see send_message_stream),
-    # which removes the dominant masker. BUT the /exports/* endpoints
-    # (export_metadata_csv / export_kg_json / export_kg_jsonld) still hold a
-    # request-scoped get_db session across their full keyset-paginated dump
-    # generators (10k+ rows) — the same streaming-hold pattern. Cutting back to
-    # the pre-masking 10+20 must wait until those get the same short-lived
-    # per-batch session treatment, else a few concurrent exports could exhaust
-    # the pool the way chat used to (project_fojin_db_pool_streaming).
-    pool_size=30,
-    max_overflow=90,
+    # Pool back to 10+20 (max 30 connections). The two streaming session-holds
+    # that forced the temporary 30+90 inflation are both gone now:
+    #  - /chat/stream no longer takes get_db/get_optional_user (see
+    #    send_message_stream);
+    #  - /exports/* (export_metadata_csv / export_kg_json / export_kg_jsonld) now
+    #    fetch each keyset batch in a short-lived per-batch session and drop the
+    #    unused get_optional_user dep, so they no longer pin a request-scoped
+    #    connection across a slow multi-MB download (see exports._fetch_batch).
+    # 30+90 also over-committed the server: max_connections is 100 and umami
+    # shares this Postgres, so a fully-saturated app pool could starve umami /
+    # migrations / admin scripts. 10+20 leaves comfortable headroom
+    # (project_fojin_db_pool_streaming).
+    pool_size=10,
+    max_overflow=20,
     pool_pre_ping=True,
     pool_recycle=3600,
     # Per-connection guards (asyncpg GUCs). These apply ONLY to the app's


### PR DESCRIPTION
## 问题

`/exports/*` 三个流式导出端点（`metadata.csv` / `kg.json` / `kg.jsonld`）在整个下载期间各**钉住两条连接池连接**：

1. handler 自己的 `db: AsyncSession = Depends(get_db)` —— FastAPI 会把 `get_db` yield 的 session 一直开到 `StreamingResponse` 全部发完为止；
2. `get_optional_user` 内部**也**有一个 `Depends(get_db)` —— 而 `user` 在这三个函数体里**从未被读取**。

慢客户端拉 10k+ 行时，这就是和当年 `/chat/stream` session-hold 同款的 self-DoS 形态（见 `project_fojin_db_pool_streaming`）。这也是 `database.py` 注释里把连接池临时撑到 30+90 迟迟不能回收的最后一个 masker。

## 修复

- 新增 `_fetch_batch(stmt)`：每个 keyset 批次在**短命 session** 内执行（`async with async_session()`），`.all()` 物化成 list 后 session 立即归还连接，**再** yield 给客户端——连接不再被慢下载占着。keyset 分页状态全在调用方 `last_id`，与 session 解耦。
- 三个流式端点去掉 `db` 和未使用的 `get_optional_user` 依赖（端点保持公开，行为不变）。
- `/exports/stats`（非流式）保留 `Depends(get_db)`。
- 连接池 `30+90 → 10+20`。两个流式 session-hold 都已消除（chat 早已重构），且 30+90 相对 `max_connections=100`（umami 共用此 PG）属**超额承诺**，回到 10+20 留足余量。

## 安全性

- detached 对象安全：sessionmaker `expire_on_commit=False`，三个生成器 session 关闭后只读取**普通映射列**（无懒加载关系），逐属性核对无误。
- code-reviewer agent 复核：detached-safety / `.all()` 物化与连接释放时机 / keyset 正确性 / ruff / auth 不变 / 连接池数学 全部通过，结论 **SHIP**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)