### PR TITLE
fix(alignment): deterministic tiebreak so juan panel == chunk deep-link

### DIFF
--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -136,7 +136,13 @@ async def get_chunk_alignment(
                 (ap.text_b_id = :tid AND ap.text_b_juan_num = :juan AND ap.text_b_chunk_index = :cidx)
             )
             AND ap.text_a_chunk_index IS NOT NULL
-            ORDER BY ap.confidence DESC
+            -- confidence is coarse and heavily tied (e.g. 0.9 for hundreds of
+            -- pairs), so confidence-only ordering picks an arbitrary 5 under the
+            -- LIMIT. Tiebreak on the counterpart identity (output cols 1,2,3 =
+            -- other_tid/other_juan/other_cidx) so this single-chunk endpoint and
+            -- the batched juan endpoint always select the SAME rows in the SAME
+            -- order — otherwise the "多语对读" panel and a chunk deep-link disagree.
+            ORDER BY ap.confidence DESC, 1, 2, 3
             LIMIT :limit
         """),
         {"tid": text_id, "juan": juan_num, "cidx": chunk_index, "limit": limit},
@@ -316,12 +322,13 @@ async def get_juan_alignment(
             SELECT source_cidx, other_tid, other_juan, other_cidx, other_lang, confidence
             FROM (
                 SELECT *, ROW_NUMBER() OVER (
-                    PARTITION BY source_cidx ORDER BY confidence DESC
+                    PARTITION BY source_cidx
+                    ORDER BY confidence DESC, other_tid, other_juan, other_cidx
                 ) AS rn
                 FROM matched
             ) t
             WHERE rn <= :pair_limit
-            ORDER BY source_cidx, confidence DESC
+            ORDER BY source_cidx, confidence DESC, other_tid, other_juan, other_cidx
         """),
         {"tid": text_id, "juan": juan_num, "cidxs": cidxs, "pair_limit": PAIR_LIMIT},
     )).fetchall()


### PR DESCRIPTION
## 背景

`alignment_pairs.confidence` 取值很粗、大量并列（如 0.9 覆盖数百条）。仅按 confidence 排序时，`LIMIT 5` / `ROW_NUMBER<=5` 在一个 source chunk 有 >5 条并列时会**任取 5 条**；即使 ≤5 条也会以**任意顺序**返回。

PR #742 把卷端点改成批量查询后，它与单 chunk 端点各自有了独立的任意顺序——于是「多语对读」面板与某段的 deep-link 可能对同一段展示**不同的对照段**。（#742 之前卷端点是直接调用单 chunk 端点的，所以天然一致。）

线上端到端核查发现 T0001 卷13 的 **76/104 段**在顺序或成员上分歧，全部源于 confidence 并列。

## 修复

给两个查询同一个全序 `confidence DESC, other_tid, other_juan, other_cidx`（单 chunk 端点用输出列序号 1,2,3 表示 other_tid/juan/cidx）。完整平行集此前已证明完全一致，因此共享全序后两端点截断的 top-N **逐字节一致**，且跨请求确定。

## 验证

合并部署后重跑 104 段对比，期望 0 分歧（见 PR 评论）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)