### PR TITLE
ops(postgres): shm_size 256m for parallel VACUUM/maintenance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,15 @@ services:
     # every connection. Raised to 3g; host has the headroom.
     mem_limit: 3g
     cpus: 1.0
+    # Docker's default /dev/shm is 64MB. Postgres puts parallel-worker shared
+    # memory there, so a parallel VACUUM / VACUUM ANALYZE on a large table
+    # (e.g. mitra_alignments ~800MB) fails with "could not resize shared memory
+    # segment ... No space left on device". 256MB is ample for maintenance and
+    # stays well under mem_limit (it's a lazily-allocated tmpfs). Autovacuum is
+    # single-process and unaffected either way. NOTE: applying a change here
+    # needs an explicit `docker compose up -d postgres` (brief DB blip) — the
+    # path-aware deploy.sh does not recreate postgres on a compose-only change.
+    shm_size: 256m
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-fojin}
       POSTGRES_USER: ${POSTGRES_USER:-fojin}


### PR DESCRIPTION
Docker 默认 `/dev/shm` 仅 64MB；Postgres 把并行 worker 的共享内存放在这里，因此对大表（如 `mitra_alignments` ~800MB）跑 parallel `VACUUM` / `VACUUM ANALYZE` 会报 `could not resize shared memory segment ... No space left on device`（本轮导入后维护时撞到）。

设 `shm_size: 256m`——对维护足够，且远低于 `mem_limit`（tmpfs 惰性分配）；autovacuum 是单进程，不受影响。

⚠️ 应用此改动需在 VPS 显式 `docker compose up -d postgres`（短暂 DB 闪断）——路径感知的 deploy.sh 不会因 compose-only 改动重建 postgres。合并后我会手动应用并验证连通性。

🤖 Generated with [Claude Code](https://claude.com/claude-code)