### PR TITLE
polish(collections): dedupe cross-canon discovery card by text, cap to top 12

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -547,7 +547,7 @@
   "collections.alignment_desc": "These texts have passage-level cross-language alignments (AI- and scholarship-aligned). Click to open the reader and view parallels alongside the main text.",
   "collections.pair_count": "{{n}} passages",
   "collections.partner_count": "{{n}} parallel versions",
-  "collections.alignment_more": "Showing the top {{n}} most-covered of {{total}}",
+  "collections.alignment_more": "Top {{n}} shown · {{total}} texts in total",
   "kg.all_types": "All types",
   "kg.pred_translated": "Translated",
   "kg.pred_member_of_school": "School",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -547,7 +547,7 @@
   "collections.alignment_desc": "以下經典已建立逐段跨語對照（AI 與學術語料對齊），點擊進入閱讀器，正文旁即可逐段查看對照。",
   "collections.pair_count": "{{n}} 段",
   "collections.partner_count": "{{n}} 部對本",
-  "collections.alignment_more": "顯示覆蓋最多的前 {{n}} 項（共 {{total}} 項）",
+  "collections.alignment_more": "顯示覆蓋最多的 {{n}} 部 · 共 {{total}} 部經",
   "kg.all_types": "全部類型",
   "kg.pred_translated": "翻譯",
   "kg.pred_member_of_school": "宗派",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -547,7 +547,7 @@
   "collections.alignment_desc": "以下经典已建立逐段跨语对照（AI 与学术语料对齐），点击进入阅读器，正文旁即可逐段查看对照。",
   "collections.pair_count": "{{n}} 段",
   "collections.partner_count": "{{n}} 部对本",
-  "collections.alignment_more": "显示覆盖最多的前 {{n}} 项（共 {{total}} 项）",
+  "collections.alignment_more": "显示覆盖最多的 {{n}} 部 · 共 {{total}} 部经",
   "kg.all_types": "全部类型",
   "kg.pred_translated": "翻译",
   "kg.pred_member_of_school": "宗派",

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -212,49 +212,69 @@ function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useN
     staleTime: 3600_000,
     retry: 1,
   });
-  // Catalog now spans ~1500 (text × lang) rows (mitra coverage merged in);
-  // entries arrive sorted by pair_count desc, so cap to the most-covered to
-  // keep this discovery card bounded. Full browse is a follow-up (dedicated page).
-  const TOP_N = 48;
-  if (!data || data.entries.length === 0) return null;
+  // The catalog spans ~1500 (text × lang) rows (mitra coverage merged in).
+  // This is a discovery card, not the full index: dedupe by text (a work with
+  // both 藏 and 梵 parallels is ONE entry, not two) and show only the most-
+  // covered handful. Full browse/filter is a dedicated page (follow-up).
+  const TOP_N = 12;
+  const groups = useMemo(() => {
+    if (!data) return [];
+    const m = new Map<
+      number,
+      { text_id: number; title: string; sample_juan: number; total: number; langs: { lang: string; count: number }[] }
+    >();
+    for (const e of data.entries) {
+      let g = m.get(e.text_id);
+      if (!g) {
+        g = { text_id: e.text_id, title: e.title_zh || e.cbeta_id, sample_juan: e.sample_juan, total: 0, langs: [] };
+        m.set(e.text_id, g);
+      }
+      g.langs.push({ lang: e.other_lang, count: e.pair_count });
+      g.total += e.pair_count;
+    }
+    const arr = [...m.values()];
+    arr.forEach((g) => g.langs.sort((a, b) => b.count - a.count));
+    return arr.sort((a, b) => b.total - a.total);
+  }, [data]);
+
+  if (!data || groups.length === 0) return null;
   return (
     <div className="coll-card" style={{ marginBottom: 24 }}>
       <div className="coll-section" style={{ padding: "16px 20px" }}>
         <div className="coll-section-title">
-          <TranslationOutlined /> {t("collections.alignment_title", { texts: new Set(data.entries.map((e) => e.text_id)).size, pairs: data.total_pairs.toLocaleString() })}
+          <TranslationOutlined /> {t("collections.alignment_title", { texts: groups.length, pairs: data.total_pairs.toLocaleString() })}
         </div>
         <p style={{ fontSize: 12, color: "var(--fj-ink-muted)", margin: "4px 0 12px" }}>
           {t("collections.alignment_desc")}
         </p>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-          {data.entries.slice(0, TOP_N).map((e) => {
-            const lang = LANG_LABELS[e.other_lang];
-            return (
-              <button
-                key={`${e.text_id}-${e.other_lang}`}
-                className="source-btn"
-                style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
-                onClick={() =>
-                  // 阅读器而非 /parallel：sample_juan 保证该卷有锚点；reader 的
-                  // 按段对照面板不依赖对本侧 text_contents 的卷结构（对本整本
-                  // 存为 juan 1，/parallel 在 juan>1 时对本栏全空）。
-                  navigate(`/texts/${e.text_id}/read?juan=${e.sample_juan}`)
-                }
-              >
-                <span>{e.title_zh || e.cbeta_id}</span>
-                <Tag color={lang?.color ?? "default"} style={{ margin: 0, fontSize: 10, lineHeight: "16px", padding: "0 4px" }}>
-                  {lang ? t(lang.labelKey) : e.other_lang}
-                </Tag>
-                <span style={{ fontSize: 11, color: "var(--fj-ink-muted)" }}>
-                  {t("collections.pair_count", { n: e.pair_count })}{e.partner_count > 1 ? ` · ${t("collections.partner_count", { n: e.partner_count })}` : ""}
-                </span>
-              </button>
-            );
-          })}
+          {groups.slice(0, TOP_N).map((g) => (
+            <button
+              key={g.text_id}
+              className="source-btn"
+              style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+              // 阅读器而非 /parallel：sample_juan 保证该卷有锚点（对本整本存为
+              // juan 1，/parallel 在 juan>1 时对本栏全空）。
+              onClick={() => navigate(`/texts/${g.text_id}/read?juan=${g.sample_juan}`)}
+            >
+              <span>{g.title}</span>
+              {g.langs.map((l) => {
+                const lang = LANG_LABELS[l.lang];
+                return (
+                  <span key={l.lang} style={{ display: "inline-flex", alignItems: "center", gap: 3 }}>
+                    <Tag color={lang?.color ?? "default"} style={{ margin: 0, fontSize: 10, lineHeight: "16px", padding: "0 4px" }}>
+                      {lang ? t(lang.labelKey) : l.lang}
+                    </Tag>
+                    <span style={{ fontSize: 11, color: "var(--fj-ink-muted)" }}>{t("collections.pair_count", { n: l.count })}</span>
+                  </span>
+                );
+              })}
+            </button>
+          ))}
         </div>
-        {data.entries.length > TOP_N && (
+        {groups.length > TOP_N && (
           <p style={{ fontSize: 11, color: "var(--fj-ink-muted)", margin: "12px 0 0" }}>
-            {t("collections.alignment_more", { n: TOP_N, total: data.entries.length })}
+            {t("collections.alignment_more", { n: TOP_N, total: groups.length })}
           </p>
         )}
       </div>


### PR DESCRIPTION
## What

Follow-up polish to #745. The merged catalog put ~1,530 (text × lang) chips into the `/collections` cross-canon card as a flat wall, and works with parallels in both 藏 and 梵 (大智度論, 大方廣佛華嚴經, …) appeared as two near-identical chips — visually cluttered.

A discovery card should **tease, not dump the full index**. This:
- **Dedupes by text**: a work's languages become sub-tags on one chip (`大智度論 [藏 25006] [梵 10762]`) instead of two chips.
- **Caps to the top 12** most-covered works (was 48).
- Footer now reads "top 12 · N texts in total" (counts distinct texts, not raw rows).

The full browsable / filterable / searchable index of all ~1,016 texts is a **dedicated page (follow-up — Approach B)**; this card just advertises the feature.

## Scope

Frontend only — no backend change. The `/catalog` endpoint still returns per-(text,lang) rows; grouping is client-side (`useMemo`). i18n `alignment_more` reworded in all 3 locales.

## Test plan
- [x] Locale JSON valid (all 3)
- [ ] CI: frontend build (tsc) / i18n ratchet
- [ ] Visual: `/collections` cross-canon card shows ~12 deduped chips with per-language tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)