### PR TITLE
feat(reader): cross-canon entry card on text detail page (signpost a)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -548,6 +548,8 @@
   "collections.pair_count": "{{n}} passages",
   "collections.partner_count": "{{n}} parallel versions",
   "collections.alignment_more": "Top {{n}} shown · {{total}} texts in total",
+  "crosscanon.entry_title": "Cross-canon parallels",
+  "crosscanon.entry_hint": "read passage-by-passage",
   "kg.all_types": "All types",
   "kg.pred_translated": "Translated",
   "kg.pred_member_of_school": "School",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -548,6 +548,8 @@
   "collections.pair_count": "{{n}} 段",
   "collections.partner_count": "{{n}} 部對本",
   "collections.alignment_more": "顯示覆蓋最多的 {{n}} 部 · 共 {{total}} 部經",
+  "crosscanon.entry_title": "跨藏對照",
+  "crosscanon.entry_hint": "藏/梵逐段對讀",
   "kg.all_types": "全部類型",
   "kg.pred_translated": "翻譯",
   "kg.pred_member_of_school": "宗派",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -548,6 +548,8 @@
   "collections.pair_count": "{{n}} 段",
   "collections.partner_count": "{{n}} 部对本",
   "collections.alignment_more": "显示覆盖最多的 {{n}} 部 · 共 {{total}} 部经",
+  "crosscanon.entry_title": "跨藏对照",
+  "crosscanon.entry_hint": "藏/梵逐段对读",
   "kg.all_types": "全部类型",
   "kg.pred_translated": "翻译",
   "kg.pred_member_of_school": "宗派",

--- a/frontend/src/components/CrossCanonEntry.tsx
+++ b/frontend/src/components/CrossCanonEntry.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { Tag } from "antd";
+import { TranslationOutlined, RightOutlined } from "@ant-design/icons";
+import { getAlignmentCatalog } from "../api/client";
+
+const LANG_LABELS: Record<string, { labelKey: string; color: string }> = {
+  pi: { labelKey: "lang.pi", color: "green" },
+  bo: { labelKey: "lang.bo", color: "purple" },
+  sa: { labelKey: "lang.sa", color: "orange" },
+};
+
+/** 段级跨藏对照入口卡：本经若有 mitra/fojin 平行段，在文本详情页给醒目入口直达阅读器对照。
+    无覆盖（catalog 未加载 / 本经不在其中）时整块隐身，可与 backend 解耦部署。
+    与 OtherVersions（作品级"其他版本"）互补：这是段级跨语对照。 */
+export default function CrossCanonEntry({ textId }: { textId: number }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { data } = useQuery({
+    queryKey: ["alignmentCatalog"],
+    queryFn: getAlignmentCatalog,
+    staleTime: 3600_000,
+    retry: 1,
+  });
+  const coverage = useMemo(() => {
+    if (!data) return null;
+    const rows = data.entries.filter((e) => e.text_id === textId);
+    if (rows.length === 0) return null;
+    const langs = rows
+      .map((r) => ({ lang: r.other_lang, count: r.pair_count }))
+      .sort((a, b) => b.count - a.count);
+    // land on the juan with the most anchors (the highest-count language's sample)
+    const sampleJuan = rows.reduce((best, r) => (r.pair_count > best.pair_count ? r : best)).sample_juan;
+    return { langs, sampleJuan };
+  }, [data, textId]);
+
+  if (!coverage) return null;
+  return (
+    <button
+      className="source-btn"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        width: "100%",
+        padding: "12px 16px",
+        marginTop: 16,
+      }}
+      onClick={() => navigate(`/texts/${textId}/read?juan=${coverage.sampleJuan}`)}
+    >
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        <TranslationOutlined style={{ color: "var(--fj-accent)", fontSize: 16 }} />
+        <span style={{ fontWeight: 600 }}>{t("crosscanon.entry_title")}</span>
+        {coverage.langs.map((l) => {
+          const lang = LANG_LABELS[l.lang];
+          return (
+            <Tag key={l.lang} color={lang?.color ?? "default"} style={{ margin: 0 }}>
+              {lang ? t(lang.labelKey) : l.lang} {l.count}
+            </Tag>
+          );
+        })}
+        <span style={{ fontSize: 12, color: "var(--fj-ink-muted)" }}>{t("crosscanon.entry_hint")}</span>
+      </span>
+      <RightOutlined style={{ color: "var(--fj-ink-muted)" }} />
+    </button>
+  );
+}

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -24,6 +24,7 @@ import { getLastPosition } from "../utils/readingHistory";
 import BookmarkButton from "../components/BookmarkButton";
 import { RelatedTextsStandalone as RelatedTexts } from "../components/RelatedTexts";
 import OtherVersions from "../components/OtherVersions";
+import CrossCanonEntry from "../components/CrossCanonEntry";
 import CitationGenerator from "../components/CitationGenerator";
 import { addViewHistory } from "../utils/history";
 
@@ -219,6 +220,8 @@ export default function TextDetailPage() {
           open={citationOpen}
           onClose={() => setCitationOpen(false)}
         />
+
+        <CrossCanonEntry textId={text.id} />
 
         <OtherVersions textId={text.id} />
 


### PR DESCRIPTION
## What

Increment ② signpost **a** (the golden discovery moment). When a text has segment-level cross-canon parallels, its detail page now shows a prominent entry card — `跨藏对照 [藏 N][梵 M] →` — that deep-links into the reader at the juan with the most anchors. The user is already engaged with this specific text, so this is the highest-relevance place to advertise the parallels.

- New `CrossCanonEntry` component: reads the cached `["alignmentCatalog"]` query client-side, filters to this `text_id`, combines languages, hidden when the text has no coverage.
- Placed above `OtherVersions` (work-level "other versions") — complementary: this is the **segment-level cross-language** view.
- i18n keys in all 3 locales.

## Scope

Frontend only — no backend change (reuses the catalog endpoint). Search badge + nav restore are separate follow-up PRs in this increment.

## Test plan
- [x] Locale JSON valid (all 3)
- [ ] CI: frontend build (tsc) / i18n ratchet
- [ ] Visual: open a text with parallels (e.g. /texts/<id> for 大智度論) → card shows; a text without → no card

🤖 Generated with [Claude Code](https://claude.com/claude-code)