### PR TITLE
feat(nav): restore Dashboard + Timeline to nav (signpost c)

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,9 +15,9 @@ import {
   RobotOutlined,
   GithubOutlined,
   GlobalOutlined,
-  // NotificationOutlined,
-  // FieldTimeOutlined,
-  // BarChartOutlined,
+  FieldTimeOutlined,
+  BarChartOutlined,
+  // NotificationOutlined,  // activity nav deferred (empty Source-Updates subtab)
 } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { currentUILang } from "../i18n";
@@ -79,13 +79,11 @@ export default function Layout() {
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
     { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
-    // 佛学动态按 owner 决定暂不上线（2026-06-11）。数据管道是健康的：feed cron
-    // 每日运行，源清单已审计换血（见 backend/scripts/fetch_academic_feeds.py），
-    // /activity 路由可直达——只是不放导航入口。
+    { icon: <FieldTimeOutlined />, label: t("nav.timeline"), path: "/timeline" },
+    { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
+    // 佛学动态(/activity)仍暂不放导航：Source-Updates 子标签无数据流（空）；
+    // 待隐掉该空子标签后再放（feed cron 每日跑、/activity 路由仍可直达）。
     // { icon: <NotificationOutlined />, label: t("nav.activity"), path: "/activity" },
-    // TODO: 时间线和数据总览暂时隐藏，待优化后重新上线
-    // { icon: <FieldTimeOutlined />, label: t("nav.timeline"), path: "/timeline" },
-    // { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
     ...(isAdmin
       ? [
           {


### PR DESCRIPTION
## What

Increment ② signpost **c**. `/dashboard` (platform stats) and `/timeline` were built but hidden from nav (`待优化后重新上线`). Both are functional and read from existing tables — un-hide them.

`/activity` stays out of nav for now: its Source-Updates subtab has no data flow (empty), so it needs that subtab hidden before surfacing — tracked separately (task #4 follow-up).

## Scope
One file (`Layout.tsx`): un-comment 2 icon imports + 2 nav entries. `nav.timeline`/`nav.dashboard` keys already exist in all 3 locales.

## Test plan
- [ ] CI: frontend build (tsc)
- [ ] Visual: nav shows 历史时间线 + 数据总览; both pages load

🤖 Generated with [Claude Code](https://claude.com/claude-code)