### PR TITLE
fix(deps): bump python-multipart + cryptography (CVEs, turns pip-audit green)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ elasticsearch[async]==8.17.0
 redis[hiredis]==5.2.1
 httpx==0.28.1
 PyJWT==2.13.0
-cryptography==46.0.7
+cryptography==48.0.1
 bcrypt==4.1.1
 defusedxml==0.7.1
 lxml==6.1.0
@@ -18,7 +18,7 @@ openai==1.58.0
 tiktoken==0.8.0
 opencc-python-reimplemented==0.1.7
 Pillow==12.2.0
-python-multipart==0.0.27
+python-multipart==0.0.31
 pypdf==6.12.0
 python-docx==1.1.2
 beautifulsoup4==4.12.3


### PR DESCRIPTION
## What

Bumps two dependencies with known CVEs that have been failing the (non-blocking) `Python dependency audit` check on every PR:

- **python-multipart 0.0.27 → 0.0.31** — CVE-2026-53538/53539/53540: form-parsing DoS (quadratic scan / unbounded read on negative Content-Length) and parameter-pollution, reachable via FastAPI `request.form()` and the chat attachment upload. Fixed in 0.0.30/0.0.31.
- **cryptography 46.0.7 → 48.0.1** — GHSA-537c-gmf6-5ccf: OpenSSL statically linked in the wheel. Fixed in 48.0.1.

## Risk

Low. fojin uses `cryptography` only via `Fernet` (symmetric encryption, `core/crypto.py`, `config.py`) and `x509` (cert parsing in `health_check_sources.py`) — both stable across 46→48. `python-multipart` is used transitively via FastAPI; 0.0.27→0.0.31 is a patch-series bump. Backend smoke tests install the new deps and gate the change.

## Test plan
- [ ] CI: **Python dependency audit should now pass** (the failures it flagged are exactly these two)
- [ ] CI: backend smoke tests (installs new deps, runs the suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)