### PR TITLE
perf(alignment): warm cross-canon catalog off the request path (kill 23s cold)

### DIFF
--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -10,6 +10,9 @@ chunk_text stored in text_embeddings is the English translation (Sujato /
 84000). The real Pāli / Tibetan source, when available in text_contents, is
 surfaced via original_preview so the panel can display both sides.
 """
+import asyncio
+import logging
+
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy import bindparam
@@ -19,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.cache import cache_get, cache_set
 from app.database import get_db
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/alignment", tags=["alignment"])
 
 # Catalog merges alignment_pairs (small) with mitra_alignments (~896K rows).
@@ -26,8 +30,16 @@ router = APIRouter(prefix="/alignment", tags=["alignment"])
 # ~77s on prod — far over the app statement_timeout (30s). Instead aggregate the
 # two sources separately (mitra side is a cheap count + mode(juan), ~7s) and
 # merge in Python, then cache the result (mitra coverage changes only on import).
+#
+# Even split + merged the compute is ~20-25s on prod, which is the whole
+# surfacing line's data layer (search badge, detail card, /collections,
+# /cross-canon). To keep any real user from ever paying that, a background loop
+# (started in main.lifespan) re-warms the cache every WARM_INTERVAL, and the TTL
+# is set comfortably longer so the entry never lapses between refreshes. A cold
+# request (e.g. right after a redis flush) still self-heals via the compute path.
 ALIGNMENT_CATALOG_CACHE_KEY = "alignment:catalog:v2"
-ALIGNMENT_CATALOG_TTL = 1800  # 30 min
+ALIGNMENT_CATALOG_TTL = 25200  # 7h — must exceed WARM_INTERVAL so the loop keeps it warm
+ALIGNMENT_CATALOG_WARM_INTERVAL = 21600  # 6h — background re-warm cadence (< TTL)
 
 # A fojin chunk (paragraph) can contain many MITRA sentence-level parallels;
 # cap per chunk so the reader panel stays bounded on dense texts.
@@ -681,7 +693,19 @@ async def get_alignment_catalog(db: AsyncSession = Depends(get_db)):
     cached = await cache_get(redis, ALIGNMENT_CATALOG_CACHE_KEY)
     if cached is not None:
         return AlignmentCatalogResponse(**cached)
+    return await compute_alignment_catalog(db, redis)
 
+
+async def compute_alignment_catalog(
+    db: AsyncSession, redis
+) -> AlignmentCatalogResponse:
+    """Heavy compute for the cross-canon catalog; caches and returns it.
+
+    Pulled out of the endpoint so the lifespan warm loop can refresh the cache
+    off the request path (see ALIGNMENT_CATALOG_* constants). A user request only
+    reaches here on a cache miss (cold start / redis flush), which self-heals by
+    re-populating the cache for the next caller.
+    """
     # 1. fojin side (alignment_pairs) — small table, full aggregation w/ partners.
     fojin_rows = (
         await db.execute(
@@ -793,3 +817,30 @@ async def get_alignment_catalog(db: AsyncSession = Depends(get_db)):
     )
     await cache_set(redis, ALIGNMENT_CATALOG_CACHE_KEY, resp.model_dump(mode="json"), ALIGNMENT_CATALOG_TTL)
     return resp
+
+
+async def warm_alignment_catalog(redis) -> None:
+    """Recompute the catalog and refresh its cache, off the request path.
+
+    Opens its own DB session (called from the lifespan loop, not a request).
+    Best-effort: any failure is logged and swallowed so it never affects the app.
+    """
+    from app.database import async_session
+
+    try:
+        async with async_session() as session:
+            resp = await compute_alignment_catalog(session, redis)
+        logger.info("alignment catalog warmed: %d entries", len(resp.entries))
+    except Exception:
+        logger.exception("alignment catalog warm failed")
+
+
+async def catalog_warm_loop(redis) -> None:
+    """Background task: warm the catalog at startup, then every WARM_INTERVAL.
+
+    Keeps the (long-TTL) cache populated so no real user ever pays the ~20-25s
+    cold compute. Cancelled on shutdown by the lifespan handler.
+    """
+    while True:
+        await warm_alignment_catalog(redis)
+        await asyncio.sleep(ALIGNMENT_CATALOG_WARM_INTERVAL)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,8 @@
+import asyncio
 import logging
 import os
 import time
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 import redis.asyncio as aioredis
 from fastapi import FastAPI, Request, Response
@@ -111,8 +112,21 @@ async def lifespan(app: FastAPI):
         )
         app.state.gaiji_normalizer = None
 
+    # Background loop: keep the cross-canon catalog cache warm so no real user
+    # ever pays the ~20-25s cold compute (see app.api.alignment.ALIGNMENT_CATALOG_*).
+    from app.api.alignment import catalog_warm_loop
+
+    app.state.catalog_warm_task = asyncio.create_task(catalog_warm_loop(app.state.redis))
+
     yield
     # Shutdown
+    warm_task = getattr(app.state, "catalog_warm_task", None)
+    if warm_task is not None:
+        warm_task.cancel()
+        # Await the cancellation so it actually completes before the loop closes
+        # (otherwise asyncio emits "Task exception was never retrieved" on teardown).
+        with suppress(asyncio.CancelledError):
+            await warm_task
     if _HAS_DIANJIN:
         await get_dianjin_client().close()
     await app.state.redis.close()


### PR DESCRIPTION
## 问题(今天实测)
公开 `/api/alignment/catalog` 冷启 **23.18s / 360KB**。它是整条触达线的数据层(搜索徽章、详情入口卡、/collections、/cross-canon)。compute 是 `alignment_pairs ∪ mitra_alignments`(896K 行)的聚合,~20-25s。此前 TTL 30min,每次缓存过期就有一个用户吃 23s。

## 修法(零 migration)
- 把重活抽成 `compute_alignment_catalog(db, redis)`,endpoint 只剩薄缓存检查。
- 后台循环 `catalog_warm_loop`(在 `main.lifespan` 启动、shutdown 取消):启动即预热,之后每 **6h** 重算;TTL 提到 **7h**,使缓存在两次刷新间永不过期 → 稳态下无用户撞冷路径。
- 真·冷未命中(如 redis flush)仍走 compute 自愈,下个请求即热。
- **刻意不加 matview/migration**,规避 alembic 撞链风险(prod alembic_version 需单独核);matview 版本可后续再上。

## 验证
- `python -m py_compile` + `ruff check` 全绿;`import app.main` / `import app.api.alignment` OK(compute/loop 存在)。
- 取消语义:`CancelledError` 属 `BaseException`,不被 `except Exception` 吞,关停可正确取消;warm 用独立 `async_session()`,startup `create_task` 不阻塞;warm 吞 `Exception` → CI 无表也只 log 不破坏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)