### PR TITLE
fix(deps): bump pypdf 6.12.0 → 6.13.0 (5 DoS CVEs)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,6 @@ tiktoken==0.8.0
 opencc-python-reimplemented==0.1.7
 Pillow==12.2.0
 python-multipart==0.0.31
-pypdf==6.12.0
+pypdf==6.13.0
 python-docx==1.1.2
 beautifulsoup4==4.12.3


### PR DESCRIPTION
## 为什么
`pip-audit` 在所有开放 PR 上转红 —— pypdf 6.12.0 被新爆 **5 个 CVE**,全是 crafted-PDF 的 DoS(内存/CPU 耗尽):
- CVE-2026-48735(XMP 元数据)、CVE-2026-49460(FlateDecode PNG predictor)、CVE-2026-49461(自引用 XObject 取文本)、CVE-2026-54530(layout-mode 取文本死循环)、CVE-2026-54531(outline 合并死循环)。

**真实暴露**:`attachment_parser.py:104` 用 `PdfReader(io.BytesIO(file_bytes))` 解析**用户上传的 PDF 附件**,DoS 可达;配合 fojin 的 OOM 防御史值得修。

## 做了什么
`pypdf==6.12.0 → 6.13.0`(覆盖全部 5 个修复版 6.12.1/6.12.2/6.13.0)。minor 升级,`PdfReader` API 不变(仅用取文本)。

## 验证
`pip-audit -r requirements.txt` → **No known vulnerabilities found**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)