### PR TITLE
ops(backup): default to CORE dump (exclude regenerable embeddings)

### DIFF
--- a/backup_db.sh
+++ b/backup_db.sh
@@ -15,8 +15,11 @@
 #   - 两段式 dump:`pg_dumpall --globals-only`(角色/权限)+ `pg_dump -Fc`
 #     (fojin 库,custom 格式,自带压缩、支持并行/选择性恢复)。两者合起来
 #     才能在一台空机器上完整重建。
+#   - CORE vs FULL:fojin 库 16GB,其中 text_embeddings(pgvector)~10GB 且可再生。
+#     默认 CORE 备份用 --exclude-table-data 跳过它的数据(保留表结构),把 dump
+#     压到 ~2GB、几分钟跑完、对生产盘安全;FULL_DUMP=1 才含全部(慎用,见上)。
 #   - 先写 .tmp 再 mv:pg_dump 中途失败(pipefail 捕获)不会留下半截"成功"文件。
-#   - 本地按日轮转(默认留 7 份)是核心止血 —— 从"零备份"到"7 天可恢复"。
+#   - 本地按日轮转(默认留 3 份,受生产盘空闲约束)—— 长期保留靠异地推送。
 #   - 异地推送是可选 env 开关(BACKUP_RSYNC_DEST 走 tailscale rsync /
 #     BACKUP_OSS_DEST 走 ossutil),脚本不硬编码任何密钥/目的地。
 #   - 失败即非零退出(set -e),交给 cron 的邮件/日志暴露,不静默吞错。
@@ -24,6 +27,9 @@
 # 恢复速查(灾难时):
 #   gunzip -c globals-YYYYMMDD.sql.gz | docker exec -i <新pg> psql -U postgres
 #   docker exec -i <新pg> pg_restore -U fojin -d fojin --clean --if-exists < fojin-YYYYMMDD.dump
+#   # CORE dump 恢复后 text_embeddings 为空 → 跑嵌入管线重嵌后语义搜索才恢复;
+#   # 其余所有数据(text_contents / mitra_alignments / alignment_pairs / 词典 /
+#   # KG / 人物 / 用户 …)都已完整恢复。
 #
 # 建议 cron(VPS,每日 03:10,避开 0:30 高德 / 3:30 DILA 同步):
 #   10 3 * * *  /home/admin/fojin/backup_db.sh >> /home/admin/fojin/logs/backup.log 2>&1
@@ -34,7 +40,13 @@ BACKUP_DIR="${BACKUP_DIR:-/home/admin/fojin/backups}"
 PG_CONTAINER="${PG_CONTAINER:-fojin-postgres}"
 PG_USER="${PG_USER:-fojin}"
 PG_DB="${PG_DB:-fojin}"
-KEEP_DAILY="${KEEP_DAILY:-7}"
+KEEP_DAILY="${KEEP_DAILY:-3}"   # 份数 × ~2GB core dump 要塞进生产盘空闲,别贪多;长期靠异地
+# text_embeddings 是 pgvector 嵌入表,约 10GB / 占 fojin 库 62%,且**可再生**
+# (从 text_contents 经 BGE-M3 嵌入管线重算)。默认 "core" 备份只跳它的**数据**
+# (--exclude-table-data 保留表定义,恢复后是空表,可直接重嵌),把 dump 压到
+# ~2GB、几分钟跑完、对生产盘安全。FULL_DUMP=1 则含全部表(仅在盘有富余 + 低峰跑)。
+EXCLUDE_TABLE_DATA="${EXCLUDE_TABLE_DATA:-public.text_embeddings}"
+FULL_DUMP="${FULL_DUMP:-0}"
 # 可选异地:二选一(或都不填 = 仅本地)
 BACKUP_RSYNC_DEST="${BACKUP_RSYNC_DEST:-}"   # 例: la-vps:/home/user/fojin-backups
 BACKUP_OSS_DEST="${BACKUP_OSS_DEST:-}"       # 例: oss://my-bucket/fojin-backups
@@ -66,8 +78,9 @@ docker inspect "$PG_CONTAINER" >/dev/null 2>&1 || die "容器 $PG_CONTAINER 不�
 mkdir -p "$BACKUP_DIR"
 
 # 磁盘预检:把盘写满会拖垮 postgres/ES 等共盘服务(fojin 有磁盘防御史),
-# 宁可提前安全退出也不写到 0 字节。默认要求至少 3GB 可用,可用 MIN_FREE_MB 覆盖。
-MIN_FREE_MB="${MIN_FREE_MB:-3072}"
+# 宁可提前安全退出也不写到 0 字节。默认要求至少 4GB 可用(core dump ~2GB + 余量),
+# 可用 MIN_FREE_MB 覆盖;FULL_DUMP 时务必自行确保 ≥20GB 空闲。
+MIN_FREE_MB="${MIN_FREE_MB:-4096}"
 free_mb="$(df -Pm "$BACKUP_DIR" | awk 'NR==2 {print $4}')"
 if [ -n "${free_mb:-}" ] && [ "$free_mb" -lt "$MIN_FREE_MB" ]; then
   die "可用空间不足:$BACKUP_DIR 仅剩 ${free_mb}MB < 阈值 ${MIN_FREE_MB}MB,本次跳过(防止写满盘)"
@@ -88,8 +101,17 @@ docker exec "$PG_CONTAINER" pg_dumpall -U "$PG_USER" --globals-only \
 mv "$globals.tmp" "$globals"
 
 # 2) fojin 库(custom 格式,自带压缩)
-log "导出 $PG_DB (custom 格式) -> $dump"
-docker exec "$PG_CONTAINER" pg_dump -U "$PG_USER" -Fc "$PG_DB" > "$dump.tmp"
+dump_args=(-U "$PG_USER" -Fc)
+if [ "$FULL_DUMP" = "1" ]; then
+  log "FULL 备份(含全部表数据)-> $dump"
+else
+  IFS=',' read -ra _ex <<< "$EXCLUDE_TABLE_DATA"
+  for tbl in "${_ex[@]}"; do
+    [ -n "$tbl" ] && dump_args+=(--exclude-table-data="$tbl")
+  done
+  log "CORE 备份(排除可再生数据: $EXCLUDE_TABLE_DATA;FULL_DUMP=1 可全量)-> $dump"
+fi
+docker exec "$PG_CONTAINER" pg_dump "${dump_args[@]}" "$PG_DB" > "$dump.tmp"
 mv "$dump.tmp" "$dump"
 
 # 3) 即时完整性检查(读得通才算成功)


### PR DESCRIPTION
## 背景(#757 首次实跑发现)
fojin 库 **16GB**,其中 `text_embeddings`(pgvector)**9.9GB / 62%**,且**可再生**(从 `text_contents` 经嵌入管线重算)。全量 `-Fc` dump 它 → ~10-13GB、单 CPU 跑 **>1h**(向量压不动)、压生产库、**逼近写满 14GB 空闲盘**(磁盘防御红线);每晚 7 份更不可能塞下。

## 改动
- **默认 CORE 备份** `--exclude-table-data=public.text_embeddings`:保留表结构(恢复后空表可重嵌),跳过 9.9GB 向量 → dump **~2GB、几分钟、盘安全**。所有不可再生数据(text_contents / mitra_alignments / alignment_pairs / 词典 / KG / 人物 / 用户…)仍**完整保留**。
- `FULL_DUMP=1` 含全部表(仅盘有富余 + 低峰)。
- `KEEP_DAILY` 7→3、`MIN_FREE_MB` 3072→4096,匹配 ~2GB dump 与受限生产盘;长期保留靠异地。
- 恢复说明注明:CORE 恢复后需重嵌才恢复语义搜索。

## 验证
两种模式 pg_dump 参数构造已 dry-run 验证;`bash -n` 通过。**已在 sg-vps 实跑 CORE 备份**(本 PR 逻辑),产物 + verify 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)