### PR TITLE
fix(nav): hide Dashboard (数据总览) tab, pending polish

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,7 +15,7 @@ import {
   RobotOutlined,
   GithubOutlined,
   GlobalOutlined,
-  BarChartOutlined,
+  // BarChartOutlined,   // dashboard nav deferred (pending polish)
   // FieldTimeOutlined,  // timeline nav deferred (pending polish)
   // NotificationOutlined,  // activity nav deferred (empty Source-Updates subtab)
 } from "@ant-design/icons";
@@ -79,7 +79,8 @@ export default function Layout() {
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
     { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
-    { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
+    // 数据总览(/dashboard)暂不放导航：待打磨后再上线（路由仍可直达 /dashboard）。
+    // { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
     // 历史时间线(/timeline)暂不放导航：待打磨后再上线（路由仍可直达 /timeline）。
     // { icon: <FieldTimeOutlined />, label: t("nav.timeline"), path: "/timeline" },
     // 佛学动态(/activity)仍暂不放导航：Source-Updates 子标签无数据流（空）；


### PR DESCRIPTION
用户反馈 fojin.app/dashboard 的「数据总览」tab 仍在导航里(未打磨好)。

同 #754(Timeline)处理:`/dashboard` 路由保留可直达,仅从导航移除该 tab。注释掉 nav 项及其现已未使用的 `BarChartOutlined` import(与已 deferred 的 `FieldTimeOutlined` 同一模式,CI 早已验证可过)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)