### PR TITLE
fix(chat): stop /chat/stream hanging on DetachedInstanceError

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -916,25 +916,26 @@ async def _load_and_render_attachments(
 
 
 async def _mark_attachments_consumed(
-    db: AsyncSession, attachments: list[ChatAttachment]
+    db: AsyncSession, pending_ids: list[int]
 ) -> None:
-    """Best-effort: stamp ``consumed_at`` so a future GC cron can prune
-    orphaned uploads. Failures here must not break the chat response —
-    the message is already saved by the time we get called.
+    """Best-effort: stamp ``consumed_at`` on the given attachment ids so a
+    future GC cron can prune orphaned uploads. Failures here must not break
+    the chat response — the message is already saved by the time we get
+    called.
 
-    Uses an explicit UPDATE rather than ``row.consumed_at = now`` because
-    ``attachments`` are loaded by ``_load_and_render_attachments`` in the
-    prep-phase session which closes before this runs (see
-    send_message_stream's two-phase session split). Mutating attributes
-    on detached rows silently no-ops on commit, which would defeat the
+    Takes plain ids rather than ORM rows: in the streaming path the
+    attachments are loaded by ``_load_and_render_attachments`` in the
+    prep-phase session, which closes (and rolls back, expiring its
+    instances) before this runs (see send_message_stream's two-phase
+    session split). Reading ``row.id`` / ``row.consumed_at`` on those
+    detached rows raises DetachedInstanceError — caught by the try/except
+    below, which would then silently SKIP the stamp and defeat the
     ``consumed_at IS NULL`` single-use mitigation that defends against
-    anonymous-upload id-enumeration (see schemas/chat.py
-    ``attachment_ids`` docstring). The UPDATE-by-id form persists
-    regardless of which session originally loaded the rows.
+    anonymous-upload id-enumeration (see schemas/chat.py ``attachment_ids``
+    docstring). Callers compute ``pending_ids`` while the rows are still
+    bound. The UPDATE keeps its own ``consumed_at IS NULL`` guard so a
+    concurrent consume doesn't overwrite the original timestamp.
     """
-    if not attachments:
-        return
-    pending_ids = [row.id for row in attachments if row.consumed_at is None]
     if not pending_ids:
         return
     now = datetime.now(UTC)
@@ -948,11 +949,6 @@ async def _mark_attachments_consumed(
             .values(consumed_at=now)
         )
         await db.commit()
-        # Patch in-memory rows so the caller's view (e.g. follow-up
-        # references via the same request) is coherent.
-        for row in attachments:
-            if row.consumed_at is None:
-                row.consumed_at = now
     except Exception:  # pragma: no cover — db quirks shouldn't surface to user
         logger.exception("Failed to mark attachments consumed")
         await db.rollback()
@@ -1173,7 +1169,11 @@ async def send_message(
         await _save_messages(db, chat_session.id, message, answer, sources)
         log_mutations(chat_session.id, _citation_mutations)
         log_quote_mutations(chat_session.id, _quote_mutations)
-        await _mark_attachments_consumed(db, attachments)
+        # Rows are still bound to this request session here, so reading
+        # .id/.consumed_at is safe (unlike the streaming save phase).
+        await _mark_attachments_consumed(
+            db, [a.id for a in attachments if a.consumed_at is None]
+        )
 
         # Auto-generate a better session title for new sessions (first message)
         if chat_session.title == message[:50]:
@@ -1310,6 +1310,10 @@ async def send_message_stream(
     # defeating the point of the split.
     prep_result = None
     prep_error: Exception | None = None
+    # Captured INSIDE the prep block (see below) as plain scalars so no
+    # detached ORM attribute is read after the session closes.
+    chat_session_id = 0
+    pending_attachment_ids: list[int] = []
     async with sessionmaker() as db_prep:
         try:
             # Production SSE path: resolve the user from the raw token inside
@@ -1332,6 +1336,25 @@ async def send_message_stream(
                 hot_question_id=hot_question_id, model_id=model_id,
                 attachment_ids=attachment_ids,
             )
+            # Capture the ORM rows' plain scalar values WHILE the instances
+            # are still bound to db_prep. On block exit, close() rolls back the
+            # still-open prep transaction (create_session's refresh() + quota
+            # flush() leave it open), and a rollback EXPIRES every instance —
+            # independent of expire_on_commit=False. Any lazy attribute read
+            # AFTER the block then raises DetachedInstanceError. For
+            # chat_session.id that killed the SSE generator before any answer
+            # or 'done' reached the client, so the frontend hung forever on
+            # "正在检索经文并生成回答". The same hazard applies to the
+            # attachment rows consumed in the post-stream save phase: reading
+            # their .id/.consumed_at there would raise inside
+            # _mark_attachments_consumed's try/except and silently skip the
+            # single-use consumed_at stamp (the anti-enumeration guard). So
+            # snapshot both here while still bound.
+            _prep_cs = prep_result[0]
+            chat_session_id = _prep_cs.id if _prep_cs else 0
+            pending_attachment_ids = [
+                a.id for a in prep_result[-1] if a.consumed_at is None
+            ]
         except (ValidationError, QuotaExceededError, AccessDeniedError, ServiceError) as exc:
             prep_error = exc
     # db_prep is closed here — connection returned to the pool before any
@@ -1353,12 +1376,15 @@ async def send_message_stream(
         return
 
     (
-        chat_session, api_url, api_key, model, is_byok, provider,
-        sources, llm_messages, attachments,
+        _chat_session, api_url, api_key, model, is_byok, provider,
+        sources, llm_messages, _attachments,
     ) = prep_result
+    # NOTE: ``_chat_session`` and ``_attachments`` are detached here (prep
+    # session closed) — never read their lazy attributes. Use the scalars
+    # ``chat_session_id`` / ``pending_attachment_ids`` captured above.
 
     # Yield session_id immediately so frontend gets a fast response
-    yield f"data: {json.dumps({'type': 'session_id', 'session_id': chat_session.id if chat_session else 0}, ensure_ascii=False)}\n\n"
+    yield f"data: {json.dumps({'type': 'session_id', 'session_id': chat_session_id}, ensure_ascii=False)}\n\n"
 
     # --- Phase 3: stream LLM (with fallback on connect-before-first-token failures) ---
     async def _stream_llm_once(u: str, k: str, m: str, p: str):
@@ -1484,7 +1510,7 @@ async def send_message_stream(
         "chat/stream phase-2 LLM done in %.2fs (%d chars, session_id=%s, provider=%s)",
         _time.monotonic() - phase2_start,
         len(full_answer),
-        chat_session.id if chat_session else 0,
+        chat_session_id,
         provider,
     )
 
@@ -1545,26 +1571,26 @@ async def send_message_stream(
     # this failure mode; the alternative (silently retry / different
     # storage path) is out of scope for this refactor.
     assistant_msg_id: int | None = None
-    if chat_session:
+    if chat_session_id:
         save_start = _time.monotonic()
         try:
             async with sessionmaker() as db_save:
                 assistant_msg_id = await _save_messages(
-                    db_save, chat_session.id, message, corrected_answer, sources
+                    db_save, chat_session_id, message, corrected_answer, sources
                 )
-                log_mutations(chat_session.id, _citation_mutations)
-                log_quote_mutations(chat_session.id, _quote_mutations)
-                await _mark_attachments_consumed(db_save, attachments)
+                log_mutations(chat_session_id, _citation_mutations)
+                log_quote_mutations(chat_session_id, _quote_mutations)
+                await _mark_attachments_consumed(db_save, pending_attachment_ids)
         except Exception:
             logger.exception(
                 "chat/stream phase-3 save failed; user got the reply but it is "
                 "not persisted (session_id=%s, user_id=%s)",
-                chat_session.id, user_id,
+                chat_session_id, user_id,
             )
         logger.info(
             "chat/stream phase-3 save %.2fs (session_id=%s, assistant_msg_id=%s)",
             _time.monotonic() - save_start,
-            chat_session.id,
+            chat_session_id,
             assistant_msg_id,
         )
         # db_save closed before the message_id yield below.

--- a/backend/tests/test_chat_stream_session_lifecycle.py
+++ b/backend/tests/test_chat_stream_session_lifecycle.py
@@ -272,34 +272,45 @@ async def test_quota_increment_uses_explicit_update():
 
 @pytest.mark.anyio
 async def test_attachments_consumed_uses_explicit_update():
-    """``_mark_attachments_consumed`` must persist via UPDATE statement,
-    not by setting ``row.consumed_at = now`` on rows loaded by a different
-    session. Same root cause as quota regression — detached rows ignored
-    by ``flush()``. Regression for code-review C2 (which has security
-    implications: ``consumed_at IS NULL`` is the anti-enumeration
-    mitigation for anonymous uploads, schemas/chat.py)."""
-    from unittest.mock import AsyncMock, MagicMock
+    """``_mark_attachments_consumed`` must persist via UPDATE statement on
+    plain ids, not by mutating ORM rows. It takes ``pending_ids: list[int]``
+    so the streaming caller can snapshot them while the rows are still bound
+    (the prep session detaches+expires them on close — reading .id there
+    would raise DetachedInstanceError and silently skip the stamp). Regression
+    for code-review C2 (security: ``consumed_at IS NULL`` is the
+    anti-enumeration mitigation for anonymous uploads, schemas/chat.py)."""
+    from unittest.mock import AsyncMock
 
     from app.services.chat import _mark_attachments_consumed
-
-    row1 = MagicMock()
-    row1.id = 11
-    row1.consumed_at = None
-    row2 = MagicMock()
-    row2.id = 22
-    row2.consumed_at = None
 
     db = AsyncMock()
     db.execute = AsyncMock()
     db.commit = AsyncMock()
 
-    await _mark_attachments_consumed(db, [row1, row2])
+    await _mark_attachments_consumed(db, [11, 22])
 
     assert db.execute.await_count == 1, (
         "_mark_attachments_consumed must issue an explicit UPDATE so "
-        "consumed_at persists for rows loaded by a foreign session."
+        "consumed_at persists for the given ids."
     )
     assert db.commit.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_empty_pending_ids_is_noop():
+    """No attachments → no UPDATE, no commit (fast path)."""
+    from unittest.mock import AsyncMock
+
+    from app.services.chat import _mark_attachments_consumed
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+
+    await _mark_attachments_consumed(db, [])
+
+    assert db.execute.await_count == 0
+    assert db.commit.await_count == 0
 
 
 @pytest.mark.anyio
@@ -362,3 +373,198 @@ async def test_anonymous_user_skips_save_phase():
         f"anonymous flow should open exactly one session (prep), got {len(counting.opens)}"
     )
     assert len(counting.closes) == 1
+
+
+class _DetachOnCloseSessionmaker:
+    """Sessionmaker that detaches a target row when its session closes —
+    faithfully reproducing SQLAlchemy's behaviour. The real prep session
+    leaves an open transaction (create_session's ``refresh()`` + quota
+    ``flush()`` never commit), so ``close()`` rolls it back, and a rollback
+    EXPIRES every loaded instance. Reading ``chat_session.id`` afterwards
+    then raises ``DetachedInstanceError``.
+
+    The first ``close`` (the prep session) flips ``row._detached`` so any
+    later ``.id`` read raises — exactly the production failure mode that the
+    legacy ``MagicMock`` fixture (``.id = 42``, never detaches) could not
+    catch.
+    """
+
+    def __init__(self, row):
+        self._row = row
+        self.closes = 0
+
+    def __call__(self):
+        outer = self
+
+        class _SessCM:
+            async def __aenter__(self_inner):
+                return AsyncMock()
+
+            async def __aexit__(self_inner, *_):
+                outer.closes += 1
+                outer._row._detached = True
+                return False
+
+        return _SessCM()
+
+
+class _DetachableSessionRow:
+    """Stand-in for a ChatSession ORM row: ``.id`` is readable while the
+    owning session is open, and raises ``DetachedInstanceError`` once the
+    session closes — the SQLAlchemy contract after a rollback-on-close."""
+
+    def __init__(self, real_id: int):
+        self._real_id = real_id
+        self._detached = False
+
+    @property
+    def id(self) -> int:
+        if self._detached:
+            from sqlalchemy.orm.exc import DetachedInstanceError
+
+            raise DetachedInstanceError(
+                "Instance <ChatSession> is not bound to a Session; "
+                "attribute refresh operation cannot proceed"
+            )
+        return self._real_id
+
+
+@pytest.mark.anyio
+async def test_session_id_read_before_prep_session_closes():
+    """``chat_session.id`` must be captured INSIDE the prep ``async with``
+    block, while the ORM row is still bound. The prep session's
+    rollback-on-close expires the row, so any ``.id`` read AFTER the block
+    raises ``DetachedInstanceError`` — the SSE generator then dies before
+    emitting any answer or ``done``, and the frontend hangs forever on
+    "正在检索经文并生成回答".
+
+    Regression for the production incident where new-conversation chats
+    stuck in that state. The pre-fix code read ``chat_session.id`` at the
+    ``session_id`` yield (and again in the save phase); this test detaches
+    the row exactly when the prep session closes, so the buggy path raises
+    and the fixed path (int captured in-block) yields ``session_id: 42``.
+    """
+    sources = _make_fake_sources()
+    row = _DetachableSessionRow(42)
+    prepare_return = (
+        row, "https://api.example.com/v1", "fake-key", "test-model",
+        False, "openai", sources, [{"role": "user", "content": "测试"}], [],
+    )
+    sessionmaker = _DetachOnCloseSessionmaker(row)
+    mock_client_cls = _make_mock_httpx_client(["般", "若"])
+
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
+         patch("app.services.chat._mark_attachments_consumed", new_callable=AsyncMock), \
+         patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
+        from app.services.chat import send_message_stream
+
+        chunks = []
+        async for chunk in send_message_stream(
+            user_id=1, message="测试", sessionmaker=sessionmaker,
+        ):
+            chunks.append(chunk)
+
+    # The session_id event must carry the real id (42), captured before the
+    # prep session closed. Pre-fix this read raised DetachedInstanceError and
+    # the generator never reached this event.
+    sid_events = [c for c in chunks if '"type": "session_id"' in c]
+    assert sid_events, f"no session_id event emitted; chunks={chunks!r}"
+    assert '"session_id": 42' in sid_events[0], (
+        f"session_id must be the captured int 42, got {sid_events[0]!r}"
+    )
+    # And the stream finished cleanly — the user gets a terminal event so the
+    # UI leaves the "正在检索…" state.
+    assert any('"type": "done"' in c for c in chunks), (
+        f"done event missing — frontend would hang. chunks={chunks!r}"
+    )
+
+
+class _DetachableAttachmentRow:
+    """ChatAttachment stand-in: ``.id`` / ``.consumed_at`` readable while the
+    prep session is bound, raising once it closes — the same rollback-on-close
+    contract as the chat_session row."""
+
+    def __init__(self, real_id: int):
+        self._real_id = real_id
+        self._detached = False
+
+    def _check(self):
+        if self._detached:
+            from sqlalchemy.orm.exc import DetachedInstanceError
+
+            raise DetachedInstanceError(
+                "Instance <ChatAttachment> is not bound to a Session"
+            )
+
+    @property
+    def id(self) -> int:
+        self._check()
+        return self._real_id
+
+    @property
+    def consumed_at(self):
+        self._check()
+        return None
+
+
+@pytest.mark.anyio
+async def test_attachment_ids_captured_before_prep_session_closes():
+    """The streaming save phase must call ``_mark_attachments_consumed`` with
+    plain ids snapshotted INSIDE the prep block — never the detached ORM
+    rows. After the prep session closes (rollback-on-close), reading
+    ``row.id`` / ``row.consumed_at`` raises DetachedInstanceError, which
+    ``_mark_attachments_consumed``'s try/except would swallow — silently
+    skipping the ``consumed_at`` stamp and defeating the single-use
+    anti-enumeration guard for anonymous uploads.
+
+    Locks the contract: the save call receives ``[7]`` (the captured int),
+    not the row object. A revert to passing rows fails this assertion.
+    """
+    sources = _make_fake_sources()
+    chat_row = _DetachableSessionRow(1)
+    attach_row = _DetachableAttachmentRow(7)
+    prepare_return = (
+        chat_row, "https://api.example.com/v1", "fake-key", "test-model",
+        False, "openai", sources, [{"role": "user", "content": "测试"}],
+        [attach_row],
+    )
+
+    mock_client_cls = _make_mock_httpx_client(["般", "若"])
+    mark_spy = AsyncMock()
+
+    # The prep close must detach BOTH rows (they belong to the same session).
+    class _BothDetachSessionmaker:
+        def __call__(self_inner):
+            class _SessCM:
+                async def __aenter__(self_cm):
+                    return AsyncMock()
+
+                async def __aexit__(self_cm, *_):
+                    chat_row._detached = True
+                    attach_row._detached = True
+                    return False
+
+            return _SessCM()
+
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
+         patch("app.services.chat._mark_attachments_consumed", mark_spy), \
+         patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
+        from app.services.chat import send_message_stream
+
+        chunks = []
+        async for chunk in send_message_stream(
+            user_id=1, message="测试", sessionmaker=_BothDetachSessionmaker(),
+        ):
+            chunks.append(chunk)
+
+    assert mark_spy.await_count == 1, (
+        f"_mark_attachments_consumed must be called once; chunks={chunks!r}"
+    )
+    passed_ids = mark_spy.await_args.args[1]
+    assert passed_ids == [7], (
+        "save phase must pass plain ids captured before the prep session "
+        f"closed, not detached rows. got {passed_ids!r}"
+    )
+    assert any('"type": "done"' in c for c in chunks)


### PR DESCRIPTION
## 症状
AI 问答（`/chat/stream`）卡在 **"正在检索经文并生成回答"**，永不返回答案。生产日志报 `sqlalchemy.orm.exc.DetachedInstanceError`。

## 根因（已用 traceback + 代码 + 复现确认）
`send_message_stream` 在 prep 阶段的 `async with db_prep` 块**关闭后**才读取 `chat_session.id`：
- `create_session` 以 `commit()` + `refresh()` 结尾 → `refresh` 开启一个**新事务**；其后的配额 `flush()`、history/RAG 的 SELECT 都让该事务保持**未提交打开**。
- 块退出时 `close()` 回滚这个打开的事务，而 **rollback 会 expire 所有 ORM 实例**（与 `expire_on_commit=False` 无关）。
- 于是 detached + expired 的 `chat_session.id` 读取触发懒加载 → `DetachedInstanceError` → SSE 生成器在吐出任何 token / 终止事件 `done` **之前**就死掉 → 前端永远停在 "正在检索经文并生成回答"。

任何**已登录用户开启新对话**（走 `create_session`）都会触发——正是本次报障路径（登录 + BYOK deepseek + 新对话），生产 `DetachedInstanceError` 时间戳与报障截图吻合。

## 修复
- 在 prep 块内（实例仍 bound 时）把 `chat_session.id` 捕获成纯 `int chat_session_id`，下游全部用它（session_id 事件 / 日志 / 保存阶段）。
- **同根因的兄弟 bug**：保存阶段的 `_mark_attachments_consumed` 读取 prep 会话里加载（已 detach）的附件行 `row.id`/`row.consumed_at`，该读取在它自己的 try/except 里抛错被吞，**静默跳过 `consumed_at` 单次使用标记**（匿名上传防枚举护栏失效）。改为在块内快照 `pending_attachment_ids`，函数改收纯 ids；非流式 `send_message` 的行仍 bound，inline 计算 ids。

## 回归测试
新增测试在 prep 会话关闭的**那一刻** detach 行（旧的 `MagicMock` fixture 永不 detach，这正是 bug 漏网的原因）：
- `test_session_id_read_before_prep_session_closes`
- `test_attachment_ids_captured_before_prep_session_closes`

两者在 buggy 代码上**失败**（复现真实 `DetachedInstanceError` / 传入 detached 行），在修复后**通过**——已用 edit-test-revert 验证。

## 验证
- `ruff check` 全过
- 全部 chat/attachment/stream 测试 **52 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)