### PR TITLE
perf: unblock event loop on attachment upload + parallelize RAG vector searches

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from pathlib import Path
 from uuid import uuid4
@@ -171,9 +172,12 @@ async def upload_chat_attachment(
     upload_dir.mkdir(parents=True, exist_ok=True)
     disk_name = f"{uuid4().hex}{ext}"
     storage_path = str(upload_dir / disk_name)
+    # Disk write and parse both run off the event loop: a 10MB PDF parse is
+    # 200-500ms of pure-CPU pypdf/docx work and would otherwise freeze the
+    # whole worker (stalling every concurrent request, including in-flight
+    # /chat/stream) for the duration of one upload.
     try:
-        with open(storage_path, "wb") as fh:
-            fh.write(file_bytes)
+        await asyncio.to_thread(Path(storage_path).write_bytes, file_bytes)
     except OSError as exc:
         logger.exception("Failed to persist chat attachment to disk")
         raise HTTPException(status_code=500, detail=f"文件保存失败：{exc}") from exc
@@ -181,7 +185,9 @@ async def upload_chat_attachment(
     parsed_text: str | None = None
     parse_error: str | None = None
     try:
-        parsed_text = parse_attachment(file_bytes, filename, file.content_type or "")
+        parsed_text = await asyncio.to_thread(
+            parse_attachment, file_bytes, filename, file.content_type or ""
+        )
     except ValueError as exc:
         parse_error = str(exc)[:500]
         logger.info("Attachment parse failed for %s: %s", filename, parse_error)

--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -1,5 +1,6 @@
 """RAG retrieval: pgvector semantic similarity search + reranking."""
 
+import asyncio
 import logging
 import re
 import time
@@ -12,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.config import settings
+from app.database import async_session
 from app.models.dictionary import DictionaryEntry
 from app.schemas.chat import ChatSource
 from app.services.embedding import generate_embedding, similarity_search, source_similarity_search
@@ -594,16 +596,43 @@ async def retrieve_rag_context(
             # Per-language top-k retrieval, then alignment-aware merging.
             # scope_text_ids (master persona mode) bypasses parallel mode
             # since master's scriptures are already filtered to a specific set.
-            lzh_hits = await similarity_search(db, query_embedding, limit=PARALLEL_LZH_K, lang_list=["lzh"])
-            pi_hits = await similarity_search(db, query_embedding, limit=PARALLEL_PI_K, lang_list=["pi"])
-            bo_hits = await similarity_search(db, query_embedding, limit=PARALLEL_BO_K, lang_list=["bo"])
+            #
+            # The three language searches and the source search are mutually
+            # independent (same query_embedding, no shared state), so run them
+            # concurrently instead of serially. Each MUST get its own session:
+            # one AsyncSession multiplexes a single asyncpg connection and
+            # cannot run concurrent queries ("another operation is in progress").
+            # Returned rows are plain dicts, so they stay valid after the
+            # session closes. During this sub-second window an in-flight
+            # /chat/stream holds up to 5 pooled connections (1 prep session +
+            # 4 search) before the LLM-streaming phase releases them all
+            # (pool 10+20) — fine at this site's concurrency, but watch
+            # pg_stat_activity if traffic grows.
+            async def _vsearch(limit, lang_list):
+                async with async_session() as s:
+                    return await similarity_search(
+                        s, query_embedding, limit=limit, lang_list=lang_list
+                    )
+
+            async def _ssearch():
+                async with async_session() as s:
+                    return await source_similarity_search(
+                        s, query_embedding, limit=3, min_score=0.5
+                    )
+
+            lzh_hits, pi_hits, bo_hits, source_results = await asyncio.gather(
+                _vsearch(PARALLEL_LZH_K, ["lzh"]),
+                _vsearch(PARALLEL_PI_K, ["pi"]),
+                _vsearch(PARALLEL_BO_K, ["bo"]),
+                _ssearch(),
+            )
             text_results = _merge_with_alignment_sync(lzh_hits, pi_hits, bo_hits)
         else:
             text_results = await similarity_search(
                 db, query_embedding, limit=pgvector_limit, scope_text_ids=scope_text_ids
             )
+            source_results = await source_similarity_search(db, query_embedding, limit=3, min_score=0.5)
 
-        source_results = await source_similarity_search(db, query_embedding, limit=3, min_score=0.5)
         logger.debug("TIMING: pgvector search took %.2fs", time.monotonic() - t1)
 
         # Filter out low-relevance chunks and deduplicate by (text_id, juan_num)


### PR DESCRIPTION
Tier-0 性能优化（来自 2026-06-18 重构评估，两处独立、纯性能、行为等价）。

## 1. `chat.py`：附件解析 + 写盘移出事件循环
`upload_chat_attachment` 在 `async def` 里同步 `open().write()` 写盘 + 同步 `parse_attachment()`（pypdf/python-docx，10MB PDF 约 200-500ms 纯 CPU），上传期间**冻结整个 worker**，拖住所有并发请求（含正在流式的 `/chat/stream`）。两处都改 `asyncio.to_thread`，行为不变。

## 2. `rag_retrieval.py`：并行 RAG 向量检索
parallel-RAG 模式下三路 per-language pgvector（lzh/pi/bo）+ source 检索本是**互相独立**（同一 query_embedding、无共享状态）却串行 await（~4×~50ms HNSW ≈ 200ms）。改 `asyncio.gather` 并发。

每个查询用**独立 session**：单个 `AsyncSession` 复用一条 asyncpg 连接，不能并发多查询（"another operation is in progress"）。返回的是 plain dict，session 关闭后仍有效。检索窗口内单条 /chat/stream 峰值持 5 连接（1 prep + 4 search），LLM 流式阶段全部释放（池 10+20），本站并发下充裕。

## 验证
- ruff（E/F/I/UP/B/SIM/RUF，line 120）：改动文件干净（唯一 finding 是既有的 rag_retrieval.py:158 RUF005，非本 PR）
- 本地测试：88（附件/RAG）+ 44（召回/stream）全过
- code-review（senior reviewer subagent）：Ready to merge，零 Critical/Important，已采纳其连接数注释更正

## 部署提醒
改 `backend/app/` = live-API 路径，merge 后 CD 会重启 backend 容器。**须确认无正在跑的长任务（如 Batch 2a 般若对齐脚本）再 merge**，否则会被重启杀掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)