### PR TITLE
perf(kg): stop ForceGraph sim rebuilds + surface CBETA lookup failures

### DIFF
--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -15,6 +15,7 @@ import {
   FileImageOutlined,
   VerticalAlignTopOutlined,
 } from "@ant-design/icons";
+import { api } from "../api/client";
 import collections, {
   RESOURCE_CATEGORIES,
   type Collection,
@@ -302,10 +303,17 @@ export default function CollectionsPage() {
       [...c.mainTexts, ...c.commentaries].map((t) => t.cbeta_id).filter(Boolean),
     );
     if (allIds.length === 0) return;
-    fetch(`/api/texts/lookup-cbeta?ids=${encodeURIComponent(allIds.join(","))}`)
-      .then((r) => r.json())
-      .then((data) => setCbetaMap(data))
-      .catch(() => {});
+    // Go through the shared axios instance (interceptors + non-2xx → throw)
+    // instead of a bare fetch whose `.then(r => r.json())` ignored the status
+    // and whose `.catch(() => {})` swallowed failures silently. CBETA links are
+    // progressive enhancement, so a failure still degrades gracefully — but it
+    // must be visible in the console, not dropped.
+    api
+      .get<Record<string, number>>("/texts/lookup-cbeta", { params: { ids: allIds.join(",") } })
+      .then((r) => setCbetaMap(r.data))
+      .catch((err) => {
+        console.warn("CBETA id 映射加载失败，相关外链将不可用", err);
+      });
   }, []);
 
   const filtered = useMemo(() => {

--- a/frontend/src/pages/KnowledgeGraphPage.tsx
+++ b/frontend/src/pages/KnowledgeGraphPage.tsx
@@ -375,11 +375,19 @@ export default function KnowledgeGraphPage() {
     if (isMobile) setMobileTab("graph");
   };
 
-  const handleGraphNodeClick = (node: { id: number }) => {
-    setSelectedEntityId(node.id);
-    // 移动端：点击图谱节点后自动切到详情 Tab
-    if (isMobile) setMobileTab("detail");
-  };
+  // Memoised so its identity is stable across KGPage re-renders. ForceGraph's
+  // d3 effect lists onNodeClick in its deps; an inline function would be a new
+  // reference every render and rebuild the entire force simulation (selectAll
+  // remove + re-layout) on any unrelated state change. onNodeExpand is already
+  // memoised for the same reason.
+  const handleGraphNodeClick = useCallback(
+    (node: { id: number }) => {
+      setSelectedEntityId(node.id);
+      // 移动端：点击图谱节点后自动切到详情 Tab
+      if (isMobile) setMobileTab("detail");
+    },
+    [isMobile],
+  );
 
   // 点击「推荐探索」入口：相当于一次带类型过滤的搜索
   const handleCurated = (label: string, type: string) => {


### PR DESCRIPTION
Tier-0 前端修复（来自 2026-06-18 重构评估，两处独立、纯前端、行为等价）。

## 1. ForceGraph 仿真重建（#4）
`handleGraphNodeClick` 是内联函数，每次 KGPage re-render 都是新引用。ForceGraph 的 d3 effect 把 `onNodeClick` 列入 deps，导致任何无关 state 变化（搜索框、tooltip、切 tab）都 `selectAll.remove()` + 重启整个力导向仿真——即"一交互图谱就抖一下"。改 `useCallback([isMobile])`（`onNodeExpand` 早已同理 memo 化）。已确认 effect 里 `showTooltip/hideTooltip` 已是 useCallback、`t` 稳定，故 `onNodeClick` 是唯一不稳定 dep。

## 2. CollectionsPage CBETA 查询静默失败（#7）
裸 `fetch` 的 `.then(r=>r.json())` 不查 HTTP 状态、`.catch(()=>{})` 静默吞错，查询失败时外链坏掉无任何信号（非 2xx 时旧码还可能把错误体塞进 cbetaMap）。改走共享 axios 实例（拦截器 + 非 2xx 自动抛）+ `console.warn`。链接仍是渐进增强、优雅降级，但失败现在可见。

## 验证
- 改动经 lint 规则核对：无 `no-console` 规则、`exhaustive-deps` 对 `[isMobile]` 正确（setter 稳定不入 deps）
- code-review（senior frontend reviewer subagent）：Ready to merge，零 Critical/Important；类型契约 `Record<string,number>` 保持
- 本地无 node_modules，tsc/eslint/vitest/build 由 CI 验证（见下方 checks）

## 部署提醒
纯前端改动：merge 后走 frontend rebuild（不重启 backend，不影响长任务）。按惯例 merge 后需手动 `docker compose build frontend` 并抓 lazy chunk 验证（前端 CD 不可靠）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)