### PR TITLE
test: fix 7 stale tests and drop the CI bypass that hid them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip install ruff==0.9.7 && ruff check app/
 
       - name: Run tests
-        run: python -m pytest -q tests/ --ignore=tests/test_annotations_workflow.py -k "not test_kg_entity_detail"
+        run: python -m pytest -q tests/
 
   frontend:
     name: Frontend build

--- a/backend/tests/test_annotations_workflow.py
+++ b/backend/tests/test_annotations_workflow.py
@@ -3,6 +3,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from app.core.exceptions import AccessDeniedError, ValidationError
 from app.services.annotation import (
     create_annotation,
     submit_annotation,
@@ -41,34 +42,28 @@ async def test_submit_draft_to_pending():
 
 @pytest.mark.anyio
 async def test_submit_non_draft_raises():
-    """submit_annotation on a non-draft annotation should raise 400."""
-    from fastapi import HTTPException
-
+    """submit_annotation on a non-draft annotation should raise ValidationError (→ 422)."""
     ann = _make_annotation(status="pending", user_id=1)
     mock_session = AsyncMock()
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = ann
     mock_session.execute.return_value = mock_result
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(ValidationError):
         await submit_annotation(mock_session, annotation_id=1, user_id=1)
-    assert exc_info.value.status_code == 400
 
 
 @pytest.mark.anyio
 async def test_submit_wrong_user_raises():
-    """submit_annotation by a different user should raise 403."""
-    from fastapi import HTTPException
-
+    """submit_annotation by a different user should raise AccessDeniedError (→ 403)."""
     ann = _make_annotation(status="draft", user_id=1)
     mock_session = AsyncMock()
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = ann
     mock_session.execute.return_value = mock_result
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(AccessDeniedError):
         await submit_annotation(mock_session, annotation_id=1, user_id=999)
-    assert exc_info.value.status_code == 403
 
 
 @pytest.mark.anyio
@@ -80,7 +75,7 @@ async def test_review_approve():
     mock_result.scalar_one_or_none.return_value = ann
     mock_session.execute.return_value = mock_result
 
-    with patch("app.services.annotation.AnnotationReview"):
+    with patch("app.models.annotation.AnnotationReview"):
         result = await review_annotation(mock_session, 1, reviewer_id=2, action="approve")
     assert result.status == "approved"
 
@@ -94,7 +89,7 @@ async def test_review_reject():
     mock_result.scalar_one_or_none.return_value = ann
     mock_session.execute.return_value = mock_result
 
-    with patch("app.services.annotation.AnnotationReview"):
+    with patch("app.models.annotation.AnnotationReview"):
         result = await review_annotation(mock_session, 1, reviewer_id=2, action="reject")
     assert result.status == "rejected"
 
@@ -108,22 +103,19 @@ async def test_review_request_change():
     mock_result.scalar_one_or_none.return_value = ann
     mock_session.execute.return_value = mock_result
 
-    with patch("app.services.annotation.AnnotationReview"):
+    with patch("app.models.annotation.AnnotationReview"):
         result = await review_annotation(mock_session, 1, reviewer_id=2, action="request_change")
     assert result.status == "draft"
 
 
 @pytest.mark.anyio
 async def test_review_non_pending_raises():
-    """review_annotation on a non-pending annotation should raise 400."""
-    from fastapi import HTTPException
-
+    """review_annotation on a non-pending annotation should raise ValidationError (→ 422)."""
     ann = _make_annotation(status="draft", user_id=1)
     mock_session = AsyncMock()
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = ann
     mock_session.execute.return_value = mock_result
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(ValidationError):
         await review_annotation(mock_session, 1, reviewer_id=2, action="approve")
-    assert exc_info.value.status_code == 400

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -320,6 +320,14 @@ async def test_kg_entity_detail(client):
     # Mock the DB session; get_entity() calls session.get(KGEntity, id)
     mock_session = AsyncMock()
     mock_session.get = AsyncMock(return_value=fake_entity)
+    # The detail route also calls get_entity_relations(), which runs
+    # session.execute(...).fetchall(). Without configuring it, AsyncMock
+    # returns a coroutine for fetchall() and the relations comprehension
+    # raises "TypeError: 'coroutine' object is not iterable". This entity
+    # has no relations in the smoke test.
+    mock_relations_result = MagicMock()
+    mock_relations_result.fetchall.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_relations_result)
 
     app.dependency_overrides[real_get_db] = lambda: mock_session
     try:


### PR DESCRIPTION
Tier-0 工程健康（来自 2026-06-18 重构评估，#6）。纯测试 + CI，**零生产代码改动**。

## 问题
CI 跑 `pytest --ignore=tests/test_annotations_workflow.py -k "not test_kg_entity_detail"`，静默跳过 7 个本地红的测试（566 pass / 7 fail）——CI 绿但不诚实，本地开发者跑全套见红。7 个失败**全是测试侧陈旧 mock/契约，生产代码无 bug**。

## 修复
- **test_kg_entity_detail**：只 mock 了 `session.get`，但详情路由还调 `get_entity_relations()` → `session.execute(...).fetchall()`，未配置的 AsyncMock 返回 coroutine → `TypeError`。配 `execute()` 返回空 `fetchall()`。
- **test_annotations_workflow（6 个）**：
  - 3 个断言 `HTTPException` 400/403，但服务抛自定义 `ValidationError`(→422)/`AccessDeniedError`(→403)（经全局 handler 映射）。断言改为真实异常类型。
  - 3 个 review 测试 patch `app.services.annotation.AnnotationReview`，但那是函数内局部 import；改 patch **源模块** `app.models.annotation.AnnotationReview`（无需改生产码）。
- **ci.yml**：删除 `--ignore`/`-k` 绕过，全套恢复在每个 PR 上运行。

## 验证
- 全套 `pytest tests/`：**566 passed / 0 failed**（删绕过前已确认零失败，删之安全）
- `git diff origin/master -- backend/app/` 为空（零生产改动）
- code-review（senior reviewer subagent）：Ready to merge；已采纳其 STATUS_MAP 准确性更正（ValidationError→422 非 400）

## 部署提醒
纯 tests/ + .github/ → deploy.sh 判为非 live-API 路径，**不重启 backend、不影响长任务**，可随时 merge。

🤖 Generated with [Claude Code](https://claude.com/claude-code)