### PR TITLE
perf(kg): cache /kg/stats + /kg/timeline, jitter cache TTLs

### DIFF
--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -5,11 +5,14 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.cache import jittered_ttl
 from app.core.exceptions import KGEntityNotFoundError
 from app.database import get_db
 
 KG_GEO_CACHE_TTL = 1800  # 30 min
 KG_LINEAGE_CACHE_TTL = 1800
+KG_STATS_CACHE_TTL = 3600  # 1 hour — recomputed on import, fine to be ~1h stale
+KG_TIMELINE_CACHE_TTL = 3600
 from app.schemas.knowledge_graph import (
     KGEntityDetailResponse,
     KGEntityResponse,
@@ -122,15 +125,31 @@ async def get_kg_entity_graph(
 
 
 @router.get("/stats")
-async def kg_stats(db: AsyncSession = Depends(get_db)):
+async def kg_stats(request: Request, db: AsyncSession = Depends(get_db)):
     """Get knowledge graph statistics (entity and relation counts by type).
 
-    获取知识图谱统计信息（各类型实体与关系数量）。"""
-    return await get_kg_stats(db)
+    获取知识图谱统计信息（各类型实体与关系数量）。
+
+    Cached: the underlying query is two full GROUP BY COUNT(*) scans over
+    kg_entities/kg_relations and the result only changes when the KG is
+    re-imported, so a ~1h cache is plenty and keeps the dashboard off the
+    hot path."""
+    redis_client = getattr(request.app.state, "redis", None)
+    cache_key = "kg:stats"
+    if redis_client:
+        cached = await redis_client.get(cache_key)
+        if cached:
+            return Response(content=cached, media_type="application/json")
+    stats = await get_kg_stats(db)
+    payload = json.dumps(stats, ensure_ascii=False, default=str)
+    if redis_client:
+        await redis_client.setex(cache_key, jittered_ttl(KG_STATS_CACHE_TTL), payload)
+    return Response(content=payload, media_type="application/json")
 
 
 @router.get("/timeline", response_model=KGTimelineResponse)
 async def get_kg_timeline(
+    request: Request,
     entity_type: str | None = Query(
         None,
         description="Filter by entity type (e.g. 'person', 'dynasty'). Omit for all temporal entities.",
@@ -140,12 +159,30 @@ async def get_kg_timeline(
 ):
     """Get knowledge graph entities with temporal data for timeline display.
 
-    返回携带有效起始年份的知识图谱实体，用于时间轴可视化。BCE年份以负整数表示。"""
+    返回携带有效起始年份的知识图谱实体，用于时间轴可视化。BCE年份以负整数表示。
+
+    Cached like /stats: scans kg_entities filtering on the JSON year fields
+    and only changes on KG re-import."""
+    redis_client = getattr(request.app.state, "redis", None)
+    cache_key = None
+    if redis_client:
+        key_payload = json.dumps(
+            {"t": entity_type, "l": limit}, sort_keys=True, separators=(",", ":")
+        )
+        cache_key = f"kg:timeline:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
+        cached = await redis_client.get(cache_key)
+        if cached:
+            return Response(content=cached, media_type="application/json")
+
     entities, total = await get_timeline_entities(db, entity_type, limit)
-    return KGTimelineResponse(
+    response = KGTimelineResponse(
         entities=[KGTimelineEntity(**e) for e in entities],
         total=total,
     )
+    payload = response.model_dump_json()
+    if redis_client and cache_key:
+        await redis_client.setex(cache_key, jittered_ttl(KG_TIMELINE_CACHE_TTL), payload)
+    return Response(content=payload, media_type="application/json")
 
 
 @router.get("/geo", response_model=KGGeoResponse)
@@ -195,7 +232,7 @@ async def get_kg_geo_entities(
     )
     payload = response.model_dump_json()
     if redis_client and cache_key:
-        await redis_client.setex(cache_key, KG_GEO_CACHE_TTL, payload)
+        await redis_client.setex(cache_key, jittered_ttl(KG_GEO_CACHE_TTL), payload)
     return Response(content=payload, media_type="application/json")
 
 
@@ -228,7 +265,7 @@ async def get_kg_lineage_arcs(
     response = KGLineageArcsResponse(arcs=arcs, total=total)
     payload = response.model_dump_json()
     if redis_client and cache_key:
-        await redis_client.setex(cache_key, KG_LINEAGE_CACHE_TTL, payload)
+        await redis_client.setex(cache_key, jittered_ttl(KG_LINEAGE_CACHE_TTL), payload)
     return Response(content=payload, media_type="application/json")
 
 

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -12,8 +12,24 @@ The ``redis`` argument may be ``None`` (caching disabled), in which case
 
 import json
 import logging
+import random
 
 logger = logging.getLogger(__name__)
+
+
+def jittered_ttl(ttl: int, spread: float = 0.15) -> int:
+    """Apply ±spread random jitter to a TTL.
+
+    A batch of keys written in the same request/loop (e.g. the KG geo /
+    lineage / stats / timeline caches, or a sweep of stats keys) would
+    otherwise all expire on the same tick, so when a hot key lapses several
+    concurrent requests miss together and stampede the expensive backing
+    query at once. Spreading the expiry smooths that herd. Returns ≥1s.
+    """
+    delta = int(ttl * spread)
+    if delta <= 0:
+        return max(1, ttl)
+    return max(1, ttl + random.randint(-delta, delta))  # nosec B311 — jitter, not crypto
 
 
 async def cache_get(redis, key: str) -> dict | None:
@@ -34,6 +50,6 @@ async def cache_set(redis, key: str, value: dict, ttl: int) -> None:
     if redis is None:
         return
     try:
-        await redis.setex(key, ttl, json.dumps(value, ensure_ascii=False, default=str))
+        await redis.setex(key, jittered_ttl(ttl), json.dumps(value, ensure_ascii=False, default=str))
     except Exception:
         logger.debug("Cache set error for key=%s", key)


### PR DESCRIPTION
Tier-0 性能优化（来自 2026-06-18 重构评估，#3 + #8）。

## #3 缓存 /kg/stats 与 /kg/timeline
两个端点此前**零缓存**：`/kg/stats` 是两次全表 `GROUP BY COUNT(*)`，`/kg/timeline` 扫 kg_entities 的 JSON 年份字段——每次 dashboard/timeline 请求都在请求路径上重算（正是评估里点名的 kg_entities 全表 JSON 扫描）。结果只在 KG 重导入时变，故按同文件 `/kg/geo`、`/kg/lineage-arcs` 已有的**直接 redis + Response 模式**缓存 ~1h。

**这一步把 kg_entities 全表扫频率从"每请求"降到"~每小时一次"，是推迟 JSON→JSONB 列迁移的便宜大赢。**

## #8 TTL 抖动防雪崩
`core/cache.py` 加 `jittered_ttl()`（±15%），在 `cache_set` 及四个 KG `setex` 应用——同批写入的 key 不再同 tick 过期、避免热键失效瞬间并发穿透打爆后端查询。

## 验证
- ruff（E/F/I/UP/B/SIM/RUF）干净；bandit 无 issue（`# nosec B311` 已加）
- 全套 `pytest tests/`：7 failed / 559 passed —— 7 个是 **master 既有失败**（6 annotations + kg_entity_detail，由 PR #766 修），本改动**零新增失败**；11 个 KG 测试（含 timeline）全过
- code-review（senior reviewer subagent）：Ready to merge，**实证确认 JSON 字节等价** + Response-under-response_model 与 geo/lineage 同款安全

## 注意
- 缓存仅 TTL 过期、无主动失效：KG 重导入后 stats/timeline 最多 ~1h 陈旧（与 geo/lineage 现状一致）。如需即时刷新，可在导入脚本末尾 `DEL kg:stats kg:timeline:*`（follow-up）。

## 部署提醒
改 `backend/app/` = live-API 路径，merge 后重启 backend。**须确认无长任务（Batch 2a 对齐脚本）再 merge**。与 #764 同属"重启批次"。CI 在本分支会绿（master 仍含测试 bypass）；若先 merge #766 去掉 bypass，本分支 rebase 后全套应 566 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)