### PR TITLE
feat: 校勘异文 panel in text reader (apparatus UI)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -697,5 +697,12 @@
   "lang.nl": "Dutch",
   "lang.pt": "Portuguese",
   "lang.ne": "Nepali",
-  "lang.hi": "Hindi"
+  "lang.hi": "Hindi",
+  "reader.apparatus.toggle": "Apparatus",
+  "reader.apparatus.tooltip": "Critical apparatus (base text vs. Song/Yuan/Ming/Goryeo witnesses)",
+  "reader.apparatus.title": "Apparatus · Fascicle {{n}}",
+  "reader.apparatus.empty": "No critical apparatus for this fascicle",
+  "reader.apparatus.summary": "{{n}} variant readings against witness canons",
+  "reader.apparatus.omission": "(omitted)",
+  "reader.apparatus.corrector": "(corr. {{resp}})"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -697,5 +697,12 @@
   "lang.nl": "荷蘭文",
   "lang.pt": "葡萄牙文",
   "lang.ne": "尼泊爾文",
-  "lang.hi": "印地文"
+  "lang.hi": "印地文",
+  "reader.apparatus.toggle": "校勘",
+  "reader.apparatus.tooltip": "校勘異文（底本與宋/元/明等校本的異讀）",
+  "reader.apparatus.title": "校勘異文 · 第{{n}}卷",
+  "reader.apparatus.empty": "此卷暫無校勘異文",
+  "reader.apparatus.summary": "底本與宋 / 元 / 明 / 麗等校本的異讀，共 {{n}} 條",
+  "reader.apparatus.omission": "（無此字）",
+  "reader.apparatus.corrector": "（{{resp}} 校）"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -697,5 +697,12 @@
   "lang.nl": "荷兰文",
   "lang.pt": "葡萄牙文",
   "lang.ne": "尼泊尔文",
-  "lang.hi": "印地文"
+  "lang.hi": "印地文",
+  "reader.apparatus.toggle": "校勘",
+  "reader.apparatus.tooltip": "校勘异文（底本与宋/元/明等校本的异读）",
+  "reader.apparatus.title": "校勘异文 · 第{{n}}卷",
+  "reader.apparatus.empty": "此卷暂无校勘异文",
+  "reader.apparatus.summary": "底本与宋 / 元 / 明 / 麗等校本的异读，共 {{n}} 条",
+  "reader.apparatus.omission": "（无此字）",
+  "reader.apparatus.corrector": "（{{resp}} 校）"
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -539,6 +539,33 @@ export async function getJuanLanguages(textId: number, juanNum: number): Promise
   return data;
 }
 
+// Critical apparatus (校勘异文)
+export interface ApparatusReadingItem {
+  reading: string;
+  witnesses: string[];
+  resp: string | null;
+  is_omission: boolean;
+}
+
+export interface ApparatusEntryItem {
+  char_start: number;
+  char_end: number;
+  lemma: string;
+  lemma_siglum: string | null;
+  readings: ApparatusReadingItem[];
+}
+
+export interface JuanApparatusResponse {
+  text_id: TextId;
+  juan_num: number;
+  entries: ApparatusEntryItem[];
+}
+
+export async function getJuanApparatus(textId: number, juanNum: number): Promise<JuanApparatusResponse> {
+  const { data } = await api.get<JuanApparatusResponse>(`/texts/${textId}/juans/${juanNum}/apparatus`);
+  return data;
+}
+
 // Content search
 export async function searchContent(params: {
   q: string;

--- a/frontend/src/components/ApparatusPanel.tsx
+++ b/frontend/src/components/ApparatusPanel.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { Drawer, List, Tag, Typography, Empty, Spin, Space } from "antd";
 import { getJuanApparatus, type ApparatusEntryItem } from "../api/client";
 
@@ -17,11 +18,8 @@ interface ApparatusPanelProps {
  * (宋/元/明/麗…). Footnote-style list; inline highlighting is a later iteration
  * (the reader reflows text, so char offsets don't map to the rendered DOM).
  */
-function readingText(reading: string, isOmission: boolean): string {
-  return isOmission ? "（無此字）" : reading;
-}
-
 export default function ApparatusPanel({ textId, juanNum, visible, onClose }: ApparatusPanelProps) {
+  const { t } = useTranslation();
   const { data, isLoading } = useQuery({
     queryKey: ["juanApparatus", textId, juanNum],
     queryFn: () => getJuanApparatus(textId, juanNum),
@@ -32,7 +30,7 @@ export default function ApparatusPanel({ textId, juanNum, visible, onClose }: Ap
 
   return (
     <Drawer
-      title={`校勘异文 · 第${juanNum}卷`}
+      title={t("reader.apparatus.title", { n: juanNum })}
       placement="right"
       width={440}
       open={visible}
@@ -43,11 +41,11 @@ export default function ApparatusPanel({ textId, juanNum, visible, onClose }: Ap
           <Spin />
         </div>
       ) : entries.length === 0 ? (
-        <Empty description="此卷暂无校勘异文" />
+        <Empty description={t("reader.apparatus.empty")} />
       ) : (
         <>
           <Text type="secondary" style={{ display: "block", marginBottom: 12 }}>
-            底本与宋 / 元 / 明 / 麗等校本的异读，共 {entries.length} 条
+            {t("reader.apparatus.summary", { n: entries.length })}
           </Text>
           <List
             size="small"
@@ -68,10 +66,10 @@ export default function ApparatusPanel({ textId, juanNum, visible, onClose }: Ap
                               {w}
                             </Tag>
                           ))}
-                          <Text>{readingText(r.reading, r.is_omission)}</Text>
+                          <Text>{r.is_omission ? t("reader.apparatus.omission") : r.reading}</Text>
                           {r.resp && (
                             <Text type="secondary" style={{ fontSize: 12 }}>
-                              （{r.resp} 校）
+                              {t("reader.apparatus.corrector", { resp: r.resp })}
                             </Text>
                           )}
                         </Space>

--- a/frontend/src/components/ApparatusPanel.tsx
+++ b/frontend/src/components/ApparatusPanel.tsx
@@ -1,0 +1,89 @@
+import { useQuery } from "@tanstack/react-query";
+import { Drawer, List, Tag, Typography, Empty, Spin, Space } from "antd";
+import { getJuanApparatus, type ApparatusEntryItem } from "../api/client";
+
+const { Text } = Typography;
+
+interface ApparatusPanelProps {
+  textId: number;
+  juanNum: number;
+  visible: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Critical apparatus (校勘异文) panel: lists this juan's variant readings —
+ * the base text (底本) lemma against the readings witnessed by other canons
+ * (宋/元/明/麗…). Footnote-style list; inline highlighting is a later iteration
+ * (the reader reflows text, so char offsets don't map to the rendered DOM).
+ */
+function readingText(reading: string, isOmission: boolean): string {
+  return isOmission ? "（無此字）" : reading;
+}
+
+export default function ApparatusPanel({ textId, juanNum, visible, onClose }: ApparatusPanelProps) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["juanApparatus", textId, juanNum],
+    queryFn: () => getJuanApparatus(textId, juanNum),
+    enabled: visible && !!textId,
+  });
+
+  const entries: ApparatusEntryItem[] = data?.entries ?? [];
+
+  return (
+    <Drawer
+      title={`校勘异文 · 第${juanNum}卷`}
+      placement="right"
+      width={440}
+      open={visible}
+      onClose={onClose}
+    >
+      {isLoading ? (
+        <div style={{ textAlign: "center", padding: 40 }}>
+          <Spin />
+        </div>
+      ) : entries.length === 0 ? (
+        <Empty description="此卷暂无校勘异文" />
+      ) : (
+        <>
+          <Text type="secondary" style={{ display: "block", marginBottom: 12 }}>
+            底本与宋 / 元 / 明 / 麗等校本的异读，共 {entries.length} 条
+          </Text>
+          <List
+            size="small"
+            dataSource={entries}
+            renderItem={(e) => (
+              <List.Item>
+                <div style={{ width: "100%" }}>
+                  <Space size={6} wrap>
+                    {e.lemma_siglum && <Tag color="gold">{e.lemma_siglum}</Tag>}
+                    <Text strong>{e.lemma}</Text>
+                  </Space>
+                  <div style={{ marginTop: 6 }}>
+                    {e.readings.map((r, i) => (
+                      <div key={i} style={{ marginTop: 2 }}>
+                        <Space size={4} wrap>
+                          {r.witnesses.map((w) => (
+                            <Tag key={w} style={{ marginInlineEnd: 0 }}>
+                              {w}
+                            </Tag>
+                          ))}
+                          <Text>{readingText(r.reading, r.is_omission)}</Text>
+                          {r.resp && (
+                            <Text type="secondary" style={{ fontSize: 12 }}>
+                              （{r.resp} 校）
+                            </Text>
+                          )}
+                        </Space>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </List.Item>
+            )}
+          />
+        </>
+      )}
+    </Drawer>
+  );
+}

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -15,11 +15,13 @@ import {
   HeartFilled,
   RobotOutlined,
   GlobalOutlined,
+  DiffOutlined,
 } from "@ant-design/icons";
 import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
 import CitationGenerator from "../components/CitationGenerator";
 import AnnotationPanel from "../components/AnnotationPanel";
+import ApparatusPanel from "../components/ApparatusPanel";
 import { ReaderDictPopover } from "../components/ReaderDictPopover";
 import { DICT_POPOVER_INIT, MAX_WORD_LEN, type DictPopoverState } from "../components/ReaderDictPopover.types";
 import ReaderAIPanel from "../components/ReaderAIPanel";
@@ -294,6 +296,7 @@ export default function TextReaderPage() {
   const [fontSize, setFontSize] = useState(getInitialFontSize);
   const [citationOpen, setCitationOpen] = useState(false);
   const [annotationOpen, setAnnotationOpen] = useState(false);
+  const [apparatusOpen, setApparatusOpen] = useState(false);
   const [parallelPanelOpen, setParallelPanelOpen] = useState(false);
 
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
@@ -737,6 +740,16 @@ export default function TextReaderPage() {
           >
             引用
           </Button>
+          <Tooltip title="校勘异文（底本与宋/元/明等校本的异读）">
+            <Button
+              size="small"
+              type={apparatusOpen ? "primary" : "default"}
+              icon={<DiffOutlined />}
+              onClick={() => setApparatusOpen((v) => !v)}
+            >
+              校勘
+            </Button>
+          </Tooltip>
           <Tooltip title="跨藏对照（其他版本 · 经级/段级对读）">
             <Button
               size="small"
@@ -875,6 +888,13 @@ export default function TextReaderPage() {
         juanNum={juanNum}
         visible={annotationOpen}
         onClose={() => setAnnotationOpen(false)}
+      />
+
+      <ApparatusPanel
+        textId={textId}
+        juanNum={juanNum}
+        visible={apparatusOpen}
+        onClose={() => setApparatusOpen(false)}
       />
 
     </div>

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Typography, Spin, Button, Select, Breadcrumb, Row, Col, message, Tooltip, Tag } from "antd";
@@ -294,6 +295,7 @@ export default function TextReaderPage() {
     return 1;
   });
   const [fontSize, setFontSize] = useState(getInitialFontSize);
+  const { t } = useTranslation();
   const [citationOpen, setCitationOpen] = useState(false);
   const [annotationOpen, setAnnotationOpen] = useState(false);
   const [apparatusOpen, setApparatusOpen] = useState(false);
@@ -740,14 +742,14 @@ export default function TextReaderPage() {
           >
             引用
           </Button>
-          <Tooltip title="校勘异文（底本与宋/元/明等校本的异读）">
+          <Tooltip title={t("reader.apparatus.tooltip")}>
             <Button
               size="small"
               type={apparatusOpen ? "primary" : "default"}
               icon={<DiffOutlined />}
               onClick={() => setApparatusOpen((v) => !v)}
             >
-              校勘
+              {t("reader.apparatus.toggle")}
             </Button>
           </Tooltip>
           <Tooltip title="跨藏对照（其他版本 · 经级/段级对读）">


### PR DESCRIPTION
## What
User-facing UI for the CBETA critical apparatus (校勘异文) shipped in #768. Adds a **校勘** toggle to the reader toolbar that opens a side panel listing the current juan's variant readings — base text (底本) lemma vs each witness canon (宋/元/明/麗…), omissions, and the corrector.

## How
- `ApparatusPanel.tsx` (antd Drawer): lazy-fetches `GET /texts/{id}/juans/{n}/apparatus` only when opened; lists entries as `【siglum】lemma → 【witnesses】reading`.
- `client.ts`: `getJuanApparatus` + types.
- `TextReaderPage.tsx`: 校勘 toggle button + panel wiring.

## Why a panel, not inline highlight
The reader's `reflowText` trims/concatenates/re-segments the body, so the raw-content char offsets the backend stores don't map to the rendered DOM. A footnote-style panel sidesteps that with zero offset-mapping risk and ships now. Inline highlighting is deferred to a later pass (cleaner once content is re-imported with the current parser — see #768 notes on content drift).

## Validation
- `tsc -b` + `vite build` clean.
- Backend API already live & verified (#768): T0001/X0240 return real variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)