### PR TITLE
fix(cross-canon): land on first aligned juan, not the densest (juan 76 → 1)

### DIFF
--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/alignment", tags=["alignment"])
 # Catalog merges alignment_pairs (small) with mitra_alignments (~896K rows).
 # A single UNION+GROUP BY with mode()/count(DISTINCT)/array_agg over 896K runs
 # ~77s on prod — far over the app statement_timeout (30s). Instead aggregate the
-# two sources separately (mitra side is a cheap count + mode(juan), ~7s) and
+# two sources separately (mitra side is a cheap count + min(juan), ~7s) and
 # merge in Python, then cache the result (mitra coverage changes only on import).
 #
 # Even split + merged the compute is ~20-25s on prod, which is the whole
@@ -724,7 +724,7 @@ async def compute_alignment_catalog(
                 SELECT n.lzh_id, n.other_lang, count(*) AS pair_count,
                        count(DISTINCT n.other_id) AS partner_count,
                        round(avg(n.confidence)::numeric, 2) AS avg_confidence,
-                       mode() WITHIN GROUP (ORDER BY n.lzh_juan) AS sample_juan,
+                       min(n.lzh_juan) AS sample_juan,
                        mode() WITHIN GROUP (ORDER BY n.other_id) AS sample_partner_id
                 FROM normalized n
                 GROUP BY n.lzh_id, n.other_lang
@@ -733,7 +733,7 @@ async def compute_alignment_catalog(
         )
     ).fetchall()
 
-    # 2. mitra side (mitra_alignments) — bulk; cheap count + mode(juan), NO join/
+    # 2. mitra side (mitra_alignments) — bulk; cheap count + min(juan), NO join/
     #    distinct/array_agg (those pushed the unified query to ~77s on 896K rows).
     #    Once mitra_e_score is backfilled, add: WHERE mitra_e_score >= 0.30
     mitra_rows = (
@@ -741,7 +741,7 @@ async def compute_alignment_catalog(
             sql_text(
                 """
                 SELECT text_id, foreign_lang, count(*) AS pair_count,
-                       mode() WITHIN GROUP (ORDER BY juan_num) AS sample_juan
+                       min(juan_num) AS sample_juan
                 FROM mitra_alignments
                 GROUP BY text_id, foreign_lang
                 """

--- a/frontend/src/components/CrossCanonEntry.tsx
+++ b/frontend/src/components/CrossCanonEntry.tsx
@@ -31,7 +31,8 @@ export default function CrossCanonEntry({ textId }: { textId: number }) {
     const langs = rows
       .map((r) => ({ lang: r.other_lang, count: r.pair_count }))
       .sort((a, b) => b.count - a.count);
-    // land on the juan with the most anchors (the highest-count language's sample)
+    // land on the first aligned juan (sample_juan = min juan with parallels) of
+    // the highest-count language — the natural start of the comparison, not mid-text.
     const sampleJuan = rows.reduce((best, r) => (r.pair_count > best.pair_count ? r : best)).sample_juan;
     return { langs, sampleJuan };
   }, [data, textId]);


### PR DESCRIPTION
用户反馈：在「跨藏对照」表格点开瑜伽師地論直接跳到**第 76 卷**而非第一卷。

## 根因
`sample_juan` 用 `mode()`（对齐锚点**最多**的卷）。瑜伽師地論藏文众数=76，所以跳到 76。但这很别扭——点开一部经期望从靠前处开始，却落在正文中段无上下文；而且 **juan 1 本身有 400 条藏文 + 10 条梵文对齐**，对照在那里完全能用。

## 修复
两处 `mode() WITHIN GROUP (ORDER BY juan)` → `min(juan)`（alignment_pairs 侧 + mitra_alignments 侧）：落在**第一个有对齐的卷** = 对照内容的自然起点，仍保证该卷有锚点。

## 验证（prod 实测）
- T1579 sample_juan：**76 → 1**（藏/梵 min 都是 1，juan 1 有 400 藏文对齐）
- 全库：改 min 后 **78% 的 (text,lang) 落在 juan 1**，其余落在各自第一个有对齐的卷（对齐从中段才开始的经）
- 后端 576 passed、前端 tsc 0、ruff 干净；同步更正了 alignment.py 与 CrossCanonEntry 的注释

## 部署
backend/app 改动 → 重启 backend（已确认 Batch 2a 对齐脚本早完成、无长跑任务）。catalog 有缓存 + 预热循环，**部署后需 bust 缓存**（redis DEL）让新 sample_juan 立即生效——我会在部署时处理 + 重新点开验证落到 juan 1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)