### PR TITLE
hardening: cover _byok_error_message + retry Amap regeo (Tier-1 #3a/#3b)

### DIFF
--- a/backend/scripts/backfill_address_regeo.py
+++ b/backend/scripts/backfill_address_regeo.py
@@ -12,6 +12,7 @@ import math
 import os
 import sys
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -61,6 +62,39 @@ def _transform_lon(x, y):
     return ret
 
 
+# Amap infocodes meaning "too fast" (per-second / concurrency QPS) — retryable
+# with backoff. Daily-quota exhaustion (10003) and key/param errors are NOT
+# retried (backoff can't recover them within the run).
+_AMAP_QPS_INFOCODES = {"10019", "10021", "10029"}
+
+
+def _amap_get_with_retry(url: str, retries: int = 3) -> dict | None:
+    """GET the Amap regeo URL with backoff on transient failures (HTTP 429/5xx,
+    network errors, timeouts, and the per-second QPS infocodes above).
+
+    The old code did a single bare urlopen, so one Amap hiccup dropped that
+    monastery for the whole daily cron run — and the free tier's ~per-second
+    limit makes those hiccups common. Returns the parsed JSON, or None when
+    every attempt failed (caller treats that as "skip, retry next run")."""
+    delay = 1.5
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read())
+            if data.get("status") == "1" or data.get("infocode") not in _AMAP_QPS_INFOCODES:
+                return data  # success, or a non-retryable failure (quota/param/key)
+        except urllib.error.HTTPError as e:
+            if e.code != 429 and e.code < 500:
+                return None  # client error (bad key/param) — retrying won't help
+        except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError):
+            pass  # transient network / parse error — fall through to retry
+        if attempt < retries - 1:
+            time.sleep(delay)
+            delay *= 2  # 1.5s → 3s
+    return None
+
+
 def regeo(lng_wgs, lat_wgs) -> dict | None:
     lng_gcj, lat_gcj = wgs84_to_gcj02(lng_wgs, lat_wgs)
     params = urllib.parse.urlencode({
@@ -70,10 +104,8 @@ def regeo(lng_wgs, lat_wgs) -> dict | None:
         "output": "json",
     })
     url = f"{AMAP_REGEO_URL}?{params}"
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=10) as resp:
-        data = json.loads(resp.read())
-    if data.get("status") != "1":
+    data = _amap_get_with_retry(url)
+    if not data or data.get("status") != "1":
         return None
     comp = data.get("regeocode", {}).get("addressComponent", {})
     province = comp.get("province", "")

--- a/backend/tests/test_byok_error_message.py
+++ b/backend/tests/test_byok_error_message.py
@@ -1,0 +1,67 @@
+"""Unit tests for _byok_error_message — the BYOK upstream-error → friendly
+Chinese mapping. It's a branch-dense pure function on the /chat path that was
+previously uncovered: a wrong model id or insufficient balance commonly hides
+behind a generic 401/400, and this function is what surfaces the real cause.
+"""
+import httpx
+import pytest
+
+from app.services.chat import _byok_error_message
+
+
+def _status_error(body: str, status: int) -> httpx.HTTPStatusError:
+    """Build an httpx.HTTPStatusError whose response.text is `body` (the
+    function reads exc.response.text[:600] to sniff the provider's message)."""
+    request = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+    response = httpx.Response(status, text=body, request=request)
+    return httpx.HTTPStatusError("upstream error", request=request, response=response)
+
+
+# (body, status, substring that MUST appear in the returned message)
+_CASES = [
+    # Model-not-found / not-authorized — recognised from the body regardless of status
+    ("model not found", 404, "模型 ID 不存在"),
+    ('{"error": {"code": "model_not_found"}}', 400, "模型 ID 不存在"),
+    ("模型不存在", 400, "模型 ID 不存在"),
+    ("该模型未开通", 403, "模型 ID 不存在"),
+    # Insufficient balance / quota
+    ("Insufficient balance", 400, "余额不足"),
+    ("您的余额不足以完成本次请求", 402, "余额不足"),
+    ("quota exceeded", 429, "余额不足"),  # body wins over the 429 status-only branch
+    # Real key failure — 401 AND an auth signal in the body
+    ("Invalid API key provided", 401, "API Key 无效"),
+    ("api key 无效", 401, "API Key 无效"),
+    # Status-only fallbacks (body didn't match any signal)
+    ("something opaque", 401, "401（认证失败）"),
+    ("not found here", 404, "404"),
+    ("rate limited", 429, "429"),
+    ("internal error", 500, "HTTP 500"),
+]
+
+
+@pytest.mark.parametrize("body,status,expected_substr", _CASES)
+def test_byok_error_message_branches(body: str, status: int, expected_substr: str):
+    msg = _byok_error_message(_status_error(body, status), status)
+    assert expected_substr in msg
+
+
+def test_byok_error_message_no_status_is_generic_unavailable():
+    # A non-HTTP failure (e.g. a connect error) with no status → generic message.
+    msg = _byok_error_message(httpx.ConnectError("connection refused"), None)
+    assert "暂时不可用" in msg
+
+
+def test_byok_error_message_body_signal_beats_status():
+    # A 401 whose body actually says "model not found" should report the model
+    # problem, not "key invalid" — the whole point of reading the body.
+    msg = _byok_error_message(_status_error("model not found", 401), 401)
+    assert "模型 ID 不存在" in msg
+    assert "API Key 无效" not in msg
+
+
+def test_byok_error_message_401_without_auth_signal_is_not_key_invalid():
+    # 401 but no auth keyword in the body → the softer 401 fallback, never the
+    # hard "your key is invalid" claim (which needs an explicit auth signal).
+    msg = _byok_error_message(_status_error("upstream hiccup", 401), 401)
+    assert "401（认证失败）" in msg
+    assert msg != "您的 API Key 无效或已过期，请在个人中心重新配置。"


### PR DESCRIPTION
Tier-1 评估里的两个便宜小项（#3a + #3b）。都不碰 `backend/app/` → **不重启 backend**。

## #3a `test(chat)`：覆盖 `_byok_error_message`
该函数把上游 BYOK 错误映射成中文（"模型 ID 不存在"/"余额不足"等，否则全被笼统 401 盖住），分支密集、之前**零覆盖**。加 16 个参数化用例覆盖每个分支 + 两个排序守卫（body 胜过 status；裸 401 绝不误报"key 无效"）。本地 16 passed。

## #3b `fix(scripts)`：Amap regeo 加重试
`backfill_address_regeo`（每日 cron）原来裸 urlopen 一次，Amap 一抖（免费档每秒 QPS 限很常见）就丢掉该寺院整轮。改 `_amap_get_with_retry`：对 429/5xx、网络错、超时、Amap 每秒/并发 QPS infocode 退避重试（1.5s→3s）；日配额耗尽/key 错不重试。

## 验证
- 本地全套 **592 passed**（576+16）、ruff 干净、backfill syntax OK + ruff 干净
- 不碰 backend/app：tests 不部署、scripts 走 git pull、cron 下次自取新版

🤖 Generated with [Claude Code](https://claude.com/claude-code)