### PR TITLE
perf(chat): memoise message bubbles to kill long-conversation streaming jank

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useCallback, useMemo, useEffect, lazy, Suspense, type ReactNode } from "react";
+import { useState, useRef, useCallback, useMemo, useEffect, lazy, Suspense, memo, type ReactNode } from "react";
 import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { Input, Button, message, Alert, Tooltip, Modal, Select, Tag, Spin } from "antd";
-import Markdown, { defaultUrlTransform } from "react-markdown";
+import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import {
@@ -57,7 +57,7 @@ import {
   uploadChatAttachment,
   type ChatAttachmentMeta,
 } from "../api/chatAttachments";
-import { useAuthStore } from "../stores/authStore";
+import { useAuthStore, type UserProfile } from "../stores/authStore";
 
 const MAX_ATTACHMENTS = 5;
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
@@ -279,6 +279,180 @@ function groupSessionsByDate(sessions: ChatSessionItem[]): { label: string; item
   if (groups.older.length) result.push({ label: "chat.session_group_older", items: groups.older });
   return result;
 }
+
+interface MessageBubbleProps {
+  m: ChatMessageItem;
+  isStreaming: boolean;
+  sending: boolean;
+  user: UserProfile | null;
+  markdownComponents: Components;
+  onSuggestionClick: (q: string) => void;
+  onShare: (m: ChatMessageItem) => void;
+  onRetry: (m: ChatMessageItem) => void;
+  onFeedback: (m: ChatMessageItem, dir: "up" | "down") => void;
+}
+
+/** One chat message row, memoised on (m, isStreaming, sending, user). A streaming
+    token swaps only the streaming message's object identity (onToken does {...m}),
+    so only THAT bubble re-renders — history is skipped. Previously the markdown
+    preprocessing (parseFollowUps / injectCitationLinks / tightenLists + the
+    react-markdown render) re-ran for every historical message on every token,
+    which was the dominant "越聊越卡" jank in long conversations. */
+function MessageBubbleInner({
+  m, isStreaming, sending, user, markdownComponents,
+  onSuggestionClick, onShare, onRetry, onFeedback,
+}: MessageBubbleProps) {
+  // Read t here (not as a prop): on a mid-conversation language switch, i18next's
+  // subscription re-renders the bubble — which memo does NOT block, since memo
+  // only short-circuits parent-driven, prop-equal re-renders — so tooltips/toasts
+  // update immediately, without `t` having to enter the comparator (and without
+  // risking the per-token memo skip if t's identity weren't stable).
+  const { t } = useTranslation();
+  const isAssistantText =
+    m.role === "assistant" && m.content !== THINKING_SENTINEL && m.content !== REQUEST_FAILED_SENTINEL;
+
+  // While streaming the 追问 block is incomplete, so skip parseFollowUps then
+  // (matches the previous inline behaviour). Memoised so a re-render that isn't
+  // a content change (e.g. `sending` toggling) doesn't re-parse.
+  const { cleanContent, suggestions } = useMemo(() => {
+    if (!isAssistantText) return { cleanContent: "", suggestions: [] as string[] };
+    return isStreaming ? { cleanContent: m.content, suggestions: [] as string[] } : parseFollowUps(m.content);
+  }, [isAssistantText, isStreaming, m.content]);
+
+  const rendered = useMemo(
+    () => (isAssistantText ? tightenLists(injectCitationLinks(cleanContent, m.sources)) + (isStreaming ? " ▌" : "") : ""),
+    [isAssistantText, cleanContent, m.sources, isStreaming],
+  );
+
+  return (
+    <div style={{
+      display: "flex", gap: 12, marginBottom: 16, padding: "0 16px",
+      flexDirection: m.role === "user" ? "row-reverse" : "row",
+    }}>
+      <div style={{
+        width: 32, height: 32, borderRadius: "50%", flexShrink: 0,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        background: m.role === "user" ? "var(--fj-accent)" : "rgba(217,208,193,0.5)",
+        color: m.role === "user" ? "#fff" : "var(--fj-ink)", fontSize: 14,
+      }}>
+        {m.role === "user" ? <UserOutlined /> : <RobotOutlined />}
+      </div>
+      <div style={{ maxWidth: "75%", display: "flex", flexDirection: "column", alignItems: m.role === "user" ? "flex-end" : "flex-start" }}>
+        <div style={{
+          padding: "10px 16px", borderRadius: 12,
+          background: m.role === "user" ? "var(--fj-accent)" : "rgba(217,208,193,0.2)",
+          color: m.role === "user" ? "#fff" : "var(--fj-ink)",
+          fontSize: 14, lineHeight: 1.8, whiteSpace: "pre-wrap", wordBreak: "break-word",
+        }}>
+          {m.role === "assistant" ? (
+            m.content === THINKING_SENTINEL ? (
+              <div className="chat-thinking">
+                {t("chat.thinking")}
+                <span className="chat-thinking-dots"><span /><span /><span /></span>
+              </div>
+            ) : m.content === REQUEST_FAILED_SENTINEL ? (
+              t("chat.request_failed")
+            ) : (
+              <>
+                <div className="chat-markdown">
+                  <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[[rehypeSanitize, CHAT_SANITIZE_SCHEMA]]} urlTransform={chatUrlTransform} components={markdownComponents}>{rendered}</Markdown>
+                </div>
+                {suggestions.length > 0 && !sending && (
+                  <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
+                    {suggestions.map((q, i) => (
+                      <span
+                        key={i}
+                        onClick={() => onSuggestionClick(q)}
+                        style={{
+                          display: "inline-block", padding: "4px 12px", borderRadius: 14,
+                          border: "1px solid var(--fj-gold, #b08d57)", color: "var(--fj-gold, #b08d57)",
+                          fontSize: 12, cursor: "pointer", background: "transparent", transition: "all 0.2s", lineHeight: 1.6,
+                        }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.1)"; e.currentTarget.style.color = "var(--fj-accent)"; e.currentTarget.style.borderColor = "var(--fj-accent)"; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--fj-gold, #b08d57)"; e.currentTarget.style.borderColor = "var(--fj-gold, #b08d57)"; }}
+                      >
+                        {q}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </>
+            )
+          ) : (
+            m.content
+          )}
+        </div>
+        {/* Action buttons outside bubble */}
+        {m.content !== THINKING_SENTINEL && !isStreaming && (
+          <div style={{ marginTop: 4, display: "flex", gap: 4 }}>
+            <Tooltip title={t("chat.copy")}>
+              <Button
+                type="text" size="small" icon={<CopyOutlined />}
+                style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
+                onClick={() => {
+                  const textToCopy = m.role === "assistant" ? parseFollowUps(m.content).cleanContent : m.content;
+                  navigator.clipboard.writeText(textToCopy);
+                  message.success(t("chat.copied"));
+                }}
+              />
+            </Tooltip>
+            {m.role === "assistant" && m.content !== REQUEST_FAILED_SENTINEL && (
+              <Tooltip title={t("chat.share_card_tooltip")}>
+                <Button
+                  type="text" size="small" icon={<ShareAltOutlined />}
+                  style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
+                  onClick={() => onShare(m)}
+                />
+              </Tooltip>
+            )}
+            {/* Hide feedback affordances until the real chat_messages.id has
+                replaced the in-flight Date.now() placeholder (≥ ~1.7e12); a click
+                during the streaming-but-not-yet-saved window would PUT to a
+                nonexistent id and 404 silently. */}
+            {m.role === "assistant" && user && m.id < 1e12 && (
+              <>
+                <Tooltip title={t("chat.feedback_helpful")}>
+                  <Button
+                    type="text" size="small"
+                    icon={m.feedback === "up" ? <LikeFilled /> : <LikeOutlined />}
+                    style={{ color: m.feedback === "up" ? "var(--fj-accent)" : "var(--fj-ink-muted)", fontSize: 12 }}
+                    onClick={() => onFeedback(m, "up")}
+                  />
+                </Tooltip>
+                <Tooltip title={t("chat.feedback_not_helpful")}>
+                  <Button
+                    type="text" size="small"
+                    icon={m.feedback === "down" ? <DislikeFilled /> : <DislikeOutlined />}
+                    style={{ color: m.feedback === "down" ? "#e74c3c" : "var(--fj-ink-muted)", fontSize: 12 }}
+                    onClick={() => onFeedback(m, "down")}
+                  />
+                </Tooltip>
+              </>
+            )}
+            {m.role === "assistant" && m.content === REQUEST_FAILED_SENTINEL && (
+              <Tooltip title={t("chat.retry")}>
+                <Button
+                  type="text" size="small" icon={<ReloadOutlined />}
+                  style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
+                  onClick={() => onRetry(m)}
+                />
+              </Tooltip>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const MessageBubble = memo(
+  MessageBubbleInner,
+  (prev, next) =>
+    prev.m === next.m &&
+    prev.isStreaming === next.isStreaming &&
+    prev.sending === next.sending &&
+    prev.user === next.user,
+);
 
 export default function ChatPage() {
   const navigate = useNavigate();
@@ -775,6 +949,42 @@ export default function ChatPage() {
     await handleSendMessage(input);
   }, [input, handleSendMessage]);
 
+  // Hoisted so MessageBubble can stay memoised. These depend on `messages`, so
+  // their identity changes when the list does — but the memo comparator ignores
+  // callback props, and the history is append-only, so a memoised historical
+  // bubble keeps a closure over an older `messages` whose relevant prefix (the
+  // preceding user question / the message to retry) is unchanged. Feedback uses
+  // the functional setMessages form, so it's correct regardless of staleness.
+  const handleShareMessage = useCallback((m: ChatMessageItem) => {
+    const idx = messages.findIndex((x) => x.id === m.id);
+    let question = "";
+    for (let i = idx - 1; i >= 0; i--) {
+      if (messages[i].role === "user") { question = messages[i].content; break; }
+    }
+    setShareTarget({
+      question: question || t("chat.share_default_question"),
+      answer: parseFollowUps(m.content).cleanContent,
+      sources: m.sources,
+    });
+  }, [messages, t]);
+
+  const handleRetryMessage = useCallback((m: ChatMessageItem) => {
+    const idx = messages.findIndex((x) => x.id === m.id);
+    const userMsg = idx > 0 ? messages[idx - 1] : null;
+    if (userMsg && userMsg.role === "user") {
+      setMessages((prev) => prev.filter((x) => x.id !== m.id && x.id !== userMsg.id));
+      handleSendMessage(userMsg.content);
+    }
+  }, [messages, handleSendMessage]);
+
+  const handleFeedbackMessage = useCallback((m: ChatMessageItem, dir: "up" | "down") => {
+    const newFeedback = m.feedback === dir ? null : dir;
+    setMessages((prev) => prev.map((x) => x.id === m.id ? { ...x, feedback: newFeedback } : x));
+    updateChatMessageFeedback(m.id, newFeedback as "up" | "down" | null).catch(() => {
+      setMessages((prev) => prev.map((x) => x.id === m.id ? { ...x, feedback: m.feedback } : x));
+    });
+  }, []);
+
   // Tab key: cycle through suggested questions when input is empty
   const tabSuggestions = useMemo(() => {
     // Prefer follow-up suggestions from the last assistant message
@@ -1102,189 +1312,18 @@ export default function ChatPage() {
               </div>
             )}
             {messages.map((m) => (
-              <div key={m.id} style={{
-                display: "flex",
-                gap: 12,
-                marginBottom: 16,
-                padding: "0 16px",
-                flexDirection: m.role === "user" ? "row-reverse" : "row",
-              }}>
-                <div style={{
-                  width: 32, height: 32, borderRadius: "50%", flexShrink: 0,
-                  display: "flex", alignItems: "center", justifyContent: "center",
-                  background: m.role === "user" ? "var(--fj-accent)" : "rgba(217,208,193,0.5)",
-                  color: m.role === "user" ? "#fff" : "var(--fj-ink)",
-                  fontSize: 14,
-                }}>
-                  {m.role === "user" ? <UserOutlined /> : <RobotOutlined />}
-                </div>
-                <div style={{ maxWidth: "75%", display: "flex", flexDirection: "column", alignItems: m.role === "user" ? "flex-end" : "flex-start" }}>
-                <div style={{
-                  padding: "10px 16px",
-                  borderRadius: 12,
-                  background: m.role === "user" ? "var(--fj-accent)" : "rgba(217,208,193,0.2)",
-                  color: m.role === "user" ? "#fff" : "var(--fj-ink)",
-                  fontSize: 14,
-                  lineHeight: 1.8,
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-word",
-                }}>
-                  {m.role === "assistant" ? (
-                    m.content === THINKING_SENTINEL ? (
-                      <div className="chat-thinking">
-                        {t("chat.thinking")}
-                        <span className="chat-thinking-dots"><span /><span /><span /></span>
-                      </div>
-                    ) : m.content === REQUEST_FAILED_SENTINEL ? (
-                      t("chat.request_failed")
-                    ) : (() => {
-                      const isStreaming = streamingIdRef.current === m.id;
-                      const { cleanContent, suggestions } = isStreaming
-                        ? { cleanContent: m.content, suggestions: [] }
-                        : parseFollowUps(m.content);
-                      return (
-                        <>
-                          <div className="chat-markdown">
-                            <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[[rehypeSanitize, CHAT_SANITIZE_SCHEMA]]} urlTransform={chatUrlTransform} components={markdownComponents}>{tightenLists(injectCitationLinks(cleanContent, m.sources)) + (isStreaming ? " ▌" : "")}</Markdown>
-                          </div>
-                          {suggestions.length > 0 && !sending && (
-                            <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
-                              {suggestions.map((q, i) => (
-                                <span
-                                  key={i}
-                                  onClick={() => handleSendMessage(q)}
-                                  style={{
-                                    display: "inline-block",
-                                    padding: "4px 12px",
-                                    borderRadius: 14,
-                                    border: "1px solid var(--fj-gold, #b08d57)",
-                                    color: "var(--fj-gold, #b08d57)",
-                                    fontSize: 12,
-                                    cursor: "pointer",
-                                    background: "transparent",
-                                    transition: "all 0.2s",
-                                    lineHeight: 1.6,
-                                  }}
-                                  onMouseEnter={(e) => {
-                                    e.currentTarget.style.background = "rgba(176,141,87,0.1)";
-                                    e.currentTarget.style.color = "var(--fj-accent)";
-                                    e.currentTarget.style.borderColor = "var(--fj-accent)";
-                                  }}
-                                  onMouseLeave={(e) => {
-                                    e.currentTarget.style.background = "transparent";
-                                    e.currentTarget.style.color = "var(--fj-gold, #b08d57)";
-                                    e.currentTarget.style.borderColor = "var(--fj-gold, #b08d57)";
-                                  }}
-                                >
-                                  {q}
-                                </span>
-                              ))}
-                            </div>
-                          )}
-                        </>
-                      );
-                    })()
-                  ) : (
-                    m.content
-                  )}
-                </div>
-                {/* Action buttons outside bubble */}
-                {m.content !== THINKING_SENTINEL && streamingIdRef.current !== m.id && (
-                  <div style={{ marginTop: 4, display: "flex", gap: 4 }}>
-                    <Tooltip title={t("chat.copy")}>
-                      <Button
-                        type="text" size="small" icon={<CopyOutlined />}
-                        style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
-                        onClick={() => {
-                          const textToCopy = m.role === "assistant"
-                            ? parseFollowUps(m.content).cleanContent
-                            : m.content;
-                          navigator.clipboard.writeText(textToCopy);
-                          message.success(t("chat.copied"));
-                        }}
-                      />
-                    </Tooltip>
-                      {m.role === "assistant" && m.content !== REQUEST_FAILED_SENTINEL && (
-                        <Tooltip title={t("chat.share_card_tooltip")}>
-                          <Button
-                            type="text" size="small" icon={<ShareAltOutlined />}
-                            style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
-                            onClick={() => {
-                              const idx = messages.findIndex((x) => x.id === m.id);
-                              let question = "";
-                              for (let i = idx - 1; i >= 0; i--) {
-                                if (messages[i].role === "user") {
-                                  question = messages[i].content;
-                                  break;
-                                }
-                              }
-                              setShareTarget({
-                                question: question || t("chat.share_default_question"),
-                                answer: parseFollowUps(m.content).cleanContent,
-                                sources: m.sources,
-                              });
-                            }}
-                          />
-                        </Tooltip>
-                      )}
-                      {m.role === "assistant" && user && m.id < 1e12 && (
-                        // Hide feedback affordances until the real
-                        // chat_messages.id has replaced the in-flight
-                        // Date.now() placeholder (Date.now() ≥ ~1.7e12,
-                        // real DB ids ≪ 1e12). A click during the
-                        // streaming-but-not-yet-saved window would PUT
-                        // to a nonexistent id and 404 silently.
-                        <>
-                          <Tooltip title={t("chat.feedback_helpful")}>
-                            <Button
-                              type="text" size="small"
-                              icon={m.feedback === "up" ? <LikeFilled /> : <LikeOutlined />}
-                              style={{ color: m.feedback === "up" ? "var(--fj-accent)" : "var(--fj-ink-muted)", fontSize: 12 }}
-                              onClick={() => {
-                                const newFeedback = m.feedback === "up" ? null : "up";
-                                setMessages((prev) => prev.map((x) => x.id === m.id ? { ...x, feedback: newFeedback } : x));
-                                updateChatMessageFeedback(m.id, newFeedback as "up" | "down" | null).catch(() => {
-                                  setMessages((prev) => prev.map((x) => x.id === m.id ? { ...x, feedback: m.feedback } : x));
-                                });
-                              }}
-                            />
-                          </Tooltip>
-                          <Tooltip title={t("chat.feedback_not_helpful")}>
-                            <Button
-                              type="text" size="small"
-                              icon={m.feedback === "down" ? <DislikeFilled /> : <DislikeOutlined />}
-                              style={{ color: m.feedback === "down" ? "#e74c3c" : "var(--fj-ink-muted)", fontSize: 12 }}
-                              onClick={() => {
-                                const newFeedback = m.feedback === "down" ? null : "down";
-                                setMessages((prev) => prev.map((x) => x.id === m.id ? { ...x, feedback: newFeedback } : x));
-                                updateChatMessageFeedback(m.id, newFeedback as "up" | "down" | null).catch(() => {
-                                  setMessages((prev) => prev.map((x) => x.id === m.id ? { ...x, feedback: m.feedback } : x));
-                                });
-                              }}
-                            />
-                          </Tooltip>
-                        </>
-                      )}
-                      {m.role === "assistant" && m.content === REQUEST_FAILED_SENTINEL && (
-                        <Tooltip title={t("chat.retry")}>
-                          <Button
-                            type="text" size="small" icon={<ReloadOutlined />}
-                            style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
-                            onClick={() => {
-                              const idx = messages.findIndex((x) => x.id === m.id);
-                              const userMsg = idx > 0 ? messages[idx - 1] : null;
-                              if (userMsg && userMsg.role === "user") {
-                                setMessages((prev) => prev.filter((x) => x.id !== m.id && x.id !== userMsg.id));
-                                handleSendMessage(userMsg.content);
-                              }
-                            }}
-                          />
-                        </Tooltip>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </div>
+              <MessageBubble
+                key={m.id}
+                m={m}
+                isStreaming={streamingIdRef.current === m.id}
+                sending={sending}
+                user={user}
+                markdownComponents={markdownComponents}
+                onSuggestionClick={handleSendMessage}
+                onShare={handleShareMessage}
+                onRetry={handleRetryMessage}
+                onFeedback={handleFeedbackMessage}
+              />
             ))}
             {/* Streaming cursor is shown inline via ▌ in the message bubble */}
             <div ref={bottomRef} />

--- a/frontend/src/pages/MessageBubble.test.tsx
+++ b/frontend/src/pages/MessageBubble.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { Components } from "react-markdown";
+import { MessageBubble } from "./ChatPage";
+import type { ChatMessageItem } from "../api/client";
+
+// antd (Button/Tooltip) reads matchMedia via useBreakpoint under jsdom.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false, media: query, onchange: null,
+      addListener: () => {}, removeListener: () => {},
+      addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+});
+
+const markdownComponents = {} as Components;
+
+function msg(o: Partial<ChatMessageItem> = {}): ChatMessageItem {
+  return { id: 1, role: "assistant", content: "answer", sources: null, created_at: "2026-06-18", ...o };
+}
+
+function renderBubble(props: Partial<React.ComponentProps<typeof MessageBubble>> = {}) {
+  const onSuggestionClick = vi.fn();
+  const onShare = vi.fn();
+  const onRetry = vi.fn();
+  const onFeedback = vi.fn();
+  render(
+    <MessageBubble
+      m={msg()}
+      isStreaming={false}
+      sending={false}
+      user={null}
+      markdownComponents={markdownComponents}
+      onSuggestionClick={onSuggestionClick}
+      onShare={onShare}
+      onRetry={onRetry}
+      onFeedback={onFeedback}
+      {...props}
+    />,
+  );
+  return { onSuggestionClick, onShare, onRetry, onFeedback };
+}
+
+describe("MessageBubble", () => {
+  it("renders an assistant message's markdown content", () => {
+    renderBubble({ m: msg({ content: "唯识无境的核心是什么" }) });
+    expect(screen.getByText(/唯识无境的核心是什么/)).toBeInTheDocument();
+  });
+
+  it("shows the streaming ▌ cursor while streaming", () => {
+    const { container } = render(
+      <MessageBubble
+        m={msg({ content: "正在生成" })} isStreaming sending user={null}
+        markdownComponents={markdownComponents}
+        onSuggestionClick={vi.fn()} onShare={vi.fn()} onRetry={vi.fn()} onFeedback={vi.fn()}
+      />,
+    );
+    expect(container.textContent).toContain("▌");
+  });
+
+  it("renders a user message verbatim (no markdown/follow-up processing)", () => {
+    renderBubble({ m: msg({ role: "user", content: "[追问] 这行不应被当作建议" }) });
+    // The user's literal text — including the bracket — is shown as-is.
+    expect(screen.getByText(/这行不应被当作建议/)).toBeInTheDocument();
+  });
+
+  it("renders the thinking indicator for the THINKING sentinel", () => {
+    // content must be the exact THINKING_SENTINEL to take the thinking branch;
+    // assert the structural .chat-thinking marker (language-independent).
+    renderBubble({ m: msg({ content: "正在检索经文并生成回答..." }) });
+    expect(document.querySelector(".chat-thinking")).not.toBeNull();
+  });
+
+  it("renders follow-up suggestions and fires onSuggestionClick", () => {
+    const { onSuggestionClick } = renderBubble({
+      m: msg({ content: "答案正文\n[追问] 什么是阿赖耶识" }),
+    });
+    const chip = screen.getByText("什么是阿赖耶识");
+    fireEvent.click(chip);
+    expect(onSuggestionClick).toHaveBeenCalledWith("什么是阿赖耶识");
+  });
+
+  it("wires the share button to onShare with the message", () => {
+    const m = msg({ id: 7, content: "可分享的回答" });
+    // assistant, not failed, no user → action row is [copy, share]
+    const { onShare } = renderBubble({ m });
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    fireEvent.click(buttons[1]); // share
+    expect(onShare).toHaveBeenCalledWith(m);
+  });
+
+  it("hides feedback for an in-flight (placeholder-id) assistant message", () => {
+    // id ≥ 1e12 is the Date.now() placeholder before the real chat_messages.id
+    // arrives; feedback would PUT to a nonexistent id, so it's hidden.
+    renderBubble({ m: msg({ id: 1.7e12 }), user: { id: 9 } as never });
+    expect(screen.getAllByRole("button")).toHaveLength(2); // copy + share only
+  });
+
+  it("shows feedback for a saved assistant message + user and fires onFeedback", () => {
+    const { onFeedback } = renderBubble({ m: msg({ id: 42 }), user: { id: 9 } as never });
+    const buttons = screen.getAllByRole("button"); // copy, share, like, dislike
+    expect(buttons).toHaveLength(4);
+    fireEvent.click(buttons[2]); // like
+    expect(onFeedback).toHaveBeenCalledWith(expect.objectContaining({ id: 42 }), "up");
+  });
+});


### PR DESCRIPTION
Tier-1 项（#2，用户选定）。/chat 长会话"越聊越卡"的结构性修复。

## 问题
消息列表内联在 `messages.map`，每个流式 token（onToken→setMessages→ChatPage 整体 re-render）都对**全部历史消息**重跑 markdown 预处理（parseFollowUps/injectCitationLinks/tightenLists）+ react-markdown 渲染。长会话里这个 O(N)/token 是卡顿主因。

## 修复
抽 `MessageBubble`（memo，比较 `m/isStreaming/sending/user`）：onToken 只换流式那条的对象身份（`{...m}`），故只有它 re-render、历史跳过（比身份非 m.id——onMessageId 会换 placeholder id）。预处理移进 bubble 的 useMemo。share/retry/feedback 上提父层 useCallback 保持 bubble memo 化（history append-only，stale 闭包正确；feedback 用函数式 setMessages）。

## 验证
- tsc 0 错、eslint 0 错（仅 1 既有 unused-disable warning，CI 容 50）、vitest **115 passed**（含新 MessageBubble.test.tsx 8 例：assistant markdown / 流式 ▌ / user 原样 / thinking / 追问点击 / share 接线 / in-flight-id 反馈守卫）、vite build OK
- **senior reviewer subagent 严格审 = Ready to merge**：逐项验证 memo 正确性（流式重渲/历史跳过、onMessageId 触发反馈按钮、流式结束最终渲染、hooks 规则、JSX 保真、压测 loadOlderMessages prepend 的 stale 闭包）。采纳其唯一 Minor：`t` 改为 bubble 内部 `useTranslation()`（切语言时 i18n 订阅触发重渲、不进比较器、不影响 per-token memo），消除中途切语言 tooltip 滞后

## 部署
改 `frontend/` → frontend rebuild（不重启 backend）。merge 后手动 build + 浏览器验证长会话渲染/流式/交互无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)