### PR TITLE
feat: CBETA line-ref citation locator + URN scroll-to-line (借鉴 #2)

### DIFF
--- a/backend/app/api/texts.py
+++ b/backend/app/api/texts.py
@@ -17,6 +17,7 @@ from app.services.content import (
     get_juan_apparatus,
     get_juan_content,
     get_juan_languages,
+    get_juan_line_anchors,
     get_juan_list,
 )
 from app.services.text import get_text_by_id, get_text_count, get_text_id_by_cbeta
@@ -107,6 +108,17 @@ class JuanApparatusResponse(BaseModel):
     text_id: int
     juan_num: int
     entries: list[ApparatusEntryItem] = []
+
+
+class LineAnchorItem(BaseModel):
+    char_offset: int
+    line_ref: str
+
+
+class JuanLineAnchorsResponse(BaseModel):
+    text_id: int
+    juan_num: int
+    anchors: list[LineAnchorItem] = []
 
 
 class ChunkContextItem(BaseModel):
@@ -208,6 +220,20 @@ async def read_juan_apparatus(
     Loaded lazily by the reader — a major text can carry thousands of entries."""
     entries = await get_juan_apparatus(db, text_id, juan_num)
     return JuanApparatusResponse(text_id=text_id, juan_num=juan_num, entries=entries)
+
+
+@router.get("/texts/{text_id}/juans/{juan_num}/line-anchors", response_model=JuanLineAnchorsResponse)
+async def read_juan_line_anchors(
+    text_id: int,
+    juan_num: int,
+    db: AsyncSession = Depends(get_db),
+):
+    """CBETA <lb> page-column-line anchors for a juan (char_offset → line_ref).
+
+    获取某一卷的页·栏·行锚点，供阅读器按需定位引用与 URN 跳行。
+    Loaded lazily by the reader; a juan can carry several hundred anchors."""
+    anchors = await get_juan_line_anchors(db, text_id, juan_num)
+    return JuanLineAnchorsResponse(text_id=text_id, juan_num=juan_num, anchors=anchors)
 
 
 @router.get("/stats")

--- a/backend/app/services/content.py
+++ b/backend/app/services/content.py
@@ -2,7 +2,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.text import BuddhistText, TextApparatus, TextContent
+from app.models.text import BuddhistText, TextApparatus, TextContent, TextLineAnchor
 from app.schemas.text import JuanContentResponse, JuanInfo, JuanLanguagesResponse, JuanListResponse
 
 
@@ -153,3 +153,15 @@ async def get_juan_apparatus(session: AsyncSession, text_id: int, juan_num: int)
         }
         for e in result.scalars().all()
     ]
+
+
+async def get_juan_line_anchors(session: AsyncSession, text_id: int, juan_num: int) -> list[dict]:
+    """CBETA <lb> page-column-line anchors for one juan, ordered by position.
+    Each: {char_offset, line_ref} (line_ref e.g. "0001a09"). Drives the reader's
+    on-demand citation locator and URN #anchor scroll-to-line."""
+    result = await session.execute(
+        select(TextLineAnchor.char_offset, TextLineAnchor.line_ref)
+        .where(TextLineAnchor.text_id == text_id, TextLineAnchor.juan_num == juan_num)
+        .order_by(TextLineAnchor.char_offset)
+    )
+    return [{"char_offset": off, "line_ref": ref} for off, ref in result.all()]

--- a/backend/tests/test_apparatus_api.py
+++ b/backend/tests/test_apparatus_api.py
@@ -7,7 +7,7 @@ query/transform logic is exercised without a DB.
 
 from unittest.mock import AsyncMock, MagicMock
 
-from app.services.content import get_juan_apparatus
+from app.services.content import get_juan_apparatus, get_juan_line_anchors
 
 
 def _reading(**kw):
@@ -53,4 +53,28 @@ async def test_get_juan_apparatus_maps_entries_and_readings():
 async def test_get_juan_apparatus_empty_when_none():
     session = _session_returning([])
     out = await get_juan_apparatus(session, text_id=1, juan_num=9)
+    assert out == []
+
+
+def _session_rows(rows):
+    """Mock session whose execute().all() returns (col, col) tuples."""
+    result = MagicMock()
+    result.all.return_value = rows
+    session = AsyncMock()
+    session.execute.return_value = result
+    return session
+
+
+async def test_get_juan_line_anchors_maps_rows():
+    session = _session_rows([(0, "0001a01"), (17, "0001a02"), (33, "0001a03")])
+    out = await get_juan_line_anchors(session, text_id=1, juan_num=1)
+    assert out == [
+        {"char_offset": 0, "line_ref": "0001a01"},
+        {"char_offset": 17, "line_ref": "0001a02"},
+        {"char_offset": 33, "line_ref": "0001a03"},
+    ]
+
+
+async def test_get_juan_line_anchors_empty():
+    out = await get_juan_line_anchors(_session_rows([]), text_id=1, juan_num=9)
     assert out == []

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -706,5 +706,9 @@
   "reader.apparatus.summary": "{{n}} variant readings against witness canons",
   "reader.apparatus.omission": "(omitted)",
   "reader.apparatus.corrector": "(corr. {{resp}})",
-  "reader.apparatus.note": "Apparatus note"
+  "reader.apparatus.note": "Apparatus note",
+  "reader.lineref.copy_citation": "Copy citation",
+  "reader.lineref.copy_link": "Copy link",
+  "reader.lineref.copied": "Copied",
+  "reader.lineref.citation": "{{title}} (CBETA {{id}}, fasc. {{juan}}, {{ref}})"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -706,5 +706,9 @@
   "reader.apparatus.summary": "底本與宋 / 元 / 明 / 麗等校本的異讀，共 {{n}} 條",
   "reader.apparatus.omission": "（無此字）",
   "reader.apparatus.corrector": "（{{resp}} 校）",
-  "reader.apparatus.note": "校註"
+  "reader.apparatus.note": "校註",
+  "reader.lineref.copy_citation": "複製引用",
+  "reader.lineref.copy_link": "複製連結",
+  "reader.lineref.copied": "已複製",
+  "reader.lineref.citation": "《{{title}}》卷{{juan}}（CBETA {{id}}, {{ref}}）"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -706,5 +706,9 @@
   "reader.apparatus.summary": "底本与宋 / 元 / 明 / 麗等校本的异读，共 {{n}} 条",
   "reader.apparatus.omission": "（无此字）",
   "reader.apparatus.corrector": "（{{resp}} 校）",
-  "reader.apparatus.note": "校注"
+  "reader.apparatus.note": "校注",
+  "reader.lineref.copy_citation": "复制引用",
+  "reader.lineref.copy_link": "复制链接",
+  "reader.lineref.copied": "已复制",
+  "reader.lineref.citation": "《{{title}}》卷{{juan}}（CBETA {{id}}, {{ref}}）"
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -566,6 +566,23 @@ export async function getJuanApparatus(textId: number, juanNum: number): Promise
   return data;
 }
 
+// CBETA <lb> page-column-line anchors (校勘行锚 / 引用定位)
+export interface LineAnchorItem {
+  char_offset: number;
+  line_ref: string;
+}
+
+export interface JuanLineAnchorsResponse {
+  text_id: TextId;
+  juan_num: number;
+  anchors: LineAnchorItem[];
+}
+
+export async function getJuanLineAnchors(textId: number, juanNum: number): Promise<JuanLineAnchorsResponse> {
+  const { data } = await api.get<JuanLineAnchorsResponse>(`/texts/${textId}/juans/${juanNum}/line-anchors`);
+  return data;
+}
+
 // Content search
 export async function searchContent(params: {
   q: string;

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -18,7 +18,7 @@ import {
   GlobalOutlined,
   DiffOutlined,
 } from "@ant-design/icons";
-import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, type ApparatusEntryItem } from "../api/client";
+import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, getJuanLineAnchors, type ApparatusEntryItem } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
 import CitationGenerator from "../components/CitationGenerator";
 import AnnotationPanel from "../components/AnnotationPanel";
@@ -256,7 +256,24 @@ type TFn = (key: string, opts?: Record<string, unknown>) => string;
 // start/end are UTF-16 offsets into the content string (converted from the
 // backend's Python code-point offsets) so they index the reflowed segments.
 interface ApparatusNumbered { entry: ApparatusEntryItem; no: number; start: number; end: number }
-type ApparatusCtx = { numbered: ApparatusNumbered[]; t: TFn } | null;
+// off = UTF-16 offset of a CBETA <lb> line anchor within the content.
+interface LineAnchorConv { off: number; ref: string }
+type ReaderCtx = { numbered: ApparatusNumbered[]; lineAnchors: LineAnchorConv[]; t: TFn } | null;
+
+/** Build a map from Python code-point index → JS UTF-16 index for `raw`.
+ * Backend offsets are code-point indices; supplementary-plane CJK (surrogate
+ * pairs) would otherwise drift the mapping. Index `[n]` = UTF-16 offset; the
+ * final sentinel covers an offset at end-of-string. */
+function cpToU16Map(raw: string): number[] {
+  const map: number[] = [];
+  let u = 0;
+  for (const ch of raw) {
+    map.push(u);
+    u += ch.length;
+  }
+  map.push(u);
+  return map;
+}
 
 /** CBETA-style inline apparatus marker: a clickable superscript [n] placed
  * right after the lemma; clicking opens a 校注 popover with base text + variants. */
@@ -289,16 +306,28 @@ function ApparatusMarker({ no, entry, t }: { no: number; entry: ApparatusEntryIt
   );
 }
 
-/** Splice inline apparatus markers into a text-bearing segment by mapping each
- * entry's raw char offset to a position within the reflowed segment text. */
-function renderSegmentChildren(seg: Extract<TextSegment, { text: string }>, numbered: ApparatusNumbered[], t: TFn): ReactNode {
+/** Splice into a text-bearing segment, by content offset: visible apparatus
+ * markers (校勘 [n]) after each lemma, and zero-width line-anchor spans (carrying
+ * the CBETA page-col-line ref) for the on-demand citation locator and URN scroll. */
+function renderSegmentChildren(seg: Extract<TextSegment, { text: string }>, ctx: NonNullable<ReaderCtx>): ReactNode {
+  const { numbered, lineAnchors, t } = ctx;
   const { text, offsets } = seg;
-  if (!numbered.length || !offsets.length) return text;
+  if (!offsets.length || (!numbered.length && !lineAnchors.length)) return text;
   const segStart = offsets[0];
   const segEnd = offsets[offsets.length - 1];
   const offToLocal = new Map<number, number>();
   for (let k = 0; k < offsets.length; k++) offToLocal.set(offsets[k], k);
-  const marks: { pos: number; m: ApparatusNumbered }[] = [];
+
+  // order: line anchors (0) before apparatus markers (1) when at the same position.
+  const ins: { pos: number; order: number; node: ReactNode }[] = [];
+  for (const la of lineAnchors) {
+    if (la.off < segStart || la.off > segEnd || !offToLocal.has(la.off)) continue;
+    ins.push({
+      pos: offToLocal.get(la.off)!,
+      order: 0,
+      node: <span key={`ln${la.ref}`} className="cbeta-line" data-ref={la.ref} />,
+    });
+  }
   for (const m of numbered) {
     const cs = m.start;
     if (cs < segStart || cs > segEnd || !offToLocal.has(cs)) continue;
@@ -307,25 +336,40 @@ function renderSegmentChildren(seg: Extract<TextSegment, { text: string }>, numb
     // locStart + the lemma's own length — robust when the lemma is followed by or
     // spans a line break (where char_end would point at a dropped "\n").
     const pos = Math.min(offToLocal.get(cs)! + m.entry.lemma.length, text.length);
-    marks.push({ pos, m });
+    ins.push({ pos, order: 1, node: <ApparatusMarker key={`ap${m.no}`} no={m.no} entry={m.entry} t={t} /> });
   }
-  if (!marks.length) return text;
-  marks.sort((a, b) => a.pos - b.pos);
+  if (!ins.length) return text;
+  ins.sort((a, b) => a.pos - b.pos || a.order - b.order);
   const nodes: ReactNode[] = [];
   let cursor = 0;
-  for (const { pos, m } of marks) {
-    if (pos > cursor) nodes.push(text.slice(cursor, pos));
-    nodes.push(<ApparatusMarker key={`ap${m.no}`} no={m.no} entry={m.entry} t={t} />);
-    cursor = Math.max(cursor, pos);
+  for (const it of ins) {
+    if (it.pos > cursor) nodes.push(text.slice(cursor, it.pos));
+    nodes.push(it.node);
+    cursor = Math.max(cursor, it.pos);
   }
   if (cursor < text.length) nodes.push(text.slice(cursor));
   return nodes;
 }
 
-function renderSegment(seg: TextSegment, i: number, ctx?: ApparatusCtx) {
+function renderSegment(seg: TextSegment, i: number, ctx?: ReaderCtx) {
   if (seg.type === "break") return <br key={i} />;
-  const children = ctx ? renderSegmentChildren(seg, ctx.numbered, ctx.t) : seg.text;
+  const children = ctx ? renderSegmentChildren(seg, ctx) : seg.text;
   return <p key={i} className={`text-${seg.type}`}>{children}</p>;
+}
+
+/** CBETA line ref (e.g. "0001a09") of the embedded <span class="cbeta-line">
+ * nearest before `startNode` — i.e. the page-col-line the selection sits in. */
+function nearestLineRef(container: HTMLElement, startNode: Node): string | null {
+  let ref: string | null = null;
+  for (const el of Array.from(container.querySelectorAll<HTMLElement>(".cbeta-line"))) {
+    const pos = el.compareDocumentPosition(startNode);
+    if (pos === 0 || pos & Node.DOCUMENT_POSITION_FOLLOWING) {
+      ref = el.dataset.ref ?? ref; // el is at/before the selection → candidate
+    } else {
+      break; // anchors are in document order; rest are after the selection
+    }
+  }
+  return ref;
 }
 
 function getInitialFontSize(): number {
@@ -463,7 +507,12 @@ export default function TextReaderPage() {
 
   // 划词查辞典
   const [dictPopover, setDictPopover] = useState<DictPopoverState>(DICT_POPOVER_INIT);
-  const closeDictPopover = useCallback(() => setDictPopover(DICT_POPOVER_INIT), []);
+  // On-demand citation locator: the CBETA line ref at the current selection.
+  const [lineLocator, setLineLocator] = useState<{ ref: string; x: number; y: number } | null>(null);
+  const closeDictPopover = useCallback(() => {
+    setDictPopover(DICT_POPOVER_INIT);
+    setLineLocator(null);
+  }, []);
 
   const handleTextSelect = useCallback(async () => {
     const sel = window.getSelection();
@@ -477,6 +526,11 @@ export default function TextReaderPage() {
     const rect = range.getBoundingClientRect();
     const x = rect.left + rect.width / 2;
     const y = rect.bottom;
+
+    // Citation locator: CBETA page-col-line at the selection (needs embedded anchors).
+    const containerEl = readerContentRef.current;
+    const ref = containerEl ? nearestLineRef(containerEl, range.startContainer) : null;
+    setLineLocator(ref ? { ref, x, y: rect.top } : null);
 
     // 短词查辞典；整句选择只显示「问小津」，不查辞典
     const isWord = text.length <= MAX_WORD_LEN;
@@ -716,32 +770,58 @@ export default function TextReaderPage() {
     staleTime: 3600000,
   });
   // Number aligned entries 1..N in reading order, converting the backend's
-  // Python code-point offsets to JS UTF-16 offsets (CJK Ext-B etc. are
-  // surrogate pairs — 1 code point but 2 UTF-16 units — so a raw index would
-  // drift after the first supplementary char).
+  // Python code-point offsets to JS UTF-16 offsets (see cpToU16Map).
   const apparatusNumbered = useMemo<ApparatusNumbered[]>(() => {
     const raw = content?.content;
     if (!apparatusData?.entries || !raw) return [];
-    const cpToU16: number[] = [];
-    let u = 0;
-    for (const ch of raw) {
-      cpToU16.push(u);
-      u += ch.length;
-    }
-    cpToU16.push(u); // sentinel for an offset at end-of-string
-    const conv = (cp: number) => (cp >= 0 && cp < cpToU16.length ? cpToU16[cp] : u);
+    const m = cpToU16Map(raw);
+    const conv = (cp: number) => (cp >= 0 && cp < m.length ? m[cp] : m[m.length - 1]);
     return [...apparatusData.entries]
       .sort((a, b) => a.char_start - b.char_start)
-      .map((entry, idx) => ({
-        entry,
-        no: idx + 1,
-        start: conv(entry.char_start),
-        end: conv(entry.char_end),
-      }));
+      .map((entry, idx) => ({ entry, no: idx + 1, start: conv(entry.char_start), end: conv(entry.char_end) }));
   }, [apparatusData, content?.content]);
-  const apparatusCtx: ApparatusCtx = apparatusOn && apparatusNumbered.length
-    ? { numbered: apparatusNumbered, t }
+
+  // CBETA <lb> line anchors for citation locating + URN scroll. Fetched for
+  // every juan (small read); offsets converted code-point → UTF-16 like apparatus.
+  const { data: lineAnchorData } = useQuery({
+    queryKey: ["juanLineAnchors", textId, juanNum],
+    queryFn: () => getJuanLineAnchors(Number(textId), juanNum),
+    enabled: !!textId,
+    staleTime: 3600000,
+  });
+  const lineAnchors = useMemo<LineAnchorConv[]>(() => {
+    const raw = content?.content;
+    if (!lineAnchorData?.anchors || !raw) return [];
+    const m = cpToU16Map(raw);
+    const conv = (cp: number) => (cp >= 0 && cp < m.length ? m[cp] : m[m.length - 1]);
+    return lineAnchorData.anchors.map((a) => ({ off: conv(a.char_offset), ref: a.line_ref }));
+  }, [lineAnchorData, content?.content]);
+
+  // One context drives both inline layers. Apparatus markers only when toggled on;
+  // line anchors always embedded (invisible) so selection/URN can locate a line.
+  const readerCtx: ReaderCtx = (apparatusOn && apparatusNumbered.length) || lineAnchors.length
+    ? { numbered: apparatusOn ? apparatusNumbered : [], lineAnchors, t }
     : null;
+
+  // URN deep-link: ?anchor=p0001a09 → scroll to that CBETA line + brief flash.
+  useEffect(() => {
+    const anchorParam = searchParams.get("anchor");
+    if (!anchorParam || !lineAnchors.length) return;
+    const ref = anchorParam.replace(/^p/, "");
+    const raf = requestAnimationFrame(() => {
+      const el = readerContentRef.current?.querySelector<HTMLElement>(
+        `.cbeta-line[data-ref="${CSS.escape(ref)}"]`,
+      );
+      if (!el) return;
+      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      const p = el.closest("p");
+      if (p) {
+        p.classList.add("cbeta-line-flash");
+        setTimeout(() => p.classList.remove("cbeta-line-flash"), 2200);
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [searchParams, lineAnchors, juanNum]);
 
   const changeFontSize = (delta: number) => {
     setFontSize((prev) => {
@@ -938,7 +1018,7 @@ export default function TextReaderPage() {
                   className="reader-body"
                   style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
                 >
-                  {reflowedContent.map((seg, i) => renderSegment(seg, i, apparatusCtx))}
+                  {reflowedContent.map((seg, i) => renderSegment(seg, i, readerCtx))}
                 </div>
               </div>
             </Col>
@@ -965,7 +1045,7 @@ export default function TextReaderPage() {
             className="reader-body"
             style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
           >
-            {reflowedContent.map((seg, i) => renderSegment(seg, i, apparatusCtx))}
+            {reflowedContent.map((seg, i) => renderSegment(seg, i, readerCtx))}
           </div>
         )
       ) : (
@@ -976,6 +1056,34 @@ export default function TextReaderPage() {
         onClose={closeDictPopover}
         onAsk={handleAskXiaojin}
       />
+      {lineLocator && content && (
+        <div
+          className="cbeta-line-locator"
+          style={{ position: "fixed", left: lineLocator.x, top: Math.max(lineLocator.y - 40, 8), transform: "translateX(-50%)" }}
+        >
+          <span className="cbeta-line-locator-ref">{content.cbeta_id} · {lineLocator.ref}</span>
+          <button
+            type="button"
+            onClick={() => {
+              navigator.clipboard?.writeText(
+                t("reader.lineref.citation", { title: content.title_zh, juan: juanNum, id: content.cbeta_id, ref: lineLocator.ref }),
+              );
+              message.success(t("reader.lineref.copied"));
+            }}
+          >
+            {t("reader.lineref.copy_citation")}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              navigator.clipboard?.writeText(`fojin:cbeta/${content.cbeta_id}.${juanNum}#p${lineLocator.ref}`);
+              message.success(t("reader.lineref.copied"));
+            }}
+          >
+            {t("reader.lineref.copy_link")}
+          </button>
+        </div>
+      )}
       </div>
 
       {/* Bottom navigation */}

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -762,3 +762,43 @@
 .apparatus-marker:hover {
   text-decoration: underline;
 }
+
+/* CBETA <lb> line anchors — zero-width inline markers for citation locating */
+.cbeta-line {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+.cbeta-line-flash {
+  animation: cbeta-line-flash-kf 2.2s ease-out;
+}
+@keyframes cbeta-line-flash-kf {
+  0%, 30% { background: rgba(184, 134, 11, 0.18); }
+  100% { background: transparent; }
+}
+/* On-demand citation locator bar (shown at the selection) */
+.cbeta-line-locator {
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  background: #1f1f1f;
+  color: #fff;
+  border-radius: 6px;
+  font-size: 13px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+  white-space: nowrap;
+}
+.cbeta-line-locator-ref { font-weight: 600; color: #ffd666; }
+.cbeta-line-locator button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #fff;
+  border-radius: 4px;
+  padding: 1px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.cbeta-line-locator button:hover { background: rgba(255, 255, 255, 0.12); }


### PR DESCRIPTION
## What
Surface the **10.2M stored CBETA `<lb>` page-col-line anchors** (data already shipped with the apparatus backfill) so they're usable for academic citation:

- **On-demand citation locator**: select any passage → a bar shows the CBETA page-col-line (e.g. `T0001 · 0001a09`) with **copy-citation** / **copy-URN-link**.
- **URN deep-link**: `?anchor=p0001a09` scrolls to that line + brief flash (the URN resolver already passes the anchor through; the reader now consumes it).

## How
- **Backend**: `get_juan_line_anchors` + `GET /texts/{id}/juans/{n}/line-anchors` (lazy, mirrors the apparatus endpoint). Pure read of `text_line_anchors`.
- **Frontend**: reuses the offset-aware `reflowText`. `renderSegmentChildren` now splices **both** apparatus markers and zero-width `.cbeta-line[data-ref]` spans, sharing the **code-point→UTF-16 conversion** (`cpToU16Map`) so offsets don't drift on supplementary-plane CJK. Selection finds the nearest preceding `.cbeta-line`; URN `?anchor` scrolls to the matching span.
- i18n: `reader.lineref.*` in zh / zh-Hant / en (citation template interpolated, no hardcoded literals).

## Scope (Phase 1 of #2)
On-demand locator + URN scroll. **RAG line-level citation (Phase 2) deferred** — it touches the chat/RAG pipeline and is done separately.

## Validation
- `tsc` + `vite build` clean; i18n ratchet holds; backend line-anchor service unit-tested (AsyncMock).
- Offset mapping is the same proven path as the apparatus markers (verified 119/119 on T0001 juan 2). End-to-end (selection bar, URN scroll) verified in-browser after deploy.

## Deploy note
Frontend change — needs manual `docker compose build frontend` on the VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)