### PR TITLE
fix: align KABC tag with 大正藏 + bump pypdf to 6.13.3

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,6 @@ tiktoken==0.8.0
 opencc-python-reimplemented==0.1.7
 Pillow==12.2.0
 python-multipart==0.0.31
-pypdf==6.13.0
+pypdf==6.13.3
 python-docx==1.1.2
 beautifulsoup4==4.12.3

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -907,9 +907,12 @@ export default function TextReaderPage() {
                 href={textDetail.kabc_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                style={{ marginLeft: 8, verticalAlign: "middle" }}
+                style={{ verticalAlign: "middle" }}
               >
-                <Tag color="green" style={{ fontSize: 13, fontWeight: "normal", cursor: "pointer" }}>
+                <Tag
+                  color="green"
+                  style={{ marginLeft: 8, verticalAlign: "middle", fontSize: 13, fontWeight: "normal", cursor: "pointer" }}
+                >
                   {t("reader.kabc.link", { k: textDetail.goryeo_k })}
                 </Tag>
               </a>


### PR DESCRIPTION
## What
- **Alignment polish**: the 高丽藏 K-number tag rendered below the 大正藏 tag (it was baseline-aligned inside its `<a>` wrapper). Moves `verticalAlign: middle` onto the `Tag` itself so both tags sit level next to the title.
- **Security/CI**: bump `pypdf` 6.13.0 → 6.13.3 ([GHSA-jm82-fx9c-mx94](https://github.com/advisories/GHSA-jm82-fx9c-mx94), crafted-PDF memory DoS). This was failing the CI Python dependency audit on every PR; the bump turns it green.

## Validation
Frontend build + dep audit verified by CI. Visual alignment confirmed post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)