### PR TITLE
fix: move 高丽藏 link into the toolbar (next to 跨藏对照)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -712,7 +712,8 @@
   "reader.lineref.copied": "Copied",
   "reader.lineref.citation": "{{title}} (CBETA {{id}}, fasc. {{juan}}, {{ref}})",
   "reader.kabc.link": "Goryeo {{k}}",
-  "reader.kabc.tooltip": "View this sutra's Goryeo (Tripitaka Koreana) edition on KABC (Dongguk Univ.)",
+  "reader.kabc.button": "Goryeo",
+  "reader.kabc.tooltip": "View this sutra's Goryeo (Tripitaka Koreana, {{k}}) edition on KABC (Dongguk Univ.)",
   "reader.pageref.toggle": "Page refs",
   "reader.pageref.tooltip": "Show Taishō page·column markers (page boundaries) in the text"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -712,7 +712,8 @@
   "reader.lineref.copied": "已複製",
   "reader.lineref.citation": "《{{title}}》卷{{juan}}（CBETA {{id}}, {{ref}}）",
   "reader.kabc.link": "高麗藏 {{k}}",
-  "reader.kabc.tooltip": "在 KABC（東國大學）查看本經的高麗再雕藏版",
+  "reader.kabc.button": "高麗藏",
+  "reader.kabc.tooltip": "在 KABC（東國大學）查看本經的高麗再雕藏版（{{k}}）",
   "reader.pageref.toggle": "頁碼",
   "reader.pageref.tooltip": "在正文顯示大正藏頁·欄（頁邊界）"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -712,7 +712,8 @@
   "reader.lineref.copied": "已复制",
   "reader.lineref.citation": "《{{title}}》卷{{juan}}（CBETA {{id}}, {{ref}}）",
   "reader.kabc.link": "高丽藏 {{k}}",
-  "reader.kabc.tooltip": "在 KABC（东国大学）查看本经的高丽再雕藏版",
+  "reader.kabc.button": "高丽藏",
+  "reader.kabc.tooltip": "在 KABC（东国大学）查看本经的高丽再雕藏版（{{k}}）",
   "reader.pageref.toggle": "页码",
   "reader.pageref.tooltip": "在正文显示大正藏页·栏（页边界）"
 }

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -901,23 +901,6 @@ export default function TextReaderPage() {
               </Tag>
             </Tooltip>
           )}
-          {textDetail?.kabc_url && (
-            <Tooltip title={t("reader.kabc.tooltip")} placement="right">
-              <a
-                href={textDetail.kabc_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ verticalAlign: "middle" }}
-              >
-                <Tag
-                  color="green"
-                  style={{ marginLeft: 8, verticalAlign: "middle", fontSize: 13, fontWeight: "normal", cursor: "pointer" }}
-                >
-                  {t("reader.kabc.link", { k: textDetail.goryeo_k })}
-                </Tag>
-              </a>
-            </Tooltip>
-          )}
         </Typography.Title>
 
         <div className="reader-nav">
@@ -1002,6 +985,17 @@ export default function TextReaderPage() {
               跨藏对照
             </Button>
           </Tooltip>
+          {textDetail?.kabc_url && (
+            <Tooltip title={t("reader.kabc.tooltip", { k: textDetail.goryeo_k })}>
+              <Button
+                size="small"
+                icon={<GlobalOutlined />}
+                onClick={() => window.open(textDetail.kabc_url!, "_blank", "noopener")}
+              >
+                {t("reader.kabc.button")}
+              </Button>
+            </Tooltip>
+          )}
           <div className="reader-font-controls">
             <Button
               size="small"


### PR DESCRIPTION
## What
Per UX feedback, move the Goryeo/KABC link from a tag on the title row into the reader toolbar, next to **跨藏对照** — both are "go view another edition/canon" actions, so they belong together. The button label is just **高丽藏** (the K-number moves into the tooltip; the title row keeps only the 大正藏 base-edition tag). Opens the work's Goryeo edition on KABC in a new tab.

## Validation
tsc + vite build clean; i18n ratchet holds (`reader.kabc.button` + tooltip with `{{k}}` in zh/zh-Hant/en). Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)