### PR TITLE
fix: 高丽藏 link jumps to the current juan (not always juan 1)

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -990,7 +990,15 @@ export default function TextReaderPage() {
               <Button
                 size="small"
                 icon={<GlobalOutlined />}
-                onClick={() => window.open(textDetail.kabc_url!, "_blank", "noopener")}
+                onClick={() =>
+                  window.open(
+                    // Jump to the current juan in KABC: work URL + _T_{juan:03d}
+                    // (Goryeo juan numbering matches Taishō for the vast majority).
+                    `${textDetail.kabc_url}_T_${String(juanNum).padStart(3, "0")}`,
+                    "_blank",
+                    "noopener",
+                  )
+                }
               >
                 {t("reader.kabc.button")}
               </Button>


### PR DESCRIPTION
## What
The 高丽藏 toolbar link opened the work's Goryeo edition at juan 1 regardless of which juan you were reading. Now it appends `_T_{juan:03d}` to the KABC dataId so it opens the **same juan** (e.g. reading 長阿含經 卷4 → `ABC_IT_K0647_T_004` = 長阿含經 卷第四 on KABC).

## Verified
- KABC supports juan-level URLs: `dataId=ABC_IT_K{num}_T_{juan:03d}`.
- `ABC_IT_K0647_T_004` loads 長阿含經 卷第四 (제4권) — Goryeo juan numbering aligns with CBETA for this (and the vast majority of) texts.

## Caveat
A minority of texts whose Goryeo juan division differs from Taishō may land on KABC's nearest juan; acceptable (recoverable by navigation), and far better than always-juan-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)