### PR TITLE
feat(chat): 义理本典保底 — doctrine-term reserved slot (ships #687)

### DIFF
--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -102,8 +102,12 @@ _JING_COMPOUND_TAIL = set("济濟验驗常过過营營历歷理典商销銷书�
 # higher term density than the source text, which is why hybrid keyword
 # retrieval is NOT the fix here). Same curated-map + reserved-slot approach
 # as the named-sutra fix above, keyed on high-precision doctrine terms.
-# Only unambiguous multi-char terms; root availability prod-verified
-# 2026-06-11 (all 10 texts have content + embeddings).
+# Multi-char terms only; root availability prod-verified 2026-06-11 (all
+# mapped texts have content + embeddings). Known accepted false positives
+# (deliberate trade-off, cost confined to the last slot on a Buddhist
+# site): lexicalized chengyu 不二法门/本来面目/直指人心 and secular 顿悟
+# also fire in everyday usage. Cross-boundary traps (毕竟空闲, 真空性质)
+# are guarded via _AMBIGUOUS_DOCTRINE_TAILS below.
 _DOCTRINE_TERM_ROOTS: dict[str, str] = {
     # 中观 → 中论 T1564
     "缘起性空": "T1564", "緣起性空": "T1564", "性空缘起": "T1564", "性空緣起": "T1564",
@@ -119,13 +123,18 @@ _DOCTRINE_TERM_ROOTS: dict[str, str] = {
     # 天台 → 摩诃止观 T1911
     "一念三千": "T1911", "三谛圆融": "T1911", "三諦圓融": "T1911",
     "一心三观": "T1911", "一心三觀": "T1911",
-    # 华严 → 华严经 T0279
-    "法界缘起": "T0279", "法界緣起": "T0279", "四法界": "T0279",
-    "事事无碍": "T0279", "事事無礙": "T0279", "十玄门": "T0279", "十玄門": "T0279",
-    "六相圆融": "T0279", "六相圓融": "T0279", "因陀罗网": "T0279", "因陀羅網": "T0279",
-    # 净土 → 阿弥陀经 T0366
+    # 华严宗义 → 华严五教章 T1866 (法藏)：四法界/十玄/六相 are patriarch-treatise
+    # vocabulary — the 80-juan sutra never states them as doctrines, so a scoped
+    # search over T0279 returns weakly related chunks. T1866 expounds them
+    # directly (202 chunks, prod-verified). 因陀罗网 stays on the sutra: the
+    # 帝网 imagery genuinely lives there.
+    "法界缘起": "T1866", "法界緣起": "T1866", "四法界": "T1866",
+    "事事无碍": "T1866", "事事無礙": "T1866", "十玄门": "T1866", "十玄門": "T1866",
+    "六相圆融": "T1866", "六相圓融": "T1866",
+    "因陀罗网": "T0279", "因陀羅網": "T0279",
+    # 净土 → 阿弥陀经 T0366；带业往生的经证是观经下品下生 → T0365
     "念佛法门": "T0366", "念佛法門": "T0366", "净土法门": "T0366", "淨土法門": "T0366",
-    "带业往生": "T0366", "帶業往生": "T0366", "西方极乐": "T0366", "西方極樂": "T0366",
+    "带业往生": "T0365", "帶業往生": "T0365", "西方极乐": "T0366", "西方極樂": "T0366",
     # 禅宗 → 六祖坛经 T2008
     "明心见性": "T2008", "明心見性": "T2008", "顿悟": "T2008", "頓悟": "T2008",
     "本来面目": "T2008", "本來面目": "T2008", "直指人心": "T2008", "见性成佛": "T2008", "見性成佛": "T2008",
@@ -140,14 +149,38 @@ _DOCTRINE_TERM_ROOTS: dict[str, str] = {
 }
 _DOCTRINE_KEYS_BY_LEN = sorted(_DOCTRINE_TERM_ROOTS, key=len, reverse=True)
 
+# Cross-boundary guard, same mechanism as _AMBIGUOUS_SHORT_ALIASES: these terms'
+# last char also heads common secular compounds, so 毕竟空|闲时间 ("after all,
+# little free time") or 真空|性质 ("properties of vacuum", matching 空+性 across
+# the word boundary) must not fire. Reject an occurrence when the next char
+# completes such a compound; accept if ANY occurrence has a clean tail.
+_AMBIGUOUS_DOCTRINE_TAILS: dict[str, set[str]] = {
+    "毕竟空": set("气氣调調间間白闲閒着隙位缺旷曠地"),
+    "畢竟空": set("气氣调調间間白闲閒着隙位缺旷曠地"),
+    "空性": set("质質能格"),
+}
+
 
 def _detect_doctrine_root(query: str) -> str | None:
     """Return the root cbeta_id for the longest curated doctrine term present in
-    the query, or None. Longest-match mirrors _detect_named_root so nested terms
-    ("缘起性空" ⊃ "空性") resolve to the more specific mapping."""
+    the query, or None. Longest-match mirrors _detect_named_root; no key currently
+    nests inside another, so the sort is future-proofing for added terms (e.g. a
+    bare "缘起" entry must never shadow "法界缘起")."""
     for term in _DOCTRINE_KEYS_BY_LEN:
-        if term in query:
-            return _DOCTRINE_TERM_ROOTS[term]
+        if term not in query:
+            continue
+        bad_tails = _AMBIGUOUS_DOCTRINE_TAILS.get(term)
+        if bad_tails:
+            start, real = 0, False
+            while (pos := query.find(term, start)) != -1:
+                tail = query[pos + len(term): pos + len(term) + 1]
+                if not tail or tail not in bad_tails:
+                    real = True
+                    break
+                start = pos + 1
+            if not real:
+                continue
+        return _DOCTRINE_TERM_ROOTS[term]
     return None
 
 

--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -94,6 +94,62 @@ _root_text_id_cache: dict[str, int | None] = {}
 _AMBIGUOUS_SHORT_ALIASES = {"心经", "心經", "坛经", "壇經"}
 _JING_COMPOUND_TAIL = set("济濟验驗常过過营營历歷理典商销銷书書文手度络絡费費办辦纬緯由")
 
+# --- 义理术语→本典 (doctrine-term root slot, Case 2 of 本经召回缺口) ----------
+# Abstract doctrine questions name no sutra ("缘起性空怎么理解"), so
+# _detect_named_root never fires, and the foundational treatise (中论,
+# 成唯识论…) loses the cosine race to dense later commentaries that repeat
+# the term more often (BM25 would skew the same way — commentaries have
+# higher term density than the source text, which is why hybrid keyword
+# retrieval is NOT the fix here). Same curated-map + reserved-slot approach
+# as the named-sutra fix above, keyed on high-precision doctrine terms.
+# Only unambiguous multi-char terms; root availability prod-verified
+# 2026-06-11 (all 10 texts have content + embeddings).
+_DOCTRINE_TERM_ROOTS: dict[str, str] = {
+    # 中观 → 中论 T1564
+    "缘起性空": "T1564", "緣起性空": "T1564", "性空缘起": "T1564", "性空緣起": "T1564",
+    "八不中道": "T1564", "空性": "T1564", "自性空": "T1564", "毕竟空": "T1564", "畢竟空": "T1564",
+    # 唯识 → 成唯识论 T1585
+    "唯识": "T1585", "唯識": "T1585", "阿赖耶": "T1585", "阿賴耶": "T1585",
+    "末那识": "T1585", "末那識": "T1585", "三自性": "T1585",
+    "遍计所执": "T1585", "遍計所執": "T1585", "依他起": "T1585", "圆成实": "T1585", "圓成實": "T1585",
+    "转识成智": "T1585", "轉識成智": "T1585", "八识": "T1585", "八識": "T1585",
+    # 佛性/如来藏 → 大般涅槃经 T0374
+    "佛性": "T0374", "如来藏": "T0374", "如來藏": "T0374",
+    "一阐提": "T0374", "一闡提": "T0374", "常乐我净": "T0374", "常樂我淨": "T0374",
+    # 天台 → 摩诃止观 T1911
+    "一念三千": "T1911", "三谛圆融": "T1911", "三諦圓融": "T1911",
+    "一心三观": "T1911", "一心三觀": "T1911",
+    # 华严 → 华严经 T0279
+    "法界缘起": "T0279", "法界緣起": "T0279", "四法界": "T0279",
+    "事事无碍": "T0279", "事事無礙": "T0279", "十玄门": "T0279", "十玄門": "T0279",
+    "六相圆融": "T0279", "六相圓融": "T0279", "因陀罗网": "T0279", "因陀羅網": "T0279",
+    # 净土 → 阿弥陀经 T0366
+    "念佛法门": "T0366", "念佛法門": "T0366", "净土法门": "T0366", "淨土法門": "T0366",
+    "带业往生": "T0366", "帶業往生": "T0366", "西方极乐": "T0366", "西方極樂": "T0366",
+    # 禅宗 → 六祖坛经 T2008
+    "明心见性": "T2008", "明心見性": "T2008", "顿悟": "T2008", "頓悟": "T2008",
+    "本来面目": "T2008", "本來面目": "T2008", "直指人心": "T2008", "见性成佛": "T2008", "見性成佛": "T2008",
+    # 不二 → 维摩诘经 T0475
+    "不二法门": "T0475", "不二法門": "T0475",
+    # 法华 → 法华经 T0262
+    "一佛乘": "T0262", "会三归一": "T0262", "會三歸一": "T0262", "开权显实": "T0262", "開權顯實": "T0262",
+    # 根本教义 → 杂阿含 T0099
+    "四圣谛": "T0099", "四聖諦": "T0099", "八正道": "T0099",
+    "十二因缘": "T0099", "十二因緣": "T0099", "四念处": "T0099", "四念處": "T0099",
+    "三法印": "T0099",
+}
+_DOCTRINE_KEYS_BY_LEN = sorted(_DOCTRINE_TERM_ROOTS, key=len, reverse=True)
+
+
+def _detect_doctrine_root(query: str) -> str | None:
+    """Return the root cbeta_id for the longest curated doctrine term present in
+    the query, or None. Longest-match mirrors _detect_named_root so nested terms
+    ("缘起性空" ⊃ "空性") resolve to the more specific mapping."""
+    for term in _DOCTRINE_KEYS_BY_LEN:
+        if term in query:
+            return _DOCTRINE_TERM_ROOTS[term]
+    return None
+
 
 def _detect_named_root(query: str) -> str | None:
     """Return the canonical root cbeta_id of the longest curated sutra alias that
@@ -136,11 +192,18 @@ async def _resolve_root_text_id(db: AsyncSession, cbeta_id: str) -> int | None:
 async def _inject_root_sutra_slot(
     db: AsyncSession, query: str, query_embedding: list[float], search_results: list[dict]
 ) -> list[dict]:
-    """If the query names a root sutra and that root isn't already in the final
-    context, prepend its best-matching chunk into a reserved slot (keeping the
-    total at MAX_CONTEXT_CHUNKS). No-op when no sutra is named or the root is
-    already present. See 本经召回缺口 note above."""
-    cbeta_id = _detect_named_root(query)
+    """Reserve a context slot for the foundational text the query is about.
+
+    Two-tier detection, mirroring the two cases of the 本经召回缺口:
+      1. Named sutra (Case 1): user explicitly names a root sutra → its best
+         chunk takes slot #1 (the user asked for THIS text).
+      2. Doctrine term (Case 2): no sutra named, but the query contains a
+         curated doctrine term (空性, 唯识, …) → the foundational treatise's
+         best chunk takes the LAST slot. It belongs in context, but the user
+         didn't name it, so it must not displace the reranked top hits.
+    No-op when neither fires or the root is already present."""
+    named = _detect_named_root(query)
+    cbeta_id = named or _detect_doctrine_root(query)
     if not cbeta_id:
         return search_results
     root_tid = await _resolve_root_text_id(db, cbeta_id)
@@ -151,11 +214,14 @@ async def _inject_root_sutra_slot(
     root_hits = await similarity_search(db, query_embedding, limit=1, scope_text_ids=[root_tid])
     if not root_hits:
         return search_results
-    logger.debug("本经召回保底: reserved slot for root %s (text_id=%d)", cbeta_id, root_tid)
     others = [r for r in search_results if r["text_id"] != root_tid]
-    # Root keeps its raw cosine (lower than the others' blended rerank scores);
-    # it sits at slot 1 by construction — do NOT re-sort search_results after this.
-    return [root_hits[0]] + others[: MAX_CONTEXT_CHUNKS - 1]
+    if named:
+        logger.debug("本经召回保底: slot #1 for named root %s (text_id=%d)", cbeta_id, root_tid)
+        # Root keeps its raw cosine (lower than the others' blended rerank
+        # scores); it sits at slot 1 by construction — do NOT re-sort after this.
+        return [root_hits[0], *others[: MAX_CONTEXT_CHUNKS - 1]]
+    logger.debug("义理本典保底: last slot for doctrine root %s (text_id=%d)", cbeta_id, root_tid)
+    return [*others[: MAX_CONTEXT_CHUNKS - 1], root_hits[0]]
 
 
 def _format_source_label(result: dict) -> str:

--- a/backend/tests/test_root_sutra_recall.py
+++ b/backend/tests/test_root_sutra_recall.py
@@ -68,3 +68,74 @@ def test_ambiguous_alias_still_matches_real_reference():
     assert _detect_named_root("心经全文") == "T0251"
     assert _detect_named_root("担心经济，但还是想读心经") == "T0251"  # 2nd occurrence is real
     assert _detect_named_root("六祖坛经讲顿悟") == "T2008"
+
+
+# --- Case 2: doctrine-term → foundational-text mapping ----------------------
+
+from app.services.rag_retrieval import _detect_doctrine_root
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        # 中观
+        ("什么是缘起性空", "T1564"),
+        ("空性怎么理解", "T1564"),
+        ("畢竟空與斷滅見的區別", "T1564"),
+        # 唯识
+        ("唯识学的三自性", "T1585"),
+        ("阿赖耶识是什么", "T1585"),
+        ("轉識成智的過程", "T1585"),
+        # 佛性
+        ("一切众生皆有佛性吗", "T0374"),
+        ("如来藏思想", "T0374"),
+        # 天台
+        ("一念三千怎么理解", "T1911"),
+        ("一心三觀的修法", "T1911"),
+        # 华严
+        ("事事无碍法界", "T0279"),
+        ("因陀羅網的比喻", "T0279"),
+        # 净土
+        ("净土法门适合我吗", "T0366"),
+        ("帶業往生可能嗎", "T0366"),
+        # 禅宗
+        ("顿悟和渐修的区别", "T2008"),
+        ("如何明心见性", "T2008"),
+        # 不二 / 法华 / 根本教义
+        ("什么是不二法门", "T0475"),
+        ("一佛乘的含义", "T0262"),
+        ("四圣谛和八正道", "T0099"),
+        ("十二因緣流轉", "T0099"),
+    ],
+)
+def test_doctrine_term_maps_to_foundational_text(query, expected):
+    assert _detect_doctrine_root(query) == expected
+
+
+def test_doctrine_longest_match_wins():
+    # "缘起性空" (T1564 via 4-char term) contains "空性"? It does not — but
+    # "自性空" ⊂ "缘起性空" is also absent. The real nesting risk: a query with
+    # both "法界缘起" (T0279) and "缘起" — bare "缘起" is deliberately unmapped,
+    # so the 4-char Huayan term must win.
+    assert _detect_doctrine_root("法界缘起与十玄门") == "T0279"
+
+
+def test_doctrine_no_false_positive():
+    assert _detect_doctrine_root("今天天气怎么样") is None
+    assert _detect_doctrine_root("怎么注册账号") is None
+    assert _detect_doctrine_root("") is None
+    # Bare generic words deliberately unmapped: 缘起 / 中道 / 念佛 / 止观.
+    assert _detect_doctrine_root("缘起是什么") is None
+    assert _detect_doctrine_root("念佛是谁") is None
+
+
+def test_named_sutra_query_not_hijacked_by_doctrine_term():
+    # Queries naming a sutra AND containing a doctrine term: named root must
+    # win inside _inject_root_sutra_slot (named checked first). Here we just
+    # pin that both detectors fire independently on such a query.
+    q = "六祖坛经讲的顿悟"
+    assert _detect_named_root(q) == "T2008"
+    assert _detect_doctrine_root(q) == "T2008"
+    q2 = "心经的空性"
+    assert _detect_named_root(q2) == "T0251"
+    assert _detect_doctrine_root(q2) == "T1564"

--- a/backend/tests/test_root_sutra_recall.py
+++ b/backend/tests/test_root_sutra_recall.py
@@ -1,12 +1,17 @@
-"""Tests for 本经召回保底 root-sutra detection (rag_retrieval._detect_named_root).
+"""Tests for 本经召回保底 root detection + reserved-slot injection.
 
-The reserved-slot injection itself needs a live pgvector corpus and is verified
-against prod; here we lock the pure name→root-cbeta_id mapping that gates it.
+Detector tests lock the pure term→root-cbeta_id mappings; injector tests
+monkeypatch the two DB awaits to pin slot placement and the cap.
 """
 
 import pytest
 
-from app.services.rag_retrieval import _detect_named_root
+from app.services import rag_retrieval
+from app.services.rag_retrieval import (
+    _detect_doctrine_root,
+    _detect_named_root,
+    _inject_root_sutra_slot,
+)
 
 
 @pytest.mark.parametrize(
@@ -72,8 +77,6 @@ def test_ambiguous_alias_still_matches_real_reference():
 
 # --- Case 2: doctrine-term → foundational-text mapping ----------------------
 
-from app.services.rag_retrieval import _detect_doctrine_root
-
 
 @pytest.mark.parametrize(
     "query,expected",
@@ -92,12 +95,14 @@ from app.services.rag_retrieval import _detect_doctrine_root
         # 天台
         ("一念三千怎么理解", "T1911"),
         ("一心三觀的修法", "T1911"),
-        # 华严
-        ("事事无碍法界", "T0279"),
+        # 华严宗义 → 五教章 (treatise vocabulary, not sutra vocabulary)
+        ("事事无碍法界", "T1866"),
+        ("四法界怎么分", "T1866"),
+        # …but the 帝网 imagery lives in the sutra itself
         ("因陀羅網的比喻", "T0279"),
         # 净土
         ("净土法门适合我吗", "T0366"),
-        ("帶業往生可能嗎", "T0366"),
+        ("帶業往生可能嗎", "T0365"),
         # 禅宗
         ("顿悟和渐修的区别", "T2008"),
         ("如何明心见性", "T2008"),
@@ -113,11 +118,31 @@ def test_doctrine_term_maps_to_foundational_text(query, expected):
 
 
 def test_doctrine_longest_match_wins():
-    # "缘起性空" (T1564 via 4-char term) contains "空性"? It does not — but
-    # "自性空" ⊂ "缘起性空" is also absent. The real nesting risk: a query with
-    # both "法界缘起" (T0279) and "缘起" — bare "缘起" is deliberately unmapped,
-    # so the 4-char Huayan term must win.
-    assert _detect_doctrine_root("法界缘起与十玄门") == "T0279"
+    # No key currently nests inside another; the longest-first sort guards
+    # future additions (a bare "缘起" entry must never shadow "法界缘起").
+    assert _detect_doctrine_root("法界缘起与十玄门") == "T1866"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # 毕竟空 + 闲/调/气 — the 空 belongs to a following secular compound.
+        "毕竟空闲时间少，怎么安排修行",
+        "毕竟空调房里打坐舒服吗",
+        "毕竟空气不好少出门",
+        # 空性 matched across the word boundary of 真空|性质, 航空|性能.
+        "真空性质和佛教的空有关系吗",
+        "航空性能怎么评估",
+    ],
+)
+def test_doctrine_cross_boundary_compound_rejected(query):
+    assert _detect_doctrine_root(query) is None
+
+
+def test_doctrine_ambiguous_term_still_matches_real_usage():
+    assert _detect_doctrine_root("毕竟空与断灭见的区别") == "T1564"
+    assert _detect_doctrine_root("何谓毕竟空") == "T1564"  # term at end of query
+    assert _detect_doctrine_root("空性怎么理解") == "T1564"
 
 
 def test_doctrine_no_false_positive():
@@ -139,3 +164,74 @@ def test_named_sutra_query_not_hijacked_by_doctrine_term():
     q2 = "心经的空性"
     assert _detect_named_root(q2) == "T0251"
     assert _detect_doctrine_root(q2) == "T1564"
+
+
+# --- Injector: slot placement, cap, precedence ------------------------------
+
+
+def _fake_results(n: int, start_tid: int = 100) -> list[dict]:
+    return [{"text_id": start_tid + i, "score": 0.9 - i * 0.01} for i in range(n)]
+
+
+@pytest.fixture
+def _patched_injector_deps(monkeypatch):
+    """Patch the two DB awaits; record which cbeta_id got resolved."""
+    resolved: dict[str, str] = {}
+
+    async def fake_resolve(db, cbeta_id):
+        resolved["cbeta_id"] = cbeta_id
+        return 999
+
+    async def fake_search(db, emb, limit=1, scope_text_ids=None, **kw):
+        return [{"text_id": scope_text_ids[0], "score": 0.42}]
+
+    monkeypatch.setattr(rag_retrieval, "_resolve_root_text_id", fake_resolve)
+    monkeypatch.setattr(rag_retrieval, "similarity_search", fake_search)
+    return resolved
+
+
+@pytest.mark.anyio
+async def test_named_root_takes_slot_one_and_caps_at_five(_patched_injector_deps):
+    out = await _inject_root_sutra_slot(None, "心经的核心思想", [0.0], _fake_results(5))
+    assert len(out) == 5
+    assert out[0]["text_id"] == 999  # root at slot #1
+    assert _patched_injector_deps["cbeta_id"] == "T0251"
+
+
+@pytest.mark.anyio
+async def test_doctrine_root_takes_last_slot_and_caps_at_five(_patched_injector_deps):
+    out = await _inject_root_sutra_slot(None, "什么是空性", [0.0], _fake_results(5))
+    assert len(out) == 5
+    assert out[-1]["text_id"] == 999  # root at LAST slot
+    assert out[0]["text_id"] == 100  # reranked top hit untouched
+    assert 104 not in [r["text_id"] for r in out]  # hit #5 displaced
+    assert _patched_injector_deps["cbeta_id"] == "T1564"
+
+
+@pytest.mark.anyio
+async def test_named_wins_over_doctrine_on_mixed_query(_patched_injector_deps):
+    # "心经的空性" names a sutra AND contains a doctrine term: named must win.
+    out = await _inject_root_sutra_slot(None, "心经的空性", [0.0], _fake_results(3))
+    assert out[0]["text_id"] == 999
+    assert _patched_injector_deps["cbeta_id"] == "T0251"
+
+
+@pytest.mark.anyio
+async def test_root_already_present_is_noop(_patched_injector_deps):
+    results = [*_fake_results(4), {"text_id": 999, "score": 0.5}]
+    out = await _inject_root_sutra_slot(None, "什么是空性", [0.0], results)
+    assert out == results
+
+
+@pytest.mark.anyio
+async def test_doctrine_with_empty_results_returns_just_root(_patched_injector_deps):
+    out = await _inject_root_sutra_slot(None, "什么是空性", [0.0], [])
+    assert [r["text_id"] for r in out] == [999]
+
+
+@pytest.mark.anyio
+async def test_no_detection_is_noop(_patched_injector_deps):
+    results = _fake_results(5)
+    out = await _inject_root_sutra_slot(None, "今天天气怎么样", [0.0], results)
+    assert out == results
+    assert "cbeta_id" not in _patched_injector_deps


### PR DESCRIPTION
Ships the work from #687 (intentionally deferred on 2026-06-11 so a CD restart wouldn't kill the then-running 25k 般若 alignment script — that script has long since finished; verified no long-running task on prod now).

## Why a fresh branch (not a rebase of #687)
`feat/doctrine-root-slot` was based on a pre-rewrite master; rebasing replayed ancient scaffold commits with 38 conflicts. More importantly, its base predates `perf(rag): run per-language + source vector searches concurrently` — a naive rebase/merge would have **reverted that perf optimization**. Instead, cherry-picked the two feature commits (`b5af3d5` feat + `a5e01e3` harden) onto current master. Verified: the concurrent-search perf code is intact AND the doctrine slot is in.

## What
Last gap of 本经召回缺口: abstract doctrine questions (no sutra named) let the foundational treatise lose the cosine race to dense commentaries. Curated ~60 high-precision multi-char doctrine terms (繁简双写) → 10 root texts; doctrine root takes the **last** slot (belongs in context, must not displace rerank top). Named-sutra still takes slot #1. Cross-boundary traps (毕竟空闲, 真空性质) guarded.

## Validation
- Cherry-pick clean, no conflicts; perf concurrent code preserved.
- 58 tests pass (`test_root_sutra_recall.py`); ruff clean.
- Post-merge prod plan: 「什么是空性」「阿赖耶识」「一念三千」 → confirm last-slot root text appears.

Closes #687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)