### PR TITLE
feat(nav): surface Dashboard (数据总览) in main nav

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,7 +15,7 @@ import {
   RobotOutlined,
   GithubOutlined,
   GlobalOutlined,
-  // BarChartOutlined,   // dashboard nav deferred (pending polish)
+  BarChartOutlined,
   // FieldTimeOutlined,  // timeline nav deferred (pending polish)
   // NotificationOutlined,  // activity nav deferred (empty Source-Updates subtab)
 } from "@ant-design/icons";
@@ -79,8 +79,7 @@ export default function Layout() {
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
     { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
-    // 数据总览(/dashboard)暂不放导航：待打磨后再上线（路由仍可直达 /dashboard）。
-    // { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
+    { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
     // 历史时间线(/timeline)暂不放导航：待打磨后再上线（路由仍可直达 /timeline）。
     // { icon: <FieldTimeOutlined />, label: t("nav.timeline"), path: "/timeline" },
     // 佛学动态(/activity)仍暂不放导航：Source-Updates 子标签无数据流（空）；


### PR DESCRIPTION
## What
Add **数据总览 / Dashboard** to the main navigation. The `/dashboard` route was already built and routed but kept out of the nav behind a `// pending polish` comment.

Verified on prod the page is complete and polished: 6 stat cards (10,531 texts · 613 sources · 4 languages · 113,582 KG entities · 27,970 relations · 747,622 dictionary entries) + dynasty distribution / language donut / category treemap / source coverage / translation activity / top translators charts. The "pending polish" note is stale → surface it.

Just uncomments `BarChartOutlined` + the nav item; `nav.dashboard` i18n already exists in zh/zh-Hant/en. First step of the surfacing track (强后端弱触达).

**Timeline and Activity stay hidden** for now — Activity still has an empty Source-Updates subtab to resolve first.

## Validation
tsc + vite build clean; i18n ratchet holds. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)