### PR TITLE
fix(nav): hide 数据总览 (Dashboard) from public navigation

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,7 +15,7 @@ import {
   RobotOutlined,
   GithubOutlined,
   GlobalOutlined,
-  BarChartOutlined,
+  // BarChartOutlined,   // dashboard nav hidden (数据总览 暂不对外公开)
   // FieldTimeOutlined,  // timeline nav deferred (pending polish)
   // NotificationOutlined,  // activity nav deferred (empty Source-Updates subtab)
 } from "@ant-design/icons";
@@ -79,7 +79,8 @@ export default function Layout() {
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
     { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
-    { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
+    // 数据总览(/dashboard)暂不对外公开：从导航撤下，路由仍可直达 /dashboard。
+    // { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
     // 历史时间线(/timeline)暂不放导航：待打磨后再上线（路由仍可直达 /timeline）。
     // { icon: <FieldTimeOutlined />, label: t("nav.timeline"), path: "/timeline" },
     // 佛学动态(/activity)仍暂不放导航：Source-Updates 子标签无数据流（空）；


### PR DESCRIPTION
Revert of the nav entry added in #787. The Dashboard surfaces platform-internal stats (user/message counts, activity, feedback) not meant for public display yet, so pull it out of the main navigation.

Comments out both the `BarChartOutlined` import and the nav item (mirrors the timeline/activity deferral pattern). The **`/dashboard` route stays live** — direct URL still works for the owner; only the visible menu entry is removed.

## Validation
tsc + vite build clean; i18n ratchet holds. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)