### PR TITLE
fix(admin): 趋势图 消息数/活跃用户 撞色修复

### DIFF
--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -199,10 +199,16 @@ export default function AdminDashboardPage() {
   // Dual Y-axis: 消息数 (tens~hundreds) on the left, 新增用户 + 活跃用户
   // (single digits ~ teens) on the right. On a shared axis the two
   // small-magnitude series flatten to the baseline and can't be read.
-  const messagesData = trends.messages.map((d) => ({ ...d, type: "消息数" }));
+  // Series labels: defined once so the chart data, the legend and the shared
+  // color domain below all reference the exact same strings (a mismatch would
+  // silently drop a series back to a default color).
+  const S_MESSAGES = "消息数";
+  const S_NEW_USERS = "新增用户";
+  const S_ACTIVE_USERS = "活跃用户";
+  const messagesData = trends.messages.map((d) => ({ ...d, type: S_MESSAGES }));
   const usersData = [
-    ...trends.registrations.map((d) => ({ ...d, type: "新增用户" })),
-    ...trends.active_users.map((d) => ({ ...d, type: "活跃用户" })),
+    ...trends.registrations.map((d) => ({ ...d, type: S_NEW_USERS })),
+    ...trends.active_users.map((d) => ({ ...d, type: S_ACTIVE_USERS })),
   ];
 
   // Latest day in the trend = default selection for the active-users table.
@@ -216,7 +222,7 @@ export default function AdminDashboardPage() {
   // both land on orange. Declaring the SAME full domain→range on both children
   // pins every series to a distinct color: 消息数 蓝 / 新增用户 橙 / 活跃用户 绿.
   const seriesColor = {
-    domain: ["消息数", "新增用户", "活跃用户"],
+    domain: [S_MESSAGES, S_NEW_USERS, S_ACTIVE_USERS],
     range: ["#1677ff", "#fa8c16", "#52c41a"],
   };
   const chartConfig = {

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -210,6 +210,15 @@ export default function AdminDashboardPage() {
     ? trends.active_users[trends.active_users.length - 1].date
     : null;
 
+  // Both children map colorField "type" to ONE shared G2 color scale (keyed by
+  // field name). If each declares only its own range, the merged scale picks up
+  // the 2-color range and cycles it across the 3 series, so 消息数 and 活跃用户
+  // both land on orange. Declaring the SAME full domain→range on both children
+  // pins every series to a distinct color: 消息数 蓝 / 新增用户 橙 / 活跃用户 绿.
+  const seriesColor = {
+    domain: ["消息数", "新增用户", "活跃用户"],
+    range: ["#1677ff", "#fa8c16", "#52c41a"],
+  };
   const chartConfig = {
     xField: "date",
     height: 360,
@@ -222,7 +231,7 @@ export default function AdminDashboardPage() {
         yField: "count",
         colorField: "type",
         smooth: true,
-        scale: { color: { range: ["#1677ff"] } },
+        scale: { color: seriesColor },
       },
       {
         data: usersData,
@@ -231,7 +240,7 @@ export default function AdminDashboardPage() {
         colorField: "type",
         smooth: true,
         axis: { y: { position: "right" } },
-        scale: { color: { range: ["#fa8c16", "#52c41a"] } },
+        scale: { color: seriesColor },
       },
     ],
     // Click any point to drill the active-users table to that day.


### PR DESCRIPTION
## 问题
管理后台「最近 30 天趋势」DualAxes 图里,**消息数** 和 **活跃用户** 都渲染成橙色,无法区分(见用户截图)。

## 根因
两个子图都用 `colorField: "type"`,G2 5 按字段名把它们合并成**一个共享颜色 scale**。原本每个子图只声明自己的 `range`(子图1=1色,子图2=2色),合并后 2 色 range 在 3 个域值上**循环**:消息数→橙、新增用户→绿、活跃用户→橙(绕回),于是消息数与活跃用户撞色。

## 修复
抽出共享 `seriesColor`,在**两个子图**都声明同一份完整 `domain→range`:
- 消息数 → 蓝 `#1677ff`(左轴)
- 新增用户 → 橙 `#fa8c16`(右轴)
- 活跃用户 → 绿 `#52c41a`(右轴)

合并幂等,每条线锁定唯一颜色。

## 验证
- `tsc --noEmit` 通过
- code-reviewer:LGTM(方法正确、无幻影图例、字符串一致)
- 视觉渲染需 merge+部署后在 /admin 确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)