### PR TITLE
feat(admin): chat 答案质量行为信号 + 后台面板

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -84,6 +84,7 @@ async def stats_module_usage(
         days=days,
         events=result["events"],
         top_search_keywords=result["top_search_keywords"],
+        answer_quality=result["answer_quality"],
     )
 
 

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -126,7 +126,23 @@ class KeywordItem(BaseModel):
     count: int
 
 
+class AnswerQuality(BaseModel):
+    """Behavioural answer-quality proxies, sourced from Umami events.
+
+    Rates are percentages against ``chat_questions`` (questions asked); they are
+    ``None`` when there is no chat volume in the window.
+    """
+    chat_questions: int
+    citation_click: int
+    chat_copy: int
+    chat_retry: int
+    citation_click_rate: float | None = None
+    copy_rate: float | None = None
+    retry_rate: float | None = None
+
+
 class AdminModuleUsage(BaseModel):
     days: int
     events: list[ModuleEventItem]
     top_search_keywords: list[KeywordItem]
+    answer_quality: AnswerQuality

--- a/backend/app/services/usage_service.py
+++ b/backend/app/services/usage_service.py
@@ -36,6 +36,13 @@ _EVENT_LABELS: dict[str, str] = {
     "cbeta-shortcut": "CBETA直跳",
 }
 
+# Behavioural answer-quality signals. Tracked as Umami events on every chat
+# answer (not just the ~0% that get an explicit 👍/👎), so they give a quality
+# proxy with real volume. Pulled OUT of the module-usage `events` list so they
+# don't clutter the "板块使用情况" board, and reported as rates against the
+# number of questions asked (the `chat` event).
+_QUALITY_EVENTS: tuple[str, ...] = ("citation_click", "chat_copy", "chat_retry")
+
 
 def _build_umami_url() -> str:
     """Derive the Umami async DB URL from the fojin app DB URL.
@@ -92,7 +99,19 @@ async def get_module_usage(days: int = 7) -> dict[str, Any]:
 
 
 def _empty_usage() -> dict[str, Any]:
-    return {"events": [], "top_search_keywords": []}
+    return {
+        "events": [],
+        "top_search_keywords": [],
+        "answer_quality": {
+            "chat_questions": 0,
+            "citation_click": 0,
+            "chat_copy": 0,
+            "chat_retry": 0,
+            "citation_click_rate": None,
+            "copy_rate": None,
+            "retry_rate": None,
+        },
+    }
 
 
 async def _query_module_usage(days: int) -> dict[str, Any]:
@@ -127,14 +146,39 @@ async def _query_module_usage(days: int) -> dict[str, Any]:
         event_rows = (await session.execute(event_sql, {"days": days})).all()
         keyword_rows = (await session.execute(keyword_sql, {"days": days})).all()
 
+    counts = {row[0]: int(row[1]) for row in event_rows}
+
+    # Module-usage board: every tracked event EXCEPT the quality signals.
     events = [
         {
-            "event_name": row[0],
-            "label": _EVENT_LABELS.get(row[0], row[0]),
-            "count": int(row[1]),
+            "event_name": name,
+            "label": _EVENT_LABELS.get(name, name),
+            "count": cnt,
         }
-        for row in event_rows
+        for name, cnt in counts.items()
+        if name not in _QUALITY_EVENTS
     ]
+
+    # Answer-quality proxies, as rates against questions asked. Denominator is
+    # the `chat` event (one per question). `None` when there is no chat volume
+    # yet so the UI can show "—" instead of a misleading 0%.
+    chat_n = counts.get("chat", 0)
+
+    def _rate(n: int) -> float | None:
+        return round(n / chat_n * 100, 1) if chat_n else None
+
+    citation_click = counts.get("citation_click", 0)
+    chat_copy = counts.get("chat_copy", 0)
+    chat_retry = counts.get("chat_retry", 0)
+    answer_quality = {
+        "chat_questions": chat_n,
+        "citation_click": citation_click,
+        "chat_copy": chat_copy,
+        "chat_retry": chat_retry,
+        "citation_click_rate": _rate(citation_click),
+        "copy_rate": _rate(chat_copy),
+        "retry_rate": _rate(chat_retry),
+    }
 
     top_search_keywords = [
         {"keyword": row[0], "count": int(row[1])}
@@ -142,4 +186,8 @@ async def _query_module_usage(days: int) -> dict[str, Any]:
         if row[0]  # skip null/empty keywords
     ]
 
-    return {"events": events, "top_search_keywords": top_search_keywords}
+    return {
+        "events": events,
+        "top_search_keywords": top_search_keywords,
+        "answer_quality": answer_quality,
+    }

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -156,6 +156,15 @@ async def test_module_usage_returns_data(client):
         "top_search_keywords": [
             {"keyword": "心经", "count": 8},
         ],
+        "answer_quality": {
+            "chat_questions": 10,
+            "citation_click": 3,
+            "chat_copy": 2,
+            "chat_retry": 1,
+            "citation_click_rate": 30.0,
+            "copy_rate": 20.0,
+            "retry_rate": 10.0,
+        },
     }
 
     app.dependency_overrides[get_current_user] = lambda: fake_admin
@@ -174,6 +183,8 @@ async def test_module_usage_returns_data(client):
             assert body["events"][0]["label"] == "检索"
             assert body["events"][0]["count"] == 42
             assert body["top_search_keywords"][0]["keyword"] == "心经"
+            assert body["answer_quality"]["citation_click_rate"] == 30.0
+            assert body["answer_quality"]["chat_questions"] == 10
     finally:
         app.dependency_overrides.pop(get_current_user, None)
 

--- a/frontend/scripts/i18n-baseline.json
+++ b/frontend/scripts/i18n-baseline.json
@@ -3,7 +3,7 @@
   "src/data/popularSutras.ts": 157,
   "src/pages/ProfilePage.tsx": 87,
   "src/data/topics.ts": 74,
-  "src/pages/AdminDashboardPage.tsx": 65,
+  "src/pages/AdminDashboardPage.tsx": 72,
   "src/pages/ExportsPage.tsx": 64,
   "src/utils/sourceUrls.ts": 52,
   "src/data/dynasty_years.ts": 46,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1222,10 +1222,21 @@ export interface KeywordItem {
   count: number;
 }
 
+export interface AnswerQuality {
+  chat_questions: number;
+  citation_click: number;
+  chat_copy: number;
+  chat_retry: number;
+  citation_click_rate: number | null;
+  copy_rate: number | null;
+  retry_rate: number | null;
+}
+
 export interface AdminModuleUsage {
   days: number;
   events: ModuleEventItem[];
   top_search_keywords: KeywordItem[];
+  answer_quality: AnswerQuality;
 }
 
 export async function getAdminModuleUsage(days: number = 7): Promise<AdminModuleUsage> {

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -396,6 +396,44 @@ function ModuleUsageCard() {
             ))}
           </Row>
 
+          {data.answer_quality && (
+            <div style={{ marginTop: 8, marginBottom: 16 }}>
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                答案质量（行为信号，相对问答次数；显式 👍👎 见上方「平台活跃度」反馈率。本批信号自部署起累计）
+              </Text>
+              <Row gutter={[16, 16]} style={{ marginTop: 4 }}>
+                <Col xs={12} sm={8}>
+                  <Tooltip title={`点开引文查看原文的次数 / 问答次数 = ${data.answer_quality.citation_click} / ${data.answer_quality.chat_questions}（越高越说明用户在验证、信任来源）`}>
+                    <Statistic
+                      title="引文点击率"
+                      value={data.answer_quality.citation_click_rate ?? "—"}
+                      suffix={data.answer_quality.citation_click_rate == null ? "" : "%"}
+                    />
+                  </Tooltip>
+                </Col>
+                <Col xs={12} sm={8}>
+                  <Tooltip title={`复制答案的次数 / 问答次数 = ${data.answer_quality.chat_copy} / ${data.answer_quality.chat_questions}（越高越说明答案被当作有用结果带走）`}>
+                    <Statistic
+                      title="复制率"
+                      value={data.answer_quality.copy_rate ?? "—"}
+                      suffix={data.answer_quality.copy_rate == null ? "" : "%"}
+                    />
+                  </Tooltip>
+                </Col>
+                <Col xs={12} sm={8}>
+                  <Tooltip title={`失败后重试的次数 / 问答次数 = ${data.answer_quality.chat_retry} / ${data.answer_quality.chat_questions}（衡量可靠性，越低越好）`}>
+                    <Statistic
+                      title="失败重试率"
+                      value={data.answer_quality.retry_rate ?? "—"}
+                      suffix={data.answer_quality.retry_rate == null ? "" : "%"}
+                      valueStyle={{ color: (data.answer_quality.retry_rate ?? 0) > 5 ? "#e74c3c" : undefined }}
+                    />
+                  </Tooltip>
+                </Col>
+              </Row>
+            </div>
+          )}
+
           {data.top_search_keywords.length > 0 && (
             <div style={{ marginTop: 8 }}>
               <Text type="secondary" style={{ fontSize: 12 }}>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -393,6 +393,10 @@ function MessageBubbleInner({
                   const textToCopy = m.role === "assistant" ? parseFollowUps(m.content).cleanContent : m.content;
                   navigator.clipboard.writeText(textToCopy);
                   message.success(t("chat.copied"));
+                  // Behavioural quality signal: copying an answer = found it useful.
+                  if (m.role === "assistant" && typeof umami !== "undefined") {
+                    umami.track("chat_copy");
+                  }
                 }}
               />
             </Tooltip>
@@ -657,6 +661,11 @@ export default function ChatPage() {
               type="button"
               onClick={(e) => {
                 e.preventDefault();
+                // Behavioural quality signal: clicking a citation = engaging
+                // with / trusting the cited source.
+                if (typeof umami !== "undefined") {
+                  umami.track("citation_click", { text_id: parsed.textId });
+                }
                 if (parsed.chunkIndex < 0) {
                   // Legacy history message without chunk_index — fall back
                   // to navigating to the reader page as before.
@@ -972,6 +981,11 @@ export default function ChatPage() {
     const idx = messages.findIndex((x) => x.id === m.id);
     const userMsg = idx > 0 ? messages[idx - 1] : null;
     if (userMsg && userMsg.role === "user") {
+      // Behavioural signal: the retry button only appears on a failed answer,
+      // so this measures failure-retries (reliability), not regenerate-on-dislike.
+      if (typeof umami !== "undefined") {
+        umami.track("chat_retry");
+      }
       setMessages((prev) => prev.filter((x) => x.id !== m.id && x.id !== userMsg.id));
       handleSendMessage(userMsg.content);
     }


### PR DESCRIPTION
## 背景
后台显示反馈率 0%——不是 bug(显式 👍👎 的 id 时序问题早在 #738 修复),而是**显式反馈天然稀疏**(全站历史仅 3 条 / 4000+ 回答),做不了可靠质量信号。

## 做法
不依赖用户点 👍👎,改为**对每条回答采集行为信号**,复用现有 Umami 管线(零新表):

| 事件 | 含义 |
|---|---|
| `citation_click` | 点开引文看原文 → 信任/参与来源 |
| `chat_copy` | 复制答案 → 觉得有用 |
| `chat_retry` | 失败后重试 → 可靠性(如实标注「失败重试」,非"不满意") |

- 前端 3 个 `umami.track`(均带 `typeof umami` 守卫)。
- `usage_service` 把这 3 个从「板块使用」列表分出,算成 `answer_quality`(率 = 事件 / 问答数,无问答时为 null→显示「—」)。
- 后台新增「答案质量」面板:引文点击率 / 复制率 / 失败重试率。
- 显式 👍👎 本 PR 不动(已能用);匿名反馈、按钮放大留作后续。

## 验证
- 后端 `ruff check app/` 通过;`tsc` 通过;i18n baseline 同步(AdminDashboard 65→72,admin 页 hardcoded-zh 约定)。
- `pytest tests/test_admin.py tests/test_stats.py` 20 passed(含新增 answer_quality 契约断言 + 修好 module-usage mock)。
- code-reviewer:LGTM(零分母/事件排除/空兜底/前后端类型一致/标签诚实 全过)。
- 行为信号自部署起累计,面板初期为低值/「—」属正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)