### PR TITLE
fix(chat): streaming quota leak + 繁简 citation strip + reasoning token starvation

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -116,6 +116,32 @@ def _convert_messages_for_anthropic(messages: list[dict]) -> tuple[str, list[dic
     return system, user_messages
 
 
+# Reasoning models (deepseek-v4*, deepseek-reasoner, *-thinking, o1/o3) emit
+# hidden reasoning_content that shares the max_tokens budget with the visible
+# answer. A tight cap — notably the 30 used for session titles — gets fully
+# consumed by the reasoning trace, leaving content empty / answers truncated.
+# bare "reasoner"/"thinking" are intentional broad substring matches (catch any
+# provider's *-reasoner / *-thinking variant); "deepseek-v4" is explicit since
+# its reasoning isn't reflected in the name.
+_REASONING_MODEL_MARKERS = (
+    "deepseek-v4", "reasoner", "thinking", "-o1", "-o3", "/o1", "/o3",
+)
+
+
+def _is_reasoning_model(model: str | None) -> bool:
+    m = (model or "").lower()
+    return any(k in m for k in _REASONING_MODEL_MARKERS)
+
+
+def _with_reasoning_headroom(model: str | None, max_tokens: int) -> int:
+    """Add budget for hidden reasoning_content on reasoning models so the
+    visible answer isn't starved. max_tokens is a ceiling, not a target, so
+    this is ~free for responses that don't hit the old cap — it only prevents
+    reasoning from eating the entire short cap (empty titles) or truncating
+    long answers."""
+    return max_tokens + 4000 if _is_reasoning_model(model) else max_tokens
+
+
 def _build_anthropic_body(model: str, messages: list[dict], *, temperature: float = 0.7,
                           max_tokens: int = 2000, stream: bool = False) -> dict:
     system, user_messages = _convert_messages_for_anthropic(messages)
@@ -833,7 +859,7 @@ async def _generate_session_title(
     try:
         async with httpx.AsyncClient(timeout=10) as client:
             if _is_anthropic(api_url, provider):
-                body = _build_anthropic_body(model, messages, temperature=0.3, max_tokens=30)
+                body = _build_anthropic_body(model, messages, temperature=0.3, max_tokens=_with_reasoning_headroom(model, 64))
                 resp = await client.post(f"{api_url}/messages", headers=_build_anthropic_headers(api_key), json=body)
                 resp.raise_for_status()
                 title = resp.json()["content"][0]["text"].strip().strip("\"'《》")
@@ -841,7 +867,7 @@ async def _generate_session_title(
                 resp = await client.post(
                     f"{api_url}/chat/completions",
                     headers={"Authorization": f"Bearer {api_key}"},
-                    json={"model": model, "messages": messages, "temperature": 0.3, "max_tokens": 30},
+                    json={"model": model, "messages": messages, "temperature": 0.3, "max_tokens": _with_reasoning_headroom(model, 64)},
                 )
                 resp.raise_for_status()
                 title = resp.json()["choices"][0]["message"]["content"].strip().strip("\"'《》")
@@ -1104,14 +1130,14 @@ async def send_message(
     async def _call_once(u: str, k: str, m: str, p: str) -> str:
         async with httpx.AsyncClient(timeout=60) as client:
             if _is_anthropic(u, p):
-                body = _build_anthropic_body(m, llm_messages, max_tokens=8000 if page_content else 2000)
+                body = _build_anthropic_body(m, llm_messages, max_tokens=_with_reasoning_headroom(m, 8000 if page_content else 2000))
                 resp = await client.post(f"{u}/messages", headers=_build_anthropic_headers(k), json=body)
                 resp.raise_for_status()
                 return resp.json()["content"][0]["text"]
             resp = await client.post(
                 f"{u}/chat/completions",
                 headers={"Authorization": f"Bearer {k}"},
-                json={"model": m, "messages": llm_messages, "temperature": 0.7, "max_tokens": 8000 if page_content else 2000},
+                json={"model": m, "messages": llm_messages, "temperature": 0.7, "max_tokens": _with_reasoning_headroom(m, 8000 if page_content else 2000)},
             )
             resp.raise_for_status()
             return resp.json()["choices"][0]["message"]["content"]
@@ -1355,6 +1381,16 @@ async def send_message_stream(
             pending_attachment_ids = [
                 a.id for a in prep_result[-1] if a.consumed_at is None
             ]
+            # Persist prep-phase writes (the _check_daily_quota UPDATE) BEFORE
+            # the block exits. Without this, close() rolls back the still-open
+            # prep transaction (see the snapshot note above) and discards the
+            # quota increment — making FREE_DAILY_LIMIT_USER a no-op on the
+            # streaming path while the non-stream path persists it via
+            # _save_messages. Scalars are already captured above, so the
+            # commit's instance-expiry is harmless. Quota is the only pending
+            # write here (create_session already committed; everything else in
+            # _prepare_chat is SELECT-only).
+            await db_prep.commit()
         except (ValidationError, QuotaExceededError, AccessDeniedError, ServiceError) as exc:
             prep_error = exc
     # db_prep is closed here — connection returned to the pool before any
@@ -1390,7 +1426,7 @@ async def send_message_stream(
     async def _stream_llm_once(u: str, k: str, m: str, p: str):
         """Inner generator that yields content chunks. Raises httpx errors on failure."""
         if _is_anthropic(u, p):
-            body = _build_anthropic_body(m, llm_messages, stream=True, max_tokens=8000 if page_content else 2000)
+            body = _build_anthropic_body(m, llm_messages, stream=True, max_tokens=_with_reasoning_headroom(m, 8000 if page_content else 2000))
             async with httpx.AsyncClient(timeout=120 if page_content else 60) as client, client.stream(
                 "POST", f"{u}/messages", headers=_build_anthropic_headers(k), json=body,
             ) as resp:
@@ -1415,7 +1451,7 @@ async def send_message_stream(
                 "POST", f"{u}/chat/completions",
                 headers={"Authorization": f"Bearer {k}"},
                 json={"model": m, "messages": llm_messages, "temperature": 0.7,
-                      "max_tokens": 8000 if page_content else 2000, "stream": True},
+                      "max_tokens": _with_reasoning_headroom(m, 8000 if page_content else 2000), "stream": True},
             ) as resp:
                 resp.raise_for_status()
                 async for line in resp.aiter_lines():

--- a/backend/app/services/citation_guard.py
+++ b/backend/app/services/citation_guard.py
@@ -42,9 +42,25 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 
+from opencc import OpenCC
+
 from app.schemas.chat import ChatSource
 
 logger = logging.getLogger(__name__)
+
+# 繁简 fold for title matching. The LLM frequently emits a simplified 经名
+# (e.g. 《地藏菩萨本愿经》) while the CBETA source title_zh is traditional
+# (地藏菩薩本願經). Without folding, the whitelist check misses and a CORRECT
+# citation gets stripped of its clickable 【】. quote_verifier already folds
+# quotes the same way; keep the two guards symmetric.
+_t2s = OpenCC("t2s")
+
+
+def _norm_title(title: str) -> str:
+    """Whitelist key: 繁→简 folded, stripped. Comparison-only — the answer
+    keeps the LLM's original title text (the frontend's injectCitationLinks
+    folds the same way, so the rendered citation still resolves)."""
+    return _t2s.convert(title).strip()
 
 
 # Matches 【《<title>》第<fascicle>卷】 or 【《<title>》】. The fascicle group
@@ -93,11 +109,11 @@ def _build_whitelist(sources: Iterable[ChatSource]) -> dict[str, set[int]]:
     for s in sources:
         if s.text_id <= 0 or not s.title_zh:
             continue
-        wl.setdefault(s.title_zh, set()).add(s.juan_num)
+        wl.setdefault(_norm_title(s.title_zh), set()).add(s.juan_num)
         for p in s.parallel_chunks:
             if p.text_id <= 0 or not p.title:
                 continue
-            wl.setdefault(p.title, set()).add(p.juan_num)
+            wl.setdefault(_norm_title(p.title), set()).add(p.juan_num)
     return wl
 
 
@@ -146,7 +162,8 @@ def enforce_citation_whitelist(
         title = match.group(1)
         original_juan, juan_is_placeholder = _parse_juan(match.group(2))
 
-        if title not in whitelist:
+        norm_title = _norm_title(title)
+        if norm_title not in whitelist:
             replacement = f"《{title}》"
             mutations.append(
                 CitationMutation(
@@ -160,7 +177,7 @@ def enforce_citation_whitelist(
             )
             return replacement
 
-        valid_juans = whitelist[title]
+        valid_juans = whitelist[norm_title]
         # Title-only citation (【《X》】 with no fascicle at all) is always
         # allowed when the title is real — it points at the text as a whole.
         if original_juan is None and not juan_is_placeholder:

--- a/backend/tests/test_chat_stream_session_lifecycle.py
+++ b/backend/tests/test_chat_stream_session_lifecycle.py
@@ -270,6 +270,62 @@ async def test_quota_increment_uses_explicit_update():
     assert user.daily_chat_count == 6
 
 
+class _HandleCapturingSessionmaker:
+    """Like _CountingSessionmaker but keeps each db handle so a test can
+    assert what was called on the prep/save sessions."""
+
+    def __init__(self):
+        self.handles: list = []
+
+    def __call__(self):
+        outer = self
+
+        class _CM:
+            async def __aenter__(self_inner):
+                h = AsyncMock()
+                outer.handles.append(h)
+                return h
+
+            async def __aexit__(self_inner, *_):
+                return False
+
+        return _CM()
+
+
+@pytest.mark.anyio
+async def test_streaming_prep_commits_so_quota_persists():
+    """The streaming prep session must COMMIT before it closes.
+
+    _check_daily_quota issues UPDATE + flush() but no commit, and the prep
+    block deliberately relies on close()->rollback to expire detached ORM
+    instances — which ALSO discards the uncommitted quota UPDATE. So on the
+    /chat/stream path the logged-in daily limit (FREE_DAILY_LIMIT_USER)
+    silently never persists, leaving the free tier effectively unbounded and
+    burning the platform key. Pin that the prep session commits. Regression
+    for the streaming quota-leak audit finding (2026-06-23)."""
+    sources = _make_fake_sources()
+    prepare_return = _make_prepare_chat_return(sources)
+    sm = _HandleCapturingSessionmaker()
+    mock_client_cls = _make_mock_httpx_client(["般", "若"])
+
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
+         patch("app.services.chat._mark_attachments_consumed", new_callable=AsyncMock), \
+         patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
+        from app.services.chat import send_message_stream
+
+        async for _ in send_message_stream(user_id=1, message="测试", sessionmaker=sm):
+            pass
+
+    assert sm.handles, "no session opened"
+    prep_handle = sm.handles[0]
+    assert prep_handle.commit.await_count >= 1, (
+        "streaming prep session must commit so _check_daily_quota's UPDATE "
+        "survives close()->rollback; otherwise logged-in daily quota is a "
+        "no-op on /chat/stream"
+    )
+
+
 @pytest.mark.anyio
 async def test_attachments_consumed_uses_explicit_update():
     """``_mark_attachments_consumed`` must persist via UPDATE statement on

--- a/backend/tests/test_citation_guard.py
+++ b/backend/tests/test_citation_guard.py
@@ -191,6 +191,25 @@ def test_fascicle_correction_falls_back_to_title_only_when_juan_set_empty():
     assert muts[0].corrected_juan == 0
 
 
+def test_simplified_citation_matches_traditional_source():
+    """LLM often writes simplified 经名 while CBETA source title_zh is
+    traditional. Without 繁简 normalisation the whitelist check misses and a
+    CORRECT citation gets stripped of its clickable 【】. Regression for the
+    2026-06-23 audit (citation_guard lacked the t2s that quote_verifier has)."""
+    answer = "见【《地藏菩萨本愿经》第1卷】所说。"  # simplified citation
+    out, muts = enforce_citation_whitelist(answer, [_src(7, "地藏菩薩本願經", 1)])  # traditional source
+    assert out == answer, "simplified citation of a traditional source must stay clickable"
+    assert not any(m.kind == "unverified_title" for m in muts)
+
+
+def test_traditional_citation_matches_simplified_source():
+    """Symmetric: traditional citation, simplified source title — t2s folds both."""
+    answer = "見【《地藏菩薩本願經》第1卷】。"  # traditional citation
+    out, muts = enforce_citation_whitelist(answer, [_src(7, "地藏菩萨本愿经", 1)])  # simplified source
+    assert out == answer
+    assert not any(m.kind == "unverified_title" for m in muts)
+
+
 def test_mutation_is_dataclass_with_full_audit_fields():
     """Locks the audit shape so a future migration that persists these
     rows has a stable schema to bind to."""

--- a/backend/tests/test_reasoning_token_budget.py
+++ b/backend/tests/test_reasoning_token_budget.py
@@ -1,0 +1,28 @@
+"""Reasoning models spend part of max_tokens on hidden reasoning_content,
+sharing the budget with the visible answer. A tight cap (the 30 used for
+session titles) gets fully consumed by the reasoning trace → empty title /
+truncated answer. These pin the detector + headroom helper. Audit 2026-06-23.
+"""
+
+from app.services.chat import _is_reasoning_model, _with_reasoning_headroom
+
+
+def test_deepseek_v4_and_reasoners_detected():
+    assert _is_reasoning_model("deepseek-v4-flash")
+    assert _is_reasoning_model("deepseek-v4-pro")
+    assert _is_reasoning_model("deepseek-reasoner")
+    assert _is_reasoning_model("qwen3-thinking")
+
+
+def test_non_reasoning_models_not_detected():
+    for m in ("deepseek-chat", "qwen3.6-plus", "glm-5.1", "kimi-k2.6", "gpt-4o", "", None):
+        assert not _is_reasoning_model(m)
+
+
+def test_headroom_added_only_for_reasoning_models():
+    # The title cap is the worst case: 30 tokens, fully eaten by reasoning.
+    assert _with_reasoning_headroom("deepseek-v4-flash", 30) == 30 + 4000
+    assert _with_reasoning_headroom("deepseek-v4-pro", 2000) == 2000 + 4000
+    # Non-reasoning models keep the tight, cheap cap unchanged.
+    assert _with_reasoning_headroom("deepseek-chat", 30) == 30
+    assert _with_reasoning_headroom("glm-5.1", 2000) == 2000


### PR DESCRIPTION
2026-06-23 全代码审计发现的 3 个**互相独立**的 chat 答案路径 bug,一并修复(都在 chat 答案管线,A/C 共用 chat.py)。

## A 流式每日配额泄漏(高 — 在烧平台 key)
`_check_daily_quota` 只 UPDATE+flush 不 commit;`send_message_stream` 的 prep session 为回收 detached ORM 实例**故意在 close() 时 rollback**,顺带把配额增量也丢了。结果:登录非 BYOK 用户的 `FREE_DAILY_LIMIT_USER=200` 在 **/chat/stream(前端实际路径)形同虚设**,100% 触发;非流式路径靠 `_save_messages` commit 正常。
- **修**:prep 块捕获 scalar 后、退出前 `await db_prep.commit()`(此时唯一 pending write 就是配额 UPDATE;错误路径在 except 前不会执行 commit)。
- 新语义:LLM 失败时也消费配额——对"防刷平台 key"是正确方向。

## B citation_guard 误剥正确引用(中高 — 直伤引用可点击率)
whitelist 用繁体 `title_zh` 做 key 且**精确比对**,而 LLM 常输出简体经名【《地藏经》】→ miss → 正确引用被剥成不可点散文。`quote_verifier` 早已用 t2s 归一,两者不对称即 bug。
- **修**:`_norm_title`(OpenCC t2s)归一 whitelist key 与查找,输出仍保留 LLM 原文(前端 injectCitationLinks 同样折叠,故仍可点)。

## C reasoning 模型 token 饿死(中)
默认 deepseek-v4 系列是 reasoning 模型,`reasoning_content` 与可见答案共享 max_tokens;**标题 cap=30 被推理吃光→标题几乎永远空**,长答偶被截断(审查用 `ai_diff.py:88-91` 独立佐证实测出现过 content="" 空返回)。
- **修**:`_is_reasoning_model` + `_with_reasoning_headroom`(reasoning 模型 +4000;max_tokens 是上限非目标,故对不截断的响应≈零成本),应用到全部 6 处调用(标题 30→64+headroom,主答 2000/8000+headroom)。

## 验证
- 已过 code-reviewer:无 Critical/Important,Minor 已清理;副作用逐条确认(错误路径不 commit、非流式不受影响、Anthropic/非 reasoning 模型不受牵连、繁简假阳可忽略)。
- `ruff check app/ eval/` ✓;`pytest -q tests/` → **677 passed**(新增 streaming-prep-commits / 繁简双向 / reasoning detector+headroom 回归测试)。
- 无 migration、无 API schema 变更。
- **合并后 prod 观察**:① 会话标题是否开始非空(C 生效);② citation_click 是否回升(B 生效,配合 #795 遥测);③ 登录用户 daily_chat_count 是否随对话累加(A 生效)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)