### PR TITLE
fix(seo): cap /dict reverse-index timeout to stop DB pool exhaustion

### DIFF
--- a/backend/app/api/seo_dict.py
+++ b/backend/app/api/seo_dict.py
@@ -29,7 +29,8 @@ from urllib.parse import unquote
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from opencc import OpenCC
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -50,6 +51,11 @@ router = APIRouter(tags=["seo"])
 _DEFINITION_PREVIEW_CHARS = 220
 _REVERSE_INDEX_LIMIT = 8
 _MAX_HEADWORD_LEN = 200
+_MIN_HEADWORD_LEN = 2  # single-char terms match ~everything + defeat the trgm index
+# Cap how long the best-effort reverse-index lookup may hold a pool connection.
+# Terms the trgm index can't serve seq-scan the 406MB content table; bounding
+# this (vs the global ~60s) is what stops crawler load from exhausting the pool.
+_REVERSE_INDEX_TIMEOUT_MS = 3000
 
 
 def _build_dict_jsonld(headword: str, entries: list[DictionaryEntry], canonical: str) -> dict:
@@ -92,12 +98,17 @@ async def _fetch_reverse_index(
 ) -> list[dict]:
     """Return up to N sutras containing this headword in their content.
 
-    Uses a vanilla ILIKE — text_contents.content has a GIN trigram index
-    (ix_text_contents_content_trgm, migration 0157) so a single-term substring
-    match is sub-second. Without that index this seq-scans the 406MB table and,
-    under crawler load, piles up and exhausts the connection pool.
+    text_contents.content has a GIN trigram index (ix_text_contents_content_trgm,
+    migration 0157) that serves most ILIKE substring matches sub-second. But
+    short/uncommon CJK terms the index can't serve seq-scan the 406MB table for
+    tens of seconds; under crawler load those pile up and exhaust the connection
+    pool (prod outage 2026-06-23). This block is a best-effort SEO nicety, so:
+      - skip single-char headwords (match ~everything, worst case for trgm), and
+      - cap the per-query statement_timeout so a slow lookup fails fast and
+        releases its pool connection instead of holding it ~60s; on timeout we
+        drop the "appears in N sutras" block rather than starve the pool.
     """
-    if len(headword) > _MAX_HEADWORD_LEN:
+    if not (_MIN_HEADWORD_LEN <= len(headword) <= _MAX_HEADWORD_LEN):
         return []
     stmt = (
         select(BuddhistText.id, BuddhistText.title_zh, BuddhistText.cbeta_id)
@@ -107,11 +118,21 @@ async def _fetch_reverse_index(
         .order_by(BuddhistText.id.asc())
         .limit(_REVERSE_INDEX_LIMIT)
     )
-    rows = await db.execute(stmt)
-    return [
-        {"id": r[0], "title_zh": (r[1] or "").strip(), "cbeta_id": (r[2] or "").strip()}
-        for r in rows.all()
-    ]
+    try:
+        # SET LOCAL applies to the request's already-open transaction (the
+        # caller fetched entries first), bounding just this lookup.
+        await db.execute(text(f"SET LOCAL statement_timeout = '{_REVERSE_INDEX_TIMEOUT_MS}ms'"))
+        rows = await db.execute(stmt)
+        return [
+            {"id": r[0], "title_zh": (r[1] or "").strip(), "cbeta_id": (r[2] or "").strip()}
+            for r in rows.all()
+        ]
+    except SQLAlchemyError as exc:
+        # Timeout / cancellation: abort the txn so the session is reusable, drop
+        # the block. This is the last DB op of the request, so rollback is safe.
+        logger.warning("reverse-index lookup gave up for %r (best-effort): %s", headword, exc)
+        await db.rollback()
+        return []
 
 
 def _render_dict_html(

--- a/backend/tests/test_seo_dict_reverse_index.py
+++ b/backend/tests/test_seo_dict_reverse_index.py
@@ -1,0 +1,60 @@
+"""Reverse-index ("appears in N sutras") lookup must not hold a pool connection
+for tens of seconds. Prod outage 2026-06-23: short/uncommon CJK headwords that
+the trgm index can't serve seq-scan the 406MB content table for ~60s; under
+crawler load these pile up and exhaust the DB pool, making backend unhealthy.
+The block is a best-effort SEO nicety — cap its statement_timeout and drop it on
+timeout rather than starve the pool.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.api.seo_dict import _fetch_reverse_index
+
+
+@pytest.mark.anyio
+async def test_skips_single_char_and_overlong_headwords():
+    # Single-char "appears in N sutras" is meaningless (matches ~everything) and
+    # is the worst case for the trgm index; overlong is junk. Neither should hit
+    # the DB at all.
+    db = AsyncMock()
+    assert await _fetch_reverse_index(db, "火") == []
+    assert await _fetch_reverse_index(db, "字" * 201) == []
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_caps_statement_timeout_before_the_ilike():
+    db = AsyncMock()
+    res = MagicMock()
+    res.all.return_value = []
+    db.execute.return_value = res
+
+    await _fetch_reverse_index(db, "般若")
+
+    first_sql = str(db.execute.await_args_list[0].args[0]).lower()
+    assert "statement_timeout" in first_sql, (
+        "must cap per-query statement_timeout BEFORE the ILIKE, so a slow "
+        "reverse-index lookup fails fast instead of holding a pool connection "
+        "~60s under crawler load"
+    )
+
+
+@pytest.mark.anyio
+async def test_best_effort_empty_and_rollback_on_db_error():
+    db = AsyncMock()
+    calls = {"n": 0}
+
+    async def _exec(*a, **k):
+        calls["n"] += 1
+        if calls["n"] >= 2:  # the SELECT, after the SET LOCAL statement_timeout
+            raise SQLAlchemyError("canceling statement due to statement timeout")
+        return MagicMock()
+
+    db.execute.side_effect = _exec
+
+    out = await _fetch_reverse_index(db, "般若")
+    assert out == []
+    db.rollback.assert_awaited()  # aborted txn cleaned so the session is reusable


### PR DESCRIPTION
## prod 故障(2026-06-23 实遇)
backend(8000)变 unhealthy:`/dict/<词>` SEO 页的"出现在 N 部经"反查对 406MB `text_contents.content` 做 `ILIKE '%词%'`。短/生僻 CJK 词(实测 2 字「火烧」)trgm 索引(`ix_text_contents_content_trgm`,0157)用不上 → seq-scan **~60s**;crawler 负载下这些慢查询堆积、各持一个池连接(QueuePool 10+20),直到池满,连 `/api/health` 都拿不到连接 → unhealthy。

## 修法(这块是 best-effort SEO 点缀,bound 成本而非删除)
`_fetch_reverse_index`:
- 跳过单字词(`_MIN_HEADWORD_LEN=2`:匹配~所有经、信息量极低、且是 trgm 最差场景);
- 查询前 `SET LOCAL statement_timeout='3000ms'`(作用于 route entries 查询已开启的事务)→ 慢查询 3s 快速失败、立即释放连接,而非持 ~60s;
- 超时/DB 错 → `db.rollback()`(本函数是 route 最后一个 DB 操作,安全)+ 返空,页面照常渲染(只少"出现在 N 部经"块)。

**重启只是清了卡死的池;本 PR 防复发**(把连接持有时间从 ~60s 压到 ≤3s,慢查询再不能占满池)。

## 验证
- 已过 code-reviewer:交叉验证 SET LOCAL 在此调用点确有 open txn 而生效(engine 未设 AUTOCOMMIT + autobegin + entries 查询在前 + 301 redirect 不经此函数);超时能捕获并释放连接;rollback 安全(expire_on_commit=False,entries 已 materialize);变异测试确认 3 个测试有真实约束力。
- `ruff check app/ eval/` ✓;`pytest -q tests/` → **688 passed**(+3:单字跳过 / timeout-cap 在 SELECT 前 / 超时 best-effort 返空+rollback)。
- 无 migration、无 API schema 变更。**合并后需重启 backend 生效**(bind mount + uvicorn 无 reload)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)