### PR TITLE
fix(reader): show 高丽藏 button on CBETA witness-variant records (T####a/b)

### DIFF
--- a/backend/app/services/goryeo.py
+++ b/backend/app/services/goryeo.py
@@ -9,11 +9,16 @@ CBETA does not publish).
 """
 
 import json
+import re
 from pathlib import Path
 
 _MAP_PATH = Path(__file__).parent.parent / "data" / "taisho_goryeo_map.json"
 _T2K: dict[str, str] = {}
 _LOADED = False
+
+# A trailing letter on a Taishō id (T0235b, T0236a) marks a different
+# 见证/edition of the SAME work; the work's Goryeo edition is the base id's K.
+_WITNESS_SUFFIX_RE = re.compile(r"[a-z]+$")
 
 KABC_BASE = "https://kabc.dongguk.edu/content/view?dataId=ABC_IT_"
 
@@ -29,13 +34,27 @@ def _load() -> None:
     _LOADED = True
 
 
-def goryeo_k(cbeta_id: str) -> str | None:
-    """Goryeo K-number for a Taishō text id, or None if it has no Goryeo parallel."""
+def goryeo_k(cbeta_id: str | None) -> str | None:
+    """Goryeo K-number for a Taishō text id, or None if it has no Goryeo parallel.
+
+    Exact match wins — some witness variants (T0150a/b) are mapped to their OWN
+    distinct K-numbers and must not be collapsed. Only on an exact miss do we
+    retry with the witness-suffix stripped, so a record like T0235b resolves to
+    its base work's Goryeo edition (the 高丽藏 button means "view this work in
+    the Goryeo canon"). Without this, the button silently vanished on every
+    suffix-variant record whose exact id wasn't separately catalogued.
+    """
     _load()
-    return _T2K.get(cbeta_id)
+    if not cbeta_id:
+        return None
+    k = _T2K.get(cbeta_id)
+    if k is not None:
+        return k
+    base = _WITNESS_SUFFIX_RE.sub("", cbeta_id)
+    return _T2K.get(base) if base != cbeta_id else None
 
 
-def kabc_url(cbeta_id: str) -> str | None:
+def kabc_url(cbeta_id: str | None) -> str | None:
     """KABC reader URL for the Goryeo edition of a Taishō text, or None."""
     k = goryeo_k(cbeta_id)
     return f"{KABC_BASE}{k}" if k else None

--- a/backend/tests/test_goryeo.py
+++ b/backend/tests/test_goryeo.py
@@ -19,3 +19,26 @@ def test_no_goryeo_parallel_returns_none():
     assert goryeo_k("X0001") is None
     assert goryeo_k("T9999") is None
     assert kabc_url("X0001") is None
+
+
+def test_witness_variant_falls_back_to_base_work():
+    # Bug 2026-06-23: a letter suffix marks a different 见证/edition of the SAME
+    # work (T0235b = a witness of 鸠摩罗什 金刚经). These weren't in the map, so the
+    # reader's 高丽藏 button silently vanished. Fall back to the base work's K.
+    assert goryeo_k("T0235b") == "K0013"
+    assert goryeo_k("T0236a") == "K0014"  # 麗本/宋本 of 菩提流支 金刚经 → that work
+    assert goryeo_k("T0236b") == "K0014"
+    assert kabc_url("T0235b") == "https://kabc.dongguk.edu/content/view?dataId=ABC_IT_K0013"
+
+
+def test_explicitly_mapped_suffix_variants_keep_their_own_K():
+    # SAFETY: T0150a/b are SEPARATELY mapped to DISTINCT K-numbers — exact match
+    # must win so the fallback never collapses them to a shared (unmapped) base.
+    assert goryeo_k("T0150a") == "K0738"
+    assert goryeo_k("T0150b") == "K0882"
+    assert goryeo_k("T0150") is None  # base genuinely unmapped (splits into a/b)
+
+
+def test_empty_and_none_return_none():
+    assert goryeo_k("") is None
+    assert goryeo_k(None) is None


### PR DESCRIPTION
## 你报的问题
金刚经 reader 没有「高丽藏」按钮,楞严经有。

## 根因(已查实)
那条金刚经页面是 **T0235b** 记录(CBETA 后缀=同一部鸠摩罗什《金刚经》的另一个见证/版本)。`goryeo_k` 对 Taishō→Goryeo 映射表做**精确 `dict.get`**,表里只有 base `T0235`(→K0013),没有 `T0235b` → 返回 None → 按钮条件渲染隐藏。**所有未单独编目的 `T####a/b` 变体记录都中招**(不止金刚经)。

## 修法
精确未命中时**剥末尾字母后缀重查**:`T0235b → T0235 → K0013`。**精确匹配仍优先**——这点关键:表里有 21 个带后缀 key,其中 `T0150a→K0738`、`T0150b→K0882`(不同 K),它们精确命中各自的 K、绝不被剥成共享 base。

## 安全性(code-review 跨全表 1481 条验证)
表里**不存在**"base 有 K 且同号后缀变体又有不同 K"的冲突对——唯一拆 a/b 的 T0150 其 base 不在表里。所以回退逻辑碰不到误映射的雷区。
> 隐性契约:回退依赖 Lancaster 表"同 Taishō 号 = 同作品不同见证"的语义(对当前数据成立)。

## 验证
- 已过 code-reviewer(可合并,无 Critical/Important;安全案例 T0150a/b 不折叠既被逻辑保证也被数据结构兜底)。
- `ruff check app/ eval/` ✓;`pytest -q tests/` → **691 passed**(6 goryeo:精确不变 / 变体回退 / distinct-K 安全 / 空/None 边界)。
- 无 migration、无 API schema 变更。**合并后需重启 backend 生效**(按钮由 goryeo_k 经 texts.py 计算)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)