### PR TITLE
fix(chat): order master selector 汉传-first, 印度 after it

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1379,12 +1379,6 @@ export default function ChatPage() {
                 options={[
                   { value: "", label: `🟢 ${t("chat.general_assistant")}` },
                   {
-                    label: t("chat.tradition_india"),
-                    options: [
-                      { value: "nagarjuna", label: t("chat.master_nagarjuna") },
-                    ],
-                  },
-                  {
                     label: t("chat.tradition_han"),
                     options: [
                       { value: "zhiyi", label: t("chat.master_zhiyi") },
@@ -1395,6 +1389,12 @@ export default function ChatPage() {
                       { value: "yinguang", label: t("chat.master_yinguang") },
                       { value: "ouyi", label: t("chat.master_ouyi") },
                       { value: "xuyun", label: t("chat.master_xuyun") },
+                    ],
+                  },
+                  {
+                    label: t("chat.tradition_india"),
+                    options: [
+                      { value: "nagarjuna", label: t("chat.master_nagarjuna") },
                     ],
                   },
                   {


### PR DESCRIPTION
Follow-up to #805. The new **印度** group (1 item: 龙树) was sitting above **汉传** (8 masters), pushing the primary-audience Chinese-tradition masters below the fold.

Reorder to **通用 → 汉传 → 印度 → 藏传 → 南传**:
- 汉传 leads — fojin's primary audience and the bulk of the roster.
- 龙树/印度 follows as the Madhyamaka headwater of 汉传 大乘 (三论/天台/净土 all derive from him) and bridges to 藏传, rather than topping the list.

Pure group-relocation in the ChatPage `<Select>` options (no logic/i18n/backend change). `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)