### PR TITLE
fix(seo): /dict/{term} 500 — snapshot entries before reverse-index rollback

### DIFF
--- a/backend/app/api/seo_dict.py
+++ b/backend/app/api/seo_dict.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from urllib.parse import unquote
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -58,7 +59,26 @@ _MIN_HEADWORD_LEN = 2  # single-char terms match ~everything + defeat the trgm i
 _REVERSE_INDEX_TIMEOUT_MS = 3000
 
 
-def _build_dict_jsonld(headword: str, entries: list[DictionaryEntry], canonical: str) -> dict:
+@dataclass(frozen=True, slots=True)
+class _DictEntryView:
+    """Primitive snapshot of a DictionaryEntry's render-relevant fields.
+
+    The render path runs AFTER the best-effort reverse-index lookup, which may
+    time out and roll back the session (see ``_fetch_reverse_index``). A rollback
+    expires every joinedload'd ORM row, so touching ``entry.source.name_zh`` /
+    ``entry.definition`` during rendering would trigger an async lazy-reload and
+    raise MissingGreenlet → 500 (live on /dict/般若 + /dict/菩提, 2026-06-24; the
+    #654/#763 detached-row trap, 3rd recurrence). Snapshotting to primitives
+    BEFORE the reverse-index call makes rendering immune to any mid-request
+    session reset.
+    """
+
+    definition: str | None
+    reading: str | None
+    source_name: str | None
+
+
+def _build_dict_jsonld(headword: str, entries: list[_DictEntryView], canonical: str) -> dict:
     """schema.org DefinedTerm — Google indexes these as glossary results.
 
     A headword often has multiple definitions across dictionaries; we fold
@@ -137,7 +157,7 @@ async def _fetch_reverse_index(
 
 def _render_dict_html(
     headword: str,
-    entries: list[DictionaryEntry],
+    entries: list[_DictEntryView],
     related_texts: list[dict],
     *,
     canonical: str,
@@ -232,9 +252,9 @@ def _render_dict_html(
     )
 
     # Group entries by source for cleaner layout.
-    by_source: dict[str, list[DictionaryEntry]] = {}
+    by_source: dict[str, list[_DictEntryView]] = {}
     for e in entries:
-        key = e.source.name_zh if e.source else "其他"
+        key = e.source_name or "其他"
         by_source.setdefault(key, []).append(e)
 
     parts.append(f'<h2>释义（{len(entries)} 部辞典）</h2>')
@@ -314,6 +334,18 @@ async def dict_seo_html(headword: str, request: Request, db: AsyncSession = Depe
     if not entries:
         raise HTTPException(status_code=404, detail="headword not found")
 
+    # Snapshot to primitives BEFORE the reverse-index lookup: that lookup may
+    # roll back the session (timeout guard), which would expire these
+    # joinedload'd rows and 500 the render on a lazy-reload. See _DictEntryView.
+    views = [
+        _DictEntryView(
+            definition=e.definition,
+            reading=e.reading,
+            source_name=(e.source.name_zh if e.source else None),
+        )
+        for e in entries
+    ]
+
     base_url = str(request.base_url).rstrip("/")
     canonical = f"{base_url}/dict/{canonical_headword}"
     headword = canonical_headword
@@ -326,7 +358,7 @@ async def dict_seo_html(headword: str, request: Request, db: AsyncSession = Depe
 
     html = _render_dict_html(
         headword,
-        entries,
+        views,
         related,
         canonical=canonical,
         base_url=base_url,

--- a/backend/tests/test_seo_dict_reverse_index.py
+++ b/backend/tests/test_seo_dict_reverse_index.py
@@ -6,12 +6,13 @@ The block is a best-effort SEO nicety — cap its statement_timeout and drop it 
 timeout rather than starve the pool.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.api.seo_dict import _fetch_reverse_index
+from app.api.seo_dict import _fetch_reverse_index, dict_seo_html
 
 
 @pytest.mark.anyio
@@ -58,3 +59,73 @@ async def test_best_effort_empty_and_rollback_on_db_error():
     out = await _fetch_reverse_index(db, "般若")
     assert out == []
     db.rollback.assert_awaited()  # aborted txn cleaned so the session is reusable
+
+
+@pytest.mark.anyio
+async def test_dict_page_survives_reverse_index_rollback():
+    """Live /dict/般若 and /dict/菩提 returned 500 (2026-06-24): those two common
+    terms make the reverse-index ILIKE time out, which rolls back the session
+    (the #801 best-effort guard) — and the rollback EXPIRES the joinedload'd
+    entries loaded earlier. Rendering then touched ``e.source.name_zh`` /
+    ``e.definition`` on the now-expired async ORM rows, triggering a lazy reload
+    → MissingGreenlet → 500. This is the #654/#763 detached-row trap, 3rd time.
+
+    The page MUST render from a primitive snapshot taken BEFORE the reverse-index
+    lookup, so a mid-request rollback can never 500 the page.
+    """
+
+    class _ExpiringEntry:
+        """An ORM row that raises on attribute access once the session is rolled
+        back — exactly how async SQLAlchemy behaves on an expired attribute."""
+
+        def __init__(self):
+            self.expired = False
+
+        def _guard(self):
+            if self.expired:
+                raise RuntimeError(
+                    "greenlet_spawn has not been called; can't reload expired "
+                    "attribute (MissingGreenlet after rollback)"
+                )
+
+        @property
+        def definition(self):
+            self._guard()
+            return "般若：智慧；超越世俗分别的洞见。"
+
+        @property
+        def reading(self):
+            self._guard()
+            return None
+
+        @property
+        def source(self):
+            self._guard()
+            return SimpleNamespace(name_zh="佛光大辞典")
+
+    entry = _ExpiringEntry()
+
+    db = AsyncMock()
+    entries_result = MagicMock()
+    entries_result.unique.return_value.scalars.return_value.all.return_value = [entry]
+    db.execute.return_value = entries_result
+
+    async def _fake_reverse(_db, _headword):
+        # Simulate the timeout path: the session was rolled back, so every
+        # previously-loaded ORM row is now expired.
+        entry.expired = True
+        return []
+
+    request = MagicMock()
+    request.base_url = "http://test/"
+
+    # 般若 is identical in simplified/traditional, so the variant probe is
+    # skipped and the only pre-render DB call is the entries SELECT (mocked).
+    with patch("app.api.seo_dict._fetch_reverse_index", _fake_reverse):
+        resp = await dict_seo_html("般若", request, db)
+
+    assert resp.status_code == 200
+    body = resp.body.decode()
+    assert "般若" in body
+    # The source name was snapshotted before the rollback, so it still renders.
+    assert "佛光大辞典" in body


### PR DESCRIPTION
## Bug (live 2026-06-24)
`/dict/般若` and `/dict/菩提` returned **500** in prod (verified: 般若 5-6/6, 菩提 6/6; other terms 禅/空/心/法/佛/涅槃 = 200).

## Root cause
Those two common terms make the reverse-index `ILIKE '%term%'` seq-scan `text_contents.content` and hit the 3s `statement_timeout` guard added in #801. The guard calls `db.rollback()` to recover the aborted txn — but the rollback **expires the joinedload'd `DictionaryEntry` rows** loaded earlier in the request. The render path then touches `e.source.name_zh` / `e.definition` on the now-expired async ORM rows → lazy-reload → **MissingGreenlet → 500**. This is the project's own #654/#763 detached-row trap, 3rd recurrence.

## Fix
Per the established lesson (cross-rollback: pass primitives, not ORM rows), snapshot each entry's render-relevant fields into a frozen `_DictEntryView` **before** the reverse-index lookup, and render from those. The page is now immune to **any** mid-request session reset, not just this path. `_fetch_reverse_index` is unchanged (its rollback is still correct).

## Verification (TDD)
- `test_dict_page_survives_reverse_index_rollback` simulates the timeout→rollback→expiry and asserts the page renders 200 (RED reproduced the 500, GREEN after fix).
- Full backend suite **697 passed**, ruff clean. The 3 existing `_fetch_reverse_index` tests unchanged + green.

Recovers two of the highest-traffic Buddhist SEO landing pages currently served 500 to Googlebot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)