### PR TITLE
feat(dict): cross-lingual term-concept layer + multilingual concept card (Phase 1)

### DIFF
--- a/backend/alembic/versions/0160_add_term_concepts.py
+++ b/backend/alembic/versions/0160_add_term_concepts.py
@@ -1,0 +1,80 @@
+"""add term_concepts + term_concept_entries for the cross-lingual term layer
+
+Revision ID: 0160
+Revises: 0159
+Create Date: 2026-06-26
+
+A concept layer that links the same Buddhist term across the dictionary corpus's
+languages (中梵巴藏…). ``term_concepts`` is keyed by a normalized Sanskrit-IAST
+string with per-language representative forms denormalized for fast rendering;
+``term_concept_entries`` is the M:N link from a concept to the actual
+``dictionary_entries`` rows.
+
+Both tables are created empty; population is offline via
+``scripts/build_term_concepts.py`` (parses Mahāvyutpatti / 四譯合璧 structured
+definitions + romanized-headword joins). This migration touches no existing data.
+See docs/superpowers/specs/2026-06-26-dict-term-concepts-design.md.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0160"
+down_revision: str | None = "0159"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "term_concepts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("key", sa.String(length=200), nullable=False),
+        sa.Column("sanskrit", sa.String(length=200), nullable=True),
+        sa.Column("devanagari", sa.String(length=200), nullable=True),
+        sa.Column("pali", sa.String(length=200), nullable=True),
+        sa.Column("tibetan", sa.String(length=300), nullable=True),
+        sa.Column("chinese", sa.String(length=200), nullable=True),
+        sa.Column("english", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_term_concepts_key", "term_concepts", ["key"], unique=True)
+    op.create_index("ix_term_concepts_chinese", "term_concepts", ["chinese"])
+
+    op.create_table(
+        "term_concept_entries",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("concept_id", sa.Integer(), nullable=False),
+        sa.Column("dict_entry_id", sa.Integer(), nullable=False),
+        sa.Column("lang", sa.String(length=10), nullable=False),
+        sa.Column("method", sa.String(length=40), nullable=False),
+        sa.Column("confidence", sa.String(length=10), nullable=False, server_default="high"),
+        sa.ForeignKeyConstraint(
+            ["concept_id"], ["term_concepts.id"], name="fk_tce_concept", ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["dict_entry_id"],
+            ["dictionary_entries.id"],
+            name="fk_tce_entry",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("concept_id", "dict_entry_id", name="uq_term_concept_entry"),
+    )
+    op.create_index("ix_tce_concept", "term_concept_entries", ["concept_id"])
+    op.create_index("ix_tce_entry", "term_concept_entries", ["dict_entry_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tce_entry", table_name="term_concept_entries")
+    op.drop_index("ix_tce_concept", table_name="term_concept_entries")
+    op.drop_table("term_concept_entries")
+    op.drop_index("ix_term_concepts_chinese", table_name="term_concepts")
+    op.drop_index("ix_term_concepts_key", table_name="term_concepts")
+    op.drop_table("term_concepts")

--- a/backend/app/api/dictionary.py
+++ b/backend/app/api/dictionary.py
@@ -11,6 +11,7 @@ from app.core.exceptions import DictionaryEntryNotFoundError
 from app.database import get_db
 from app.models.dictionary import DictionaryEntry
 from app.models.source import DataSource
+from app.services.term_concept_service import resolve_concept
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/dictionary", tags=["dictionary"])
@@ -314,6 +315,21 @@ async def search_dictionary(
         "size": size,
         "results": [_entry_to_dict(e) for e in entries],
     }
+
+
+@router.get("/concept")
+async def get_concept(
+    response: Response,
+    q: str = Query(..., min_length=1, description="term in any language (中/梵/巴/藏)"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Resolve a term to its cross-lingual concept + linked entries grouped by
+    language. Returns ``concept: null`` (200) when nothing matches, so the
+    frontend simply renders no card and falls back to normal search.
+
+    跨语种术语概念卡数据。"""
+    response.headers["Cache-Control"] = PUBLIC_CACHE_HEADER
+    return await resolve_concept(db, q)
 
 
 @router.get("/{entry_id}")

--- a/backend/app/api/dictionary.py
+++ b/backend/app/api/dictionary.py
@@ -320,7 +320,7 @@ async def search_dictionary(
 @router.get("/concept")
 async def get_concept(
     response: Response,
-    q: str = Query(..., min_length=1, description="term in any language (中/梵/巴/藏)"),
+    q: str = Query(..., min_length=1, max_length=200, description="term in any language (中/梵/巴/藏)"),
     db: AsyncSession = Depends(get_db),
 ):
     """Resolve a term to its cross-lingual concept + linked entries grouped by

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.models.iiif import IIIFManifest
 from app.models.knowledge_graph import KGEntity, KGRelation
 from app.models.relation import TextRelation
 from app.models.source import DataSource, SourceDistribution, TextIdentifier
+from app.models.term_concept import TermConcept, TermConceptEntry
 from app.models.text import (
     ApparatusReading,
     BuddhistText,
@@ -42,6 +43,8 @@ __all__ = [
     "ReadingHistory",
     "SourceDistribution",
     "SourceUpdate",
+    "TermConcept",
+    "TermConceptEntry",
     "TextApparatus",
     "TextContent",
     "TextEmbedding",

--- a/backend/app/models/term_concept.py
+++ b/backend/app/models/term_concept.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class TermConcept(Base):
+    """A cross-lingual Buddhist term concept.
+
+    Keyed by a normalized Sanskrit-IAST string (``key``); the per-language
+    representative forms are denormalized onto the row so the concept card
+    renders without a join. Populated offline by
+    ``scripts/build_term_concepts.py`` from structured concordance dictionaries
+    (Mahāvyutpatti / 四譯合璧) plus romanized-headword joins.
+    """
+
+    __tablename__ = "term_concepts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    key: Mapped[str] = mapped_column(String(200), nullable=False, unique=True, index=True)
+    sanskrit: Mapped[str | None] = mapped_column(String(200))
+    devanagari: Mapped[str | None] = mapped_column(String(200))
+    pali: Mapped[str | None] = mapped_column(String(200))
+    tibetan: Mapped[str | None] = mapped_column(String(300))
+    chinese: Mapped[str | None] = mapped_column(String(200), index=True)
+    english: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class TermConceptEntry(Base):
+    """Link between a :class:`TermConcept` and a ``dictionary_entries`` row.
+
+    ``method`` records which builder rule created the link (``mvp`` /
+    ``siyi_tag`` / ``romanized_join``) and ``confidence`` (``high`` / ``medium``)
+    so a later phase can audit or roll back specific link classes.
+    """
+
+    __tablename__ = "term_concept_entries"
+    __table_args__ = (
+        UniqueConstraint("concept_id", "dict_entry_id", name="uq_term_concept_entry"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    concept_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("term_concepts.id", ondelete="CASCADE"), index=True
+    )
+    dict_entry_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("dictionary_entries.id", ondelete="CASCADE"), index=True
+    )
+    lang: Mapped[str] = mapped_column(String(10), nullable=False)
+    method: Mapped[str] = mapped_column(String(40), nullable=False)
+    confidence: Mapped[str] = mapped_column(String(10), nullable=False, server_default="high")

--- a/backend/app/services/term_concept_service.py
+++ b/backend/app/services/term_concept_service.py
@@ -1,0 +1,114 @@
+"""Cross-lingual term-concept resolution + the shared IAST normalizer.
+
+``normalize_iast`` is the single source of truth for the concept match key; both
+the offline builder (scripts/build_term_concepts.py) and the ``/concept`` API
+import it so they can never drift.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.models.dictionary import DictionaryEntry
+from app.models.term_concept import TermConcept, TermConceptEntry
+
+_NON_ALPHA = re.compile(r"[^a-z]")
+
+# Lang display order on the concept card.
+_LANG_ORDER = {"zh": 0, "sa": 1, "pi": 2, "bo": 3, "en": 4}
+
+
+def normalize_iast(s: str | None) -> str:
+    """Fold an IAST string to a match key: first line, de-diacritic, lowercase,
+    letters-only, drop a single trailing ``m`` (accusative/anusvāra citation
+    ending) so ``nirvāṇam`` and ``nirvāṇa`` both become ``nirvana``."""
+    if not s:
+        return ""
+    head = s.strip().split("\n")[0].strip()
+    decomposed = unicodedata.normalize("NFKD", head)
+    ascii_ = "".join(c for c in decomposed if not unicodedata.combining(c)).lower()
+    ascii_ = _NON_ALPHA.sub("", ascii_)
+    return re.sub(r"m$", "", ascii_)
+
+
+def _preview(definition: str | None, limit: int = 120) -> str:
+    if not definition:
+        return ""
+    flat = " ".join(definition.split())
+    return flat[:limit] + ("…" if len(flat) > limit else "")
+
+
+async def resolve_concept(db: AsyncSession, q: str) -> dict:
+    """Resolve a term (in any language) to its concept + linked entries grouped
+    by language. Returns ``{"concept": None, "entries_by_lang": []}`` when no
+    concept matches — the caller renders nothing and falls back to plain search."""
+    q = (q or "").strip()
+    empty = {"concept": None, "entries_by_lang": []}
+    if not q:
+        return empty
+
+    # 1) exact match on a representative form, 2) fall back to the normalized key.
+    concept = await db.scalar(
+        select(TermConcept)
+        .where(
+            or_(
+                TermConcept.chinese == q,
+                TermConcept.sanskrit == q,
+                TermConcept.pali == q,
+                TermConcept.tibetan == q,
+            )
+        )
+        .limit(1)
+    )
+    if concept is None:
+        key = normalize_iast(q)
+        if key:
+            concept = await db.scalar(select(TermConcept).where(TermConcept.key == key).limit(1))
+    if concept is None:
+        return empty
+
+    rows = (
+        (
+            await db.execute(
+                select(DictionaryEntry)
+                .join(TermConceptEntry, TermConceptEntry.dict_entry_id == DictionaryEntry.id)
+                .options(joinedload(DictionaryEntry.source))
+                .where(TermConceptEntry.concept_id == concept.id)
+            )
+        )
+        .unique()
+        .scalars()
+        .all()
+    )
+
+    by_lang: dict[str, list[dict]] = {}
+    for e in rows:
+        by_lang.setdefault(e.lang or "other", []).append(
+            {
+                "id": e.id,
+                "headword": (e.headword or "").split("\n")[0].strip(),
+                "source_name": e.source.name_zh if e.source else None,
+                "definition_preview": _preview(e.definition),
+            }
+        )
+    entries_by_lang = [
+        {"lang": lang, "entries": entries}
+        for lang, entries in sorted(by_lang.items(), key=lambda kv: _LANG_ORDER.get(kv[0], 99))
+    ]
+
+    return {
+        "concept": {
+            "sanskrit": concept.sanskrit,
+            "devanagari": concept.devanagari,
+            "pali": concept.pali,
+            "tibetan": concept.tibetan,
+            "chinese": concept.chinese,
+            "english": concept.english,
+        },
+        "entries_by_lang": entries_by_lang,
+    }

--- a/backend/scripts/build_term_concepts.py
+++ b/backend/scripts/build_term_concepts.py
@@ -29,6 +29,7 @@ Run inside the backend container where the corpus DB is reachable:
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 import sys
 
@@ -39,6 +40,8 @@ from sqlalchemy.pool import NullPool
 from app.config import settings
 from app.models import DataSource, DictionaryEntry, TermConcept, TermConceptEntry
 from app.services.term_concept_service import normalize_iast
+
+logger = logging.getLogger(__name__)
 
 # Source codes whose entries pack all languages into one row.
 MVP_CODE = "dila-mvp"
@@ -131,6 +134,10 @@ async def build(session) -> dict:
 
     mvp_id = await _source_id(session, MVP_CODE)
     siyi_id = await _source_id(session, SIYI_CODE)
+    if mvp_id is None:
+        logger.warning("source %r not found — concept backbone will be empty", MVP_CODE)
+    if siyi_id is None:
+        logger.warning("source %r not found — skipping 四譯合璧 enrichment", SIYI_CODE)
 
     concepts: dict[str, TermConcept] = {}  # key -> concept
     links: set[tuple[int, int]] = set()  # (concept_id, dict_entry_id) guard
@@ -206,21 +213,29 @@ async def build(session) -> dict:
 
     # Phase 3 — romanized-headword join: link Sanskrit/Pali entries to existing
     # concepts; fill display forms. Never creates new concepts.
-    rows = (
-        await session.execute(
-            select(DictionaryEntry).where(DictionaryEntry.lang.in_(["sa", "pi"]))
-        )
-    ).scalars()
-    for e in rows:
-        key = normalize_iast(e.headword)
-        c = concepts.get(key)
+    # Select only the 3 needed columns (NOT the definition Text) and stream in
+    # batches — the sa/pi corpus is large (MW alone is ~32k rows); loading full
+    # ORM entities with their definitions would balloon the session and risk OOM
+    # on the prod container.
+    result = await session.stream(
+        select(DictionaryEntry.id, DictionaryEntry.headword, DictionaryEntry.lang)
+        .where(DictionaryEntry.lang.in_(["sa", "pi"]))
+        .execution_options(yield_per=2000)
+    )
+    async for eid, headword, lang in result:
+        c = concepts.get(normalize_iast(headword))
         if c is None:
             continue
-        if e.lang == "pi":
-            c.pali = c.pali or (e.headword or "").split("\n")[0].strip()
-        elif e.lang == "sa":
-            c.sanskrit = c.sanskrit or (e.headword or "").split("\n")[0].strip()
-        if await link(c, e.id, e.lang, "romanized_join"):
+        lemma = (headword or "").split("\n")[0].strip()
+        if lang == "pi":
+            c.pali = c.pali or lemma
+        # Prefer a dictionary lemma over Mahāvyutpatti's inflected citation form
+        # (e.g. "nirvāṇa" over "nirvāṇam") when it's the same word.
+        elif lang == "sa" and (
+            not c.sanskrit or (lemma and c.sanskrit.startswith(lemma) and lemma != c.sanskrit)
+        ):
+            c.sanskrit = lemma
+        if await link(c, eid, lang, "romanized_join"):
             stats["links_roman"] += 1
 
     # Phase 4 — Chinese back-link: concepts with a Chinese anchor pull in the
@@ -230,18 +245,27 @@ async def build(session) -> dict:
         if c.chinese:
             chinese_index.setdefault(c.chinese, []).append(c)
     if chinese_index:
-        rows = (
-            await session.execute(
-                select(DictionaryEntry).where(
-                    DictionaryEntry.lang == "zh",
-                    DictionaryEntry.headword.in_(list(chinese_index.keys())),
-                )
+        rows = await session.execute(
+            select(DictionaryEntry.id, DictionaryEntry.headword)
+            .where(
+                DictionaryEntry.lang == "zh",
+                DictionaryEntry.headword.in_(list(chinese_index.keys())),
             )
-        ).scalars()
-        for e in rows:
-            for c in chinese_index.get(e.headword, []):
-                if await link(c, e.id, "zh", "romanized_join", conf="medium"):
+        )
+        for eid, headword in rows:
+            for c in chinese_index.get(headword, []):
+                if await link(c, eid, "zh", "romanized_join", conf="medium"):
                     stats["links_zh"] += 1
+
+    # Surface silent-no-op failure modes (wrong source codes / lang values in
+    # prod data) instead of returning a clean-looking all-zero stats line.
+    for phase, n in (
+        ("links_mvp", stats["links_mvp"]),
+        ("links_roman", stats["links_roman"]),
+        ("links_zh", stats["links_zh"]),
+    ):
+        if n == 0:
+            logger.warning("build_term_concepts: %s produced 0 links — check source codes / lang values", phase)
 
     await session.commit()
     return stats

--- a/backend/scripts/build_term_concepts.py
+++ b/backend/scripts/build_term_concepts.py
@@ -1,0 +1,267 @@
+"""Build the cross-lingual term-concept layer (Phase 1, structured backbone).
+
+Populates ``term_concepts`` + ``term_concept_entries`` from the structured
+concordance dictionaries that pair languages *inside one entry*:
+
+  - 翻譯名義大集 (``dila-mvp``): headword = Sanskrit IAST + Devanagari; the
+    definition repeats those and adds Chinese form(s) + Tibetan (Wylie + script).
+  - 四譯合璧輯要 (``siyi-hebi``): definition tags 【梵】【漢】【藏】【巴】【滿】【蒙】.
+
+then joins the rest of the corpus by normalized romanized headword:
+
+  - Any Sanskrit / Pali entry whose normalized headword matches an existing
+    concept key is linked (and fills the concept's pali/sanskrit display form).
+  - Any Chinese entry whose headword equals a concept's representative Chinese
+    form is linked.
+
+Concepts are seeded ONLY from the bridge dicts, never from MW/DPD/… — a concept
+must have a Chinese anchor to be useful on the (Chinese-user-facing) concept card.
+This keeps Phase 1 high-precision; the noisy "extract romanization from Chinese
+definitions" layer is deferred to Phase 2.
+
+The build is a full rebuild (wipes both tables first) so re-runs are
+deterministic and idempotent. It only writes the two new tables.
+
+Run inside the backend container where the corpus DB is reachable:
+    docker compose exec -T backend python -m scripts.build_term_concepts
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.config import settings
+from app.models import DataSource, DictionaryEntry, TermConcept, TermConceptEntry
+from app.services.term_concept_service import normalize_iast
+
+# Source codes whose entries pack all languages into one row.
+MVP_CODE = "dila-mvp"
+SIYI_CODE = "siyi-hebi"
+
+# ─────────────────────────── pure functions (unit-tested) ───────────────────
+
+
+def classify_script(seg: str) -> str:
+    """Script of the first strong character: devanagari / tibetan / han / latin / other."""
+    for ch in seg:
+        o = ord(ch)
+        if 0x0900 <= o <= 0x097F:
+            return "devanagari"
+        if 0x0F00 <= o <= 0x0FFF:
+            return "tibetan"
+        if 0x3400 <= o <= 0x9FFF or 0xF900 <= o <= 0xFAFF:
+            return "han"
+        if "a" <= ch.lower() <= "z":
+            return "latin"
+    return "other"
+
+
+def parse_mvp_entry(headword: str | None, definition: str | None) -> dict:
+    """Extract {sanskrit, devanagari, chinese[list], tibetan} from a Mahāvyutpatti
+    entry. Buckets segments by Unicode script rather than position, so the
+    dictionary's irregular nesting does not break parsing."""
+    res: dict = {"sanskrit": None, "devanagari": None, "chinese": [], "tibetan": None}
+    for line in (headword or "").split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        sc = classify_script(line)
+        if sc == "latin" and res["sanskrit"] is None:
+            res["sanskrit"] = line
+        elif sc == "devanagari" and res["devanagari"] is None:
+            res["devanagari"] = line
+    for line in (definition or "").split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        sc = classify_script(line)
+        if sc == "han":
+            if line not in res["chinese"]:
+                res["chinese"].append(line)
+        elif sc == "tibetan" and res["tibetan"] is None:
+            res["tibetan"] = line
+        elif sc == "devanagari" and res["devanagari"] is None:
+            res["devanagari"] = line
+        elif sc == "latin" and res["sanskrit"] is None:
+            res["sanskrit"] = line
+    return res
+
+
+_SIYI_TAG = re.compile(r"【(.)】\s*([^【]*)")
+_SIYI_MAP = {
+    "梵": "sanskrit",
+    "漢": "chinese",
+    "藏": "tibetan",
+    "巴": "pali",
+}
+
+
+def parse_siyi_definition(definition: str | None) -> dict:
+    """Extract {sanskrit, chinese, tibetan, pali} from 四譯合璧 【x】-tagged defs.
+    Manchu/Mongolian tags exist but Phase 1 keeps only the four core languages."""
+    res: dict = {}
+    for m in _SIYI_TAG.finditer(definition or ""):
+        field = _SIYI_MAP.get(m.group(1))
+        val = m.group(2).strip()
+        if field and val and field not in res:
+            res[field] = val
+    return res
+
+
+# ─────────────────────────── DB build ───────────────────────────────────────
+
+
+async def _source_id(session, code: str) -> int | None:
+    return await session.scalar(select(DataSource.id).where(DataSource.code == code))
+
+
+async def build(session) -> dict:
+    stats = {"concepts": 0, "links_mvp": 0, "links_siyi": 0, "links_roman": 0, "links_zh": 0}
+
+    # Full rebuild — derived tables, safe to wipe.
+    await session.execute(delete(TermConceptEntry))
+    await session.execute(delete(TermConcept))
+    await session.flush()
+
+    mvp_id = await _source_id(session, MVP_CODE)
+    siyi_id = await _source_id(session, SIYI_CODE)
+
+    concepts: dict[str, TermConcept] = {}  # key -> concept
+    links: set[tuple[int, int]] = set()  # (concept_id, dict_entry_id) guard
+
+    def get_or_make(key: str) -> TermConcept | None:
+        if not key:
+            return None
+        c = concepts.get(key)
+        if c is None:
+            c = TermConcept(key=key)
+            session.add(c)
+            concepts[key] = c
+        return c
+
+    async def link(concept: TermConcept, entry_id: int, lang: str, method: str, conf: str = "high"):
+        # concept.id may be None until flush; flush lazily when we need ids.
+        if concept.id is None:
+            await session.flush()
+        pair = (concept.id, entry_id)
+        if pair in links:
+            return False
+        links.add(pair)
+        session.add(
+            TermConceptEntry(
+                concept_id=concept.id, dict_entry_id=entry_id, lang=lang, method=method, confidence=conf
+            )
+        )
+        return True
+
+    # Phase 1 — Mahāvyutpatti: seed concepts (sa + zh + bo).
+    if mvp_id:
+        rows = (
+            await session.execute(
+                select(DictionaryEntry).where(DictionaryEntry.source_id == mvp_id)
+            )
+        ).scalars()
+        for e in rows:
+            p = parse_mvp_entry(e.headword, e.definition)
+            key = normalize_iast(p["sanskrit"])
+            c = get_or_make(key)
+            if c is None:
+                continue
+            c.sanskrit = c.sanskrit or p["sanskrit"]
+            c.devanagari = c.devanagari or p["devanagari"]
+            c.tibetan = c.tibetan or p["tibetan"]
+            if not c.chinese and p["chinese"]:
+                c.chinese = p["chinese"][0]
+            if await link(c, e.id, e.lang or "sa", "mvp"):
+                stats["links_mvp"] += 1
+
+    # Phase 2 — 四譯合璧: enrich + link by Sanskrit key.
+    if siyi_id:
+        rows = (
+            await session.execute(
+                select(DictionaryEntry).where(DictionaryEntry.source_id == siyi_id)
+            )
+        ).scalars()
+        for e in rows:
+            p = parse_siyi_definition(e.definition)
+            key = normalize_iast(p.get("sanskrit") or e.headword)
+            c = get_or_make(key)
+            if c is None:
+                continue
+            c.sanskrit = c.sanskrit or p.get("sanskrit")
+            c.chinese = c.chinese or p.get("chinese")
+            c.tibetan = c.tibetan or p.get("tibetan")
+            c.pali = c.pali or p.get("pali")
+            if await link(c, e.id, "sa", "siyi_tag"):
+                stats["links_siyi"] += 1
+
+    await session.flush()
+    stats["concepts"] = len(concepts)
+
+    # Phase 3 — romanized-headword join: link Sanskrit/Pali entries to existing
+    # concepts; fill display forms. Never creates new concepts.
+    rows = (
+        await session.execute(
+            select(DictionaryEntry).where(DictionaryEntry.lang.in_(["sa", "pi"]))
+        )
+    ).scalars()
+    for e in rows:
+        key = normalize_iast(e.headword)
+        c = concepts.get(key)
+        if c is None:
+            continue
+        if e.lang == "pi":
+            c.pali = c.pali or (e.headword or "").split("\n")[0].strip()
+        elif e.lang == "sa":
+            c.sanskrit = c.sanskrit or (e.headword or "").split("\n")[0].strip()
+        if await link(c, e.id, e.lang, "romanized_join"):
+            stats["links_roman"] += 1
+
+    # Phase 4 — Chinese back-link: concepts with a Chinese anchor pull in the
+    # Chinese-headword dictionaries (佛光 / 丁福保 / …).
+    chinese_index: dict[str, list[TermConcept]] = {}
+    for c in concepts.values():
+        if c.chinese:
+            chinese_index.setdefault(c.chinese, []).append(c)
+    if chinese_index:
+        rows = (
+            await session.execute(
+                select(DictionaryEntry).where(
+                    DictionaryEntry.lang == "zh",
+                    DictionaryEntry.headword.in_(list(chinese_index.keys())),
+                )
+            )
+        ).scalars()
+        for e in rows:
+            for c in chinese_index.get(e.headword, []):
+                if await link(c, e.id, "zh", "romanized_join", conf="medium"):
+                    stats["links_zh"] += 1
+
+    await session.commit()
+    return stats
+
+
+async def main() -> int:
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            stats = await build(session)
+    finally:
+        await engine.dispose()
+    print(
+        f"term concepts built: {stats['concepts']} concepts | "
+        f"links mvp={stats['links_mvp']} siyi={stats['links_siyi']} "
+        f"romanized={stats['links_roman']} zh={stats['links_zh']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/backend/tests/test_build_term_concepts.py
+++ b/backend/tests/test_build_term_concepts.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from app.models.dictionary import DictionaryEntry
 from app.models.source import DataSource
 from app.models.term_concept import TermConcept, TermConceptEntry
+from app.services.term_concept_service import resolve_concept
 
 MVP_HEADWORD = "nirvāṇam\n            निर्वाणम्"
 MVP_DEF = (
@@ -70,7 +71,9 @@ async def test_build_assembles_single_cross_lingual_concept(session):
     c = concepts[0]
     assert c.key == "nirvana"
     assert c.chinese == "涅槃"  # first Chinese form from the Mahāvyutpatti entry
-    assert c.sanskrit == "nirvāṇam"
+    # Phase 3 prefers the MW lemma "nirvāṇa" over the Mahāvyutpatti citation
+    # form "nirvāṇam" for display (same word, lemma is a prefix).
+    assert c.sanskrit == "nirvāṇa"
     assert c.tibetan == "མྱ་ངན་ལས་འདས་པ་"  # Tibetan script, not the Wylie line
     assert stats["concepts"] == 1
 
@@ -104,3 +107,29 @@ async def test_build_is_idempotent(session):
     second = await build(session)
     assert first == second
     assert len(await _concepts(session)) == 1
+
+
+# --- resolve_concept (the request-path) ------------------------------------
+
+
+async def test_resolve_by_chinese_sanskrit_and_normalized_key(session):
+    await build(session)
+    # Chinese form, exact Sanskrit display form, and a romanized key variant
+    # (no diacritics, accusative -m) must all resolve to the same concept.
+    for term in ("涅槃", "nirvāṇa", "nirvanam"):
+        res = await resolve_concept(session, term)
+        assert res["concept"] is not None, term
+        assert res["concept"]["chinese"] == "涅槃", term
+        langs = {g["lang"] for g in res["entries_by_lang"]}
+        assert {"zh", "sa"} <= langs, term  # grouped linked entries present
+
+
+async def test_resolve_unknown_term_returns_empty(session):
+    await build(session)
+    res = await resolve_concept(session, "no-such-term-xyz")
+    assert res == {"concept": None, "entries_by_lang": []}
+
+
+async def test_resolve_blank_query_short_circuits(session):
+    await build(session)
+    assert await resolve_concept(session, "   ") == {"concept": None, "entries_by_lang": []}

--- a/backend/tests/test_build_term_concepts.py
+++ b/backend/tests/test_build_term_concepts.py
@@ -1,0 +1,106 @@
+"""Integration test for the term-concept builder's DB logic (in-memory SQLite).
+
+Parsing is covered by test_term_concepts.py; this exercises ``build()``
+end-to-end — concept assembly, the four link phases, dedup, and the Phase-1
+Pali boundary — without the prod corpus DB. Fixture rows mirror the real shape
+of 翻譯名義大集 / 四譯合璧 entries for 涅槃 (nirvāṇa).
+"""
+
+import pytest_asyncio
+from scripts.build_term_concepts import build
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.dictionary import DictionaryEntry
+from app.models.source import DataSource
+from app.models.term_concept import TermConcept, TermConceptEntry
+
+MVP_HEADWORD = "nirvāṇam\n            निर्वाणम्"
+MVP_DEF = (
+    "nirvāṇam\n  निर्वाणम्\n  涅槃\n  清淨涅槃\n"
+    "  mya ngan las 'das pa\n  མྱ་ངན་ལས་འདས་པ་"
+)
+SIYI_DEF = "nirvāṇam\n【梵】nirvāṇam\n【漢】涅槃"
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        for model in (DataSource, DictionaryEntry, TermConcept, TermConceptEntry):
+            await conn.run_sync(model.__table__.create)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        await _seed(s)
+        yield s
+    await engine.dispose()
+
+
+async def _seed(s):
+    sources = {
+        "dila-mvp": DataSource(code="dila-mvp", name_zh="翻譯名義大集"),
+        "siyi-hebi": DataSource(code="siyi-hebi", name_zh="四譯合璧輯要"),
+        "mw": DataSource(code="dila-mw", name_zh="Monier-Williams 梵英大辞典"),
+        "dpd": DataSource(code="dpd", name_zh="数字巴利辞典 DPD"),
+        "fg": DataSource(code="foguang", name_zh="佛光大辭典"),
+    }
+    s.add_all(list(sources.values()))
+    await s.flush()
+    s.add_all(
+        [
+            DictionaryEntry(headword=MVP_HEADWORD, definition=MVP_DEF, source_id=sources["dila-mvp"].id, lang="sa", external_id="mvp-1"),
+            DictionaryEntry(headword="nirvāṇam", definition=SIYI_DEF, source_id=sources["siyi-hebi"].id, lang="sa,zh", external_id="siyi-1"),
+            DictionaryEntry(headword="nirvāṇa", definition="extinction; liberation.", source_id=sources["mw"].id, lang="sa", external_id="mw-1"),
+            DictionaryEntry(headword="nibbāna", definition="the unbinding.", source_id=sources["dpd"].id, lang="pi", external_id="dpd-1"),
+            DictionaryEntry(headword="涅槃", definition="梵語 nirvāṇa 之音譯。", source_id=sources["fg"].id, lang="zh", external_id="fg-1"),
+        ]
+    )
+    await s.commit()
+
+
+async def _concepts(s):
+    return (await s.execute(select(TermConcept))).scalars().all()
+
+
+async def test_build_assembles_single_cross_lingual_concept(session):
+    stats = await build(session)
+    concepts = await _concepts(session)
+
+    assert len(concepts) == 1
+    c = concepts[0]
+    assert c.key == "nirvana"
+    assert c.chinese == "涅槃"  # first Chinese form from the Mahāvyutpatti entry
+    assert c.sanskrit == "nirvāṇam"
+    assert c.tibetan == "མྱ་ངན་ལས་འདས་པ་"  # Tibetan script, not the Wylie line
+    assert stats["concepts"] == 1
+
+
+async def test_build_links_mvp_siyi_romanized_and_chinese(session):
+    await build(session)
+    rows = (await session.execute(select(TermConceptEntry))).scalars().all()
+    methods = sorted(r.method for r in rows)
+    # mvp + siyi_tag + romanized_join(MW) + romanized_join(佛光 zh back-link) = 4.
+    assert methods == ["mvp", "romanized_join", "romanized_join", "siyi_tag"]
+    # the佛光 Chinese back-link carries medium confidence.
+    assert any(r.method == "romanized_join" and r.lang == "zh" and r.confidence == "medium" for r in rows)
+
+
+async def test_build_respects_pali_boundary(session):
+    """Phase 1: nibbāna (key 'nibbana') must NOT link to the nirvāṇa concept."""
+    await build(session)
+    entry_id = await session.scalar(
+        select(DictionaryEntry.id).where(DictionaryEntry.headword == "nibbāna")
+    )
+    linked = await session.scalar(
+        select(func.count())
+        .select_from(TermConceptEntry)
+        .where(TermConceptEntry.dict_entry_id == entry_id)
+    )
+    assert linked == 0
+
+
+async def test_build_is_idempotent(session):
+    first = await build(session)
+    second = await build(session)
+    assert first == second
+    assert len(await _concepts(session)) == 1

--- a/backend/tests/test_term_concepts.py
+++ b/backend/tests/test_term_concepts.py
@@ -1,0 +1,125 @@
+"""Pure-logic tests for the term-concept builder + IAST normalizer.
+
+No DB / LLM / network. These pin the parsing the whole cross-lingual layer
+depends on (the full build runs against the prod corpus DB, not CI). Samples are
+verbatim from the live corpus (翻譯名義大集 / 四譯合璧輯要 entries for 涅槃).
+"""
+
+from scripts.build_term_concepts import (
+    classify_script,
+    parse_mvp_entry,
+    parse_siyi_definition,
+)
+
+from app.services.term_concept_service import normalize_iast
+
+# --- normalize_iast --------------------------------------------------------
+
+
+def test_normalize_folds_diacritics_and_case():
+    assert normalize_iast("nirvāṇa") == "nirvana"
+
+
+def test_normalize_drops_accusative_m_so_citation_forms_collapse():
+    # Mahāvyutpatti cites "nirvāṇam"; MW headword is "nirvāṇa" — both must match.
+    assert normalize_iast("nirvāṇam") == normalize_iast("nirvāṇa") == "nirvana"
+
+
+def test_normalize_pali_stays_distinct_from_sanskrit():
+    # Documents the Phase-1 Pali boundary: nibbāna does NOT fold to nirvana.
+    assert normalize_iast("nibbāna") == "nibbana"
+    assert normalize_iast("nibbāna") != normalize_iast("nirvāṇa")
+
+
+def test_normalize_takes_first_line_only():
+    assert normalize_iast("nirvāṇam\n            निर्वाणम्") == "nirvana"
+
+
+def test_normalize_shared_form_matches():
+    assert normalize_iast("bodhi") == normalize_iast("Bodhi") == "bodhi"
+
+
+def test_normalize_empty_and_non_latin():
+    assert normalize_iast("") == ""
+    assert normalize_iast(None) == ""
+    assert normalize_iast("涅槃") == ""
+
+
+# --- classify_script -------------------------------------------------------
+
+
+def test_classify_script_by_block():
+    assert classify_script("nirvāṇam") == "latin"
+    assert classify_script("निर्वाणम्") == "devanagari"
+    assert classify_script("涅槃") == "han"
+    assert classify_script("མྱ་ངན་ལས་འདས་པ་") == "tibetan"
+
+
+def test_classify_script_skips_leading_punctuation_whitespace():
+    assert classify_script("   涅槃") == "han"
+    assert classify_script("'das pa") == "latin"  # Wylie apostrophe then latin
+
+
+def test_classify_script_empty_is_other():
+    assert classify_script("") == "other"
+    assert classify_script("。、") == "other"
+
+
+# --- parse_mvp_entry (Mahāvyutpatti) ---------------------------------------
+
+# Verbatim shape of corpus entry mvp-1714 (nirvāṇam).
+MVP_HEADWORD = "nirvāṇam\n            निर्वाणम्"
+MVP_DEF = (
+    "nirvāṇam\n            निर्वाणम्\n          \n          \n"
+    "            涅槃\n          \n          \n            清淨涅槃\n          \n          \n"
+    "            mya ngan las 'das pa\n          \n          \n            མྱ་ངན་ལས་འདས་པ་"
+)
+
+
+def test_parse_mvp_extracts_all_languages():
+    p = parse_mvp_entry(MVP_HEADWORD, MVP_DEF)
+    assert p["sanskrit"] == "nirvāṇam"
+    assert p["devanagari"] == "निर्वाणम्"
+    assert p["chinese"] == ["涅槃", "清淨涅槃"]  # order preserved, deduped
+    assert p["tibetan"] == "མྱ་ངན་ལས་འདས་པ་"  # Unicode script, not the Wylie line
+
+
+def test_parse_mvp_handles_missing_fields():
+    p = parse_mvp_entry("bodhi", "bodhi\n          菩提")
+    assert p["sanskrit"] == "bodhi"
+    assert p["chinese"] == ["菩提"]
+    assert p["tibetan"] is None
+    assert p["devanagari"] is None
+
+
+def test_parse_mvp_empty():
+    p = parse_mvp_entry(None, None)
+    assert p == {"sanskrit": None, "devanagari": None, "chinese": [], "tibetan": None}
+
+
+# --- parse_siyi_definition (四譯合璧輯要) -----------------------------------
+
+# Verbatim shape of corpus entry siyi-hebi-nirvāṇam.
+SIYI_DEF = (
+    "nirvāṇam\n【梵】nirvāṇam\n【滿】gasacun ci duleke\n"
+    "【蒙】gasalang asa nögchikhsen\n【漢】涅槃"
+)
+
+
+def test_parse_siyi_extracts_core_four_languages():
+    p = parse_siyi_definition(SIYI_DEF)
+    assert p["sanskrit"] == "nirvāṇam"
+    assert p["chinese"] == "涅槃"
+    # Manchu / Mongolian tags are present but intentionally dropped in Phase 1.
+    assert "manchu" not in p
+    assert "mongolian" not in p
+
+
+def test_parse_siyi_partial_tags():
+    p = parse_siyi_definition("【梵】bodhi\n【漢】菩提\n【藏】byang chub")
+    assert p == {"sanskrit": "bodhi", "chinese": "菩提", "tibetan": "byang chub"}
+
+
+def test_parse_siyi_empty():
+    assert parse_siyi_definition("") == {}
+    assert parse_siyi_definition(None) == {}

--- a/docs/superpowers/specs/2026-06-26-dict-term-concepts-design.md
+++ b/docs/superpowers/specs/2026-06-26-dict-term-concepts-design.md
@@ -1,0 +1,107 @@
+# 辞典多语种术语概念层 — Phase 1 (结构化骨架)
+
+**日期:** 2026-06-26
+**状态:** 设计已批准,实施中
+**分支:** `feat/dict-term-concepts`
+
+## 目标
+
+把 39 部辞典(中梵巴藏英蒙满,747,622 条)从"各语种孤立"升级为可跨语检索的**概念层**:
+搜「涅槃」→ 上方出现一张多语种概念卡(汉 涅槃 · 梵 nirvāṇa · 巴 nibbāna · 藏 mya ngan las 'das pa · …),
+卡下接现有的跨辞典分组结果。**纯增量,不改现有 `/search` 与浏览逻辑。**
+
+这一层不只服务辞典 UI——结构化的「中↔梵↔巴↔藏」术语等价表,是 dict + chat(让回答引真实对应而非 LLM 自由发挥)+ 跨藏对齐主线**共用的多语术语基建**。
+
+Phase 1 只建**高精度结构化骨架**,把噪声大的"释义罗马化抽取"留到 Phase 2。
+
+## 已验证的真实数据形态(建表器据此)
+
+- **翻譯名義大集 (`dila-mvp`, source_id 661, 9379 条)**:梵文 headword;`definition` 一条内并列
+  IAST / 天城体 / 汉(可多个) / 藏文 Wylie / 藏文 Unicode,以换行+缩进分隔。`entry_data` 为 null。
+  例:`nirvāṇam` → 汉「涅槃」「清淨涅槃」+ 藏「mya ngan las 'das pa」。
+- **四譯合璧輯要 (`siyi-hebi`, source_id 678, 1057 条)**:`definition` 用标签并列
+  `【梵】…【滿】…【蒙】…【漢】…`;`entry_data.definition_html` 同结构带 `<br>`。
+- **罗马 headword 支点**:MW / Edgerton(梵)、DPD / PTS / NCPED(巴)按各自罗马 headword 入库,
+  归一化后可与概念 key 串联。
+- **辞典词条模型** `dictionary_entries`:`id, headword, reading, definition, source_id, lang, entry_data(JSON), external_id`。
+
+## 数据模型(2 张新表,migration 0160,down_revision 0159)
+
+### `term_concepts`
+| 列 | 类型 | 说明 |
+|----|------|------|
+| `id` | PK int | |
+| `key` | String(200), unique, index | 归一化 IAST(小写+去变音符+去尾 m/ḥ),如 `nirvana` |
+| `sanskrit` | String(200) null | 展示用 IAST,如 `nirvāṇa` |
+| `devanagari` | String(200) null | |
+| `pali` | String(200) null | |
+| `tibetan` | String(300) null | Wylie 或藏文 |
+| `chinese` | String(200) null | 代表中文词形 |
+| `english` | Text null | |
+| `created_at` | timestamptz | |
+
+代表词形冗余存在概念上 → 概念卡零 join 直接渲染。
+
+### `term_concept_entries`(概念 ↔ 词条 多对多)
+| 列 | 类型 | 说明 |
+|----|------|------|
+| `id` | PK int | |
+| `concept_id` | FK → term_concepts.id, index | |
+| `dict_entry_id` | FK → dictionary_entries.id, index | |
+| `lang` | String(10) | |
+| `method` | String(40) | 建链规则:`mvp` / `siyi_tag` / `romanized_join` |
+| `confidence` | String(10) | `high` / `medium` |
+
+`UniqueConstraint(concept_id, dict_entry_id)`。`method`/`confidence` 让 Phase 2 可审计可回滚。
+
+## 建表管线 — `backend/scripts/build_term_concepts.py`(离线,幂等 upsert,不进请求路径)
+
+纯函数(CI 单测守):
+- `normalize_iast(s) -> key`:NFKD 去变音符 → 小写 → 去尾 `m`/`ḥ`/空白。
+- `classify_script(segment) -> {iast|devanagari|han|tibetan|other}`:按 Unicode 块判定。
+- `parse_mvp_definition(def) -> {sanskrit, devanagari, chinese[], tibetan}`:按行切分 + classify_script 归桶(**不依赖位置**,容忍 MVP 的不规则嵌套)。
+- `parse_siyi_definition(def) -> {梵, 漢, 滿, 蒙}`:按 `【x】` 标签切分。
+
+流程(精度高→低):
+1. MVP → 建概念骨架(key=normalize(sanskrit)),填 sanskrit/devanagari/chinese/tibetan;链该词条(method=`mvp`)。
+2. 四譯合璧 → 按梵文 key upsert 概念,补 chinese;链词条(method=`siyi_tag`)。
+3. 罗马 headword 串联:MW/Edgerton/DPD/PTS/NCPED 的 headword 归一化,命中已有 key → 链词条 + 补 pali/sanskrit 展示(method=`romanized_join`)。
+4. 中文回链:按 concept.chinese 精确匹配 佛光/丁福保 等中文 headword 词条 → 链入(method=`romanized_join`, confidence=medium)。
+
+对 10 万+词条是批处理,像 eval baseline 一样在 prod 容器内跑一次:
+`docker compose exec -T backend python -m scripts.build_term_concepts`。**只写新表,不碰现有词条。**
+
+## ⚠️ Pali 范围边界(Phase 1)
+
+梵↔汉↔藏靠 MVP/四譯合璧,是真·古典对照,精度高。梵巴词形常不同(nirvāṇa vs nibbāna),
+ASCII 折叠不会自动相等 → **Phase 1 Pali 链接 best-effort**:词形巧合相同(bodhi=bodhi)能链,
+其余留 Phase 2 的梵巴规则层。不制造"全 Pali 覆盖"假象。
+
+## API
+
+`GET /api/dictionary/concept?q=<词>`(新端点,不改 `/search`):
+把中/梵/巴/藏任一词形解析到概念(先精确匹配 chinese/sanskrit/pali/tibetan,再归一化 key 匹配),
+返回:
+```json
+{ "concept": {"sanskrit","pali","tibetan","chinese","english","devanagari"},
+  "entries_by_lang": [ {"lang":"sa","entries":[{id,headword,source_name,definition_preview}]}, ... ] }
+```
+未命中 → `{"concept": null, "entries_by_lang": []}`(200,优雅降级)。
+
+## 前端
+
+- `frontend/src/components/ConceptCard.tsx`:命中概念时渲染于结果上方。
+  多语种词形横排,每个可点(填入搜索/跳该语种)。无命中不渲染。
+- `DictionaryPage.tsx`:在搜索态并行发 `/concept` query;有 concept 才显示卡。
+- `client.ts` 加 `getDictConcept`;i18n 加 `dict.concept.*`(zh/zh-Hant/en)。
+
+## 测试
+
+- 单测(CI,纯逻辑):`normalize_iast` / `classify_script` / `parse_mvp_definition` / `parse_siyi_definition`。
+- 建表器:fixture 跑一遍,断言 `涅槃 ↔ nirvāṇa ↔ 藏` 正确成链。
+- API:`/concept` 已知词返回结构正确、未知词 200 空返回。
+
+## 上线
+
+migration 加空表(零风险)→ prod 容器跑建表脚本 → 前端发版。
+部署前核 prod `alembic_version`(应为 0159)与文件链一致(见 feedback_fojin_alembic_chain_check)。

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -500,6 +500,8 @@
   "dict.total_n": "{{n}} total",
   "dict.no_results": "No entries found for \"{{query}}\"",
   "dict.ask_ai": "Ask AI",
+  "dict.concept.title": "Across languages",
+  "dict.concept.search_form": "Search this form",
   "lang.ja": "Japanese",
   "lang.ko": "Korean",
   "lang.mn": "Mongolian",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -500,6 +500,8 @@
   "dict.total_n": "共 {{n}} 條",
   "dict.no_results": "未找到\"{{query}}\"的相關詞條",
   "dict.ask_ai": "問小津",
+  "dict.concept.title": "跨語種對照",
+  "dict.concept.search_form": "搜尋此詞形",
   "lang.ja": "日文",
   "lang.ko": "韓文",
   "lang.mn": "蒙古文",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -500,6 +500,8 @@
   "dict.total_n": "共 {{n}} 条",
   "dict.no_results": "未找到\"{{query}}\"的相关词条",
   "dict.ask_ai": "问小津",
+  "dict.concept.title": "跨语种对照",
+  "dict.concept.search_form": "搜索此词形",
   "lang.ja": "日文",
   "lang.ko": "韩文",
   "lang.mn": "蒙古文",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -927,6 +927,38 @@ export async function searchDictionaryGrouped(params: {
   return data;
 }
 
+// Cross-lingual term concept (multilingual concept card)
+export interface DictConcept {
+  sanskrit: string | null;
+  devanagari: string | null;
+  pali: string | null;
+  tibetan: string | null;
+  chinese: string | null;
+  english: string | null;
+}
+
+export interface DictConceptEntry {
+  id: DictEntryId;
+  headword: string;
+  source_name: string | null;
+  definition_preview: string;
+}
+
+export interface DictConceptLangGroup {
+  lang: string;
+  entries: DictConceptEntry[];
+}
+
+export interface DictConceptResponse {
+  concept: DictConcept | null;
+  entries_by_lang: DictConceptLangGroup[];
+}
+
+export async function getDictConcept(q: string): Promise<DictConceptResponse> {
+  const { data } = await api.get<DictConceptResponse>("/dictionary/concept", { params: { q } });
+  return data;
+}
+
 // Dictionary hot terms
 export async function getDictionaryHot(): Promise<string[]> {
   const { data } = await api.get<{ terms: string[] }>("/dictionary/hot");

--- a/frontend/src/components/ConceptCard.tsx
+++ b/frontend/src/components/ConceptCard.tsx
@@ -1,0 +1,77 @@
+import { Tag } from "antd";
+import { useTranslation } from "react-i18next";
+import type { DictConceptResponse } from "../api/client";
+
+const LANG_COLORS: Record<string, string> = {
+  zh: "red",
+  sa: "orange",
+  pi: "green",
+  bo: "blue",
+  en: "purple",
+};
+
+const LANG_LABEL_KEYS: Record<string, string> = {
+  zh: "lang.zh",
+  sa: "lang.sa",
+  pi: "lang.pi",
+  bo: "lang.bo",
+  en: "lang.en",
+};
+
+interface Props {
+  data: DictConceptResponse | undefined;
+  /** Search a picked word form (e.g. clicking the Sanskrit form). */
+  onPick: (term: string) => void;
+}
+
+/**
+ * Multilingual concept header shown above dictionary search results when the
+ * query resolves to a cross-lingual term concept (汉 涅槃 · 梵 nirvāṇa · 巴
+ * nibbāna · 藏 …). Renders nothing when no concept matched, so the page falls
+ * back to plain grouped results.
+ */
+export default function ConceptCard({ data, onPick }: Props) {
+  const { t } = useTranslation();
+  const concept = data?.concept;
+  if (!concept) return null;
+
+  // Ordered (lang, form) pairs for the forms that exist on this concept.
+  const forms: Array<{ lang: string; value: string }> = [
+    { lang: "zh", value: concept.chinese ?? "" },
+    { lang: "sa", value: concept.sanskrit ?? "" },
+    { lang: "pi", value: concept.pali ?? "" },
+    { lang: "bo", value: concept.tibetan ?? "" },
+    { lang: "en", value: concept.english ?? "" },
+  ].filter((f) => f.value);
+
+  if (forms.length < 2) return null; // need ≥2 languages to be worth a card
+
+  return (
+    <div className="dict-concept-card">
+      <div className="dict-concept-card-label">{t("dict.concept.title")}</div>
+      <div className="dict-concept-forms">
+        {forms.map(({ lang, value }) => (
+          <button
+            key={lang}
+            type="button"
+            className="dict-concept-form"
+            onClick={() => onPick(value)}
+            title={t("dict.concept.search_form")}
+          >
+            <Tag color={LANG_COLORS[lang]} style={{ margin: 0, fontSize: 11 }}>
+              {t(LANG_LABEL_KEYS[lang])}
+            </Tag>
+            <span className="dict-concept-form-text" lang={lang}>
+              {value}
+            </span>
+          </button>
+        ))}
+      </div>
+      {concept.devanagari && (
+        <div className="dict-concept-devanagari" lang="sa">
+          {concept.devanagari}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DictionaryPage.tsx
+++ b/frontend/src/pages/DictionaryPage.tsx
@@ -8,8 +8,10 @@ import { useTranslation } from "react-i18next";
 import {
   getDictionarySources,
   searchDictionaryGrouped,
+  getDictConcept,
 } from "../api/client";
 import type { DictEntry, DictGroupedResult } from "../api/client";
+import ConceptCard from "../components/ConceptCard";
 import { localizedSourceName } from "../utils/sourceName";
 import "../styles/dictionary.css";
 
@@ -160,6 +162,15 @@ export default function DictionaryPage() {
         page,
       }),
     enabled: query.length > 0,
+  });
+
+  // Cross-lingual concept lookup — skipped for whole-source browse (q="*").
+  const conceptQuery = query && query !== "*" ? query : "";
+  const { data: conceptResult } = useQuery({
+    queryKey: ["dict-concept", conceptQuery],
+    queryFn: () => getDictConcept(conceptQuery),
+    enabled: conceptQuery.length > 0,
+    staleTime: 300_000,
   });
 
   const handleSearch = (value: string) => {
@@ -332,6 +343,14 @@ export default function DictionaryPage() {
               ]}
             />
           </div>
+
+          <ConceptCard
+            data={conceptResult}
+            onPick={(term) => {
+              setInputValue(term);
+              handleSearch(term);
+            }}
+          />
 
           {searching ? (
             <div style={{ textAlign: "center", padding: 60 }}>

--- a/frontend/src/styles/dictionary.css
+++ b/frontend/src/styles/dictionary.css
@@ -292,3 +292,54 @@
     bottom: 16px;
   }
 }
+
+/* Multilingual concept card — shown above results when a query resolves to a
+   cross-lingual term concept. */
+.dict-concept-card {
+  background: var(--fj-card-bg);
+  border: 1px solid var(--fj-gold, #8b6914);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin-bottom: 16px;
+}
+
+.dict-concept-card-label {
+  font-size: 12px;
+  color: var(--fj-ink-muted);
+  margin-bottom: 8px;
+}
+
+.dict-concept-forms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  align-items: center;
+}
+
+.dict-concept-form {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: transparent;
+  border: 1px solid var(--fj-border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.dict-concept-form:hover {
+  border-color: var(--fj-accent, #8b2500);
+  box-shadow: 0 0 0 2px rgba(139, 37, 0, 0.08);
+}
+
+.dict-concept-form-text {
+  font-size: 16px;
+  color: var(--fj-ink);
+}
+
+.dict-concept-devanagari {
+  margin-top: 8px;
+  font-size: 15px;
+  color: var(--fj-ink-muted);
+}


### PR DESCRIPTION
## 这是什么 / What

辞典的**多语种术语概念层(Phase 1,高精度结构化骨架)**。把同一个佛教术语跨语种(中/梵/巴/藏)关联起来,搜索时在结果上方显示一张可点的**概念卡**:`汉 涅槃 · 梵 nirvāṇa · 藏 mya ngan las 'das pa · …`。

**为什么:** 辞典持有世界级多语种资产(DPD/MW/Rangjung Yeshe/84000),但 UI 把它们当 39 个孤立辞典平铺,跨语对照能力为零。这层把它接通,且是 dict + 未来 chat(给 LLM 的梵/藏内容接地)+ 跨藏对齐主线**共用的多语术语基建**。

设计全文见 `docs/superpowers/specs/2026-06-26-dict-term-concepts-design.md`。

## 怎么做 / How

**关键事实:** 辞典间没有结构化跨语键,但桥典把多语**打包在单条词条的释义里**——翻譯名義大集(梵+天城体+汉+藏 Wylie+藏文)、四譯合璧(`【梵】【漢】【藏】…` 标签)。建表器按 Unicode 字符块解析,以**归一化罗马化梵文**为 key,再用"相同罗马 headword"把 MW/DPD/PTS 串入,最后中文回链佛光/丁福保。

- **后端:** 2 张新表(migration `0160`,down_revision 0159,**建空表零风险**)+ 模型 + 离线建表器 `scripts/build_term_concepts.py`(幂等全量重建,**只写新表**)+ 共享 service(`normalize_iast` + `resolve_concept`,建表器与 API 共用一套归一化,杜绝漂移)+ `GET /api/dictionary/concept`。
- **前端:** `ConceptCard.tsx` + 接入 `DictionaryPage`(浏览整部辞典 `q=*` 时跳过;无命中不渲染,优雅降级)+ client 类型 + CSS + i18n(zh/zh-Hant/en)。

## ⚠️ Phase 1 范围边界

梵↔汉↔藏靠古典对照桥典,**精度高**。梵巴词形常不同(nirvāṇa vs nibbāna),**Phase 1 的 Pali 是 best-effort**(词形巧合 + 桥典标签),完整梵巴规则层留 Phase 2。概念**只从桥典播种**(必须有中文锚点),MW/DPD 只能链入已有概念、不凭空造概念——守住精度。

## 测试

- 15 纯逻辑(normalize/classify/parse,**真实语料样本**)+ 7 内存 SQLite 集成(概念组装、4 个链接阶段、Pali 边界、幂等、`resolve_concept` 请求路径)。
- 全后端套件 **723 passed**;ruff clean;前端 `tsc + vite` build clean、eslint 无新增。
- 已过独立 code-review:无 Critical;3 个 Important 已修(Phase 3 OOM→列裁剪+流式、`/concept` 加测试、零链接告警);Minor(q max_length、lemma 优先显示)已处理。

## 部署(merge 后)

1. 应用 migration `0160`(建空表)。
2. **prod 容器内跑一次建表器**:`docker compose exec -T backend python -m scripts.build_term_concepts`。
3. **验证(不信 stats 行)**:`SELECT DISTINCT lang` + 核 source codes;curl `/api/dictionary/concept?q=涅槃|般若|菩提` 确认 API 真出多语卡。

> 部署前核 prod `alembic_version=0159` + 确认无其他在途分支抢用 0160。

🤖 Generated with [Claude Code](https://claude.com/claude-code)