### PR TITLE
fix(dict): purge catalog/TOC junk entries leading the dictionary browse

### DIFF
--- a/backend/alembic/versions/0161_purge_dict_catalog_junk.py
+++ b/backend/alembic/versions/0161_purge_dict_catalog_junk.py
@@ -1,0 +1,38 @@
+"""purge catalog/TOC/production-note junk rows from dictionary_entries
+
+Revision ID: 0161
+Revises: 0160
+Create Date: 2026-06-26
+
+Some source dictionaries embedded their catalog structure / production notes as
+"entries": e.g. ``00000製作說明【阿彌陀佛】``, ``00 總目錄``,
+``001-01 教義類〈一般教義〉`` (中華佛教百科全書 section headers). These are not
+lexical terms — they sort to the very top of a dictionary's browse view
+(ASCII digits precede CJK) and were the first thing a user saw.
+
+Buddhist headwords use Chinese numerals (一二三), never a leading ASCII digit, so
+``headword ~ '^[0-9]'`` is a safe junk filter. Verified on prod before writing:
+83 such rows, all catalog/TOC/製作說明 metadata, with 0 term_concept_entries
+referencing them. The importer (import_dila_dict.py) now skips the same pattern
+so they don't return on re-import.
+
+Irreversible by nature (deleted junk can't be restored); downgrade is a no-op.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0161"
+down_revision: str | None = "0160"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("DELETE FROM dictionary_entries WHERE headword ~ '^[0-9]'")
+
+
+def downgrade() -> None:
+    # Deleted rows were junk metadata and cannot be reconstructed.
+    pass

--- a/backend/scripts/import_dila_dict.py
+++ b/backend/scripts/import_dila_dict.py
@@ -118,6 +118,14 @@ class DilaBaseImporter(BaseImporter):
                     skipped += 1
                     continue
 
+                # Skip catalog/TOC/production-note metadata rows that some source
+                # dicts embed as entries (e.g. "00000製作說明【…】", "001-01 教義類〈…〉",
+                # "00 總目錄"). Buddhist headwords use Chinese numerals (一二三), never
+                # a leading ASCII digit, so this is a safe junk filter.
+                if headword[0] in "0123456789":
+                    skipped += 1
+                    continue
+
                 external_id = parsed.get("external_id", f"{self.SOURCE_CODE}-{i}")
                 entry_data = parsed.get("entry_data")
                 entry_data_json = (


### PR DESCRIPTION
Browsing a dictionary led with junk, not terms — `㘞`, `䞋`, then **`0000說明【阿彌陀佛】`** before the first real entry (`一`). Root cause: some source dicts embedded their catalog structure / production notes as "entries", and ASCII digits sort before CJK so they float to the top.

**Verified on prod before touching anything:** 83 rows match `headword ~ '^[0-9]'` — all of them catalog/TOC/production-note metadata (`00000製作說明【阿彌陀佛】` ×13, `00 總目錄` ×8, `001-01 教義類〈…〉` section headers). **0 `term_concept_entries` reference them.** Buddhist headwords use Chinese numerals (一二三), never a leading ASCII digit → safe filter.

- **Migration 0161** deletes them (`DELETE … WHERE headword ~ '^[0-9]'`). Irreversible by nature (junk); downgrade is a no-op.
- **`import_dila_dict.py`** now skips the same pattern so they don't return on re-import.
- Leaves the borderline `台灣佛教【名剎圖片集】` resource-index headings alone (not the digit junk the user flagged).

Scope: this is ① (data cleanup). I did **not** re-add hot-term chips (② ) — those were removed per a prior user request (`DictionaryPage.tsx`: "Hot terms removed per user request").

CI's "Alembic upgrade (dry-run)" validates the migration applies. Offline importer + data migration only — no app/API/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)