### PR TITLE
feat(reader): 经文阅读页新增回到顶部悬浮按钮

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -717,5 +717,6 @@
   "reader.lineref.citation": "{{title}} (CBETA {{id}}, fasc. {{juan}}, {{ref}})",
   "reader.kabc.link": "Goryeo {{k}}",
   "reader.kabc.button": "Goryeo",
-  "reader.kabc.tooltip": "View this sutra's Goryeo (Tripitaka Koreana, {{k}}) edition on KABC (Dongguk Univ.)"
+  "reader.kabc.tooltip": "View this sutra's Goryeo (Tripitaka Koreana, {{k}}) edition on KABC (Dongguk Univ.)",
+  "reader.backtop": "Back to top"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -717,5 +717,6 @@
   "reader.lineref.citation": "《{{title}}》卷{{juan}}（CBETA {{id}}, {{ref}}）",
   "reader.kabc.link": "高麗藏 {{k}}",
   "reader.kabc.button": "高麗藏",
-  "reader.kabc.tooltip": "在 KABC（東國大學）查看本經的高麗再雕藏版（{{k}}）"
+  "reader.kabc.tooltip": "在 KABC（東國大學）查看本經的高麗再雕藏版（{{k}}）",
+  "reader.backtop": "回到頂部"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -717,5 +717,6 @@
   "reader.lineref.citation": "《{{title}}》卷{{juan}}（CBETA {{id}}, {{ref}}）",
   "reader.kabc.link": "高丽藏 {{k}}",
   "reader.kabc.button": "高丽藏",
-  "reader.kabc.tooltip": "在 KABC（东国大学）查看本经的高丽再雕藏版（{{k}}）"
+  "reader.kabc.tooltip": "在 KABC（东国大学）查看本经的高丽再雕藏版（{{k}}）",
+  "reader.backtop": "回到顶部"
 }

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -17,6 +17,7 @@ import {
   RobotOutlined,
   GlobalOutlined,
   DiffOutlined,
+  VerticalAlignTopOutlined,
 } from "@ant-design/icons";
 import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, getJuanLineAnchors, type ApparatusEntryItem } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
@@ -432,6 +433,8 @@ export default function TextReaderPage() {
 
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
   const [compareLang, setCompareLang] = useState<string | null>(null);
+  // 回到顶部按钮：滚过一屏后浮现
+  const [showBackTop, setShowBackTop] = useState(false);
   const { user } = useAuthStore();
   const queryClient = useQueryClient();
   const readerContentRef = useRef<HTMLDivElement>(null);
@@ -704,6 +707,29 @@ export default function TextReaderPage() {
       }
     };
   }, [content, textId, juanNum]);
+
+  // 回到顶部：滚过 ~一屏后浮现按钮。和续读同理，AI 面板打开时滚动发生在
+  // .reader-container（不冒泡），只能在 window 捕获阶段收到 scroll 事件；
+  // 偏移量按真实 scroller 取值，document 滚动时回退 window.scrollY。
+  useEffect(() => {
+    const update = () => {
+      const el = readerContentRef.current;
+      const scroller = el ? findScrollContainer(el) : null;
+      const offset = scroller ? scroller.scrollTop : window.scrollY;
+      setShowBackTop(offset > 400);
+    };
+    update();
+    window.addEventListener("scroll", update, { passive: true, capture: true });
+    return () => window.removeEventListener("scroll", update, { capture: true });
+    // aiPanelOpen/parallelPanelOpen 都会切换真实 scroller（reader-ai-active），需重评
+  }, [content, aiPanelOpen, parallelPanelOpen]);
+
+  const scrollToTop = useCallback(() => {
+    const el = readerContentRef.current;
+    const scroller = el ? findScrollContainer(el) : null;
+    if (scroller) scroller.scrollTo({ top: 0, behavior: "smooth" });
+    else window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
 
   // Deep-link from the chat citation drawer: ?highlight_chunk=N
   // Chunks are 500 chars wide with 50-char overlap (see scripts/archive/misc/generate_embeddings.py),
@@ -1184,6 +1210,20 @@ export default function TextReaderPage() {
           icon={<RobotOutlined />}
           onClick={() => setAiPanelOpen(true)}
           aria-label="AI 解读"
+        />
+      </Tooltip>
+    )}
+
+    {/* 回到顶部：AI 面板关闭时 AI FAB 占据右下角，故上移以免重叠 */}
+    {showBackTop && (
+      <Tooltip title={t("reader.backtop")} placement="left">
+        <Button
+          className={`reader-backtop-fab${aiPanelOpen ? "" : " reader-backtop-fab-stacked"}`}
+          shape="circle"
+          size="large"
+          icon={<VerticalAlignTopOutlined />}
+          onClick={scrollToTop}
+          aria-label={t("reader.backtop")}
         />
       </Tooltip>
     )}

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -334,6 +334,38 @@
   box-shadow: 0 6px 16px rgba(139, 105, 20, 0.4);
 }
 
+/* ── Back-to-top FAB ── */
+.reader-backtop-fab {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 100;
+  width: 48px !important;
+  height: 48px !important;
+  background: #fff !important;
+  border-color: var(--fj-accent, #8b6914) !important;
+  color: var(--fj-accent, #8b6914) !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  animation: reader-backtop-in 0.2s ease;
+}
+
+/* AI 面板关闭时 AI FAB 在 bottom:24，回到顶部上移一档避免重叠 */
+.reader-backtop-fab-stacked {
+  bottom: 84px;
+}
+
+.reader-backtop-fab:hover {
+  background: var(--fj-accent, #8b6914) !important;
+  border-color: var(--fj-accent, #8b6914) !important;
+  color: #fff !important;
+  box-shadow: 0 6px 16px rgba(139, 105, 20, 0.4);
+}
+
+@keyframes reader-backtop-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 /* ── AI inline sidebar panel ── */
 .reader-ai-sidebar {
   flex-shrink: 0;


### PR DESCRIPTION
## 背景

经文阅读页（`/texts/:id/read`）卷数较长时，读到底部后需手动滚回卷首。本 PR 在右下角新增「回到顶部」悬浮按钮。

## 行为

- 滚过约一屏（>400px）后**淡入**，点击**平滑滚回卷首**。
- 兼容两种滚动模式：AI 面板打开（默认，滚动发生在 `.reader-container`，事件不冒泡）与关闭（滚动发生在 document）。复用既有 `findScrollContainer` + window 捕获阶段 `scroll` 监听，与「续读」「引文深链」同一套机制。
- AI 面板关闭时 AI FAB 占据右下角 `bottom:24`，按钮上移一档（`bottom:84`）避免重叠；面板打开时 FAB 隐藏，按钮回到 `bottom:24`。
- 文案走 i18n（`reader.backtop`，zh / zh-Hant / en 三语），与品牌金色风格统一（白底金边，hover 反色）。

## 验证

- `tsc -b` ✅  `eslint` ✅  `i18n:check`（ratchet）✅
- 经独立 code review：滚动目标、可见性追踪、与 AI FAB 的避让反向逻辑、i18n 三语均确认正确。

🤖 Generated with [Claude Code](https://claude.com/claude-code)