### PR TITLE
fix(reader): 回到顶部按钮让开 AI 解读面板

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -433,8 +433,9 @@ export default function TextReaderPage() {
 
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
   const [compareLang, setCompareLang] = useState<string | null>(null);
-  // 回到顶部按钮：滚过一屏后浮现
+  // 回到顶部按钮：滚过一屏后浮现；落点跟随"阅读列"右下角
   const [showBackTop, setShowBackTop] = useState(false);
+  const [backTopStyle, setBackTopStyle] = useState<{ right: number; bottom: number }>({ right: 24, bottom: 84 });
   const { user } = useAuthStore();
   const queryClient = useQueryClient();
   const readerContentRef = useRef<HTMLDivElement>(null);
@@ -723,6 +724,24 @@ export default function TextReaderPage() {
     return () => window.removeEventListener("scroll", update, { capture: true });
     // aiPanelOpen/parallelPanelOpen 都会切换真实 scroller（reader-ai-active），需重评
   }, [content, aiPanelOpen, parallelPanelOpen]);
+
+  // 按钮落点跟随"阅读列"右下角：实测 .reader-container 右缘，让按钮右缘落在其内侧 16px。
+  // 直接量 DOM 而非按面板宽度推算 —— 面板未必贴视口右缘（滚动条/留白），且移动端面板纵向
+  // 堆叠、阅读列占满宽度，量 DOM 对桌面并排 / 移动堆叠 / 居中三种布局都成立。
+  // AI 面板关闭时右下角被 AI FAB 占据（bottom:24），按钮上移一档避免重叠。
+  useEffect(() => {
+    const compute = () => {
+      const rc = readerContentRef.current?.closest(".reader-container");
+      const viewportRight = document.documentElement.clientWidth;
+      const right = rc
+        ? Math.max(24, Math.round(viewportRight - rc.getBoundingClientRect().right + 16))
+        : 24;
+      setBackTopStyle({ right, bottom: aiPanelOpen ? 24 : 84 });
+    };
+    compute();
+    window.addEventListener("resize", compute);
+    return () => window.removeEventListener("resize", compute);
+  }, [content, aiPanelOpen, parallelPanelOpen, aiPanelWidth, parallelPanelWidth]);
 
   const scrollToTop = useCallback(() => {
     const el = readerContentRef.current;
@@ -1214,11 +1233,12 @@ export default function TextReaderPage() {
       </Tooltip>
     )}
 
-    {/* 回到顶部：AI 面板关闭时 AI FAB 占据右下角，故上移以免重叠 */}
+    {/* 回到顶部：落点由 backTopStyle 动态计算（让开 AI 面板与 AI FAB） */}
     {showBackTop && (
       <Tooltip title={t("reader.backtop")} placement="left">
         <Button
-          className={`reader-backtop-fab${aiPanelOpen ? "" : " reader-backtop-fab-stacked"}`}
+          className="reader-backtop-fab"
+          style={backTopStyle}
           shape="circle"
           size="large"
           icon={<VerticalAlignTopOutlined />}

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -349,11 +349,6 @@
   animation: reader-backtop-in 0.2s ease;
 }
 
-/* AI 面板关闭时 AI FAB 在 bottom:24，回到顶部上移一档避免重叠 */
-.reader-backtop-fab-stacked {
-  bottom: 84px;
-}
-
 .reader-backtop-fab:hover {
   background: var(--fj-accent, #8b6914) !important;
   border-color: var(--fj-accent, #8b6914) !important;


### PR DESCRIPTION
## 问题

#826 把「回到顶部」按钮固定在视口右下角（`right:24`）。但阅读页 AI 解读面板**默认打开**，面板底部的输入框 / 发送键正好在视口右下角 —— 按钮压住了发送键（见下方修复前后对比）。

## 修复

不再按面板宽度推算，而是**实测 `.reader-container`（阅读列）的右缘**，让按钮右缘落在其内侧 16px：

- 桌面端面板打开 → 按钮落在阅读列右下角，让开右侧面板与分隔条
- 移动端（≤1024）面板纵向堆叠、阅读列占满宽度 → 按钮自然贴右 24
- AI 面板关闭时右下角被既有 AI FAB 占据（`bottom:24`）→ 按钮上移一档（`bottom:84`）避免竖向重叠
- 随窗口 `resize` 与面板拖拽改宽实时重算

量 DOM 而非推算，对「桌面并排 / 移动堆叠 / 居中」三种布局都成立。

## 验证

- `tsc -b` ✅  `eslint` ✅  `i18n:check` ✅
- 在生产页面注入实测：clientWidth=1585，阅读列右缘=1125，按钮右缘落在 **1109px < 分隔条 1125px < 面板左缘 1133px**，完全让开面板。

🤖 Generated with [Claude Code](https://claude.com/claude-code)