### PR TITLE
feat(sources): 2026-06-28 audit — +4 sources, fix 2 URLs, reactivate FEMC, retire 1 dead

### DIFF
--- a/backend/alembic/versions/0162_update_and_add_sources_20260628.py
+++ b/backend/alembic/versions/0162_update_and_add_sources_20260628.py
@@ -129,7 +129,7 @@ def upgrade() -> None:
             """
             UPDATE data_sources
                SET is_active = true,
-                   base_url = 'https://femc.huma-num.fr',
+                   base_url = 'https://femc.huma-num.fr/',
                    health_status = 'ok',
                    health_checked_at = NULL,
                    unreachable_since = NULL
@@ -181,13 +181,15 @@ def downgrade() -> None:
     op.execute(
         sa_text("UPDATE data_sources SET is_active = true WHERE code = 'fodocs-list'")
     )
-    # Reverse FIX-URL.
+    # Reverse FIX-URL. Only base_url is restored — health_status is the
+    # cron-owned reachability signal (it self-heals on the next probe) and
+    # this migration's upgrade only cleared the stale badge transiently, so
+    # the downgrade deliberately leaves health_status to the health checker.
     op.execute(
         sa_text(
             """
             UPDATE data_sources
-               SET base_url = 'https://budsir.mahidol.ac.th/',
-                   health_status = 'cert_invalid'
+               SET base_url = 'https://budsir.mahidol.ac.th/'
              WHERE code = 'mahidol-tipitaka'
             """
         )
@@ -196,8 +198,7 @@ def downgrade() -> None:
         sa_text(
             """
             UPDATE data_sources
-               SET base_url = 'https://www.indica-et-buddhica.com/repositorium',
-                   health_status = 'unreachable'
+               SET base_url = 'https://www.indica-et-buddhica.com/repositorium'
              WHERE code = 'indica-buddhica-repo'
             """
         )
@@ -208,7 +209,7 @@ def downgrade() -> None:
             """
             UPDATE data_sources
                SET is_active = false,
-                   base_url = 'https://femc.huma-num.fr'
+                   base_url = 'https://femc.huma-num.fr/'
              WHERE code = 'femc-khmer'
             """
         )

--- a/backend/alembic/versions/0162_update_and_add_sources_20260628.py
+++ b/backend/alembic/versions/0162_update_and_add_sources_20260628.py
@@ -1,0 +1,224 @@
+"""Update and add data sources from the 2026-06-28 source audit.
+
+Triggered by a full re-audit of the public /sources catalog (613 active
+sources at audit time). Two findings drive this migration:
+
+1. The 38 "unreachable / cert_invalid" health badges are ~95% FALSE
+   POSITIVES. ``health_checked_at`` is NULL on every row — the statuses
+   were hand-set in old migrations (0132/0143/0144) and never re-probed.
+   Re-verification (WebSearch liveness + cross-checking the 0144 audit
+   notes; the audit host itself sits behind a TLS-resetting proxy, the
+   SAME failure mode behind the production false positives) found only
+   ONE genuinely dead site. The rest resolve fine and should flip back to
+   ``ok`` on the next clean-network health pass — see the source_health
+   checker, which must learn to treat 403 / 405 / Cloudflare / cert-SAN
+   mismatch as ALIVE rather than unreachable.
+
+2. The May 2026 candidate dragnet (0133/0134/0140, +81 sources) was
+   thorough: only a handful of genuinely net-new, high-value sources
+   remain, plus two gaps.
+
+This migration only touches catalog data (is_active / base_url /
+health_status / new rows) — no schema change, fully reversible.
+
+ADD (net-new, value 4-5; never previously in the catalog):
+  nlab-bhutan       www.library.gov.bt        不丹国家图书与档案馆 (value 5)
+  cter              cter.info                 CTER 历代刻本汉文藏经 (value 5)
+  thai-nl-dlibrary  digital.nlt.go.th/dlib    泰国国家图书馆 D-Library (value 4)
+  itkc-korea        db.itkc.or.kr             韩国古典综合数据库 ITKC (value 4)
+
+REACTIVATE (row exists, retired in 0144 as NXDOMAIN on 2026-05-29;
+re-audit found femc.huma-num.fr live again — huma-num.fr is a stable FR
+national research infra. is_active flipped back on; health_status reset
+to ``ok`` so the next VPS health pass re-confirms it — trivially
+reversible if it is still down):
+  femc-khmer        femc.huma-num.fr          EFEO-FEMC 柬埔寨贝叶库 (value 5)
+
+FIX-URL (institution alive, base_url stale — verified via search,
+health_status reset so the badge re-probes at the new URL):
+  indica-buddhica-repo  www.indica-et-buddhica.com/repositorium (dead .com)
+                        -> indica-et-buddhica.org/repositorium  (live .org Repositorium/Lexica)
+  mahidol-tipitaka      budsir.mahidol.ac.th (cert SAN only *.ict.mahidol.ac.th, 302s away)
+                        -> budsir.ict.mahidol.ac.th  (canonical host, valid cert)
+
+RETIRE (only confirmed-dead site in the 38; list.fodocs.com and
+www.fodocs.com both serve only the default nginx welcome page, 443 has no
+valid TLS, and search engines index zero fodocs content):
+  fodocs-list       list.fodocs.com           寂光云流Lib
+
+NOT CHANGED (documented as false positive — do NOT retire): the other ~33
+flagged sources, e.g. iriz-hanazono, pts-ped, cbc-dila, haeinsa,
+suttacentral-voice, koreanbuddhism, princeton-*, paauk-ebooks. Notably
+``taiwan-buddhism-dila`` keeps https://taiwanbuddhism.dila.edu.tw/ — that
+dedicated subdomain IS the current canonical host (consistent with DILA's
+0144 move bza -> bza.dila.edu.tw); its red badge is anti-scrape noise.
+
+Revision ID: 0162
+Revises: 0161
+Create Date: 2026-06-28
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text as sa_text
+
+revision: str = "0162"
+down_revision: str | None = "0161"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. ADD four net-new sources.
+    op.execute(
+        sa_text(
+            """
+            INSERT INTO data_sources (
+                code, name_zh, name_en, base_url, description,
+                access_type, region, languages, research_fields,
+                supports_search, supports_fulltext,
+                has_local_fulltext, has_remote_fulltext,
+                supports_iiif, supports_api,
+                sort_order, is_active, health_status, created_at
+            ) VALUES
+            (
+                'nlab-bhutan', '不丹国家图书与档案馆',
+                'National Library and Archives of Bhutan',
+                'https://www.library.gov.bt',
+                '不丹国家图书与档案馆官方数字馆藏，约 6100 部藏文/宗喀语典籍与 9000 余块传统印经木刻板，系统保存竹巴噶举、宁玛伏藏与寺院写本，是不丹藏传文献的国家级机构。',
+                'external', '不丹', 'bo,dz,en', 'tibetan',
+                false, false, false, false, false, false,
+                900, true, 'ok', NOW()
+            ),
+            (
+                'cter', 'CTER 汉文佛教大藏经电子资源',
+                'CTER Chinese Buddhist Canon Electronic Resources',
+                'https://cter.info',
+                'CTER 汉文佛教大藏经电子资源，聚合嘉兴藏、洪武南藏、永乐南北藏、高丽再雕藏等历代刻本藏经的全帙 PDF 与图像，2025 年持续增补，是库内缺失的刻本藏经聚合入口。',
+                'external', '中国大陆', 'lzh,zh', 'han',
+                false, false, false, true, false, false,
+                900, true, 'ok', NOW()
+            ),
+            (
+                'thai-nl-dlibrary', '泰国国家图书馆数字图书馆',
+                'National Library of Thailand D-Library',
+                'https://digital.nlt.go.th/dlib/',
+                '泰国国家图书馆数字图书馆（D-Library），约 25 万叶贝叶写本（含大量巴利佛典）与逾万件碑铭的数字化检索平台，是全泰规模最大的贝叶写本数字库。',
+                'external', '泰国', 'th,pi', 'theravada',
+                true, false, false, false, false, false,
+                900, true, 'ok', NOW()
+            ),
+            (
+                'itkc-korea', '韩国古典综合数据库',
+                'ITKC Korean Classics Database',
+                'https://db.itkc.or.kr',
+                '韩国古典翻译院（ITKC）古典综合数据库，收录《韩国文集丛刊》等朝鲜时代文集原文与韩译，含禅僧文集、注疏与佛教相关汉文典籍。',
+                'external', '韩国', 'ko,lzh', 'han',
+                true, false, false, true, false, false,
+                900, true, 'ok', NOW()
+            )
+            ON CONFLICT (code) DO NOTHING
+            """
+        )
+    )
+
+    # 2. REACTIVATE femc-khmer (retired NXDOMAIN in 0144; live again).
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET is_active = true,
+                   base_url = 'https://femc.huma-num.fr',
+                   health_status = 'ok',
+                   health_checked_at = NULL,
+                   unreachable_since = NULL
+             WHERE code = 'femc-khmer'
+            """
+        )
+    )
+
+    # 3. FIX-URL two relocated sources + clear their stale red badges.
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET base_url = 'https://indica-et-buddhica.org/repositorium',
+                   health_status = 'ok',
+                   health_checked_at = NULL,
+                   unreachable_since = NULL
+             WHERE code = 'indica-buddhica-repo'
+            """
+        )
+    )
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET base_url = 'https://budsir.ict.mahidol.ac.th/',
+                   health_status = 'ok',
+                   health_checked_at = NULL,
+                   unreachable_since = NULL
+             WHERE code = 'mahidol-tipitaka'
+            """
+        )
+    )
+
+    # 4. RETIRE the one confirmed-dead source.
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET is_active = false
+             WHERE code = 'fodocs-list'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Reverse RETIRE.
+    op.execute(
+        sa_text("UPDATE data_sources SET is_active = true WHERE code = 'fodocs-list'")
+    )
+    # Reverse FIX-URL.
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET base_url = 'https://budsir.mahidol.ac.th/',
+                   health_status = 'cert_invalid'
+             WHERE code = 'mahidol-tipitaka'
+            """
+        )
+    )
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET base_url = 'https://www.indica-et-buddhica.com/repositorium',
+                   health_status = 'unreachable'
+             WHERE code = 'indica-buddhica-repo'
+            """
+        )
+    )
+    # Reverse REACTIVATE.
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET is_active = false,
+                   base_url = 'https://femc.huma-num.fr'
+             WHERE code = 'femc-khmer'
+            """
+        )
+    )
+    # Reverse ADD.
+    op.execute(
+        sa_text(
+            """
+            DELETE FROM data_sources
+             WHERE code IN ('nlab-bhutan', 'cter', 'thai-nl-dlibrary', 'itkc-korea')
+            """
+        )
+    )


### PR DESCRIPTION
## 背景
对公开 /sources 目录（**613 个活跃源**）做了全面重审。两个发现驱动本 PR：

1. **38 个 unreachable/cert_invalid 红标里约 95% 是误报。** `health_checked_at` 全为 NULL——这些状态是旧迁移（0132/0143/0144）手写死的、从未真正复检。重新核验（WebSearch 存活 + 比对 0144 审计记录）后，**只有 1 个站点确证已死**。其余在干净网络的下一次健康巡检会自动翻绿——健康检查器需要学会把 `403/405/Cloudflare/证书 SAN 不符` 当作存活而非 unreachable。
2. **5 月那批候选拉网（0133/0134/0140，+81 源）已很彻底**，只剩少数真·净新增高价值源 + 两个缺口。

纯数据迁移，无 schema 变更，完全可逆。

## 改动（migration 0162）
**ADD（净新增 v4-5，从未入库）**
| code | 域名 | 名称 | 价值 |
|---|---|---|---|
| nlab-bhutan | www.library.gov.bt | 不丹国家图书与档案馆 | 5 |
| cter | cter.info | CTER 历代刻本汉文藏经 | 5 |
| thai-nl-dlibrary | digital.nlt.go.th/dlib | 泰国国家图书馆 D-Library | 4 |
| itkc-korea | db.itkc.or.kr | 韩国古典综合数据库 ITKC | 4 |

**REACTIVATE**：`femc-khmer`（EFEO-FEMC 柬埔寨贝叶，0144 曾因 NXDOMAIN 退役，重审发现复活；is_active 翻回，health 重置待 VPS 复探确认）
**FIX-URL**：`indica-buddhica-repo`（.com→.org/repositorium）、`mahidol-tipitaka`（→budsir.ict 子域消 cert 红标）
**RETIRE**：`fodocs-list`（38 个里唯一确证死站：list/www.fodocs.com 仅 nginx 默认页、443 无有效 TLS、搜索零索引）
**不动（误报）**：其余 ~33 个，含 `taiwan-buddhism-dila`——其现有 URL `taiwanbuddhism.dila.edu.tw` 本就是 DILA 规范子域（与 0144 的 bza→bza.dila.edu.tw 一致），红标是反爬噪声。

## 验证
- ✅ 单头 0162，链 0161→0162 干净（`alembic heads`）
- ✅ INSERT 19 列与 `DataSource` 模型完全对齐，NOT NULL 全提供，`ON CONFLICT (code) DO NOTHING`
- ✅ 离线渲染 SQL（`alembic upgrade 0161:0162 --sql`）正确生成 1 INSERT + 4 UPDATE
- ✅ ruff + py_compile 通过
- ✅ 过 code-reviewer：downgrade 已改为只还原 base_url（health_status 归 cron 自愈）

> ⚠️ URL 类改动经搜索 + 比对 0144 核验；本审计主机处于 TLS 重置代理后，最终以 VPS 干净网络的下一次健康巡检为准（均可逆）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)