### PR TITLE
feat(answer-quality): 失败答案不入库/不入队 + 校准阈值 + 精炼检测器

### DIFF
--- a/backend/app/services/answer_quality.py
+++ b/backend/app/services/answer_quality.py
@@ -10,20 +10,31 @@ from app.models.answer_review import AnswerReview
 from app.models.chat import ChatMessage
 
 # --- Detection config -------------------------------------------------------
-# Calibrate WEAK_EVIDENCE_THRESHOLD post-deploy from the score_distribution
-# the queue endpoint returns (default = roughly the 10th percentile of
-# max(source.score)). ChatSource.score is the blended vector+rerank score.
-WEAK_EVIDENCE_THRESHOLD = 0.50
-MIN_CONTENT_LEN = 40  # answers shorter than this (chars) are abnormal
-ERROR_MARKERS = ("发送失败", "请求超时", "网络错误", "请求失败", "服务暂时不可用")
+# Calibrated 2026-06-30 to ~p10 of the live max(source.score) distribution
+# (p10≈0.366), so weak_evidence flags only the bottom decile of retrieval
+# strength rather than ~the bottom quartile. ChatSource.score is the blended
+# vector+rerank score. Re-read score_distribution from the queue endpoint and
+# adjust if the corpus/reranker changes.
+WEAK_EVIDENCE_THRESHOLD = 0.37
+
+# Prefixes of LLM-failure replies (see chat._FAILED_ANSWER_PREFIXES). Failed /
+# empty generations are bugs, not reviewable answers — they are excluded from
+# the queue entirely (the chat save-guard stops new ones; this defends against
+# legacy junk rows already in the table).
+_FAILED_ANSWER_PREFIXES = ("抱歉，AI 服务", "AI 服务返回", "您的 API Key 无效")
 
 # reason tag -> base weight in the suspicion score
 WEIGHTS = {
     "downvoted": 5.0,
-    "abnormal": 4.0,
     "no_citation": 2.0,
     "weak_evidence": 1.0,  # plus a graded bonus, see classify_answer
 }
+
+
+def _is_failed_answer(content: str | None) -> bool:
+    """Empty answer or a known LLM-failure reply — excluded from the queue."""
+    text = (content or "").strip()
+    return not text or text.startswith(_FAILED_ANSWER_PREFIXES)
 
 
 def _max_source_score(sources) -> float | None:
@@ -67,11 +78,6 @@ def classify_answer(
     if feedback == "down":
         tags.append("downvoted")
         score += WEIGHTS["downvoted"]
-
-    text = (content or "").strip()
-    if len(text) < MIN_CONTENT_LEN or any(m in text for m in ERROR_MARKERS):
-        tags.append("abnormal")
-        score += WEIGHTS["abnormal"]
 
     max_score = _max_source_score(sources)
     if max_score is None:
@@ -173,6 +179,11 @@ async def build_bad_answer_queue(
     items: list[QueueItem] = []
     score_samples: list[float] = []
     for m in rows:
+        # Failed/empty generations are bugs, not reviewable answers — never
+        # surface them in the quality queue (nor let them skew the score
+        # distribution used for calibration).
+        if _is_failed_answer(m.content):
+            continue
         ms = _max_source_score(m.sources)
         if ms is not None:
             score_samples.append(ms)

--- a/backend/app/services/answer_quality.py
+++ b/backend/app/services/answer_quality.py
@@ -69,9 +69,11 @@ def _clean_sources(sources) -> list[dict]:
 def classify_answer(
     content: str | None, sources, feedback: str | None
 ) -> tuple[list[str], float]:
-    """Pure detector. Given an assistant message's own columns, return the
-    reason tags it trips and a suspicion score (0.0 = not suspect). Every
-    detector reads the answer itself — the question is not needed here."""
+    """Pure detector. Given an assistant message's columns, return the reason
+    tags it trips and a suspicion score (0.0 = not suspect). Detectors read
+    ``feedback`` (downvoted) and ``sources`` (no_citation / weak_evidence);
+    ``content`` is unused today (kept for the signature + future content-based
+    detectors) — failed/empty answers are filtered upstream, not scored here."""
     tags: list[str] = []
     score = 0.0
 

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -823,6 +823,24 @@ def _strip_followup_suggestions(text: str) -> str:
     return "\n".join(cleaned).rstrip()
 
 
+# Prefixes of the failure replies produced by the LLM error branches in
+# _prepare_chat / _stream_chat and _byok_error_message. A reply that starts
+# with one of these (or is empty) is a failed generation, not a real answer:
+# the user already saw the error live, so persisting it only pollutes chat
+# history, the answer-quality queue, and the quality metrics.
+_FAILED_ANSWER_PREFIXES = (
+    "抱歉，AI 服务",  # 暂时不可用 / 响应超时 / 返回错误（HTTP …）
+    "AI 服务返回",  # _byok_error_message 401/404/429/balance/model-not-found
+    "您的 API Key 无效",
+)
+
+
+def _is_failed_answer(content: str | None) -> bool:
+    """True for an empty answer or one of the known LLM-failure replies."""
+    text = (content or "").strip()
+    return not text or text.startswith(_FAILED_ANSWER_PREFIXES)
+
+
 async def _save_messages(
     db: AsyncSession, session_id: int, message: str, answer: str, sources: list[ChatSource]
 ) -> int | None:
@@ -833,6 +851,11 @@ async def _save_messages(
     chat_messages row instead of the local `Date.now()` placeholder it
     used while streaming. Returns None when the message cannot be
     persisted (defensive — current callers always supply a session)."""
+    # Don't persist failed/empty generations — neither the user turn nor the
+    # error reply. The user saw the error live via the stream/response; saving
+    # it would leave a junk turn in history and poison the answer-quality data.
+    if _is_failed_answer(answer):
+        return None
     user_msg = ChatMessage(session_id=session_id, role="user", content=message)
     assistant_msg = ChatMessage(
         session_id=session_id,

--- a/backend/tests/test_answer_quality.py
+++ b/backend/tests/test_answer_quality.py
@@ -12,6 +12,7 @@ from app.models.answer_review import AnswerReview
 from app.models.chat import ChatMessage, ChatSession
 from app.services.answer_quality import (
     WEAK_EVIDENCE_THRESHOLD,
+    _is_failed_answer,
     _max_source_score,
     _percentiles,
     build_bad_answer_queue,
@@ -55,20 +56,19 @@ def test_weak_evidence_is_flagged_and_graded():
     assert score_far > score_near  # deeper below threshold => more suspect
 
 
-def test_abnormal_short_answer_is_flagged():
-    tags, _ = classify_answer("太短了", _sources(0.9), None)
-    assert "abnormal" in tags
-
-
-def test_abnormal_error_marker_is_flagged():
-    tags, _ = classify_answer("发送失败，请稍后重试" + "x" * 50, _sources(0.9), None)
-    assert "abnormal" in tags
-
-
 def test_multiple_detectors_stack():
-    tags, score = classify_answer("短", None, "down")
-    assert {"downvoted", "abnormal", "no_citation"} <= set(tags)
-    assert score > 5  # all three weights add up
+    tags, score = classify_answer("一段正常的回答" * 3, None, "down")
+    assert {"downvoted", "no_citation"} <= set(tags)
+    assert score > 5  # downvoted(5) + no_citation(2)
+
+
+def test_is_failed_answer():
+    assert _is_failed_answer("")
+    assert _is_failed_answer("   ")
+    assert _is_failed_answer(None)
+    assert _is_failed_answer("抱歉，AI 服务暂时不可用，请稍后重试。")
+    assert _is_failed_answer("AI 服务返回 429：触发限流，请稍后重试。")
+    assert not _is_failed_answer("一段正常的佛学回答内容，解释五蕴。")
 
 
 def test_max_source_score_handles_bad_json():
@@ -198,9 +198,27 @@ async def test_no_citation_item_serializes_without_sources(aq_session):
 
 
 @pytest.mark.anyio
+async def test_failed_answers_excluded_from_queue(aq_session):
+    # Error-string and empty answers are bugs, not reviewable — never queued.
+    await _seed_turn(
+        aq_session,
+        question="问一",
+        answer="抱歉，AI 服务暂时不可用，请稍后重试。",
+        sources=None,
+    )
+    await _seed_turn(aq_session, question="问二", answer="", sources=None)
+    res = await build_bad_answer_queue(aq_session)
+    assert res["total_unreviewed"] == 0
+
+
+@pytest.mark.anyio
 async def test_review_removes_item_and_snapshots(aq_session):
     mid = await _seed_turn(
-        aq_session, question="问", answer="短", sources=None, feedback="down"
+        aq_session,
+        question="问",
+        answer="一段正常但无引经的回答" * 2,
+        sources=None,
+        feedback="down",
     )
     before = await build_bad_answer_queue(aq_session)
     assert before["total_unreviewed"] == 1
@@ -226,4 +244,4 @@ async def test_review_removes_item_and_snapshots(aq_session):
     assert row.verdict == "bad"
     assert row.failure_category == "recall"
     assert row.suspicion_score > 0
-    assert set(row.detection_reasons) >= {"downvoted", "abnormal", "no_citation"}
+    assert set(row.detection_reasons) >= {"downvoted", "no_citation"}

--- a/backend/tests/test_answer_quality.py
+++ b/backend/tests/test_answer_quality.py
@@ -245,3 +245,39 @@ async def test_review_removes_item_and_snapshots(aq_session):
     assert row.failure_category == "recall"
     assert row.suspicion_score > 0
     assert set(row.detection_reasons) >= {"downvoted", "no_citation"}
+
+
+@pytest.mark.anyio
+async def test_chat_save_guard_skips_failed_answers(aq_session):
+    # The chat-side guard in _save_messages must not persist failed/empty
+    # generations (neither the user nor the assistant turn).
+    from app.services.chat import _save_messages
+
+    session = ChatSession(user_id=None)
+    aq_session.add(session)
+    await aq_session.flush()
+
+    assert (
+        await _save_messages(
+            aq_session, session.id, "问", "抱歉，AI 服务暂时不可用，请稍后重试。", []
+        )
+        is None
+    )
+    assert await _save_messages(aq_session, session.id, "问", "", []) is None
+    mid = await _save_messages(
+        aq_session, session.id, "问", "一段正常的佛学回答内容，解释五蕴。", []
+    )
+    assert mid is not None
+
+    # only the one real turn persisted (user + assistant = 2 rows)
+    rows = (await aq_session.execute(select(ChatMessage))).scalars().all()
+    assert len(rows) == 2
+
+
+def test_failed_answer_prefixes_match_chat():
+    # The prefix set is duplicated in chat.py (save guard) and answer_quality.py
+    # (queue filter); they must stay identical or legacy-junk filtering drifts.
+    from app.services import answer_quality as aq
+    from app.services import chat
+
+    assert chat._FAILED_ANSWER_PREFIXES == aq._FAILED_ANSWER_PREFIXES

--- a/frontend/scripts/i18n-baseline.json
+++ b/frontend/scripts/i18n-baseline.json
@@ -8,7 +8,7 @@
   "src/utils/sourceUrls.ts": 52,
   "src/data/dynasty_years.ts": 46,
   "src/pages/TextReaderPage.tsx": 39,
-  "src/pages/AdminAnswerQualityPage.tsx": 38,
+  "src/pages/AdminAnswerQualityPage.tsx": 37,
   "src/components/ReaderParallelPanel.tsx": 36,
   "src/pages/AdminFeedbacksPage.tsx": 34,
   "src/pages/AdminAnnotationsPage.tsx": 27,

--- a/frontend/src/pages/AdminAnswerQualityPage.tsx
+++ b/frontend/src/pages/AdminAnswerQualityPage.tsx
@@ -20,17 +20,19 @@ import {
 
 const REASON_LABELS: Record<string, string> = {
   downvoted: "被踩",
-  abnormal: "答案异常",
   no_citation: "未引经",
   weak_evidence: "召回证据弱",
 };
 
 const REASON_COLORS: Record<string, string> = {
   downvoted: "red",
-  abnormal: "volcano",
   no_citation: "orange",
   weak_evidence: "gold",
 };
+
+// Mirrors backend WEAK_EVIDENCE_THRESHOLD (answer_quality.py) — keep in sync if
+// the backend threshold is recalibrated. Display-only (reds weak sources).
+const WEAK_SCORE = 0.37;
 
 const CATEGORY_OPTIONS = [
   { value: "recall", label: "召回弱/不全" },
@@ -188,7 +190,7 @@ export default function AdminAnswerQualityPage() {
                   {item.sources.map((s, i) => (
                     <li
                       key={i}
-                      style={{ color: (s.score ?? 1) < 0.5 ? "#cf1322" : undefined }}
+                      style={{ color: (s.score ?? 1) < WEAK_SCORE ? "#cf1322" : undefined }}
                     >
                       {s.title_zh}（卷{s.juan_num}，score {s.score ?? "—"}）：
                       {s.chunk_text.slice(0, 80)}


### PR DESCRIPTION
## 背景
差答案队列 v1（#830）上线当天就暴露：1306 条里 ~114 条是**基础设施故障**（LLM 错误串 / 空答案被当作正式答案存库并显示给用户），不是可复核的质量问题。它们污染历史、指标、队列，还让用户看了困惑。本 PR 把工具从"看着乱"修成"名副其实"。

## 改动（数据驱动的 v1.1 精炼）
1. **chat 保存闸**（`chat.py` `_save_messages`）：失败/空答案（错误串前缀 或 空内容）**不再持久化**——user 与 assistant 两条都不存。止住源头 + 不再污染用户对话历史。（空答案多源于 reasoning model 把 max_tokens 烧在 reasoning 上、content 为空。）
2. **队列剔除失败答案**（`answer_quality.py`）：防御历史遗留垃圾行；**删掉基于长度的 `abnormal` 检测器**（它的活就是抓这些故障，长度本身不是可靠质量信号）。保留 3 个真信号：`downvoted` / `no_citation` / `weak_evidence`。
3. **阈值校准** `WEAK_EVIDENCE_THRESHOLD` 0.50 → **0.37**（线上 p10），weak_evidence 只标召回强度最低的 10%，而非约 25%。
4. **前端**：去掉「答案异常」标签；红色高亮阈值对齐 0.37。

净效果：队列顶部从"满屏答案异常 + 错误/空答案"变成"真问题（龙树/天台华严判教…）+ 真质量短板"。

## 验证
- 后端：`ruff` 干净；`pytest tests/test_answer_quality.py tests/test_admin.py` → 31 passed；chat 测试 45 passed（保存闸未破坏现有流程）。
- 前端：`tsc` / `i18n:check`（债务 38→37）/ `build` 全过。

## Code review（superpowers code-reviewer）：无 Critical
核验通过：保存闸 None 返回两个调用方都正确处理、空答案捕获、错误前缀完备、半截答案（已出首 token 才中断）正确保留、前后端阈值同步。已处理：
- 修 `classify_answer` 过时 docstring。
- 补 `test_chat_save_guard_skips_failed_answers`（现有 chat 测试都 patch 掉 `_save_messages`，新闸原本无覆盖）。
- 补前缀漂移守卫测试（两文件 `_FAILED_ANSWER_PREFIXES` 必须一致）。

## 已知 / 可选 follow-up（不阻塞）
- 失败的"首条消息"会留一个空 session（既存类，非本 PR 引入）；可在 `list_sessions` 加 `EXISTS(messages)` 过滤一并清理。
- 非流式失败后仍会跑一次 `_generate_session_title`（浪费一次调用，无害）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)