### PR TITLE
feat(reader): 「显示行首」开关 — 让 CBETA 页·栏·行号可见

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -716,6 +716,8 @@
   "reader.lineref.copy_link": "Copy link",
   "reader.lineref.copied": "Copied",
   "reader.lineref.citation": "{{title}} (CBETA {{id}}, fasc. {{juan}}, {{ref}})",
+  "reader.lineref.toggle": "Line refs",
+  "reader.lineref.tooltip": "Show CBETA page-column-line refs (e.g. 0001a09) for precise citation",
   "reader.export.button": "Export",
   "reader.export.this_juan": "This fascicle",
   "reader.export.whole_text": "Whole text",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -716,6 +716,8 @@
   "reader.lineref.copy_link": "複製連結",
   "reader.lineref.copied": "已複製",
   "reader.lineref.citation": "《{{title}}》卷{{juan}}（CBETA {{id}}, {{ref}}）",
+  "reader.lineref.toggle": "行首",
+  "reader.lineref.tooltip": "顯示 CBETA 頁·欄·行號（如 0001a09），便於精確引用與核對",
   "reader.export.button": "匯出",
   "reader.export.this_juan": "本卷",
   "reader.export.whole_text": "全經",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -716,6 +716,8 @@
   "reader.lineref.copy_link": "复制链接",
   "reader.lineref.copied": "已复制",
   "reader.lineref.citation": "《{{title}}》卷{{juan}}（CBETA {{id}}, {{ref}}）",
+  "reader.lineref.toggle": "行首",
+  "reader.lineref.tooltip": "显示 CBETA 页·栏·行号（如 0001a09），便于精确引用与核对",
   "reader.export.button": "导出",
   "reader.export.this_juan": "本卷",
   "reader.export.whole_text": "全经",

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -19,6 +19,7 @@ import {
   DiffOutlined,
   VerticalAlignTopOutlined,
   DownloadOutlined,
+  NumberOutlined,
 } from "@ant-design/icons";
 import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, getJuanLineAnchors, type ApparatusEntryItem } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
@@ -430,6 +431,7 @@ export default function TextReaderPage() {
   const [citationOpen, setCitationOpen] = useState(false);
   const [annotationOpen, setAnnotationOpen] = useState(false);
   const [apparatusOn, setApparatusOn] = useState(false);
+  const [showLineRef, setShowLineRef] = useState(false);
   const [parallelPanelOpen, setParallelPanelOpen] = useState(false);
 
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
@@ -1031,6 +1033,16 @@ export default function TextReaderPage() {
               {t("reader.apparatus.toggle")}
             </Button>
           </Tooltip>
+          <Tooltip title={t("reader.lineref.tooltip")}>
+            <Button
+              size="small"
+              type={showLineRef ? "primary" : "default"}
+              icon={<NumberOutlined />}
+              onClick={() => setShowLineRef((v) => !v)}
+            >
+              {t("reader.lineref.toggle")}
+            </Button>
+          </Tooltip>
           <Tooltip title="跨藏对照（其他版本 · 经级/段级对读）">
             <Button
               size="small"
@@ -1111,7 +1123,7 @@ export default function TextReaderPage() {
               <div className="bilingual-column">
                 <div className="bilingual-label">{LANG_LABELS[langData?.default_lang || ""] || "原文"}</div>
                 <div
-                  className="reader-body"
+                  className={`reader-body${showLineRef ? " show-lineref" : ""}`}
                   style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
                 >
                   {reflowedContent.map((seg, i) => renderSegment(seg, i, readerCtx))}
@@ -1138,7 +1150,7 @@ export default function TextReaderPage() {
           </Row>
         ) : (
           <div
-            className="reader-body"
+            className={`reader-body${showLineRef ? " show-lineref" : ""}`}
             style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
           >
             {reflowedContent.map((seg, i) => renderSegment(seg, i, readerCtx))}

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -797,6 +797,21 @@
   height: 0;
   overflow: hidden;
 }
+/* 「显示行首」开：把零宽行锚渲染成 CBETA 页·栏·行号浅色上标。 */
+.reader-body.show-lineref .cbeta-line {
+  width: auto;
+  height: auto;
+  overflow: visible;
+  vertical-align: super;
+  margin: 0 0.25em;
+  font-size: 0.6em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: #b8860b;
+  user-select: none;
+}
+.reader-body.show-lineref .cbeta-line::before {
+  content: attr(data-ref);
+}
 .cbeta-line-flash {
   animation: cbeta-line-flash-kf 2.2s ease-out;
 }


### PR DESCRIPTION
## 背景

CBETA 借鉴路线的收尾项。行锚点全链路(解析→`/line-anchors` API→前端渲染→划词定位复制→URN 深链跳转)此前已合并,但 `.cbeta-line` 是**零宽 span**,行首号(如 `0001a09`)对读者不可见——只在划词时被动浮现。本 PR 对齐 CBETA 的「显示行首」开关,把它变成常显。

## 改动(纯前端)

- 工具栏加「行首」按钮(state `showLineRef`),开启时给 `.reader-body` 加 `show-lineref` 类。
- CSS 用 `content: attr(data-ref)` 把每个零宽行锚渲染成浅色等宽上标;关闭时回到零宽,零影响。
- 只作用于携带行锚的正文列(主列 + 双语主列),对照译文列不受影响。
- i18n:`reader.lineref.toggle` / `reader.lineref.tooltip`,zh / zh-Hant / en 三语。

不改渲染逻辑、不加任何请求。

## 质量门
`tsc -b` / `eslint` / **i18n ratchet**(baseline 未增)全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)