### PR TITLE
feat(export): 导出版式对齐网页阅读器（reflow）

### DIFF
--- a/backend/app/services/text_export.py
+++ b/backend/app/services/text_export.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.text import BuddhistText, TextContent
+from app.services.text_reflow import Segment, reflow
 
 # format → (file extension, media type)
 FORMATS: dict[str, tuple[str, str]] = {
@@ -41,7 +42,10 @@ _EPUB_MODIFIED = "2026-01-01T00:00:00Z"
 @dataclass
 class ExportJuan:
     juan_num: int
+    # Raw stripped source lines — used by TXT (no layout) and as the reflow input.
     lines: list[str] = field(default_factory=list)
+    # Reflowed layout segments — used by HTML/EPUB/DOCX to match the web reader.
+    segments: list[Segment] = field(default_factory=list)
 
 
 @dataclass
@@ -80,6 +84,30 @@ def render_txt(doc: ExportDoc) -> str:
 
 # --- HTML --------------------------------------------------------------------
 
+# Mirrors the web reader's reader.css typography (.text-prose/.text-verse/…) so
+# the exported page reads like fojin.app: flowing prose paragraphs (2em indent),
+# indented verse, centred juan/section headings, right-aligned byline.
+_HTML_STYLE = (
+    "body{font-family:'Noto Serif SC','Source Han Serif SC',serif;max-width:42em;"
+    "margin:2em auto;padding:0 1.2em;line-height:1.8;color:#1a1a1a;"
+    "line-break:strict}"
+    "h1{font-size:1.5em;margin:0 0 .2em}"
+    ".byline-doc{color:#666;margin:0 0 .1em}.src{color:#999;font-size:.85em;margin:0 0 1.5em}"
+    ".juan{font-size:1.1em;color:#8b6914;text-align:center;margin:1.5em 0 1em}"
+    ".head{font-size:1.2em;color:#8b6914;text-align:center;margin:.5em 0 1em}"
+    ".byline{color:#408080;text-align:right;margin:0 0 1.2em;font-size:.95em}"
+    ".section{text-align:center;margin:1.5em 0 1em;font-size:1.05em}"
+    ".prose{text-indent:2em;margin:0 0 1em}"
+    ".verse{margin:0;padding-left:4em;text-indent:0}"
+)
+
+
+def _seg_html(seg: Segment) -> str:
+    if seg.type == "break":
+        return ""
+    return f'<p class="{seg.type}">{escape(seg.text)}</p>'
+
+
 def render_html(doc: ExportDoc) -> str:
     parts: list[str] = [
         "<!DOCTYPE html>",
@@ -88,20 +116,18 @@ def render_html(doc: ExportDoc) -> str:
         '<meta charset="utf-8">',
         '<meta name="viewport" content="width=device-width, initial-scale=1">',
         f"<title>{escape(doc.title)}</title>",
-        "<style>body{font-family:serif;max-width:42em;margin:2em auto;line-height:1.9;padding:0 1em}"
-        "h1{font-size:1.5em}.byline{color:#666}.src{color:#999;font-size:.85em}"
-        "h2{font-size:1.1em;margin-top:2em;border-top:1px solid #eee;padding-top:1em}p{margin:.3em 0}</style>",
+        f"<style>{_HTML_STYLE}</style>",
         "</head>",
         "<body>",
         f"<h1>{escape(doc.title)}</h1>",
     ]
     byline = _byline(doc)
     if byline:
-        parts.append(f'<p class="byline">{escape(byline)}</p>')
+        parts.append(f'<p class="byline-doc">{escape(byline)}</p>')
     parts.append(f'<p class="src">CBETA {escape(doc.cbeta_id)}</p>')
     for j in doc.juans:
-        parts.append(f"<h2>{escape(_juan_label(j.juan_num))}</h2>")
-        parts.extend(f"<p>{escape(line)}</p>" for line in j.lines)
+        parts.append(f'<h2 class="juan">{escape(_juan_label(j.juan_num))}</h2>')
+        parts.extend(html for html in (_seg_html(s) for s in j.segments) if html)
     parts.append("</body>")
     parts.append("</html>")
     return "\n".join(parts) + "\n"
@@ -111,6 +137,8 @@ def render_html(doc: ExportDoc) -> str:
 
 def render_docx(doc: ExportDoc) -> bytes:
     from docx import Document
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Pt
 
     d = Document()
     d.add_heading(doc.title, level=0)
@@ -120,8 +148,22 @@ def render_docx(doc: ExportDoc) -> bytes:
     d.add_paragraph(f"CBETA {doc.cbeta_id}")
     for j in doc.juans:
         d.add_heading(_juan_label(j.juan_num), level=1)
-        for line in j.lines:
-            d.add_paragraph(line)
+        for seg in j.segments:
+            if seg.type == "break":
+                continue
+            if seg.type in ("head", "juan"):
+                h = d.add_heading(seg.text, level=2)
+                h.alignment = WD_ALIGN_PARAGRAPH.CENTER
+                continue
+            p = d.add_paragraph(seg.text)
+            if seg.type == "section":
+                p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            elif seg.type == "byline":
+                p.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+            elif seg.type == "prose":
+                p.paragraph_format.first_line_indent = Pt(24)
+            elif seg.type == "verse":
+                p.paragraph_format.left_indent = Pt(48)
     buf = BytesIO()
     d.save(buf)
     return buf.getvalue()
@@ -129,15 +171,34 @@ def render_docx(doc: ExportDoc) -> bytes:
 
 # --- EPUB --------------------------------------------------------------------
 
+# Inline CSS shared by every juan document — same typography as the HTML export.
+_EPUB_CSS = (
+    "body{font-family:'Noto Serif SC',serif;line-height:1.8}"
+    ".juan{font-size:1.1em;text-align:center;margin:1.5em 0 1em}"
+    ".head{font-size:1.2em;text-align:center;margin:.5em 0 1em}"
+    ".byline{text-align:right;margin:0 0 1.2em;font-size:.95em}"
+    ".section{text-align:center;margin:1.5em 0 1em}"
+    ".prose{text-indent:2em;margin:0 0 1em}"
+    ".verse{margin:0;padding-left:4em}"
+)
+
+
+def _seg_xhtml(seg: Segment) -> str:
+    if seg.type == "break":
+        return ""
+    return f'    <p class="{seg.type}">{xml_escape(seg.text)}</p>'
+
+
 def _epub_juan_xhtml(title: str, j: ExportJuan) -> str:
-    body = "\n".join(f"    <p>{xml_escape(line)}</p>" for line in j.lines)
+    body = "\n".join(x for x in (_seg_xhtml(s) for s in j.segments) if x)
     return (
         '<?xml version="1.0" encoding="utf-8"?>\n'
         '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="zh-Hant">\n'
         f"  <head><title>{xml_escape(title)} {_juan_label(j.juan_num)}</title>\n"
-        '  <meta charset="utf-8"/></head>\n'
+        '  <meta charset="utf-8"/>\n'
+        f"  <style>{_EPUB_CSS}</style></head>\n"
         "  <body>\n"
-        f"    <h2>{xml_escape(_juan_label(j.juan_num))}</h2>\n"
+        f'    <h2 class="juan">{xml_escape(_juan_label(j.juan_num))}</h2>\n'
         f"{body}\n"
         "  </body>\n"
         "</html>\n"
@@ -262,7 +323,14 @@ async def build_export_doc(
     if not rows:
         return None
 
-    juans = [ExportJuan(juan_num=r.juan_num, lines=_split_lines(r.content or "")) for r in rows]
+    juans = [
+        ExportJuan(
+            juan_num=r.juan_num,
+            lines=_split_lines(r.content or ""),
+            segments=reflow(r.content or ""),
+        )
+        for r in rows
+    ]
     return ExportDoc(
         title=bt.title_zh,
         cbeta_id=bt.cbeta_id,

--- a/backend/app/services/text_reflow.py
+++ b/backend/app/services/text_reflow.py
@@ -1,0 +1,158 @@
+"""Reflow CBETA hard-wrapped source text into layout segments.
+
+A faithful Python port of the frontend ``reflowText`` (TextReaderPage.tsx) so
+that exported HTML/EPUB/DOCX match the web reader's typography instead of the
+raw one-line-per-source-line layout. Offsets are dropped (exports place no
+inline apparatus markers), which keeps this a plain string transform.
+
+Segment types mirror the frontend: prose / verse / break / head / juan /
+byline / section.
+
+Known parity caveat: length comparisons use ``len()`` (code points) while the
+JS source uses ``.length`` (UTF-16 units). These differ only for
+supplementary-plane glyphs (e.g. CJK Ext-B, U+20000+) sitting exactly on a
+length threshold — rare enough that we accept the divergence rather than thread
+UTF-16 width everywhere. ASCII-digit parity (``\d`` → ``0-9``) IS handled, since
+fullwidth digits in juan/section titles are comparatively common.
+"""
+
+import re
+from dataclasses import dataclass
+
+_SENTENCE_END = re.compile(r"[。！？」』]$")
+_VERSE_MARKER = re.compile(r"頌曰[：:]?|偈曰[：:]?")
+_PROSE_MARKER = re.compile(r"^(論曰|述曰|疏曰|解曰|釋曰)")
+_ALL_PUNCT = re.compile(r"[，。、；：！？]")
+_VERSE_END = re.compile(r"[，。；]$")
+_WS_GAP = re.compile(r"\s{2,}")
+
+
+@dataclass
+class Segment:
+    type: str  # prose | verse | break | head | juan | byline | section
+    text: str = ""
+
+
+def _is_verse(line: str) -> bool:
+    n = len(line)
+    if n < 4 or n > 22:
+        return False
+    if not _VERSE_END.search(line):
+        return False
+    all_puncts = len(_ALL_PUNCT.findall(line))
+    if all_puncts > 2:
+        return False
+    if _WS_GAP.search(line):
+        return True
+    if all_puncts == 2:
+        parts = re.split(r"[，。、；]", line)
+        if len(parts) >= 2 and len(parts[0]) > 0 and len(parts[1]) > 0:
+            ratio = min(len(parts[0]), len(parts[1])) / max(len(parts[0]), len(parts[1]))
+            return ratio >= 0.5
+    return all_puncts == 1 and n <= 12
+
+
+def _is_head(line: str, idx: int) -> bool:
+    if idx > 2:
+        return False
+    if len(line) > 15 or len(line) < 2:
+        return False
+    return bool(re.search(r"[經论論律品序疏記集傳]", line)) and not re.search(r"[，。；：！？、]", line)
+
+
+def _is_juan(line: str) -> bool:
+    # \d → 0-9 (ASCII only): mirror JS RegExp \d, which — unlike Python's
+    # Unicode \d — does not match fullwidth digits. Keeps parity with the reader.
+    return bool(re.search(r"卷第?[一二三四五六七八九十百千0-9]+", line)) and len(line) <= 25 and not re.search(r"[，。]", line)
+
+
+def _is_byline(line: str) -> bool:
+    return bool(re.search(r"[譯译述撰注疏記造]$", line)) and len(line) <= 25 and not re.search(r"[，。；]", line)
+
+
+def _is_section(line: str) -> bool:
+    # \d → 0-9 (ASCII only) to mirror JS RegExp \d — see _is_juan.
+    if re.match(r"^[（(][一二三四五六七八九十0-9]+[）)]", line):
+        return True
+    return bool(re.search(r"[品分經]第[一二三四五六七八九十百0-9]+", line)) and len(line) <= 20 and not re.search(r"[，。]", line)
+
+
+def reflow(raw: str) -> list[Segment]:
+    lines = raw.split("\n")
+    segments: list[Segment] = []
+    prose_buf = ""
+
+    def flush_prose() -> None:
+        nonlocal prose_buf
+        if prose_buf:
+            segments.append(Segment("prose", prose_buf))
+            prose_buf = ""
+
+    in_verse_block = False
+    before_first_prose = True
+    first_nonempty_idx = -1
+    last_nonempty_line = ""
+
+    for i, rawline in enumerate(lines):
+        trimmed = rawline.strip()
+
+        if trimmed == "":
+            if _SENTENCE_END.search(last_nonempty_line):
+                flush_prose()
+                segments.append(Segment("break"))
+            continue
+
+        last_nonempty_line = trimmed
+        if first_nonempty_idx < 0:
+            first_nonempty_idx = i
+        rel_idx = i - first_nonempty_idx
+
+        if _is_juan(trimmed):
+            flush_prose()
+            segments.append(Segment("juan", trimmed))
+            continue
+        if _is_byline(trimmed):
+            flush_prose()
+            segments.append(Segment("byline", trimmed))
+            continue
+        if _is_section(trimmed):
+            flush_prose()
+            segments.append(Segment("section", trimmed))
+            continue
+        if _is_head(trimmed, rel_idx):
+            flush_prose()
+            segments.append(Segment("head", trimmed))
+            continue
+
+        has_verse_marker = bool(_VERSE_MARKER.search(trimmed))
+        is_prose_marker = bool(_PROSE_MARKER.search(trimmed))
+
+        if is_prose_marker:
+            before_first_prose = False
+            in_verse_block = False
+            if prose_buf:
+                flush_prose()
+            prose_buf = trimmed
+            continue
+
+        if has_verse_marker:
+            before_first_prose = False
+            prose_buf += trimmed
+            flush_prose()
+            in_verse_block = True
+            continue
+
+        if (in_verse_block or before_first_prose) and _is_verse(trimmed):
+            flush_prose()
+            segments.append(Segment("verse", trimmed))
+            continue
+
+        if in_verse_block and not _is_verse(trimmed):
+            in_verse_block = False
+        if before_first_prose and not _is_verse(trimmed):
+            before_first_prose = False
+
+        prose_buf += trimmed
+
+    flush_prose()
+    return segments

--- a/backend/tests/test_text_export.py
+++ b/backend/tests/test_text_export.py
@@ -21,6 +21,13 @@ from app.services.text_export import (
     render_html,
     render_txt,
 )
+from app.services.text_reflow import reflow
+
+
+def _juan(juan_num: int, lines: list[str]) -> ExportJuan:
+    """Build a juan the way build_export_doc does: raw lines + reflow segments."""
+    raw = "\n".join(lines)
+    return ExportJuan(juan_num=juan_num, lines=lines, segments=reflow(raw))
 
 
 def _doc(**kw) -> ExportDoc:
@@ -32,8 +39,8 @@ def _doc(**kw) -> ExportDoc:
         juans=kw.get(
             "juans",
             [
-                ExportJuan(juan_num=1, lines=["如是我聞。", "一時佛在。"]),
-                ExportJuan(juan_num=2, lines=["爾時世尊。"]),
+                _juan(1, ["爾時世尊，處於此座，成最正覺。", "智入三世，悉皆平等。"]),
+                _juan(2, ["其身充滿一切世間，其音普順十方國土。"]),
             ],
         ),
     )
@@ -45,8 +52,8 @@ def test_render_txt_includes_title_metadata_and_all_lines():
     out = render_txt(_doc())
     assert "佛說長阿含經" in out
     assert "佛陀耶舍共竺佛念譯" in out
-    assert "如是我聞。" in out
-    assert "爾時世尊。" in out
+    assert "爾時世尊，處於此座，成最正覺。" in out
+    assert "其身充滿一切世間，其音普順十方國土。" in out
     # both juans are marked
     assert out.count("卷") >= 2
 
@@ -59,7 +66,7 @@ def test_render_txt_omits_missing_metadata():
 # --- HTML --------------------------------------------------------------------
 
 def test_render_html_is_wellformed_and_escapes():
-    doc = _doc(juans=[ExportJuan(juan_num=1, lines=["善男子<惡>&未來。"])])
+    doc = _doc(juans=[_juan(1, ["善男子，<惡>&未來，皆悉明見。"])])
     out = render_html(doc)
     assert out.startswith("<!DOCTYPE html>")
     assert '<meta charset="utf-8"' in out
@@ -68,6 +75,15 @@ def test_render_html_is_wellformed_and_escapes():
     assert "<惡>" not in out
     assert "&lt;惡&gt;" in out
     assert "&amp;" in out
+
+
+def test_render_html_uses_web_layout_classes():
+    # HTML must carry the reader.css-matching segment classes, not bare <p>.
+    doc = _doc(juans=[_juan(1, ["諸一切種諸冥滅，", "拔眾生出生死泥，"])])
+    out = render_html(doc)
+    assert 'class="verse"' in out          # opening equal-clause lines → verse
+    assert 'class="juan"' in out           # juan heading
+    assert ".prose{text-indent:2em" in out  # prose paragraph style present
 
 
 # --- DOCX --------------------------------------------------------------------
@@ -80,8 +96,8 @@ def test_render_docx_roundtrips_content():
     parsed = Document(BytesIO(data))
     all_text = "\n".join(p.text for p in parsed.paragraphs)
     assert "佛說長阿含經" in all_text
-    assert "如是我聞。" in all_text
-    assert "爾時世尊。" in all_text
+    assert "爾時世尊，處於此座，成最正覺。" in all_text
+    assert "其身充滿一切世間，其音普順十方國土。" in all_text
 
 
 # --- EPUB --------------------------------------------------------------------
@@ -102,7 +118,7 @@ def test_render_epub_is_valid_container():
     juan_docs = [n for n in names if n.endswith(".xhtml")]
     assert juan_docs
     body = "\n".join(zf.read(n).decode("utf-8") for n in juan_docs)
-    assert "如是我聞。" in body
+    assert "爾時世尊，處於此座，成最正覺。" in body
 
 
 def test_render_epub_has_dcterms_modified():
@@ -118,7 +134,7 @@ def test_render_epub_has_dcterms_modified():
 
 
 def test_render_epub_escapes_xml():
-    doc = _doc(juans=[ExportJuan(juan_num=1, lines=["a<b>&c"])])
+    doc = _doc(juans=[_juan(1, ["善哉，a<b>&c，如是我說。"])])
     zf = zipfile.ZipFile(BytesIO(render_epub(doc)))
     body = "\n".join(zf.read(n).decode("utf-8") for n in zf.namelist() if n.endswith(".xhtml"))
     assert "<b>" not in body
@@ -202,7 +218,7 @@ async def test_export_endpoint_sets_download_headers(client):
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/plain")
     assert 'filename="T0001.txt"' in resp.headers["content-disposition"]
-    assert "如是我聞。" in resp.text
+    assert "爾時世尊，處於此座，成最正覺。" in resp.text
 
 
 async def test_export_endpoint_single_juan_filename(client):

--- a/backend/tests/test_text_reflow.py
+++ b/backend/tests/test_text_reflow.py
@@ -1,0 +1,82 @@
+"""Reflow tests — port of the frontend reflowText heuristic.
+
+These pin the segment classification (prose merge, verse, structural lines)
+so the exported HTML/EPUB/DOCX matches the web reader's layout.
+"""
+
+from app.services.text_reflow import Segment, reflow
+
+
+def _types(segs: list[Segment]) -> list[str]:
+    return [s.type for s in segs]
+
+
+def test_prose_lines_merge_into_one_paragraph():
+    # CBETA hard-wraps prose every ~18 chars; reflow rejoins into flowing paras.
+    raw = "聖眾，故先讚德方申敬禮。諸言所表謂佛\n世尊具眾德故，故先讚歎然後歸禮。"
+    segs = reflow(raw)
+    prose = [s for s in segs if s.type == "prose"]
+    assert len(prose) == 1
+    assert prose[0].text == "聖眾，故先讚德方申敬禮。諸言所表謂佛世尊具眾德故，故先讚歎然後歸禮。"
+
+
+def test_blank_line_breaks_paragraph_only_after_sentence_end():
+    # Break only when the previous line ends with sentence-final punctuation.
+    # Use multi-clause prose lines (3+ puncts) so they aren't caught as verse.
+    raw = "聖眾，故先讚德方申敬禮，具眾德故。\n\n諸言所表，謂佛世尊，具眾德故。"
+    segs = reflow(raw)
+    assert _types(segs) == ["prose", "break", "prose"]
+
+    # Mid-word blank (no sentence-final punct) must NOT break.
+    raw2 = "淨\n\n色相海。"
+    segs2 = reflow(raw2)
+    assert [s.type for s in segs2] == ["prose"]
+    assert segs2[0].text == "淨色相海。"
+
+
+def test_juan_byline_section_head_are_structural():
+    raw = (
+        "大方廣佛華嚴經\n"
+        "大方廣佛華嚴經卷第一\n"
+        "于闐國三藏實叉難陀奉　制譯\n"
+        "世主妙嚴品第一之一\n"
+        "爾時世尊，處於此座，於一切法成最正覺。"
+    )
+    segs = reflow(raw)
+    by_type = {s.type: s.text for s in segs}
+    assert by_type["head"] == "大方廣佛華嚴經"
+    assert by_type["juan"] == "大方廣佛華嚴經卷第一"
+    assert by_type["byline"] == "于闐國三藏實叉難陀奉　制譯"
+    assert by_type["section"] == "世主妙嚴品第一之一"
+    assert by_type["prose"] == "爾時世尊，處於此座，於一切法成最正覺。"
+
+
+def test_opening_verse_detected_before_first_prose():
+    # Equal-length clause lines before any 論曰 are opening verses.
+    raw = "諸一切種諸冥滅，\n拔眾生出生死泥，"
+    segs = reflow(raw)
+    assert _types(segs) == ["verse", "verse"]
+
+
+def test_verse_block_after_marker_then_prose_exits():
+    raw = "頌曰：\n身從無相中受生，\n猶如幻出諸形相。\n論曰：如是等義。"
+    segs = reflow(raw)
+    types = _types(segs)
+    assert "verse" in types
+    # the 論曰 line is prose, not verse
+    assert segs[-1].type == "prose"
+    assert segs[-1].text.startswith("論曰")
+
+
+def test_empty_input_yields_no_segments():
+    assert reflow("") == []
+    assert reflow("\n\n") == []
+
+
+def test_juan_digit_class_is_ascii_only_like_js():
+    # JS RegExp \d matches ASCII digits only; Python's Unicode \d also matches
+    # fullwidth digits. We pin ASCII-only so the export mirrors the web reader.
+    # ASCII digit juan → recognised
+    assert reflow("大方廣佛華嚴經卷第1")[0].type == "juan"
+    # Fullwidth-digit juan → NOT a juan (matches JS), falls through to prose
+    assert reflow("大方廣佛華嚴經卷第１")[0].type != "juan"


### PR DESCRIPTION
## 问题

用户反馈:导出的 HTML 与网页阅读器观感差异很大——散文被切成「一句一行」的碎裂效果,而网页做了 CBETA 版式重排(散文合并成流动段落、偈颂缩进、卷题居中等)。

根因:导出后端只做了最原始的「每源行一个 `<p>`」,完全没有网页那套 `reflowText` 版式重排。

## 改动

- 新增 `backend/app/services/text_reflow.py`:把前端 `TextReaderPage.tsx` 的 `reflowText` 启发式**忠实移植**到 Python——散文行合并成流动段落、偈颂(isVerse)识别、卷题/署名/品名/标题结构识别、空行仅在句末标点后断段、`in_verse_block`/`before_first_prose` 状态机。
- `text_export.py` 的 HTML/EPUB/DOCX 改为按 `segment.type` 渲染:
  - **HTML/EPUB**:内联 CSS 复刻 `reader.css`——散文首行缩进 2em、偈颂缩进 4em、卷题/标题居中、署名右对齐、Noto Serif + 1.8 行高。
  - **DOCX**:Word 段落对齐/缩进映射。
  - **TXT**:保持纯行(无版式)。

## 忠实度与质量

- 移植经**逐行对照审查**确认忠实(状态机、判定顺序、所有正则字符类字节一致)。
- 一处语义差异已修:Python `\d` 匹配全角数字而 JS `\d` 只匹配 ASCII,卷题/品名正则改用 `[0-9]` 对齐,并加回归测试钉死。
- 一处已知低频取舍(辅助平面生僻字的 UTF-16 长度边界)在模块注释中记录,不做过度工程。
- **测试**:新增 `test_text_reflow.py`(散文合并/断段/结构行/偈颂/全角数字)+ 更新 `test_text_export.py` 覆盖 segment 渲染。后端全量 **766 passed**,`ruff==0.9.7` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)