### PR TITLE
chore(deps): bump pypdf 6.13.3 → 6.14.2

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,6 @@ tiktoken==0.8.0
 opencc-python-reimplemented==0.1.7
 Pillow==12.2.0
 python-multipart==0.0.32
-pypdf==6.13.3
+pypdf==6.14.2
 python-docx==1.1.2
 beautifulsoup4==4.12.3


### PR DESCRIPTION
Supersedes dependabot #813 after merge conflict with #812.

Made with [Cursor](https://cursor.com)