### PR TITLE
feat(deploy): expose runtime version for smoke checks

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -44,21 +44,32 @@ jobs:
           cache: npm
           cache-dependency-path: e2e/package-lock.json
 
-      # Conservative belt-and-suspenders: after a deploy-success dispatch the
-      # containers should already be up, but the webhook CD can still be
-      # mid-rebuild. We can't poll a commit hash (no version endpoint yet), but
-      # the en locale key count is a deterministic deploy signal whenever
-      # locales changed; when they didn't, any moment is equally valid to test.
-      # Wait until served == repo, give up after 12 min and test anyway (the
-      # functional specs are mostly version-independent). Harmless under
-      # schedule/workflow_dispatch since this step is gated to the dispatch.
-      - name: Wait for CD rollout
+      - name: Wait for deployed backend commit
+        if: github.event_name == 'repository_dispatch'
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url || 'https://fojin.app' }}
+          EXPECTED_SHA: ${{ github.event.client_payload.commit || github.sha }}
+        run: |
+          echo "expected backend commit: $EXPECTED_SHA"
+          for i in $(seq 1 24); do
+            SERVED=$(curl -sf --max-time 10 "$BASE_URL/api/version" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>console.log(JSON.parse(d).commit || ''))" 2>/dev/null || echo "")
+            if [ "$SERVED" = "$EXPECTED_SHA" ]; then
+              echo "backend commit in sync after $((i*30))s ($SERVED)"
+              exit 0
+            fi
+            echo "waiting for backend commit... served=${SERVED:-unavailable} ($((i*30))s)"
+            sleep 30
+          done
+          echo "::error::Production backend did not report expected commit $EXPECTED_SHA"
+          exit 1
+
+      - name: Wait for frontend locale
         if: github.event_name == 'repository_dispatch'
         run: |
           REPO_KEYS=$(node -e "console.log(Object.keys(require('../frontend/public/locales/en/translation.json')).length)")
           echo "repo en keys: $REPO_KEYS"
           for i in $(seq 1 24); do
-            SERVED=$(curl -sf --max-time 10 https://fojin.app/locales/en/translation.json | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>console.log(Object.keys(JSON.parse(d)).length))" 2>/dev/null || echo -1)
+            SERVED=$(curl -sf -A 'Mozilla/5.0' --max-time 10 https://fojin.app/locales/en/translation.json | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>console.log(Object.keys(JSON.parse(d)).length))" 2>/dev/null || echo -1)
             if [ "$SERVED" = "$REPO_KEYS" ]; then
               echo "locale in sync after $((i*30))s (served=$SERVED)"
               exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Deploy state (per-host markers used by deploy.sh)
 .deploy-state/
+backend/.deploy-version.json
 
 # Python
 __pycache__/

--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -1,0 +1,49 @@
+"""Runtime deploy identity helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+APP_NAME = "fojin"
+DEFAULT_APP_VERSION = "3.0.0"
+DEPLOY_VERSION_FILE = Path(__file__).resolve().parents[2] / ".deploy-version.json"
+
+
+def _clean(value: str | None) -> str | None:
+    value = (value or "").strip()
+    return value or None
+
+
+def _read_deploy_version_file() -> dict[str, Any]:
+    try:
+        data = json.loads(DEPLOY_VERSION_FILE.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def get_deploy_identity() -> dict[str, str]:
+    """Return app/version/commit identity for deploy smoke checks."""
+
+    file_data = _read_deploy_version_file()
+    commit = (
+        _clean(os.environ.get("FOJIN_COMMIT_SHA"))
+        or _clean(os.environ.get("GITHUB_SHA"))
+        or _clean(str(file_data.get("commit") or ""))
+        or "unknown"
+    )
+    version = (
+        _clean(os.environ.get("APP_VERSION"))
+        or _clean(str(file_data.get("version") or ""))
+        or DEFAULT_APP_VERSION
+    )
+    commit_short = commit[:7] if commit != "unknown" else "unknown"
+    return {
+        "app": APP_NAME,
+        "version": version,
+        "commit": commit,
+        "commit_short": commit_short,
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from app.config import settings
 from app.core.elasticsearch import close_es, get_es, init_es
 from app.core.exceptions import FoJinError, fojin_error_to_http
 from app.core.rate_limit import RateLimitMiddleware
+from app.core.version import get_deploy_identity
 from app.database import engine as async_engine
 
 try:
@@ -561,4 +562,9 @@ async def health(request: Request):
 
     all_ok = all(v == "ok" for v in components.values())
     status = "ok" if all_ok else "degraded"
-    return {"status": status, **components}
+    return {"status": status, **components, "version": get_deploy_identity()}
+
+
+@app.get("/api/version")
+async def version():
+    return get_deploy_identity()

--- a/backend/tests/test_deploy_proof_chain_static.py
+++ b/backend/tests/test_deploy_proof_chain_static.py
@@ -1,0 +1,22 @@
+"""Static checks for the deploy proof chain."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_deploy_script_writes_runtime_version_file_and_dispatches_smoke():
+    deploy_script = (ROOT / "deploy.sh").read_text(encoding="utf-8")
+
+    assert "backend/.deploy-version.json" in deploy_script
+    assert "event_type=deploy-success" in deploy_script
+    assert "client_payload" in deploy_script
+    assert "git rev-parse HEAD" in deploy_script
+
+
+def test_production_smoke_waits_for_backend_commit_identity():
+    smoke_workflow = (ROOT / ".github" / "workflows" / "smoke.yml").read_text(encoding="utf-8")
+
+    assert "/api/version" in smoke_workflow
+    assert "EXPECTED_SHA" in smoke_workflow
+    assert "client_payload.commit" in smoke_workflow

--- a/backend/tests/test_search_api.py
+++ b/backend/tests/test_search_api.py
@@ -33,3 +33,31 @@ async def test_health_endpoint(client):
     assert resp.status_code == 200
     data = resp.json()
     assert "status" in data
+
+
+@pytest.mark.asyncio
+async def test_version_endpoint_reports_deploy_identity(client, monkeypatch):
+    monkeypatch.setenv("FOJIN_COMMIT_SHA", "abcdef1234567890")
+    monkeypatch.setenv("APP_VERSION", "2026.07.02")
+
+    resp = await client.get("/api/version")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "app": "fojin",
+        "version": "2026.07.02",
+        "commit": "abcdef1234567890",
+        "commit_short": "abcdef1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_includes_deploy_identity(client, monkeypatch):
+    monkeypatch.setenv("GITHUB_SHA", "1234567890abcdef")
+    monkeypatch.delenv("FOJIN_COMMIT_SHA", raising=False)
+
+    resp = await client.get("/api/health")
+
+    assert resp.status_code == 200
+    assert resp.json()["version"]["commit"] == "1234567890abcdef"
+    assert resp.json()["version"]["commit_short"] == "1234567"

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,6 +50,7 @@ BRANCH="${BRANCH:-master}"
 STATE_DIR="$REPO_DIR/.deploy-state"
 FRONTEND_BUILD_MARKER="$STATE_DIR/last-frontend-build"
 BACKEND_RESTART_MARKER="$STATE_DIR/last-backend-restart"
+DEPLOY_VERSION_FILE="$REPO_DIR/backend/.deploy-version.json"
 mkdir -p "$STATE_DIR"
 
 log()  { printf '\n\033[1;36m>>> %s\033[0m\n' "$*"; }
@@ -74,6 +75,52 @@ marker_commit() {
 # True iff $1 is a known git commit in this repo.
 is_known_commit() {
   git rev-parse --verify --quiet "$1^{commit}" >/dev/null 2>&1
+}
+
+write_deploy_version_file() {
+  local commit="$1"
+  local version="${APP_VERSION:-3.0.0}"
+  command -v python3 >/dev/null || fail "python3 不在 PATH — 无法写入部署版本文件。"
+  python3 - "$DEPLOY_VERSION_FILE" "$commit" "$version" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+commit = sys.argv[2]
+version = sys.argv[3]
+path.write_text(
+    json.dumps(
+        {
+            "app": "fojin",
+            "version": version,
+            "commit": commit,
+            "commit_short": commit[:7],
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+PY
+  log "Wrote deploy identity $(git rev-parse HEAD) -> backend/.deploy-version.json"
+}
+
+dispatch_deploy_success() {
+  local commit="$1"
+  local repo="${GITHUB_REPOSITORY:-xr843/fojin}"
+  if ! command -v gh >/dev/null 2>&1; then
+    warn "gh 不在 PATH — 跳过 deploy-success dispatch。"
+    return 0
+  fi
+  gh api --method POST "repos/${repo}/dispatches" \
+    -f event_type=deploy-success \
+    -f "client_payload[branch]=${BRANCH}" \
+    -f "client_payload[commit]=${commit}" \
+    >/dev/null \
+    || { warn "deploy-success dispatch 失败 — 部署已完成，但生产 smoke 未触发。"; return 0; }
+  log "Triggered deploy-success smoke for ${repo}@${commit:0:7}."
 }
 
 # --- 0. 并发锁 ---------------------------------------------------------------
@@ -200,6 +247,8 @@ if ! $frontend_changed && ! $backend_changed; then
   exit 0
 fi
 
+write_deploy_version_file "$NEW_REV"
+
 # --- 3. 前端: 改了就重建镜像 + 重建容器 --------------------------------------
 if $frontend_changed; then
   log "Frontend changed — building image + recreating container ..."
@@ -284,5 +333,7 @@ docker compose ps
 log "Pruning build cache + dangling images ..."
 docker builder prune -f >/dev/null
 docker image prune -f   >/dev/null
+
+dispatch_deploy_success "$NEW_REV"
 
 log "Done. Deployed $(git rev-parse --short HEAD) on $BRANCH."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,8 @@ services:
       API_KEY_ENCRYPTION_KEY: ${API_KEY_ENCRYPTION_KEY:?Set API_KEY_ENCRYPTION_KEY in .env (Fernet.generate_key() output)}
       # Drives the production fail-fast block in app/config.py.
       FOJIN_ENV: ${FOJIN_ENV:-production}
+      APP_VERSION: ${APP_VERSION:-}
+      FOJIN_COMMIT_SHA: ${FOJIN_COMMIT_SHA:-}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173,http://localhost:5174}
       LLM_API_URL: ${LLM_API_URL:-}
       LLM_API_KEY: ${LLM_API_KEY:-}


### PR DESCRIPTION
## Summary\n- add /api/version and include deploy identity in /api/health\n- write backend/.deploy-version.json during deploy so production can report the deployed commit\n- trigger deploy-success repository_dispatch after deploy health checks\n- make production smoke wait for the backend commit reported by /api/version\n\n## Validation\n- cd backend && python3 -m pytest tests/test_search_api.py tests/test_deploy_proof_chain_static.py -q\n- cd backend && python3 -m ruff check app/core/version.py app/main.py tests/test_search_api.py tests/test_deploy_proof_chain_static.py\n- bash -n deploy.sh\n- git diff --check