### PR TITLE
chore(sources): add governance audit report

### DIFF
--- a/backend/app/services/source_governance.py
+++ b/backend/app/services/source_governance.py
@@ -1,0 +1,109 @@
+"""Source governance audit helpers.
+
+The public /sources catalog mixes catalog pointers, remote search endpoints,
+local full-text corpora, and primary ingest feeds. These helpers turn that
+metadata into small review queues for health and rights clean-up.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+
+def _primary_ingest_distributions(source: Any) -> list[Any]:
+    return [
+        dist
+        for dist in getattr(source, "distributions", []) or []
+        if getattr(dist, "is_active", False) and getattr(dist, "is_primary_ingest", False)
+    ]
+
+
+def _has_fulltext_surface(source: Any) -> bool:
+    return any(
+        bool(getattr(source, attr, False))
+        for attr in ("supports_fulltext", "has_local_fulltext", "has_remote_fulltext")
+    )
+
+
+def _has_any_product_surface(source: Any) -> bool:
+    return any(
+        bool(getattr(source, attr, False))
+        for attr in (
+            "supports_search",
+            "supports_fulltext",
+            "has_local_fulltext",
+            "has_remote_fulltext",
+            "supports_api",
+            "supports_iiif",
+        )
+    )
+
+
+def _needs_license_review(source: Any) -> bool:
+    if not (_has_fulltext_surface(source) or _primary_ingest_distributions(source)):
+        return False
+    return any(
+        value is None or value == ""
+        for value in (
+            getattr(source, "license_spdx", None),
+            getattr(source, "license_verified_at", None),
+            getattr(source, "embedding_allowed", None),
+            getattr(source, "redistribution_allowed", None),
+        )
+    )
+
+
+def build_source_governance_report(sources: list[Any]) -> dict[str, Any]:
+    """Build a deterministic governance summary for active data sources."""
+
+    active_sources = [source for source in sources if getattr(source, "is_active", False)]
+    health_counts = Counter(getattr(source, "health_status", "unknown") or "unknown" for source in active_sources)
+
+    primary_ingest_codes: list[str] = []
+    health_review_codes: list[str] = []
+    license_review_codes: list[str] = []
+    catalog_only_codes: list[str] = []
+    missing_primary_ingest_codes: list[str] = []
+
+    for source in active_sources:
+        code = getattr(source, "code", "")
+        primary_distributions = _primary_ingest_distributions(source)
+        if primary_distributions:
+            primary_ingest_codes.append(code)
+        if (getattr(source, "health_status", "ok") or "ok") != "ok":
+            health_review_codes.append(code)
+        if _needs_license_review(source):
+            license_review_codes.append(code)
+        if (
+            (getattr(source, "health_status", "ok") or "ok") == "ok"
+            and not _has_any_product_surface(source)
+            and not primary_distributions
+        ):
+            catalog_only_codes.append(code)
+        if _has_fulltext_surface(source) and not primary_distributions:
+            missing_primary_ingest_codes.append(code)
+
+    return {
+        "total_active": len(active_sources),
+        "health_status_counts": dict(sorted(health_counts.items())),
+        "health_review_codes": health_review_codes,
+        "license_review_codes": license_review_codes,
+        "catalog_only_codes": catalog_only_codes,
+        "missing_primary_ingest_codes": missing_primary_ingest_codes,
+        "local_or_remote_fulltext_count": sum(1 for source in active_sources if _has_fulltext_surface(source)),
+        "primary_ingest_count": len(primary_ingest_codes),
+        "primary_ingest_codes": primary_ingest_codes,
+        "missing_license_spdx_count": sum(
+            1 for source in active_sources if not getattr(source, "license_spdx", None)
+        ),
+        "missing_license_verified_count": sum(
+            1 for source in active_sources if getattr(source, "license_verified_at", None) is None
+        ),
+        "embedding_unknown_count": sum(
+            1 for source in active_sources if getattr(source, "embedding_allowed", None) is None
+        ),
+        "redistribution_unknown_count": sum(
+            1 for source in active_sources if getattr(source, "redistribution_allowed", None) is None
+        ),
+    }

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -47,3 +47,5 @@
 ### 诊断工具（可重复运行）
 
 - `audit_*.py`、`check_*.py`、`validate_*.py`、`show_data_sources.py`
+- `audit_source_governance.py` — 汇总数据源健康、license 元数据、主导入渠道、
+  catalog-only 覆盖缺口；支持 `--json` 供后续治理批次使用。

--- a/backend/scripts/audit_source_governance.py
+++ b/backend/scripts/audit_source_governance.py
@@ -1,0 +1,72 @@
+"""Audit source health, ingest coverage, and license metadata gaps.
+
+Usage:
+    cd backend
+    python -m scripts.audit_source_governance
+    python -m scripts.audit_source_governance --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+
+def _print_text(report: dict) -> None:
+    print("FoJin source governance audit")
+    print("=" * 34)
+    print(f"active sources:              {report['total_active']}")
+    print(f"health status counts:        {report['health_status_counts']}")
+    print(f"health review queue:         {len(report['health_review_codes'])}")
+    print(f"license review queue:        {len(report['license_review_codes'])}")
+    print(f"catalog-only sources:        {len(report['catalog_only_codes'])}")
+    print(f"fulltext-capable sources:    {report['local_or_remote_fulltext_count']}")
+    print(f"primary ingest sources:      {report['primary_ingest_count']}")
+    print(f"missing SPDX count:          {report['missing_license_spdx_count']}")
+    print(f"missing license verified:    {report['missing_license_verified_count']}")
+    print(f"embedding unknown count:     {report['embedding_unknown_count']}")
+    print(f"redistribution unknown count:{report['redistribution_unknown_count']}")
+
+    for title, key in [
+        ("Health review codes", "health_review_codes"),
+        ("License review codes", "license_review_codes"),
+        ("Missing primary ingest codes", "missing_primary_ingest_codes"),
+        ("Catalog-only codes", "catalog_only_codes"),
+    ]:
+        codes = report[key]
+        print(f"\n{title} ({len(codes)}):")
+        print("  " + ", ".join(codes) if codes else "  none")
+
+
+async def _load_report() -> dict:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from app.config import settings
+    from app.services.source import get_all_sources
+    from app.services.source_governance import build_source_governance_report
+
+    engine = create_async_engine(settings.database_url)
+    try:
+        async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            sources = await get_all_sources(session, active_only=True)
+        return build_source_governance_report(sources)
+    finally:
+        await engine.dispose()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args()
+
+    report = await _load_report()
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        _print_text(report)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_source_governance.py
+++ b/backend/tests/test_source_governance.py
@@ -1,0 +1,92 @@
+"""Tests for source governance audit summaries."""
+
+from types import SimpleNamespace
+
+from app.services.source_governance import build_source_governance_report
+
+
+def _dist(code: str, primary: bool = False, active: bool = True):
+    return SimpleNamespace(code=code, is_primary_ingest=primary, is_active=active)
+
+
+def _source(
+    code: str,
+    *,
+    active: bool = True,
+    health: str = "ok",
+    license_spdx: str | None = "CC-BY-4.0",
+    license_verified: object | None = object(),
+    embedding_allowed: bool | None = True,
+    redistribution_allowed: bool | None = True,
+    supports_fulltext: bool = False,
+    has_local_fulltext: bool = False,
+    has_remote_fulltext: bool = False,
+    supports_search: bool = False,
+    supports_api: bool = False,
+    supports_iiif: bool = False,
+    distributions: list[object] | None = None,
+):
+    return SimpleNamespace(
+        code=code,
+        is_active=active,
+        health_status=health,
+        license_spdx=license_spdx,
+        license_verified_at=license_verified,
+        embedding_allowed=embedding_allowed,
+        redistribution_allowed=redistribution_allowed,
+        supports_fulltext=supports_fulltext,
+        has_local_fulltext=has_local_fulltext,
+        has_remote_fulltext=has_remote_fulltext,
+        supports_search=supports_search,
+        supports_api=supports_api,
+        supports_iiif=supports_iiif,
+        distributions=distributions or [],
+    )
+
+
+def test_governance_report_prioritizes_license_gaps_for_ingested_fulltext_sources():
+    sources = [
+        _source(
+            "cbeta",
+            has_local_fulltext=True,
+            supports_fulltext=True,
+            distributions=[_dist("cbeta-xml", primary=True)],
+        ),
+        _source(
+            "unknown-fulltext",
+            has_remote_fulltext=True,
+            supports_fulltext=True,
+            license_spdx=None,
+            license_verified=None,
+            embedding_allowed=None,
+            distributions=[_dist("unknown-dump", primary=True)],
+        ),
+        _source("catalog-only", license_spdx=None, license_verified=None),
+        _source("dead-site", health="unreachable"),
+        _source("inactive-source", active=False, health="unreachable", license_spdx=None),
+    ]
+
+    report = build_source_governance_report(sources)
+
+    assert report["total_active"] == 4
+    assert report["health_status_counts"] == {"ok": 3, "unreachable": 1}
+    assert report["health_review_codes"] == ["dead-site"]
+    assert report["license_review_codes"] == ["unknown-fulltext"]
+    assert report["catalog_only_codes"] == ["catalog-only"]
+    assert report["local_or_remote_fulltext_count"] == 2
+    assert report["primary_ingest_count"] == 2
+    assert report["missing_license_spdx_count"] == 2
+    assert report["missing_license_verified_count"] == 2
+    assert report["embedding_unknown_count"] == 1
+
+
+def test_governance_report_flags_fulltext_without_primary_ingest_distribution():
+    sources = [
+        _source("sc", supports_fulltext=True, has_remote_fulltext=True),
+        _source("iiif-only", supports_iiif=True),
+    ]
+
+    report = build_source_governance_report(sources)
+
+    assert report["missing_primary_ingest_codes"] == ["sc"]
+    assert report["catalog_only_codes"] == []


### PR DESCRIPTION
## Summary\n- add a source governance summary helper for health, license, ingest, and catalog-only review queues\n- add a repeatable audit_source_governance CLI with text and JSON output\n- document the script in backend/scripts/README.md\n\n## Validation\n- cd backend && python3 -m pytest tests/test_source_governance.py -q\n- cd backend && python3 -m ruff check app/services/source_governance.py scripts/audit_source_governance.py tests/test_source_governance.py\n- cd backend && python3 -m scripts.audit_source_governance --help\n- git diff --check