### PR TITLE
[codex] Localize topic content data

### DIFF
--- a/frontend/scripts/i18n-baseline.json
+++ b/frontend/scripts/i18n-baseline.json
@@ -1,6 +1,5 @@
 {
   "src/data/collections.ts": 1166,
   "src/data/popularSutras.ts": 157,
-  "src/data/topics.ts": 74,
   "src/data/dynasty_years.ts": 46
 }

--- a/frontend/src/content/topicLocales/en.json
+++ b/frontend/src/content/topicLocales/en.json
@@ -1,0 +1,174 @@
+{
+  "prajna": {
+    "name": "Prajna Classics",
+    "description": "A family of texts centered on emptiness wisdom, from the concise Heart Sutra to the vast Great Prajnaparamita collection.",
+    "searchQuery": "般若",
+    "texts": [
+      {
+        "title": "Heart Sutra",
+        "description": "The shortest and most distilled Prajnaparamita text, summarizing the heart of prajna thought in 260 Chinese characters."
+      },
+      {
+        "title": "Diamond Sutra",
+        "description": "Uses the diamond as an image for prajna wisdom and became a major scriptural basis for Chan Buddhism."
+      },
+      {
+        "title": "Large Prajnaparamita Sutra",
+        "description": "An important Prajnaparamita translation by Kumarajiva."
+      },
+      {
+        "title": "Great Prajnaparamita Sutra",
+        "description": "Xuanzang's 600-fascicle collection, the most comprehensive Chinese Prajnaparamita corpus."
+      }
+    ]
+  },
+  "pureland": {
+    "name": "Pure Land Five Scriptures",
+    "description": "Core Pure Land texts describing Sukhavati and the path of rebirth through Amitabha practice.",
+    "searchQuery": "净土",
+    "texts": [
+      {
+        "title": "Amitabha Sutra",
+        "description": "One of the Three Pure Land Sutras and the most widely recited Pure Land scripture."
+      },
+      {
+        "title": "Infinite Life Sutra",
+        "description": "Presents Amitabha Buddha's Forty-eight Vows in detail."
+      },
+      {
+        "title": "Contemplation Sutra",
+        "description": "Teaches the sixteen contemplations and the nine grades of rebirth."
+      },
+      {
+        "title": "Dashizhi Bodhisattva's Perfect Penetration Through Buddha Recitation",
+        "description": "A concise teaching on Buddha-recitation practice from the Shurangama Sutra."
+      },
+      {
+        "title": "Samantabhadra's Aspiration Chapter",
+        "description": "From the Avatamsaka Sutra, directing the ten great vows toward rebirth in Sukhavati."
+      }
+    ]
+  },
+  "lotus": {
+    "name": "Lotus Classics",
+    "description": "Foundational Tiantai texts centered on revealing the real through the provisional and unifying the three vehicles.",
+    "searchQuery": "法华",
+    "texts": [
+      {
+        "title": "Lotus Sutra",
+        "description": "Kumarajiva's translation and the foundational scripture of Tiantai Buddhism."
+      },
+      {
+        "title": "Zhengfa Hua Sutra",
+        "description": "Dharmaraksha's translation, the earliest Chinese translation of the Lotus Sutra."
+      },
+      {
+        "title": "Sutra on the Practice of Contemplating Samantabhadra",
+        "description": "One of the three Lotus scriptures, focused on repentance and purification."
+      }
+    ]
+  },
+  "chan": {
+    "name": "Chan Texts",
+    "description": "Core scriptures, recorded sayings, lamp records, and koan collections for direct pointing and seeing one's nature.",
+    "searchQuery": "禅宗",
+    "texts": [
+      {
+        "title": "Platform Sutra of the Sixth Patriarch",
+        "description": "Teachings of Huineng, the Sixth Patriarch of Chan, and the only Chinese Buddhist patriarchal work called a sutra."
+      },
+      {
+        "title": "Jingde Record of the Transmission of the Lamp",
+        "description": "A representative lamp-record text preserving Chan lineage accounts."
+      },
+      {
+        "title": "Blue Cliff Record",
+        "description": "Yuanwu Keqin's annotated collection, often called the foremost Chan koan book."
+      },
+      {
+        "title": "Compendium of the Five Lamps",
+        "description": "A comprehensive compilation of five lamp records and Chan encounter dialogues."
+      }
+    ]
+  },
+  "vinaya": {
+    "name": "Vinaya Selections",
+    "description": "Buddhist disciplinary texts on monastic life, communal order, and practice norms.",
+    "searchQuery": "律藏",
+    "texts": [
+      {
+        "title": "Four-Part Vinaya",
+        "description": "Dharmaguptaka Vinaya, the most widely used vinaya tradition in Chinese Buddhism."
+      },
+      {
+        "title": "Brahma Net Sutra",
+        "description": "A foundational Mahayana bodhisattva precepts text."
+      },
+      {
+        "title": "Mahasamghika Vinaya",
+        "description": "The vinaya text of the Mahasamghika school."
+      }
+    ]
+  },
+  "agama": {
+    "name": "Agama / Nikaya",
+    "description": "Early scriptures shared across northern and southern traditions, preserving direct records of the Buddha's early teachings.",
+    "searchQuery": "阿含",
+    "texts": [
+      {
+        "title": "Dirgha Agama",
+        "description": "A 22-fascicle collection corresponding to the Pali Digha Nikaya, including texts such as the Mahaparinirvana Sutra."
+      },
+      {
+        "title": "Madhyama Agama",
+        "description": "A 60-fascicle collection corresponding to the Pali Majjhima Nikaya."
+      },
+      {
+        "title": "Samyukta Agama",
+        "description": "A 50-fascicle collection corresponding to the Pali Samyutta Nikaya and close to early Buddhist teaching strata."
+      },
+      {
+        "title": "Ekottarika Agama",
+        "description": "A 51-fascicle collection corresponding to the Pali Anguttara Nikaya."
+      }
+    ]
+  },
+  "yogacara": {
+    "name": "Yogacara Texts",
+    "description": "Core Yogacara scriptures and treatises analyzing the structure and transformation of consciousness.",
+    "searchQuery": "唯识",
+    "texts": [
+      {
+        "title": "Samdhinirmocana Sutra",
+        "description": "A foundational Yogacara scripture and classic statement of the three-turnings teaching."
+      },
+      {
+        "title": "Cheng Weishi Lun",
+        "description": "Xuanzang's synthetic translation and a defining work of East Asian Yogacara."
+      },
+      {
+        "title": "Yogacarabhumi",
+        "description": "A 100-fascicle Yogacara encyclopedia attributed to Maitreya and transmitted by Asanga."
+      },
+      {
+        "title": "Mahayanasamgraha",
+        "description": "Asanga's concise outline of Yogacara thought."
+      }
+    ]
+  },
+  "avatamsaka": {
+    "name": "Avatamsaka Classics",
+    "description": "Foundational Huayan texts presenting dharmadhatu dependent arising and the unobstructed interpenetration of all phenomena.",
+    "searchQuery": "华严",
+    "texts": [
+      {
+        "title": "Avatamsaka Sutra",
+        "description": "The 80-fascicle translation by Shikshananda and the central scripture of Huayan Buddhism."
+      },
+      {
+        "title": "Avatamsaka Sutra (Sixty-Fascicle Version)",
+        "description": "The 60-fascicle translation by Buddhabhadra."
+      }
+    ]
+  }
+}

--- a/frontend/src/content/topicLocales/zh-Hant.json
+++ b/frontend/src/content/topicLocales/zh-Hant.json
@@ -1,0 +1,87 @@
+{
+  "prajna": {
+    "name": "般若系經典",
+    "description": "以空性智慧為核心的經典群，從《心經》260字的精要到《大般若經》600卷的浩瀚。",
+    "searchQuery": "般若",
+    "texts": [
+      { "title": "般若波羅蜜多心經", "description": "最簡短的般若經典，260字概括般若思想精髓" },
+      { "title": "金剛般若波羅蜜經", "description": "以金剛喻般若智慧，禪宗重要依據經典" },
+      { "title": "摩訶般若波羅蜜經", "description": "鳩摩羅什譯，般若系重要經典" },
+      { "title": "大般若波羅蜜多經", "description": "玄奘譯，600卷，般若類經典集大成" }
+    ]
+  },
+  "pureland": {
+    "name": "淨土五經",
+    "description": "淨土宗核心經典，描述西方極樂世界及往生法門。",
+    "searchQuery": "淨土",
+    "texts": [
+      { "title": "佛說阿彌陀經", "description": "淨土三經之一，最廣為流傳的淨土經典" },
+      { "title": "佛說無量壽經", "description": "詳述阿彌陀佛四十八願" },
+      { "title": "佛說觀無量壽佛經", "description": "十六觀法與九品往生" },
+      { "title": "大勢至菩薩念佛圓通章", "description": "出自《楞嚴經》，念佛法門精要" },
+      { "title": "普賢菩薩行願品", "description": "出自《華嚴經》，十大願王導歸極樂" }
+    ]
+  },
+  "lotus": {
+    "name": "法華系經典",
+    "description": "天台宗根本經典，開權顯實，會三歸一。",
+    "searchQuery": "法華",
+    "texts": [
+      { "title": "妙法蓮華經", "description": "鳩摩羅什譯，天台宗根本經典" },
+      { "title": "正法華經", "description": "竺法護譯，法華經最早漢譯本" },
+      { "title": "觀普賢菩薩行法經", "description": "法華三部之一，懺悔滅罪" }
+    ]
+  },
+  "chan": {
+    "name": "禪宗典籍",
+    "description": "直指人心、見性成佛，禪宗的核心經典與語錄。",
+    "searchQuery": "禪宗",
+    "texts": [
+      { "title": "六祖大師法寶壇經", "description": "禪宗六祖惠能說法，中國佛教唯一稱「經」的祖師著作" },
+      { "title": "景德傳燈錄", "description": "禪宗燈錄體代表作，記錄歷代禪師傳承" },
+      { "title": "碧巖錄", "description": "圓悟克勤評唱，禪門第一書" },
+      { "title": "五燈會元", "description": "五部燈錄彙編，禪宗公案大全" }
+    ]
+  },
+  "vinaya": {
+    "name": "律藏精選",
+    "description": "佛教戒律典籍，僧團生活與修行規範。",
+    "searchQuery": "律藏",
+    "texts": [
+      { "title": "四分律", "description": "法藏部律典，漢傳佛教最通行的律典" },
+      { "title": "梵網經", "description": "大乘菩薩戒經典" },
+      { "title": "摩訶僧祇律", "description": "大眾部律典" }
+    ]
+  },
+  "agama": {
+    "name": "阿含/尼柯耶",
+    "description": "佛陀原始教法的直接記錄，南北傳共有的早期經典。",
+    "searchQuery": "阿含",
+    "texts": [
+      { "title": "長阿含經", "description": "22卷，對應巴利長部，含大般涅槃經等" },
+      { "title": "中阿含經", "description": "60卷，對應巴利中部" },
+      { "title": "雜阿含經", "description": "50卷，對應巴利相應部，最接近原始佛法" },
+      { "title": "增壹阿含經", "description": "51卷，對應巴利增支部" }
+    ]
+  },
+  "yogacara": {
+    "name": "唯識經論",
+    "description": "瑜伽行派（唯識宗）核心經論，深入分析心識結構。",
+    "searchQuery": "唯識",
+    "texts": [
+      { "title": "解深密經", "description": "唯識學根本經典，三轉法輪" },
+      { "title": "成唯識論", "description": "玄奘糅譯，唯識學集大成之作" },
+      { "title": "瑜伽師地論", "description": "彌勒說、無著記，100卷瑜伽行派百科全書" },
+      { "title": "攝大乘論", "description": "無著造，唯識學綱要" }
+    ]
+  },
+  "avatamsaka": {
+    "name": "華嚴系經典",
+    "description": "華嚴宗根本經典，法界緣起、事事無礙的圓融世界觀。",
+    "searchQuery": "華嚴",
+    "texts": [
+      { "title": "大方廣佛華嚴經", "description": "實叉難陀譯80卷本，華嚴宗根本經典" },
+      { "title": "大方廣佛華嚴經（六十華嚴）", "description": "佛馱跋陀羅譯60卷本" }
+    ]
+  }
+}

--- a/frontend/src/content/topicLocales/zh.json
+++ b/frontend/src/content/topicLocales/zh.json
@@ -1,0 +1,87 @@
+{
+  "prajna": {
+    "name": "般若系经典",
+    "description": "以空性智慧为核心的经典群，从《心经》260字的精要到《大般若经》600卷的浩瀚。",
+    "searchQuery": "般若",
+    "texts": [
+      { "title": "般若波罗蜜多心经", "description": "最简短的般若经典，260字概括般若思想精髓" },
+      { "title": "金刚般若波罗蜜经", "description": "以金刚喻般若智慧，禅宗重要依据经典" },
+      { "title": "摩诃般若波罗蜜经", "description": "鸠摩罗什译，般若系重要经典" },
+      { "title": "大般若波罗蜜多经", "description": "玄奘译，600卷，般若类经典集大成" }
+    ]
+  },
+  "pureland": {
+    "name": "净土五经",
+    "description": "净土宗核心经典，描述西方极乐世界及往生法门。",
+    "searchQuery": "净土",
+    "texts": [
+      { "title": "佛说阿弥陀经", "description": "净土三经之一，最广为流传的净土经典" },
+      { "title": "佛说无量寿经", "description": "详述阿弥陀佛四十八愿" },
+      { "title": "佛说观无量寿佛经", "description": "十六观法与九品往生" },
+      { "title": "大势至菩萨念佛圆通章", "description": "出自《楞严经》，念佛法门精要" },
+      { "title": "普贤菩萨行愿品", "description": "出自《华严经》，十大愿王导归极乐" }
+    ]
+  },
+  "lotus": {
+    "name": "法华系经典",
+    "description": "天台宗根本经典，开权显实，会三归一。",
+    "searchQuery": "法华",
+    "texts": [
+      { "title": "妙法莲华经", "description": "鸠摩罗什译，天台宗根本经典" },
+      { "title": "正法华经", "description": "竺法护译，法华经最早汉译本" },
+      { "title": "观普贤菩萨行法经", "description": "法华三部之一，忏悔灭罪" }
+    ]
+  },
+  "chan": {
+    "name": "禅宗典籍",
+    "description": "直指人心、见性成佛，禅宗的核心经典与语录。",
+    "searchQuery": "禅宗",
+    "texts": [
+      { "title": "六祖大师法宝坛经", "description": "禅宗六祖惠能说法，中国佛教唯一称'经'的祖师著作" },
+      { "title": "景德传灯录", "description": "禅宗灯录体代表作，记录历代禅师传承" },
+      { "title": "碧岩录", "description": "圆悟克勤评唱，禅门第一书" },
+      { "title": "五灯会元", "description": "五部灯录汇编，禅宗公案大全" }
+    ]
+  },
+  "vinaya": {
+    "name": "律藏精选",
+    "description": "佛教戒律典籍，僧团生活与修行规范。",
+    "searchQuery": "律藏",
+    "texts": [
+      { "title": "四分律", "description": "法藏部律典，汉传佛教最通行的律典" },
+      { "title": "梵网经", "description": "大乘菩萨戒经典" },
+      { "title": "摩诃僧祇律", "description": "大众部律典" }
+    ]
+  },
+  "agama": {
+    "name": "阿含/尼柯耶",
+    "description": "佛陀原始教法的直接记录，南北传共有的早期经典。",
+    "searchQuery": "阿含",
+    "texts": [
+      { "title": "长阿含经", "description": "22卷，对应巴利长部，含大般涅槃经等" },
+      { "title": "中阿含经", "description": "60卷，对应巴利中部" },
+      { "title": "杂阿含经", "description": "50卷，对应巴利相应部，最接近原始佛法" },
+      { "title": "增壹阿含经", "description": "51卷，对应巴利增支部" }
+    ]
+  },
+  "yogacara": {
+    "name": "唯识经论",
+    "description": "瑜伽行派（唯识宗）核心经论，深入分析心识结构。",
+    "searchQuery": "唯识",
+    "texts": [
+      { "title": "解深密经", "description": "唯识学根本经典，三转法轮" },
+      { "title": "成唯识论", "description": "玄奘糅译，唯识学集大成之作" },
+      { "title": "瑜伽师地论", "description": "弥勒说、无著记，100卷瑜伽行派百科全书" },
+      { "title": "摄大乘论", "description": "无著造，唯识学纲要" }
+    ]
+  },
+  "avatamsaka": {
+    "name": "华严系经典",
+    "description": "华严宗根本经典，法界缘起、事事无碍的圆融世界观。",
+    "searchQuery": "华严",
+    "texts": [
+      { "title": "大方广佛华严经", "description": "实叉难陀译80卷本，华严宗根本经典" },
+      { "title": "大方广佛华严经（六十华严）", "description": "佛驮跋陀罗译60卷本" }
+    ]
+  }
+}

--- a/frontend/src/data/topics.ts
+++ b/frontend/src/data/topics.ts
@@ -1,3 +1,7 @@
+import topicsEn from "../content/topicLocales/en.json";
+import topicsZhHant from "../content/topicLocales/zh-Hant.json";
+import topicsZh from "../content/topicLocales/zh.json";
+
 export interface TopicText {
   title: string;
   textId?: number;
@@ -9,101 +13,67 @@ export interface Topic {
   name: string;
   icon: string;
   description: string;
+  searchQuery: string;
   texts: TopicText[];
 }
 
-export const TOPICS: Topic[] = [
-  {
-    id: "prajna",
-    name: "般若系经典",
-    icon: "\u{1F4DC}",
-    description: "以空性智慧为核心的经典群，从《心经》260字的精要到《大般若经》600卷的浩瀚。",
-    texts: [
-      { title: "般若波罗蜜多心经", description: "最简短的般若经典，260字概括般若思想精髓" },
-      { title: "金刚般若波罗蜜经", description: "以金刚喻般若智慧，禅宗重要依据经典" },
-      { title: "摩诃般若波罗蜜经", description: "鸠摩罗什译，般若系重要经典" },
-      { title: "大般若波罗蜜多经", description: "玄奘译，600卷，般若类经典集大成" },
-    ],
-  },
-  {
-    id: "pureland",
-    name: "净土五经",
-    icon: "\u{1FAB7}",
-    description: "净土宗核心经典，描述西方极乐世界及往生法门。",
-    texts: [
-      { title: "佛说阿弥陀经", description: "净土三经之一，最广为流传的净土经典" },
-      { title: "佛说无量寿经", description: "详述阿弥陀佛四十八愿" },
-      { title: "佛说观无量寿佛经", description: "十六观法与九品往生" },
-      { title: "大势至菩萨念佛圆通章", description: "出自《楞严经》，念佛法门精要" },
-      { title: "普贤菩萨行愿品", description: "出自《华严经》，十大愿王导归极乐" },
-    ],
-  },
-  {
-    id: "lotus",
-    name: "法华系经典",
-    icon: "\u{1F338}",
-    description: "天台宗根本经典，开权显实，会三归一。",
-    texts: [
-      { title: "妙法莲华经", description: "鸠摩罗什译，天台宗根本经典" },
-      { title: "正法华经", description: "竺法护译，法华经最早汉译本" },
-      { title: "观普贤菩萨行法经", description: "法华三部之一，忏悔灭罪" },
-    ],
-  },
-  {
-    id: "chan",
-    name: "禅宗典籍",
-    icon: "\u{1F9D8}",
-    description: "直指人心、见性成佛，禅宗的核心经典与语录。",
-    texts: [
-      { title: "六祖大师法宝坛经", description: "禅宗六祖惠能说法，中国佛教唯一称'经'的祖师著作" },
-      { title: "景德传灯录", description: "禅宗灯录体代表作，记录历代禅师传承" },
-      { title: "碧岩录", description: "圆悟克勤评唱，禅门第一书" },
-      { title: "五灯会元", description: "五部灯录汇编，禅宗公案大全" },
-    ],
-  },
-  {
-    id: "vinaya",
-    name: "律藏精选",
-    icon: "\u{1F4CF}",
-    description: "佛教戒律典籍，僧团生活与修行规范。",
-    texts: [
-      { title: "四分律", description: "法藏部律典，汉传佛教最通行的律典" },
-      { title: "梵网经", description: "大乘菩萨戒经典" },
-      { title: "摩诃僧祇律", description: "大众部律典" },
-    ],
-  },
-  {
-    id: "agama",
-    name: "阿含/尼柯耶",
-    icon: "\u{1F4D6}",
-    description: "佛陀原始教法的直接记录，南北传共有的早期经典。",
-    texts: [
-      { title: "长阿含经", description: "22卷，对应巴利长部，含大般涅槃经等" },
-      { title: "中阿含经", description: "60卷，对应巴利中部" },
-      { title: "杂阿含经", description: "50卷，对应巴利相应部，最接近原始佛法" },
-      { title: "增壹阿含经", description: "51卷，对应巴利增支部" },
-    ],
-  },
-  {
-    id: "yogacara",
-    name: "唯识经论",
-    icon: "\u{1F50D}",
-    description: "瑜伽行派（唯识宗）核心经论，深入分析心识结构。",
-    texts: [
-      { title: "解深密经", description: "唯识学根本经典，三转法轮" },
-      { title: "成唯识论", description: "玄奘糅译，唯识学集大成之作" },
-      { title: "瑜伽师地论", description: "弥勒说、无著记，100卷瑜伽行派百科全书" },
-      { title: "摄大乘论", description: "无著造，唯识学纲要" },
-    ],
-  },
-  {
-    id: "avatamsaka",
-    name: "华严系经典",
-    icon: "\u2728",
-    description: "华严宗根本经典，法界缘起、事事无碍的圆融世界观。",
-    texts: [
-      { title: "大方广佛华严经", description: "实叉难陀译80卷本，华严宗根本经典" },
-      { title: "大方广佛华严经（六十华严）", description: "佛驮跋陀罗译60卷本" },
-    ],
-  },
+interface TopicBase {
+  id: Topic["id"];
+  icon: string;
+}
+
+interface TopicLocaleContent {
+  name: string;
+  description: string;
+  searchQuery: string;
+  texts: TopicText[];
+}
+
+type TopicLocaleMap = Record<string, TopicLocaleContent>;
+type TopicLocaleKey = "en" | "zh" | "zh-Hant";
+
+const TOPIC_BASE: TopicBase[] = [
+  { id: "prajna", icon: "\u{1F4DC}" },
+  { id: "pureland", icon: "\u{1FAB7}" },
+  { id: "lotus", icon: "\u{1F338}" },
+  { id: "chan", icon: "\u{1F9D8}" },
+  { id: "vinaya", icon: "\u{1F4CF}" },
+  { id: "agama", icon: "\u{1F4D6}" },
+  { id: "yogacara", icon: "\u{1F50D}" },
+  { id: "avatamsaka", icon: "\u2728" },
 ];
+
+const TOPIC_LOCALES: Record<TopicLocaleKey, TopicLocaleMap> = {
+  en: topicsEn,
+  zh: topicsZh,
+  "zh-Hant": topicsZhHant,
+};
+
+function normalizeTopicLocale(language: string): TopicLocaleKey {
+  if (language.startsWith("en")) return "en";
+  if (
+    language.startsWith("zh-Hant") ||
+    language.startsWith("zh-TW") ||
+    language.startsWith("zh-HK")
+  ) {
+    return "zh-Hant";
+  }
+  return "zh";
+}
+
+export function getLocalizedTopics(language: string): Topic[] {
+  const locale = normalizeTopicLocale(language);
+  const content = TOPIC_LOCALES[locale];
+  const fallback = TOPIC_LOCALES.zh;
+
+  return TOPIC_BASE.map((topic) => {
+    const localized = content[topic.id] ?? fallback[topic.id];
+    return {
+      id: topic.id,
+      icon: topic.icon,
+      ...localized,
+    };
+  });
+}
+
+export const TOPICS: Topic[] = getLocalizedTopics("zh");

--- a/frontend/src/pages/RemainingPageI18n.test.tsx
+++ b/frontend/src/pages/RemainingPageI18n.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import type { ReactElement } from "react";
 import i18n from "../i18n";
 import enTranslation from "../../public/locales/en/translation.json";
@@ -82,6 +82,11 @@ function renderWithProviders(ui: ReactElement, initialEntries = ["/"]) {
       </QueryClientProvider>
     </HelmetProvider>,
   );
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
 }
 
 const overview: AdminOverview = {
@@ -352,6 +357,34 @@ describe("remaining page i18n", () => {
     expect(screen.getByText(/topics/)).toBeInTheDocument();
     fireEvent.click(document.querySelector(".topic-card-header")!);
     expect(screen.getByRole("button", { name: /Search related texts on FoJin/ })).toBeInTheDocument();
+  });
+
+  it("renders topic content from locale data while keeping canonical search queries", async () => {
+    renderWithProviders(
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <>
+              <TopicsPage />
+              <LocationProbe />
+            </>
+          }
+        />
+        <Route path="/search" element={<LocationProbe />} />
+      </Routes>,
+    );
+
+    expect(screen.getByText("Prajna Classics")).toBeInTheDocument();
+    expect(screen.getByText(/emptiness wisdom/)).toBeInTheDocument();
+    expect(screen.queryByText("般若系经典")).not.toBeInTheDocument();
+
+    fireEvent.click(document.querySelector(".topic-card-header")!);
+    expect(screen.getByText("Heart Sutra")).toBeInTheDocument();
+    expect(screen.queryByText("般若波罗蜜多心经")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Search related texts on FoJin/ }));
+    expect(screen.getByTestId("location")).toHaveTextContent("/search?q=%E8%88%AC%E8%8B%A5");
   });
 
   it("renders home visitor tip in the active UI language", async () => {

--- a/frontend/src/pages/TopicsPage.tsx
+++ b/frontend/src/pages/TopicsPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { Empty } from "antd";
 import { SearchOutlined, VerticalAlignTopOutlined } from "@ant-design/icons";
-import { TOPICS, type Topic } from "../data/topics";
+import { getLocalizedTopics, type Topic } from "../data/topics";
 import "../styles/sources.css";
 import "../styles/topics.css";
 import { useEffect } from "react";
@@ -45,7 +45,7 @@ function TopicCard({ topic }: { topic: Topic }) {
           <div className="topic-card-actions">
             <button
               className="source-btn source-btn-search"
-              onClick={() => navigate(`/search?q=${encodeURIComponent(topic.name.replace(/系经典|经论|典籍|精选/g, ""))}`)}
+              onClick={() => navigate(`/search?q=${encodeURIComponent(topic.searchQuery)}`)}
             >
               <SearchOutlined /> {t("topics.card.search_related")}
             </button>
@@ -57,8 +57,9 @@ function TopicCard({ topic }: { topic: Topic }) {
 }
 
 export default function TopicsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [showTop, setShowTop] = useState(false);
+  const topics = getLocalizedTopics(i18n.language);
 
   useEffect(() => {
     const onScroll = () => setShowTop(window.scrollY > 400);
@@ -66,7 +67,7 @@ export default function TopicsPage() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
-  const totalTexts = TOPICS.reduce((sum, t) => sum + t.texts.length, 0);
+  const totalTexts = topics.reduce((sum, t) => sum + t.texts.length, 0);
 
   return (
     <div className="sources-page">
@@ -81,15 +82,15 @@ export default function TopicsPage() {
       <div className="sources-header">
         <h1 className="sources-title">{t("topics.page.heading")}</h1>
         <p className="sources-desc">
-          {t("topics.page.summary", { topics: TOPICS.length, texts: totalTexts })}
+          {t("topics.page.summary", { topics: topics.length, texts: totalTexts })}
         </p>
       </div>
 
-      {TOPICS.length === 0 ? (
+      {topics.length === 0 ? (
         <Empty description={t("topics.page.empty")} style={{ marginTop: 60 }} />
       ) : (
         <div className="topic-grid">
-          {TOPICS.map((topic) => (
+          {topics.map((topic) => (
             <TopicCard key={topic.id} topic={topic} />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Move topic page content data into locale JSON files for English, Simplified Chinese, and Traditional Chinese.
- Keep canonical Chinese search queries separate from localized display names.
- Update the i18n hardcoded-string baseline and add regression coverage for localized topic content plus search navigation.

## Validation
- `npx vitest run src/pages/RemainingPageI18n.test.tsx -t "renders topic content" --reporter=dot`
- `npx vitest run src/pages/RemainingPageI18n.test.tsx --reporter=dot`
- `npm run i18n:check`
- `npx eslint src/ --max-warnings 0`
- `npx tsc -b --noEmit`
- `npm run test -- --reporter=dot`
- `npm run build`
- `git diff --check`