### PR TITLE
feat(ops): make CD stalls loud — drift watchdog + stale-lock detection

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -44,6 +44,40 @@ jobs:
           cache: npm
           cache-dependency-path: e2e/package-lock.json
 
+      # Drift watchdog for scheduled runs. The dispatch path below asserts the
+      # deploy that just finished; this asserts CD is alive AT ALL. The 2026-07
+      # incident: dirty VPS worktree made every ff-merge abort, prod silently
+      # froze for 1.5 days while webhooks returned 200 — the only red signal
+      # was an indirect locale-count assertion. Compare what prod actually
+      # runs (/api/version) against master; allow a grace window so a deploy
+      # racing a fresh merge doesn't false-alarm.
+      - name: Assert production tracks master (drift watchdog)
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SERVED=$(curl -sf --max-time 15 -A 'fojin-smoke' https://fojin.app/api/version \
+            | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>console.log(JSON.parse(d).commit||''))" 2>/dev/null || echo "")
+          if [ -z "$SERVED" ]; then
+            echo "::error::/api/version unreachable or missing commit — backend down or running pre-versioning code."
+            exit 1
+          fi
+          echo "prod: $SERVED / master: $GITHUB_SHA"
+          [ "$SERVED" = "$GITHUB_SHA" ] && { echo "in sync"; exit 0; }
+          CMP=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${SERVED}...${GITHUB_SHA}" 2>/dev/null) || {
+            echo "::error::prod commit $SERVED is unknown to this repo — investigate what is deployed."
+            exit 1
+          }
+          BEHIND=$(echo "$CMP" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>console.log(JSON.parse(d).ahead_by))")
+          HEAD_DATE=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}" --jq '.commit.committer.date')
+          AGE_MIN=$(( ($(date +%s) - $(date -d "$HEAD_DATE" +%s)) / 60 ))
+          echo "prod is $BEHIND commit(s) behind; master head is ${AGE_MIN}min old"
+          if [ "$BEHIND" -gt 0 ] && [ "$AGE_MIN" -gt 120 ]; then
+            echo "::error::Production is $BEHIND commit(s) behind a master that has been quiet for ${AGE_MIN}min — CD looks stalled (check VPS deploy.log / worktree cleanliness)."
+            exit 1
+          fi
+          echo "lag within grace window (master head <120min old) — CD may still be rolling out"
+
       - name: Wait for deployed backend commit
         if: github.event_name == 'repository_dispatch'
         env:

--- a/deploy.sh
+++ b/deploy.sh
@@ -129,12 +129,25 @@ dispatch_deploy_success() {
 # 注意: 仓外的 webhook CD 若不经由 deploy.sh, 必须自己也取这把同一文件锁
 # ($STATE_DIR/deploy.lock) 才能完全堵住与它的竞争 — 否则只挡住 deploy.sh 自身。
 # 非阻塞获取: 抢不到锁就干净退出 (另一个 deploy 已在处理同一份代码)。
+# 但"干净退出"不能是无限期的: 若持锁者僵死 (卡住的 build、挂起的 docker),
+# 每次 webhook 都会静默让出, CD 就无声停摆 (2026-07 事故的失败模式之一)。
+# 持锁者把 "PID 时间戳" 写进 holder 文件; 竞争失败时检查锁龄, 超过 45min
+# (正常 build ≤ ~20min) 就以非零退出报僵死, 让 deploy.log / webhook 侧变红。
+# 锁文件本身的 mtime 不可用: 每个竞争者的 `exec 200>` 都会 touch 它。
 DEPLOY_LOCK="$STATE_DIR/deploy.lock"
+LOCK_HOLDER="$STATE_DIR/deploy.holder"
 exec 200>"$DEPLOY_LOCK"
 if ! flock -n 200; then
-  warn "另一个 deploy 正在运行 (lock: $DEPLOY_LOCK) — 退出，避免并发 build 触发 OOM。"
+  holder="$(cat "$LOCK_HOLDER" 2>/dev/null || true)"
+  holder_pid="${holder%% *}"
+  holder_ts="${holder##* }"
+  if [[ "$holder_ts" =~ ^[0-9]+$ ]] && (( $(date +%s) - holder_ts > 2700 )); then
+    fail "deploy.lock 已被 PID ${holder_pid:-?} 持有超过 45min — 疑似僵死。请人工检查该进程 (kill 后重跑 deploy.sh)。"
+  fi
+  warn "另一个 deploy 正在运行 (PID ${holder_pid:-?}, lock: $DEPLOY_LOCK) — 退出，避免并发 build 触发 OOM。"
   exit 0
 fi
+echo "$$ $(date +%s)" > "$LOCK_HOLDER"
 
 # --- 1. 取最新代码 -----------------------------------------------------------
 log "Fetching origin/$BRANCH ..."


### PR DESCRIPTION
## Why

During the 2026-07-02 CD stall (#871), production silently froze for ~1.5 days: webhook deliveries returned 200, `deploy.sh` failed fast on every run (ff-merge refused), and nothing turned red until the twice-daily smoke run tripped over an indirect symptom (locale key count). Two hardening measures so the next stall — whatever its cause — surfaces within hours:

## What

**`.github/workflows/smoke.yml`** — scheduled runs get a drift watchdog before the suite: fetch `/api/version` from prod, compare against `master` via the GitHub compare API. If prod is ≥1 commit behind **and** master's head has been quiet for >120 min (grace window for in-flight rollouts), the run fails with an actionable error pointing at the VPS deploy log / worktree. Also fails if `/api/version` is unreachable or reports a commit unknown to the repo. The dispatch path keeps its existing post-deploy assertion — this one catches "CD is dead entirely".

**`deploy.sh`** — the winner of the deploy lock now records `PID timestamp` into `.deploy-state/deploy.holder`. On lock contention, if the holder is >45 min old (a normal full build is ≤~20 min) the script exits **1** with a "suspected wedged deploy" error instead of the old unconditional silent `exit 0`, which let a wedged holder turn every subsequent webhook into a successful no-op forever. Fresh contention keeps the old quiet-yield behavior. Lock-file mtime is unusable for aging because every contender's `exec 200>` touches it — hence the sidecar file.

Verified: `bash -n` clean, YAML parses, stale/fresh/missing-holder branches exercised in simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)