### PR TITLE
fix(frontend): resolve all react-hooks 7.x violations, bump plugin to 7.1.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,7 +53,7 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^6.0.3",
         "eslint": "^9.39.4",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "jsdom": "^29.0.1",
         "msw": "^2.14.6",
@@ -9224,16 +9224,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -10243,6 +10250,23 @@
       "dependencies": {
         "@types/set-cookie-parser": "^2.4.10",
         "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -17775,6 +17799,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zstd-codec": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.3",
     "eslint": "^9.39.4",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "jsdom": "^29.0.1",
     "msw": "^2.14.6",

--- a/frontend/src/components/ReaderAIPanel.tsx
+++ b/frontend/src/components/ReaderAIPanel.tsx
@@ -106,7 +106,7 @@ export default function ReaderAIPanel({
   const [sessionId, setSessionId] = useState<number | undefined>();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const streamingIdRef = useRef(0);
+  const [streamingId, setStreamingId] = useState(0);
   const consumedRef = useRef(false);
 
   // When selectedText changes, auto-fill it as a question
@@ -144,7 +144,7 @@ export default function ReaderAIPanel({
     };
 
     const assistantId = Date.now() + 1;
-    streamingIdRef.current = assistantId;
+    setStreamingId(assistantId);
     const assistantMsg: ChatMessageItem = {
       id: assistantId,
       role: "assistant",
@@ -217,7 +217,7 @@ export default function ReaderAIPanel({
       onDone: () => {
         clearTimeout(timeoutId);
         abortRef.current = null;
-        streamingIdRef.current = 0;
+        setStreamingId(0);
         setSending(false);
       },
     }, { signal: abortController.signal, readingContext });
@@ -287,7 +287,7 @@ export default function ReaderAIPanel({
         )}
         {messages.map((m) => {
           const isAssistant = m.role === "assistant";
-          const isStreaming = isAssistant && m.id === streamingIdRef.current && sending;
+          const isStreaming = isAssistant && m.id === streamingId && sending;
           const { cleanContent, suggestions } = isAssistant
             ? parseFollowUps(m.content)
             : { cleanContent: m.content, suggestions: [] };

--- a/frontend/src/components/ReaderParallelPanel.tsx
+++ b/frontend/src/components/ReaderParallelPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Empty, Spin, Alert, Collapse, Tag, Progress, Tabs, Button } from "antd";
 import { LinkOutlined, BookOutlined, ExpandAltOutlined } from "@ant-design/icons";
@@ -395,7 +395,11 @@ export default function ReaderParallelPanel({ textId, juanNum }: Props) {
   // shares CanonicalView's cache key (deduped). activeKey=undefined means
   // "auto"; a user click pins it. Reset on textId change so auto re-applies.
   const [activeKey, setActiveKey] = useState<string | undefined>(undefined);
-  useEffect(() => setActiveKey(undefined), [textId]);
+  const [prevTextId, setPrevTextId] = useState(textId);
+  if (prevTextId !== textId) {
+    setPrevTextId(textId);
+    setActiveKey(undefined);
+  }
   const { data: canonical, isSuccess, isError } = useQuery({
     queryKey: ["canonical-parallels", textId],
     queryFn: () => getCanonicalParallels(textId),

--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -86,11 +86,18 @@ export default function ShareCard({ open, onClose, question, answer, sources }: 
   const [shareUrl, setShareUrl] = useState<string>(FALLBACK_SHARE_URL);
   const [creatingShare, setCreatingShare] = useState(false);
 
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (open) {
+      setCreatingShare(true);
+      setShareUrl(FALLBACK_SHARE_URL);
+    }
+  }
+
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    setCreatingShare(true);
-    setShareUrl(FALLBACK_SHARE_URL);
     createSharedQA({ question, answer, sources })
       .then((res) => {
         if (!cancelled) setShareUrl(res.url);

--- a/frontend/src/components/kg-map/DeckGLMap.tsx
+++ b/frontend/src/components/kg-map/DeckGLMap.tsx
@@ -70,17 +70,21 @@ export default function DeckGLMap({
   const [viewState, setViewState] = useState<typeof INITIAL_VIEW_STATE & { transitionDuration?: number }>(INITIAL_VIEW_STATE);
   const mapRef = useRef<MapRef>(null);
 
-  // Fly to focused entity when it changes
-  useEffect(() => {
-    if (!focusEntity || focusEntity.longitude == null || focusEntity.latitude == null) return;
-    setViewState((prev) => ({
-      ...prev,
-      longitude: focusEntity.longitude,
-      latitude: focusEntity.latitude,
-      zoom: Math.max(prev.zoom, 9),
-      transitionDuration: 1200,
-    }));
-  }, [focusEntity]);
+  // Fly to focused entity when it changes (state adjusted during render so the
+  // transition starts on the same commit, without an effect-driven extra pass)
+  const [prevFocusEntity, setPrevFocusEntity] = useState(focusEntity);
+  if (prevFocusEntity !== focusEntity) {
+    setPrevFocusEntity(focusEntity);
+    if (focusEntity && focusEntity.longitude != null && focusEntity.latitude != null) {
+      setViewState((prev) => ({
+        ...prev,
+        longitude: focusEntity.longitude,
+        latitude: focusEntity.latitude,
+        zoom: Math.max(prev.zoom, 9),
+        transitionDuration: 1200,
+      }));
+    }
+  }
 
   // Pulse animation for highlight ring
   const [pulseScale, setPulseScale] = useState(1.0);

--- a/frontend/src/components/kg/KGMentionsPanel.tsx
+++ b/frontend/src/components/kg/KGMentionsPanel.tsx
@@ -31,11 +31,16 @@ export default function KGMentionsPanel({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const [prevEntityId, setPrevEntityId] = useState(entityId);
+  if (prevEntityId !== entityId) {
+    setPrevEntityId(entityId);
     setLoading(true);
     setError(null);
     setMentions(null);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
     getKGEntityMentions(entityId)
       .then((res) => {
         if (cancelled) return;

--- a/frontend/src/pages/AdminAnnotationsPage.tsx
+++ b/frontend/src/pages/AdminAnnotationsPage.tsx
@@ -35,35 +35,46 @@ export default function AdminAnnotationsPage() {
   const [items, setItems] = useState<AdminAnnotationItem[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState<string | undefined>("pending");
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await getAdminAnnotations({
-        page,
-        size: 20,
-        status: statusFilter,
+  const fetchData = useCallback(() => {
+    return getAdminAnnotations({ page, size: 20, status: statusFilter })
+      .then((res) => {
+        setItems(res.items);
+        setTotal(res.total);
+      })
+      .catch(() => {
+        message.error(t("admin_crud.annotation.load_error"));
+      })
+      .finally(() => {
+        setLoading(false);
       });
-      setItems(res.items);
-      setTotal(res.total);
-    } catch {
-      message.error(t("admin_crud.annotation.load_error"));
-    } finally {
-      setLoading(false);
-    }
   }, [page, statusFilter, t]);
 
+  // Spinner state for param changes is adjusted during render; the fetch
+  // effect below only sets state from promise callbacks.
+  const queryKey = `${page}|${statusFilter}`;
+  const [prevQueryKey, setPrevQueryKey] = useState(queryKey);
+  if (prevQueryKey !== queryKey) {
+    setPrevQueryKey(queryKey);
+    setLoading(true);
+  }
+
   useEffect(() => {
-    fetchData();
+    void fetchData();
+  }, [fetchData]);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    void fetchData();
   }, [fetchData]);
 
   const handleReview = async (id: number, action: string) => {
     try {
       await reviewAnnotation(id, { action });
       message.success(action === "approve" ? t("admin_crud.annotation.approved") : t("admin_crud.annotation.rejected"));
-      fetchData();
+      refresh();
     } catch {
       message.error(t("admin_crud.common.action_failed"));
     }

--- a/frontend/src/pages/AdminAnswerQualityPage.tsx
+++ b/frontend/src/pages/AdminAnswerQualityPage.tsx
@@ -57,7 +57,7 @@ export default function AdminAnswerQualityPage() {
   const [total, setTotal] = useState(0);
   const [dist, setDist] = useState<ScoreDistribution | null>(null);
   const [reviewStats, setReviewStats] = useState<AnswerReviewStats | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [windowDays, setWindowDays] = useState(90);
   const [minSuspicion, setMinSuspicion] = useState(0);
   const [reasonFilters, setReasonFilters] = useState<string[]>([]);
@@ -65,30 +65,45 @@ export default function AdminAnswerQualityPage() {
     Record<number, { category?: string; note?: string }>
   >({});
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const [res, stats] = await Promise.all([
-        getAnswerQualityQueue({
-          window: windowDays,
-          min_suspicion: minSuspicion,
-          category: reasonFilters.length ? reasonFilters.join(",") : undefined,
-          limit: 50,
-        }),
-        getAnswerReviewStats(),
-      ]);
-      setItems(res.items);
-      setTotal(res.total_unreviewed);
-      setDist(res.score_distribution);
-      setReviewStats(stats);
-    } catch {
-      message.error(t("admin_aq.load_error"));
-    } finally {
-      setLoading(false);
-    }
+  const load = useCallback(() => {
+    return Promise.all([
+      getAnswerQualityQueue({
+        window: windowDays,
+        min_suspicion: minSuspicion,
+        category: reasonFilters.length ? reasonFilters.join(",") : undefined,
+        limit: 50,
+      }),
+      getAnswerReviewStats(),
+    ])
+      .then(([res, stats]) => {
+        setItems(res.items);
+        setTotal(res.total_unreviewed);
+        setDist(res.score_distribution);
+        setReviewStats(stats);
+      })
+      .catch(() => {
+        message.error(t("admin_aq.load_error"));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, [minSuspicion, reasonFilters, t, windowDays]);
 
+  // Spinner state for param changes is adjusted during render; the fetch
+  // effect below only sets state from promise callbacks.
+  const queryKey = `${windowDays}|${minSuspicion}|${reasonFilters.join(",")}`;
+  const [prevQueryKey, setPrevQueryKey] = useState(queryKey);
+  if (prevQueryKey !== queryKey) {
+    setPrevQueryKey(queryKey);
+    setLoading(true);
+  }
+
   useEffect(() => {
+    void load();
+  }, [load]);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
     void load();
   }, [load]);
 
@@ -234,7 +249,7 @@ export default function AdminAnswerQualityPage() {
             label: t(labelKey),
           }))}
         />
-        <Button onClick={() => void load()}>{t("admin_aq.refresh")}</Button>
+        <Button onClick={() => refresh()}>{t("admin_aq.refresh")}</Button>
       </Space>
 
       <Table<AnswerQueueItem>

--- a/frontend/src/pages/AdminAuditLogPage.tsx
+++ b/frontend/src/pages/AdminAuditLogPage.tsx
@@ -62,24 +62,34 @@ export default function AdminAuditLogPage() {
   const [items, setItems] = useState<AdminAuditLogItem[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [actionFilter, setActionFilter] = useState<string | undefined>(undefined);
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await getAdminAuditLog({ page, size: 20, action: actionFilter });
-      setItems(res.items);
-      setTotal(res.total);
-    } catch {
-      message.error(t("admin_crud.audit.load_error"));
-    } finally {
-      setLoading(false);
-    }
+  const fetchData = useCallback(() => {
+    return getAdminAuditLog({ page, size: 20, action: actionFilter })
+      .then((res) => {
+        setItems(res.items);
+        setTotal(res.total);
+      })
+      .catch(() => {
+        message.error(t("admin_crud.audit.load_error"));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, [page, actionFilter, t]);
 
+  // Spinner state for param changes is adjusted during render; the fetch
+  // effect below only sets state from promise callbacks.
+  const queryKey = `${page}|${actionFilter}`;
+  const [prevQueryKey, setPrevQueryKey] = useState(queryKey);
+  if (prevQueryKey !== queryKey) {
+    setPrevQueryKey(queryKey);
+    setLoading(true);
+  }
+
   useEffect(() => {
-    fetchData();
+    void fetchData();
   }, [fetchData]);
 
   const columns = [

--- a/frontend/src/pages/AdminFeedbacksPage.tsx
+++ b/frontend/src/pages/AdminFeedbacksPage.tsx
@@ -27,38 +27,49 @@ export default function AdminFeedbacksPage() {
   const [items, setItems] = useState<AdminFeedbackItem[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState<string | undefined>();
   const [replyModal, setReplyModal] = useState<AdminFeedbackItem | null>(null);
   const [replyText, setReplyText] = useState("");
   const [replying, setReplying] = useState(false);
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await getAdminFeedbacks({
-        page,
-        size: 20,
-        status: statusFilter,
+  const fetchData = useCallback(() => {
+    return getAdminFeedbacks({ page, size: 20, status: statusFilter })
+      .then((res) => {
+        setItems(res.items);
+        setTotal(res.total);
+      })
+      .catch(() => {
+        message.error(t("admin_crud.feedback.load_error"));
+      })
+      .finally(() => {
+        setLoading(false);
       });
-      setItems(res.items);
-      setTotal(res.total);
-    } catch {
-      message.error(t("admin_crud.feedback.load_error"));
-    } finally {
-      setLoading(false);
-    }
   }, [page, statusFilter, t]);
 
+  // Spinner state for param changes is adjusted during render; the fetch
+  // effect below only sets state from promise callbacks.
+  const queryKey = `${page}|${statusFilter}`;
+  const [prevQueryKey, setPrevQueryKey] = useState(queryKey);
+  if (prevQueryKey !== queryKey) {
+    setPrevQueryKey(queryKey);
+    setLoading(true);
+  }
+
   useEffect(() => {
-    fetchData();
+    void fetchData();
+  }, [fetchData]);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    void fetchData();
   }, [fetchData]);
 
   const handleStatusChange = async (id: number, status: string) => {
     try {
       await updateFeedbackStatus(id, status);
       message.success(t("admin_crud.feedback.status_updated"));
-      fetchData();
+      refresh();
     } catch {
       message.error(t("admin_crud.common.action_failed"));
     }
@@ -77,7 +88,7 @@ export default function AdminFeedbacksPage() {
       message.success(t("admin_crud.feedback.reply_sent"));
       setReplyModal(null);
       setReplyText("");
-      fetchData();
+      refresh();
     } catch {
       message.error(t("admin_crud.feedback.reply_failed"));
     } finally {

--- a/frontend/src/pages/AdminSuggestionsPage.tsx
+++ b/frontend/src/pages/AdminSuggestionsPage.tsx
@@ -28,31 +28,46 @@ export default function AdminSuggestionsPage() {
   const [items, setItems] = useState<SourceSuggestionItem[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState<string | undefined>();
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await getSourceSuggestions(page, 20, statusFilter);
-      setItems(res.items);
-      setTotal(res.total);
-    } catch {
-      message.error(t("admin_crud.suggestion.load_error"));
-    } finally {
-      setLoading(false);
-    }
+  const fetchData = useCallback(() => {
+    return getSourceSuggestions(page, 20, statusFilter)
+      .then((res) => {
+        setItems(res.items);
+        setTotal(res.total);
+      })
+      .catch(() => {
+        message.error(t("admin_crud.suggestion.load_error"));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, [page, statusFilter, t]);
 
+  // Spinner state for param changes is adjusted during render; the fetch
+  // effect below only sets state from promise callbacks.
+  const queryKey = `${page}|${statusFilter}`;
+  const [prevQueryKey, setPrevQueryKey] = useState(queryKey);
+  if (prevQueryKey !== queryKey) {
+    setPrevQueryKey(queryKey);
+    setLoading(true);
+  }
+
   useEffect(() => {
-    fetchData();
+    void fetchData();
+  }, [fetchData]);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    void fetchData();
   }, [fetchData]);
 
   const handleStatusChange = async (id: number, status: string) => {
     try {
       await updateSuggestionStatus(id, status);
       message.success(status === "accepted" ? t("admin_crud.suggestion.accepted") : t("admin_crud.suggestion.rejected"));
-      fetchData();
+      refresh();
     } catch {
       message.error(t("admin_crud.common.action_failed"));
     }
@@ -62,7 +77,7 @@ export default function AdminSuggestionsPage() {
     try {
       await deleteSourceSuggestion(id);
       message.success(t("admin_crud.suggestion.deleted"));
-      fetchData();
+      refresh();
     } catch {
       message.error(t("admin_crud.suggestion.delete_failed"));
     }

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -23,39 +23,54 @@ export default function AdminUsersPage() {
   const [items, setItems] = useState<AdminUserItem[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = useState("created_at");
   const [sortOrder, setSortOrder] = useState("desc");
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await getAdminUsers({
-        page,
-        size: 20,
-        q: search || undefined,
-        sort_by: sortBy,
-        sort_order: sortOrder,
+  const fetchData = useCallback(() => {
+    return getAdminUsers({
+      page,
+      size: 20,
+      q: search || undefined,
+      sort_by: sortBy,
+      sort_order: sortOrder,
+    })
+      .then((res) => {
+        setItems(res.items);
+        setTotal(res.total);
+      })
+      .catch(() => {
+        message.error(t("admin_crud.users.load_error"));
+      })
+      .finally(() => {
+        setLoading(false);
       });
-      setItems(res.items);
-      setTotal(res.total);
-    } catch {
-      message.error(t("admin_crud.users.load_error"));
-    } finally {
-      setLoading(false);
-    }
   }, [page, search, sortBy, sortOrder, t]);
 
+  // Spinner state for param changes is adjusted during render; the fetch
+  // effect below only sets state from promise callbacks.
+  const queryKey = `${page}|${search}|${sortBy}|${sortOrder}`;
+  const [prevQueryKey, setPrevQueryKey] = useState(queryKey);
+  if (prevQueryKey !== queryKey) {
+    setPrevQueryKey(queryKey);
+    setLoading(true);
+  }
+
   useEffect(() => {
-    fetchData();
+    void fetchData();
+  }, [fetchData]);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    void fetchData();
   }, [fetchData]);
 
   const handleToggleActive = async (record: AdminUserItem) => {
     try {
       await updateAdminUser(record.id, { is_active: !record.is_active });
       message.success(record.is_active ? t("admin_crud.users.disabled") : t("admin_crud.users.enabled"));
-      fetchData();
+      refresh();
     } catch {
       message.error(t("admin_crud.common.action_failed"));
     }
@@ -65,7 +80,7 @@ export default function AdminUsersPage() {
     try {
       await updateAdminUser(record.id, { role });
       message.success(t("admin_crud.users.role_updated"));
-      fetchData();
+      refresh();
     } catch {
       message.error(t("admin_crud.common.action_failed"));
     }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -507,7 +507,18 @@ export default function ChatPage() {
     try { window.localStorage.setItem("fojin.chat.modelId", id); } catch { /* ignore */ }
   }, []);
   const [sessionId, setSessionId] = useState<number | undefined>();
-  const [messages, setMessages] = useState<ChatMessageItem[]>([]);
+  const [messages, setMessages] = useState<ChatMessageItem[]>(() => {
+    // 登录归来恢复暂存对话（无论登录成功与否，回到 /chat 都不该丢对话）。
+    // 读取放在惰性初始化（纯读取），removeItem 留给下面的挂载 effect。
+    try {
+      const raw = sessionStorage.getItem("fojin.chat.guestTranscript");
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+      }
+    } catch { /* ignore */ }
+    return [];
+  });
   const [sending, setSending] = useState(false);
   // 游客转化钩子：游客拿到第一条 AI 回复后提示"登录可保存历史"。
   // 数据背景：月 730 chat 用户 vs 65 注册——多数游客不知道对话会丢。
@@ -532,17 +543,8 @@ export default function ChatPage() {
     } catch { /* ignore */ }
     navigate("/login");
   }, [messages, navigate]);
-  // 登录归来恢复暂存对话（无论登录成功与否，回到 /chat 都不该丢对话）
   useEffect(() => {
-    try {
-      const raw = sessionStorage.getItem("fojin.chat.guestTranscript");
-      if (!raw) return;
-      sessionStorage.removeItem("fojin.chat.guestTranscript");
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed) && parsed.length > 0) {
-        setMessages((prev) => (prev.length === 0 ? parsed : prev));
-      }
-    } catch { /* ignore */ }
+    try { sessionStorage.removeItem("fojin.chat.guestTranscript"); } catch { /* ignore */ }
   }, []);
   const [attachments, setAttachments] = useState<ChatAttachmentMeta[]>([]);
   const [uploadingAttachment, setUploadingAttachment] = useState(false);
@@ -560,7 +562,7 @@ export default function ChatPage() {
     });
   };
   const [sessionFilter, setSessionFilter] = useState("");
-  const tabIndexRef = useRef(-1);
+  const [tabIndex, setTabIndex] = useState(-1);
   const [hasOlderMessages, setHasOlderMessages] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -802,7 +804,7 @@ export default function ChatPage() {
     });
   };
 
-  const streamingIdRef = useRef<number>(0);
+  const [streamingId, setStreamingId] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
 
   const handleCancel = useCallback(() => {
@@ -866,7 +868,7 @@ export default function ChatPage() {
     };
 
     const assistantId = Date.now() + 1;
-    streamingIdRef.current = assistantId;
+    setStreamingId(assistantId);
     const assistantMsg: ChatMessageItem = {
       id: assistantId,
       role: "assistant",
@@ -972,7 +974,7 @@ export default function ChatPage() {
       onDone: () => {
         clearTimeout(timeoutId);
         abortRef.current = null;
-        streamingIdRef.current = 0;
+        setStreamingId(0);
         setSending(false);
         // Clear attachment chips only after successful stream completion.
         // On error the chips stay so the user can retry without re-uploading.
@@ -1065,13 +1067,13 @@ export default function ChatPage() {
       if (val && !tabSuggestions.includes(val)) return;
       e.preventDefault();
       e.stopPropagation();
-      const nextIndex = (tabIndexRef.current + 1) % tabSuggestions.length;
-      tabIndexRef.current = nextIndex;
+      const nextIndex = (tabIndex + 1) % tabSuggestions.length;
+      setTabIndex(nextIndex);
       setInput(tabSuggestions[nextIndex]);
     };
     el.addEventListener("keydown", handler);
     return () => el.removeEventListener("keydown", handler);
-  }, [tabSuggestions]);
+  }, [tabSuggestions, tabIndex]);
 
   // Handle pre-filled message from URL params (e.g. from "Ask XiaoJin" button on reader page)
   const [searchParams, setSearchParams] = useSearchParams();
@@ -1369,7 +1371,7 @@ export default function ChatPage() {
               <MessageBubble
                 key={m.id}
                 m={m}
-                isStreaming={streamingIdRef.current === m.id}
+                isStreaming={streamingId === m.id}
                 sending={sending}
                 user={user}
                 markdownComponents={markdownComponents}
@@ -1468,13 +1470,13 @@ export default function ChatPage() {
               <Input.TextArea
                 ref={(instance) => { inputRef.current = instance?.resizableTextArea?.textArea ?? null; }}
                 value={input}
-                onChange={(e) => { setInput(e.target.value); tabIndexRef.current = -1; }}
+                onChange={(e) => { setInput(e.target.value); setTabIndex(-1); }}
                 onPressEnter={(e) => {
                   if (e.shiftKey) return;
                   e.preventDefault();
                   handleSend();
                 }}
-                placeholder={tabSuggestions.length > 0 ? `${tabSuggestions[(tabIndexRef.current + 1) % tabSuggestions.length]}    ⇥ Tab    ⇧⏎ ${t("chat.newline_hint")}` : t("chat.input_placeholder")}
+                placeholder={tabSuggestions.length > 0 ? `${tabSuggestions[(tabIndex + 1) % tabSuggestions.length]}    ⇥ Tab    ⇧⏎ ${t("chat.newline_hint")}` : t("chat.input_placeholder")}
                 disabled={sending}
                 autoSize={{ minRows: 2, maxRows: 8 }}
                 variant="borderless"

--- a/frontend/src/pages/ParallelReaderPage.tsx
+++ b/frontend/src/pages/ParallelReaderPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import {
@@ -106,12 +106,13 @@ export default function ParallelReaderPage() {
     [alignmentKey],
   );
 
-  // Refs to each column's scroll container — kept as a stable array
+  // Refs to each column's scroll container. Entries are (re)written by the
+  // inline ref callbacks in the JSX below on every commit; here we only trim
+  // stale tail entries when columns shrink (ref writes in effects are fine).
   const scrollRefs = useRef<ColumnRef[]>([]);
-  scrollRefs.current = columns.map((col, i) => ({
-    textId: col.text.text_id,
-    el: scrollRefs.current[i]?.el ?? null,
-  }));
+  useEffect(() => {
+    scrollRefs.current.length = columns.length;
+  }, [columns.length]);
 
   useSyncScroll(scrollRefs, alignmentMap);
 

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -72,10 +72,13 @@ export default function SearchPage() {
     }, 300);
   }, []);
 
-  // Sync acInput when URL query changes (e.g. clicking "did you mean" link)
-  useEffect(() => {
+  // Sync acInput when the URL query changes (e.g. clicking a "did you mean"
+  // link). Adjusted during render — no effect pass.
+  const [prevQuery, setPrevQuery] = useState(query);
+  if (prevQuery !== query) {
+    setPrevQuery(query);
     setAcInput(query);
-  }, [query]);
+  }
 
   // CBETA ID 直跳：用户输入 T0278 / X0235a 等时，命中即跳 /texts/{id}，
   // 跳过结果列表。404/非 CBETA 静默 fallback 到常规搜索。
@@ -171,17 +174,18 @@ export default function SearchPage() {
 
   // Dictionary knowledge card (parallel, non-blocking)
   const [dictCardDismissed, setDictCardDismissed] = useState(false);
+  // Reset dismissal when the query changes — adjusted during render.
+  const [prevDictQuery, setPrevDictQuery] = useState(query);
+  if (prevDictQuery !== query) {
+    setPrevDictQuery(query);
+    setDictCardDismissed(false);
+  }
   const { data: dictKnowledge } = useQuery<DictGroupedSearchResponse>({
     queryKey: ["dictKnowledge", query],
     queryFn: () => searchDictionaryGrouped({ q: query }),
     enabled: query.length > 0 && tab !== "dictionary",
     staleTime: 5 * 60 * 1000,
   });
-
-  // Reset dismissed state when query changes
-  useEffect(() => {
-    setDictCardDismissed(false);
-  }, [query]);
 
   const { data: sources } = useQuery({ queryKey: ["sources"], queryFn: getSources });
 

--- a/frontend/src/pages/SharedQAPage.tsx
+++ b/frontend/src/pages/SharedQAPage.tsx
@@ -31,9 +31,14 @@ export default function SharedQAPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [prevId, setPrevId] = useState(id);
+  if (prevId !== id) {
+    setPrevId(id);
+    setLoading(true);
+  }
+
   useEffect(() => {
     if (!id) return;
-    setLoading(true);
     getSharedQA(id)
       .then((d) => {
         setData(d);

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -116,6 +116,14 @@ export default function SourcesPage() {
     (v: Capability) => setCapability(capability === v ? null : v),
     [capability, setCapability],
   );
+  // Local mirrors for free-text inputs so typing stays smooth; URL is written
+  // after a short debounce. Resynced below when URL changes externally
+  // (back/forward, shared link landing).
+  const [searchInput, setSearchInput] = useState(search);
+  const [tryInput, setTryInput] = useState(searchQuery);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
+
   const setGroupBy = useCallback(
     (v: GroupBy) => {
       updateParam("group", v, "region");
@@ -127,25 +135,22 @@ export default function SourcesPage() {
     [updateParam],
   );
 
-  // Local mirrors for free-text inputs so typing stays smooth; URL is written
-  // after a short debounce. useEffect resyncs when URL changes externally
-  // (back/forward, shared link landing).
-  const [searchInput, setSearchInput] = useState(search);
-  const [tryInput, setTryInput] = useState(searchQuery);
-  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
-  const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
   const GROUP_COLLAPSE_LIMIT = 12;
   const toggleGroup = useCallback((name: string) => {
     setExpandedGroups((prev) => ({ ...prev, [name]: !prev[name] }));
   }, []);
 
-  useEffect(() => {
+  // Resync mirrors when the URL changes externally — adjusted during render.
+  const [prevSearch, setPrevSearch] = useState(search);
+  if (prevSearch !== search) {
+    setPrevSearch(search);
     setSearchInput(search);
-  }, [search]);
-
-  useEffect(() => {
+  }
+  const [prevSearchQuery, setPrevSearchQuery] = useState(searchQuery);
+  if (prevSearchQuery !== searchQuery) {
+    setPrevSearchQuery(searchQuery);
     setTryInput(searchQuery);
-  }, [searchQuery]);
+  }
 
   const handleSearchInputChange = useCallback(
     (v: string) => {

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -409,23 +409,24 @@ export default function TextReaderPage() {
   const highlightChunkParam = searchParams.get("highlight_chunk");
   const highlightChunkIndex = highlightChunkParam ? parseInt(highlightChunkParam, 10) : null;
   // 续读：URL 显式指定卷或深链高亮时尊重 URL；否则恢复上次阅读位置。
-  // resumeRef 在首次渲染时一次性决定，供后续滚动恢复 effect 消费。
-  const resumeRef = useRef<{ juan: number; ratio: number } | null>(null);
-  const [juanNum, setJuanNum] = useState(() => {
+  // 首次渲染时一次性决定（惰性 state），resumeRef 用它做初值，供滚动恢复
+  // effect 消费后置空。
+  const [initialReading] = useState<{ juan: number; resume: { juan: number; ratio: number } | null }>(() => {
     const last = highlightChunkParam ? null : getLastPosition(Number(id));
     if (initialJuanParam && Number.isFinite(initialJuan) && initialJuan > 0) {
       // URL 显式指定卷：尊重 URL；若与记录同卷（如详情页"继续阅读"），仍恢复滚动。
-      if (last && last.juan === initialJuan && last.ratio > 0.03) {
-        resumeRef.current = { juan: initialJuan, ratio: last.ratio };
-      }
-      return initialJuan;
+      const resume = last && last.juan === initialJuan && last.ratio > 0.03
+        ? { juan: initialJuan, ratio: last.ratio }
+        : null;
+      return { juan: initialJuan, resume };
     }
     if (last && last.juan > 0 && (last.juan > 1 || last.ratio > 0.03)) {
-      resumeRef.current = { juan: last.juan, ratio: last.ratio };
-      return last.juan;
+      return { juan: last.juan, resume: { juan: last.juan, ratio: last.ratio } };
     }
-    return 1;
+    return { juan: 1, resume: null };
   });
+  const resumeRef = useRef<{ juan: number; ratio: number } | null>(initialReading.resume);
+  const [juanNum, setJuanNum] = useState(initialReading.juan);
   const [fontSize, setFontSize] = useState(getInitialFontSize);
   const { t } = useTranslation();
   const getLangLabel = useCallback((lang: string) => {
@@ -815,13 +816,15 @@ export default function TextReaderPage() {
   // dict-popover opens, and AI-panel resize-drags don't re-parse the whole text
   // on every render. Keyed on content only — render-time concerns (font size) are
   // CSS, not part of the parse.
+  const contentText = content?.content ?? null;
+  const compareText = compareContent?.content ?? null;
   const reflowedContent = useMemo(
-    () => (content?.content ? reflowText(content.content) : []),
-    [content?.content],
+    () => (contentText ? reflowText(contentText) : []),
+    [contentText],
   );
   const reflowedCompare = useMemo(
-    () => (compareContent?.content ? reflowText(compareContent.content) : []),
-    [compareContent?.content],
+    () => (compareText ? reflowText(compareText) : []),
+    [compareText],
   );
 
   // Critical apparatus (校勘异文): fetched lazily only when the 校勘 toggle is on.


### PR DESCRIPTION
## Why

Dependabot's eslint-plugin-react-hooks 5→7 bump (#864) failed CI because the v7 compiler-powered rules caught **27 latent issues** in existing code — real bug classes (refs driving rendered output, cascading-render effects), not lint pedantry. This PR fixes the code and lands the plugin bump together, superseding #864.

## What

**Refs read/written during render (6)** — values that drive rendering must be state:
- `streamingIdRef` → `streamingId` state (ReaderAIPanel, ChatPage): the streaming-message indicator read the ref during render, so an update without a co-occurring render could leave a stale indicator. Every write site already sat next to a `setSending` call, so no extra renders are introduced.
- `tabIndexRef` → `tabIndex` state (ChatPage): rendered into the input placeholder.
- TextReaderPage: the resume-reading plan is now computed once in a lazy `useState` and seeds `resumeRef` via `useRef(initial)` — no render-phase ref write.
- ParallelReaderPage: dropped the render-phase `scrollRefs.current` rebuild; the inline JSX ref callbacks already repopulate entries every commit, and an effect trims stale tail entries when columns shrink.

**setState synchronously in effects (14)**:
- Prop-driven resets (ReaderParallelPanel, ShareCard, DeckGLMap, KGMentionsPanel, SharedQAPage, SearchPage ×2, SourcesPage ×2) use the documented [adjust-state-during-render](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) pattern — same behavior, one render pass instead of two.
- The six admin list pages (Annotations/Feedbacks/Suggestions/Users/AuditLog/AnswerQuality) now start with `loading=true`, flip the spinner on query-param changes during render, fetch via promise chains (setState only in `.then/.catch/.finally`), and expose `refresh()` for post-mutation reloads. Spinner timing is unchanged.
- ChatPage's guest-transcript restore moved into the lazy state initializer (pure read); `removeItem` stays in a mount effect.

**Manual memoization (3)** + **declaration order (SourcesPage)**: extracted `content?.content` to plain variables so `useMemo` deps match compiler inference; moved state declarations above the callbacks that close over them.

## Verification

`eslint --max-warnings 0` ✅ · `tsc -b --noEmit` ✅ · vitest **156/156** ✅ · i18n ratchet ✅ · `vite build` ✅

Closes #864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)