### PR TITLE
chore(deps): group related Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
     labels:
       - dependencies
       - backend
+    groups:
+      # Batch routine pip bumps into one weekly PR; majors stay individual so breaking
+      # changes to security-sensitive libs (cryptography, PyJWT, bcrypt) get reviewed one by one.
+      pip-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: npm
     directory: /frontend
@@ -17,6 +26,45 @@ updates:
     labels:
       - dependencies
       - frontend
+    groups:
+      # React runtime and its @types must move together: a solo @types/react-dom 19.x bump
+      # against React 18 failed npm install on an unsatisfiable peer dep (PR #866).
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      # i18next plugins peer-depend on the i18next core, so the family bumps as one PR.
+      i18n:
+        patterns:
+          - "i18next"
+          - "i18next-*"
+          - "react-i18next"
+      # ESLint core, shared configs and plugins are dev tooling that version in lockstep;
+      # one PR instead of several reduces review noise.
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "eslint-plugin-*"
+      # Remaining dev-dependency minor/patch bumps arrive as one weekly PR; majors are
+      # excluded so breaking changes stay individually reviewable.
+      dev-minor-and-patch:
+        dependency-type: development
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+        exclude-patterns: # already owned by the groups above
+          - "@types/react"
+          - "@types/react-dom"
+          - "eslint"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "eslint-plugin-*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Why

Dependabot currently opens one PR per dependency, which recently produced a broken standalone bump: #866 raised `@types/react-dom` to 19.x while the project pins React 18, so `npm install` failed on an unsatisfiable peer dependency and the PR had to be closed. Related packages need to travel in the same PR.

## What

Adds `groups` to `.github/dependabot.yml`:

**npm — /frontend**
- **react**: `react`, `react-dom`, `@types/react`, `@types/react-dom` — types and runtime always move together (prevents a repeat of #866). All update types grouped, including majors, since a React major requires bumping all four at once.
- **i18n**: `i18next`, `i18next-*` (http-backend, browser-languagedetector), `react-i18next` — plugins peer-depend on the i18next core.
- **eslint**: `eslint`, `@eslint/*`, `typescript-eslint`, `eslint-plugin-*` — lockstep dev tooling, one PR instead of several.
- **dev-minor-and-patch**: remaining devDependencies, **minor/patch only** — routine small bumps arrive as one weekly PR. Majors are deliberately excluded so breaking changes stay individually reviewable. Packages owned by the groups above are excluded.

**pip — /backend**
- **pip-minor-and-patch**: all packages, **minor/patch only**. Majors stay individual PRs so breaking changes to security-sensitive libs (`cryptography`, `PyJWT`, `bcrypt`) each get their own review.

**github-actions** entry is unchanged (monthly, low volume).

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses OK.
- Verified against `frontend/package.json` that all grouped packages exist (i18next, i18next-http-backend, i18next-browser-languagedetector, react-i18next; eslint, @eslint/js, typescript-eslint, eslint-plugin-react-hooks, eslint-plugin-react-refresh).

## Note

`/e2e` and `/workers/prerender` have their own `package.json` but are not covered by Dependabot at all today; left out of scope here, could be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)