### PR TITLE
test(es): add real-Elasticsearch integration lane (8.13.4 + ICU)

### DIFF
--- a/.github/workflows/es-integration.yml
+++ b/.github/workflows/es-integration.yml
@@ -1,0 +1,95 @@
+# Real-Elasticsearch integration lane.
+#
+# The default backend CI job mocks the ES client entirely (tests/conftest.py),
+# so a client bump (e.g. dependabot elasticsearch 8.x -> 9.x) can go green
+# without ever talking to a real server. This lane builds the repo's own
+# elasticsearch/Dockerfile (8.13.4 + analysis-icu — exactly what prod runs),
+# boots it on the runner, and runs backend/tests_integration/ against it.
+#
+# Intentionally a separate, path-filtered, NON-required workflow: it only
+# runs when ES-relevant files change and never slows down or gates the main
+# CI jobs.
+
+name: ES Integration
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "backend/requirements.txt"
+      - "backend/requirements-dev.txt"
+      - "backend/app/core/elasticsearch.py"
+      - "backend/app/services/search.py"
+      - "backend/tests_integration/**"
+      - "elasticsearch/Dockerfile"
+      - ".github/workflows/es-integration.yml"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "backend/requirements.txt"
+      - "backend/requirements-dev.txt"
+      - "backend/app/core/elasticsearch.py"
+      - "backend/app/services/search.py"
+      - "backend/tests_integration/**"
+      - "elasticsearch/Dockerfile"
+      - ".github/workflows/es-integration.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  es-integration:
+    name: Backend tests vs real Elasticsearch
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build production Elasticsearch image (8.13.4 + analysis-icu)
+        run: docker build -t fojin-es-test elasticsearch/
+
+      - name: Start Elasticsearch container
+        # Mirrors the runtime env in docker-compose.yml (single node,
+        # security off, modest heap).
+        run: |
+          docker run -d --name fojin-es-test \
+            -p 9200:9200 \
+            -e discovery.type=single-node \
+            -e xpack.security.enabled=false \
+            -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+            fojin-es-test
+
+      - name: Wait for Elasticsearch to be healthy
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=2s" > /dev/null; then
+              echo "Elasticsearch healthy after ~$((i * 2))s"
+              curl -s "http://localhost:9200"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Elasticsearch did not become healthy within 120s"
+          docker logs fojin-es-test
+          exit 1
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements-dev.txt
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install -r requirements-dev.txt
+
+      - name: Run integration tests against real Elasticsearch
+        working-directory: backend
+        env:
+          ES_HOST: http://localhost:9200
+        run: python -m pytest -q tests_integration/
+
+      - name: Dump Elasticsearch logs on failure
+        if: failure()
+        run: docker logs fojin-es-test

--- a/backend/tests_integration/conftest.py
+++ b/backend/tests_integration/conftest.py
@@ -1,0 +1,94 @@
+"""Fixtures for real-Elasticsearch integration tests.
+
+Unlike tests/conftest.py, this conftest does NOT mock Elasticsearch.
+These tests talk to a live ES server (the repo's own elasticsearch/Dockerfile
+image: 8.13.4 + analysis-icu) and exist to catch what the mocked unit suite
+cannot: client/server version mismatches, missing ICU plugin, invalid
+analyzer/mapping definitions, and query DSL the real server rejects.
+
+They are intentionally NOT collected by the default `pytest tests/` run
+(pytest.ini testpaths = tests). Run them explicitly:
+
+    ES_HOST=http://localhost:9200 python -m pytest -q tests_integration/
+
+Hermetic by construction: tests create their own uniquely-named indices
+(it_* prefix) and delete them in teardown, so pointing ES_HOST at a dev
+cluster will not touch the real buddhist_texts / text_contents indices.
+"""
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from app.config import settings
+from app.core.elasticsearch import (
+    CONTENT_INDEX_SETTINGS,
+    INDEX_SETTINGS,
+    close_es,
+    init_es,
+)
+
+# Dedicated test index names so we never touch real data on a shared cluster.
+TEST_INDEX = "it_buddhist_texts"
+TEST_CONTENT_INDEX = "it_text_contents"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_live_es():
+    """Fail loudly (do not skip) when ES is unreachable.
+
+    This lane is opt-in; if it runs at all, a missing server is an
+    infrastructure failure that must be visible, not a silent skip.
+    """
+    url = settings.es_host.rstrip("/") + "/"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:  # nosec B310
+            json.loads(resp.read())
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        pytest.exit(
+            f"Integration tests require a live Elasticsearch at {settings.es_host} "
+            f"(set ES_HOST to override): {exc!r}. "
+            "Start one with: docker build -t fojin-es elasticsearch/ && "
+            "docker run -d -p 9200:9200 -e discovery.type=single-node "
+            '-e xpack.security.enabled=false -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" fojin-es',
+            returncode=1,
+        )
+
+
+@pytest.fixture
+async def es():
+    """Real AsyncElasticsearch client via the app's own init path.
+
+    Uses init_es()/close_es() so the exact client construction the FastAPI
+    lifespan performs (app/main.py) is what gets exercised.
+    """
+    client = await init_es()
+    yield client
+    await close_es()
+
+
+@pytest.fixture
+async def search_indices(es, monkeypatch):
+    """Create both app indices (real mappings/analyzers) under test names.
+
+    Monkeypatches the module-level index names bound inside
+    app.services.search so the service functions run against the test
+    indices. Index creation itself is the first real assertion: it fails
+    on any server that lacks the analysis-icu plugin (icu_transform).
+    """
+    monkeypatch.setattr("app.services.search.INDEX_NAME", TEST_INDEX)
+    monkeypatch.setattr("app.services.search.CONTENT_INDEX_NAME", TEST_CONTENT_INDEX)
+
+    await es.indices.delete(
+        index=[TEST_INDEX, TEST_CONTENT_INDEX], ignore_unavailable=True
+    )
+    await es.indices.create(index=TEST_INDEX, body=INDEX_SETTINGS)
+    await es.indices.create(index=TEST_CONTENT_INDEX, body=CONTENT_INDEX_SETTINGS)
+    try:
+        yield es
+    finally:
+        await es.indices.delete(
+            index=[TEST_INDEX, TEST_CONTENT_INDEX], ignore_unavailable=True
+        )

--- a/backend/tests_integration/test_es_real.py
+++ b/backend/tests_integration/test_es_real.py
@@ -1,0 +1,282 @@
+"""Integration tests against a real Elasticsearch (8.13.4 + analysis-icu).
+
+The mocked unit suite (tests/) patches the ES client entirely, so it can
+never catch client/server wire mismatches, missing plugins, or query DSL
+the real server rejects. These tests close that blind spot by exercising
+the actual client handshake, the real index mappings/analyzers from
+app.core.elasticsearch, and the real service-layer query paths from
+app.services.search that the API layer (app/api/search.py) calls.
+"""
+
+import elasticsearch
+import pytest
+
+from app.core.elasticsearch import get_es
+from app.schemas.text import SearchResponse
+from app.services.search import (
+    get_aggregations,
+    get_suggestions,
+    search_content,
+    search_texts,
+)
+from tests_integration.conftest import TEST_CONTENT_INDEX, TEST_INDEX
+
+# --- Seed data ---------------------------------------------------------------
+# Titles are stored in Traditional Chinese, exactly as CBETA data is in prod.
+# Queries below use Simplified forms to prove the icu_transform
+# (Traditional-Simplified) filter is doing real work.
+
+TEXT_DOCS = [
+    {
+        "id": 1,
+        "taisho_id": "T0235",
+        "cbeta_id": "T0235",
+        "title_zh": "金剛般若波羅蜜經",
+        "title_en": "The Diamond Perfection of Wisdom Sutra",
+        "translator": "姚秦 鳩摩羅什",
+        "dynasty": "姚秦",
+        "category": "般若部",
+        "fascicle_count": 1,
+        "lang": "lzh",
+        "source_code": "cbeta",
+        "has_content": True,
+    },
+    {
+        "id": 2,
+        "taisho_id": "T0251",
+        "cbeta_id": "T0251",
+        "title_zh": "般若波羅蜜多心經",
+        "title_en": "Heart Sutra",
+        "translator": "唐 玄奘",
+        "dynasty": "唐",
+        "category": "般若部",
+        "fascicle_count": 1,
+        "lang": "lzh",
+        "source_code": "cbeta",
+        "has_content": True,
+    },
+    {
+        "id": 3,
+        "taisho_id": "T0262",
+        "cbeta_id": "T0262",
+        "title_zh": "妙法蓮華經",
+        "title_en": "The Lotus Sutra",
+        "translator": "後秦 鳩摩羅什",
+        "dynasty": "後秦",
+        "category": "法華部",
+        "fascicle_count": 7,
+        "lang": "lzh",
+        "source_code": "cbeta",
+        "has_content": False,
+    },
+]
+
+CONTENT_DOCS = [
+    {
+        "text_id": 1,
+        "cbeta_id": "T0235",
+        "title_zh": "金剛般若波羅蜜經",
+        "translator": "鳩摩羅什",
+        "dynasty": "姚秦",
+        "juan_num": 1,
+        "content": "如是我聞：一時，佛在舍衛國祇樹給孤獨園，與大比丘眾千二百五十人俱。",
+        "char_count": 33,
+        "lang": "lzh",
+        "source_code": "cbeta",
+    },
+    {
+        "text_id": 1,
+        "cbeta_id": "T0235",
+        "title_zh": "金剛般若波羅蜜經",
+        "translator": "鳩摩羅什",
+        "dynasty": "姚秦",
+        "juan_num": 2,
+        "content": "如是我聞：須菩提！於意云何？可以身相見如來不？",
+        "char_count": 23,
+        "lang": "lzh",
+        "source_code": "cbeta",
+    },
+    {
+        "text_id": 2,
+        "cbeta_id": "T0251",
+        "title_zh": "般若波羅蜜多心經",
+        "translator": "玄奘",
+        "dynasty": "唐",
+        "juan_num": 1,
+        "content": "觀自在菩薩，行深般若波羅蜜多時，照見五蘊皆空，度一切苦厄。",
+        "char_count": 28,
+        "lang": "lzh",
+        "source_code": "cbeta",
+    },
+]
+
+
+@pytest.fixture
+async def seeded_indices(search_indices):
+    es = search_indices
+    for doc in TEXT_DOCS:
+        await es.index(index=TEST_INDEX, id=str(doc["id"]), document=doc)
+    for i, doc in enumerate(CONTENT_DOCS):
+        await es.index(index=TEST_CONTENT_INDEX, id=str(i + 1), document=doc)
+    await es.indices.refresh(index=[TEST_INDEX, TEST_CONTENT_INDEX])
+    return es
+
+
+# --- Handshake / environment sanity ------------------------------------------
+
+
+async def test_client_server_handshake(es):
+    """info() must succeed and client/server majors must agree.
+
+    This is the test that would have failed loudly on the dependabot
+    elasticsearch 8.17 -> 9.4 bump instead of sailing through mocked CI.
+    """
+    info = await es.info()
+    server_version = info["version"]["number"]
+    server_major = int(server_version.split(".")[0])
+    client_major = int(elasticsearch.__versionstr__.split(".")[0])
+    assert client_major == server_major, (
+        f"elasticsearch-py {elasticsearch.__versionstr__} vs server "
+        f"{server_version}: major version mismatch — bumping the client "
+        f"past the server major breaks the wire protocol in production."
+    )
+    # init_es() must have wired the module-level client the app uses.
+    assert get_es() is es
+
+
+async def test_analysis_icu_plugin_installed(es):
+    """Prod images are built from elasticsearch/Dockerfile which installs
+    analysis-icu; the app's analyzers (icu_transform) hard-depend on it."""
+    plugins = await es.cat.plugins(format="json")
+    components = {p["component"] for p in plugins}
+    assert "analysis-icu" in components, (
+        f"analysis-icu plugin missing (found: {sorted(components)}); "
+        "index creation and all CJK search would fail in production."
+    )
+
+
+# --- Index creation / mappings / analyzers ------------------------------------
+
+
+async def test_index_mappings_and_settings(search_indices):
+    """INDEX_SETTINGS / CONTENT_INDEX_SETTINGS are accepted by the real
+    server and persist the analyzer wiring we expect."""
+    es = search_indices
+
+    mapping = await es.indices.get_mapping(index=TEST_INDEX)
+    props = mapping[TEST_INDEX]["mappings"]["properties"]
+    assert props["title_zh"]["analyzer"] == "cjk_bigram"
+    assert props["title_zh"]["fields"]["raw"]["type"] == "keyword"
+    assert props["taisho_id"]["type"] == "keyword"
+    assert props["has_content"]["type"] == "boolean"
+
+    cmapping = await es.indices.get_mapping(index=TEST_CONTENT_INDEX)
+    cprops = cmapping[TEST_CONTENT_INDEX]["mappings"]["properties"]
+    assert cprops["content"]["analyzer"] == "cjk_content"
+    assert cprops["content"]["term_vector"] == "with_positions_offsets"
+
+    idx_settings = await es.indices.get_settings(index=TEST_INDEX)
+    analysis = idx_settings[TEST_INDEX]["settings"]["index"]["analysis"]
+    assert analysis["filter"]["t2s"]["type"] == "icu_transform"
+    assert analysis["filter"]["t2s"]["id"] == "Traditional-Simplified"
+
+
+async def test_icu_transform_analyzes_traditional_to_simplified(search_indices):
+    """The custom analyzers must actually run the ICU Traditional->Simplified
+    transform and CJK bigramming on the real server."""
+    es = search_indices
+
+    resp = await es.indices.analyze(
+        index=TEST_INDEX, body={"analyzer": "cjk_bigram", "text": "金剛般若"}
+    )
+    tokens = [t["token"] for t in resp["tokens"]]
+    # Traditional 金剛般若 -> simplified 金刚般若 -> CJK bigrams
+    assert tokens == ["金刚", "刚般", "般若"]
+
+    resp = await es.indices.analyze(
+        index=TEST_CONTENT_INDEX, body={"analyzer": "cjk_content", "text": "羅漢"}
+    )
+    tokens = [t["token"] for t in resp["tokens"]]
+    assert tokens == ["罗汉"]
+
+
+# --- Real service-layer search paths (what app/api/search.py calls) -----------
+
+
+async def test_search_texts_simplified_query_hits_traditional_title(seeded_indices):
+    """A Simplified-Chinese abbreviation ("金刚经") must find the
+    Traditional-titled Diamond Sutra via t2s + the abbreviation boost."""
+    es = seeded_indices
+    resp = await search_texts(es, "金刚经")
+    assert isinstance(resp, SearchResponse)
+    assert resp.total >= 1
+    assert resp.results[0].cbeta_id == "T0235"
+    assert resp.results[0].title_zh == "金剛般若波羅蜜經"
+
+
+async def test_search_texts_english_title(seeded_indices):
+    es = seeded_indices
+    resp = await search_texts(es, "Diamond")
+    assert resp.total >= 1
+    assert resp.results[0].cbeta_id == "T0235"
+    assert resp.results[0].highlight, "expected a real highlight from the server"
+
+
+async def test_search_texts_term_filters(seeded_indices):
+    es = seeded_indices
+    resp = await search_texts(es, "", dynasty="唐")
+    assert resp.total == 1
+    assert resp.results[0].cbeta_id == "T0251"
+
+    resp = await search_texts(es, "", category="般若部")
+    assert {r.cbeta_id for r in resp.results} == {"T0235", "T0251"}
+
+
+async def test_get_aggregations(seeded_indices):
+    es = seeded_indices
+    aggs = await get_aggregations(es)
+    assert set(aggs["dynasties"]) == {"姚秦", "唐", "後秦"}
+    assert set(aggs["categories"]) == {"般若部", "法華部"}
+    assert aggs["languages"] == ["lzh"]
+    assert aggs["sources"] == ["cbeta"]
+
+
+async def test_get_suggestions_cjk_prefix(seeded_indices):
+    es = seeded_indices
+    suggestions = await get_suggestions(es, "般若")
+    # get_suggestions swallows server errors and returns [] — a non-empty
+    # result proves the match_phrase_prefix query is valid on the real server.
+    assert suggestions
+    assert all("般若" in s for s in suggestions)
+
+
+async def test_search_content_collapses_by_work(seeded_indices):
+    """Simplified query "如是我闻" must match Traditional content 如是我聞,
+    collapse the two matching juans of T0235 into one work-level result,
+    and produce real server-side highlights."""
+    es = seeded_indices
+    resp = await search_content(es, "如是我闻")
+    assert resp["total"] == 1  # one unique work (cardinality agg)
+    assert resp["total_juans"] == 2  # both juans of T0235 matched
+    hit = resp["results"][0]
+    assert hit["text_id"] == 1
+    assert hit["cbeta_id"] == "T0235"
+    assert hit["matched_juan_count"] == 2
+    assert hit["highlight"] and "<em>" in hit["highlight"][0]
+    assert {j["juan_num"] for j in hit["matched_juans"]} == {1, 2}
+
+
+@pytest.mark.xfail(
+    reason=(
+        "sort='title' sorts on title_zh.keyword (and sort='dynasty' on "
+        "dynasty.keyword) but the mapping defines the keyword subfield as "
+        "title_zh.raw and dynasty as a plain keyword field — the real server "
+        "rejects the sort. The mocked unit suite can never see this; kept as "
+        "xfail documentation until the mapping/sort mismatch is fixed."
+    ),
+    strict=False,
+)
+async def test_search_texts_title_sort(seeded_indices):
+    es = seeded_indices
+    resp = await search_texts(es, "般若", sort="title")
+    assert resp.total >= 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -205,11 +205,12 @@ elif [ "$BE_BASE" != "$NEW_REV" ]; then
   # Live API path: backend/ minus dirs that don't ride the uvicorn process.
   # - backend/scripts/   : CLI tools (build_alignments, build_works, audits, …)
   # - backend/tests/     : pytest fixtures / unit tests
+  # - backend/tests_integration/ : real-ES integration tests (CI-only lane)
   # - backend/eval/      : RAG eval harness
   # - backend/alembic/   : migration files (apply via `alembic upgrade`, not restart)
   # Changing any of these MUST NOT bounce a running uvicorn — and, more importantly,
   # MUST NOT kill long-running scripts a developer has launched via `docker exec`.
-  BE_LIVE_DIFF="$(echo "$BE_DIFF" | grep -E '^backend/' | grep -vE '^backend/(scripts|tests|eval|alembic)/' || true)"
+  BE_LIVE_DIFF="$(echo "$BE_DIFF" | grep -E '^backend/' | grep -vE '^backend/(scripts|tests|tests_integration|eval|alembic)/' || true)"
   if [ -n "$BE_LIVE_DIFF" ]; then
     log "backend/ live-API 路径自 ${BE_BASE:0:7} 起有变更 — 触发 restart。"
     echo "$BE_LIVE_DIFF" | sed 's/^/    /'


### PR DESCRIPTION
## Why

`backend/tests/conftest.py` patches the ES client with mocks, so the entire backend suite goes green without ever talking to a real Elasticsearch. That made CI meaningless for client bumps — the dependabot `elasticsearch 8.17 -> 9.4` PR had to be closed on faith because nothing in CI would have caught a broken wire protocol, a missing plugin, or query DSL the real server rejects.

Production runs **ES 8.13.4 + analysis-icu**, built from the repo's own `elasticsearch/Dockerfile`. This PR adds an opt-in integration lane that tests against exactly that image.

## What

### New workflow: `.github/workflows/es-integration.yml`
- Separate, **non-required**, path-filtered workflow — it does not touch or slow down the existing CI jobs, and only triggers when ES-relevant files change (`backend/requirements*.txt`, `app/core/elasticsearch.py`, `app/services/search.py`, `tests_integration/`, `elasticsearch/Dockerfile`) or on `workflow_dispatch`.
- Builds `elasticsearch/Dockerfile` (so version + ICU plugin match prod bit-for-bit), runs it single-node with security off and a 512m heap (mirroring `docker-compose.yml`), waits up to 120s for cluster health, then runs the integration tests with `ES_HOST` pointed at the container. Dumps container logs on failure.

### New tests: `backend/tests_integration/` (11 tests)
Deliberately outside `tests/` so the default `python -m pytest -q tests/` lane (and `pytest.ini` `testpaths`) never collects them. Own `conftest.py` with **no ES mocking**; uses the app's real `init_es()`/`close_es()` path. Hermetic: indices are created under `it_*` test names (module-level index names monkeypatched) and deleted in teardown, so the suite is safe to point at a dev cluster.

- **Handshake / version sanity** — `info()` must succeed and client major must equal server major. This is the test that fails loudly on an 8.x -> 9.x client bump.
- **analysis-icu plugin presence** — fails with a clear message if the image isn't the repo's own build.
- **Index creation + mappings** — `INDEX_SETTINGS` / `CONTENT_INDEX_SETTINGS` are accepted by the real server (creation itself fails without ICU) and persist the expected analyzer wiring.
- **ICU analyzer proof** — `_analyze` with `cjk_bigram`: Traditional `金剛般若` must tokenize to Simplified bigrams `金刚 / 刚般 / 般若`.
- **Real service-layer search paths** (the functions `app/api/search.py` calls): `search_texts` with a Simplified abbreviation (`金刚经`) hitting the Traditional-titled Diamond Sutra, English-title search with real server highlights, term filters, `get_aggregations`, `get_suggestions`, and `search_content` collapse-by-work with a Simplified query matching Traditional content across two juans.

### Bonus finding (documented as `xfail`)
The lane immediately surfaced a real bug the mocked suite can never see: `search_texts(sort="title")` sorts on `title_zh.keyword`, but the mapping defines the keyword subfield as `title_zh.raw` (same story for `sort="dynasty"` vs the plain-keyword `dynasty` field). Verified against the real 8.13.4 server: `BadRequestError(400, 'search_phase_execution_exception', 'No mapping found for [title_zh.keyword] in order to sort on')` — i.e. the `sort=title` / `sort=dynasty` API options are broken in production today. Kept as a non-strict `xfail` test documenting the mismatch; fixing the sort/mapping should flip it to a real test.

### deploy.sh
Added `backend/tests_integration/` to the path-aware restart exclusion so a test-only change never bounces prod uvicorn (same treatment as `backend/tests/`).

## Verification

- `python -m pytest -q tests/` from `backend/`: **809 passed** — untouched.
- Docker is not usable in the dev environment, so the lane was validated by running ES **8.13.4 from the official tarball (sha512-verified) + the analysis-icu 8.13.4 plugin** locally — the same version/plugin the Dockerfile builds, same single-node/security-off/512m-heap env: **10 passed, 1 xfailed** (the documented sort bug). The Dockerfile-built container path itself is exercised by this PR's own CI run (the workflow triggers on its own paths).
- Workflow YAML validated; `ruff check` clean on the new files.

## Cost note

The lane pulls the ES 8.13.4 base image (~1.4 GB) and installs the ICU plugin on every run — roughly 2–4 minutes of runner time and ~2 GB of disk. Acceptable because the path filter means it only runs when ES-relevant files change, and it is not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
