### PR TITLE
fix(search): sort=title/dynasty use fields the ES mapping doesn't have

### DIFF
--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -245,9 +245,13 @@ async def search_texts(
 
     sort_clause = []
     if sort == "title":
-        sort_clause = [{"title_zh.keyword": "asc"}, "_score"]
+        # title_zh is analyzed text; its keyword sub-field is mapped as "raw",
+        # not "keyword" (see INDEX_SETTINGS in app/core/elasticsearch.py).
+        sort_clause = [{"title_zh.raw": "asc"}, "_score"]
     elif sort == "dynasty":
-        sort_clause = [{"dynasty.keyword": "asc"}, "_score"]
+        # dynasty is mapped directly as `keyword` (no analyzed variant), so it
+        # has no ".keyword" sub-field — sort on the field itself.
+        sort_clause = [{"dynasty": "asc"}, "_score"]
     elif sort != "relevance":
         # Default: relevance (use ES default _score sorting)
         pass

--- a/backend/tests_integration/test_es_real.py
+++ b/backend/tests_integration/test_es_real.py
@@ -266,17 +266,22 @@ async def test_search_content_collapses_by_work(seeded_indices):
     assert {j["juan_num"] for j in hit["matched_juans"]} == {1, 2}
 
 
-@pytest.mark.xfail(
-    reason=(
-        "sort='title' sorts on title_zh.keyword (and sort='dynasty' on "
-        "dynasty.keyword) but the mapping defines the keyword subfield as "
-        "title_zh.raw and dynasty as a plain keyword field — the real server "
-        "rejects the sort. The mocked unit suite can never see this; kept as "
-        "xfail documentation until the mapping/sort mismatch is fixed."
-    ),
-    strict=False,
-)
 async def test_search_texts_title_sort(seeded_indices):
+    """sort="title" must sort on the real keyword sub-field (title_zh.raw,
+    not title_zh.keyword) — a mismatch the mocked unit suite can't see,
+    caught here because the real server 400s on an unmapped field."""
     es = seeded_indices
     resp = await search_texts(es, "般若", sort="title")
-    assert resp.total >= 1
+    assert resp.total == 2
+    # 般若波羅蜜多心經 (般 U+822C) sorts before 金剛般若波羅蜜經 (金 U+91D1).
+    assert [r.cbeta_id for r in resp.results] == ["T0251", "T0235"]
+
+
+async def test_search_texts_dynasty_sort(seeded_indices):
+    """sort="dynasty" must sort on the dynasty field itself — it's mapped as
+    a plain `keyword`, so it has no ".keyword" sub-field to sort on."""
+    es = seeded_indices
+    resp = await search_texts(es, "", sort="dynasty")
+    assert resp.total == 3
+    # 唐 (U+5510) < 姚秦 (U+59DA) < 後秦 (U+5F8C)
+    assert [r.dynasty for r in resp.results] == ["唐", "姚秦", "後秦"]


### PR DESCRIPTION
## Why

The real-ES integration lane added in #884 documented (as `xfail`) that production's `sort=title` and `sort=dynasty` search options are broken: they request fields that don't exist in the index mapping, and the real server rejects the query with a 400. The mocked unit suite (`tests/`) can never catch this class of bug — a mock never rejects a nonexistent field name.

## What

`app/services/search.py`:
- `sort=title` was requesting `title_zh.keyword`. The mapping (`app/core/elasticsearch.py`) names the analyzed field's keyword sub-field `raw`, not `keyword`. Fixed to `title_zh.raw`.
- `sort=dynasty` was requesting `dynasty.keyword`. `dynasty` is mapped directly as `type: keyword` — it's not an analyzed text field, so it has no `.keyword` sub-field at all. Fixed to sort on `dynasty` itself.

`tests_integration/test_es_real.py`: converted the single `xfail` placeholder into two real regression tests that assert actual sort order against the seeded Traditional-Chinese title/dynasty data (order verified independently via Python's own Unicode codepoint comparison, which matches ES's default keyword-sort collation).

## Verification

Docker isn't available in this environment (same constraint the #884 agent hit), so the authoritative real-ES check is this PR's own CI run of the `es-integration` lane built in #884 — that's the whole point of having it. Locally verified no regressions: `python -m pytest -q tests/` → **809 passed**, `ruff check` clean, both changed files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)