### PR TITLE
feat(seo): add hreflang en/zh-Hant alternates to six detail/index pages

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -97,6 +97,8 @@ export default function HomePage() {
         <title>{t("app.title")}</title>
         <link rel="alternate" hrefLang="x-default" href="https://fojin.app/" />
         <link rel="alternate" hrefLang="zh" href="https://fojin.app/" />
+        <link rel="alternate" hrefLang="en" href="https://fojin.app/?lang=en" />
+        <link rel="alternate" hrefLang="zh-Hant" href="https://fojin.app/?lang=zh-Hant" />
       </Helmet>
       <section className="home-hero">
         <div className="home-hero-bg">

--- a/frontend/src/pages/PersonPage.test.tsx
+++ b/frontend/src/pages/PersonPage.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import i18n from "../i18n";
+import PersonPage from "./PersonPage";
+import { getKGEntity, type KGEntityDetail } from "../api/client";
+
+beforeAll(() => {
+  i18n.changeLanguage("zh");
+});
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    getKGEntity: vi.fn(),
+  };
+});
+
+const mockGetKGEntity = vi.mocked(getKGEntity);
+
+function entity(o: Partial<KGEntityDetail> = {}): KGEntityDetail {
+  return {
+    id: 1 as KGEntityDetail["id"],
+    entity_type: "person",
+    name_zh: "鸠摩罗什",
+    name_sa: null,
+    name_pi: null,
+    name_bo: null,
+    name_en: "Kumārajīva",
+    description: null,
+    properties: null,
+    text_id: null,
+    external_ids: null,
+    relations: [],
+    ...o,
+  };
+}
+
+function renderPage(id = "1") {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[`/person/${id}`]}>
+          <Routes>
+            <Route path="/person/:id" element={<PersonPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+}
+
+describe("PersonPage", () => {
+  it("emits hreflang alternates for every supported UI language", async () => {
+    mockGetKGEntity.mockResolvedValue(entity());
+
+    renderPage("1");
+
+    await waitFor(() => expect(screen.getAllByText("鸠摩罗什").length).toBeGreaterThan(0));
+    await waitFor(() => expect(document.head.querySelectorAll('link[rel="alternate"]').length).toBeGreaterThan(0));
+
+    const alternates = new Map(
+      Array.from(document.head.querySelectorAll('link[rel="alternate"]')).map((el) => [
+        el.getAttribute("hreflang"),
+        el.getAttribute("href"),
+      ]),
+    );
+    expect(alternates.get("x-default")).toBe("https://fojin.app/person/1");
+    expect(alternates.get("zh")).toBe("https://fojin.app/person/1");
+    expect(alternates.get("en")).toBe("https://fojin.app/person/1?lang=en");
+    expect(alternates.get("zh-Hant")).toBe("https://fojin.app/person/1?lang=zh-Hant");
+  });
+});

--- a/frontend/src/pages/PersonPage.tsx
+++ b/frontend/src/pages/PersonPage.tsx
@@ -316,6 +316,10 @@ export default function PersonPage() {
         <title>{helmetTitle}</title>
         <meta name="description" content={helmetDesc} />
         <link rel="canonical" href={`https://fojin.app/person/${entity.id}`} />
+        <link rel="alternate" hrefLang="x-default" href={`https://fojin.app/person/${entity.id}`} />
+        <link rel="alternate" hrefLang="zh" href={`https://fojin.app/person/${entity.id}`} />
+        <link rel="alternate" hrefLang="en" href={`https://fojin.app/person/${entity.id}?lang=en`} />
+        <link rel="alternate" hrefLang="zh-Hant" href={`https://fojin.app/person/${entity.id}?lang=zh-Hant`} />
         <meta property="og:type" content="profile" />
         <meta property="og:title" content={helmetTitle} />
         <meta property="og:description" content={helmetDesc} />

--- a/frontend/src/pages/RemainingPageI18n.test.tsx
+++ b/frontend/src/pages/RemainingPageI18n.test.tsx
@@ -348,6 +348,18 @@ describe("remaining page i18n", () => {
     expect(screen.getByRole("button", { name: /Text details/ })).toBeInTheDocument();
     expect(screen.getByText("More popular sutras")).toBeInTheDocument();
     expect(screen.getByText(/Scripture data provided by/)).toBeInTheDocument();
+
+    await waitFor(() => expect(document.head.querySelectorAll('link[rel="alternate"]').length).toBeGreaterThan(0));
+    const alternates = new Map(
+      Array.from(document.head.querySelectorAll('link[rel="alternate"]')).map((el) => [
+        el.getAttribute("hreflang"),
+        el.getAttribute("href"),
+      ]),
+    );
+    expect(alternates.get("x-default")).toBe("https://fojin.app/sutras/heart-sutra");
+    expect(alternates.get("zh")).toBe("https://fojin.app/sutras/heart-sutra");
+    expect(alternates.get("en")).toBe("https://fojin.app/sutras/heart-sutra?lang=en");
+    expect(alternates.get("zh-Hant")).toBe("https://fojin.app/sutras/heart-sutra?lang=zh-Hant");
   });
 
   it("renders sutra landing content from locale data", async () => {
@@ -407,5 +419,17 @@ describe("remaining page i18n", () => {
 
     expect(screen.getByText(/Search and browse freely, no account needed/)).toBeInTheDocument();
     expect(screen.getByText("Sign in")).toBeInTheDocument();
+
+    await waitFor(() => expect(document.head.querySelectorAll('link[rel="alternate"]').length).toBeGreaterThan(0));
+    const alternates = new Map(
+      Array.from(document.head.querySelectorAll('link[rel="alternate"]')).map((el) => [
+        el.getAttribute("hreflang"),
+        el.getAttribute("href"),
+      ]),
+    );
+    expect(alternates.get("x-default")).toBe("https://fojin.app/");
+    expect(alternates.get("zh")).toBe("https://fojin.app/");
+    expect(alternates.get("en")).toBe("https://fojin.app/?lang=en");
+    expect(alternates.get("zh-Hant")).toBe("https://fojin.app/?lang=zh-Hant");
   });
 });

--- a/frontend/src/pages/SourcesPage.test.tsx
+++ b/frontend/src/pages/SourcesPage.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import i18n from "../i18n";
+import SourcesPage from "./SourcesPage";
+import { getSources, type DataSource } from "../api/client";
+
+beforeAll(() => {
+  i18n.changeLanguage("zh");
+  if (!window.matchMedia) {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList;
+  }
+});
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    getSources: vi.fn(),
+  };
+});
+
+const mockGetSources = vi.mocked(getSources);
+
+function source(o: Partial<DataSource> = {}): DataSource {
+  return {
+    id: 1 as DataSource["id"],
+    code: "cbeta",
+    name_zh: "CBETA",
+    name_en: "CBETA",
+    base_url: "https://cbetaonline.dila.edu.tw",
+    description: null,
+    access_type: "external",
+    region: "Taiwan, China",
+    languages: "lzh",
+    research_fields: null,
+    supports_search: true,
+    supports_fulltext: true,
+    has_local_fulltext: false,
+    has_remote_fulltext: true,
+    supports_iiif: false,
+    supports_api: false,
+    sort_order: 0,
+    is_active: true,
+    health_status: "ok",
+    health_checked_at: null,
+    health_detail: null,
+    distributions: [],
+    ...o,
+  };
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={["/sources"]}>
+          <SourcesPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+}
+
+describe("SourcesPage", () => {
+  it("emits hreflang alternates for every supported UI language", async () => {
+    mockGetSources.mockResolvedValue([source()]);
+
+    renderPage();
+
+    await waitFor(() => expect(document.head.querySelectorAll('link[rel="alternate"]').length).toBeGreaterThan(0));
+
+    const alternates = new Map(
+      Array.from(document.head.querySelectorAll('link[rel="alternate"]')).map((el) => [
+        el.getAttribute("hreflang"),
+        el.getAttribute("href"),
+      ]),
+    );
+    expect(alternates.get("x-default")).toBe("https://fojin.app/sources");
+    expect(alternates.get("zh")).toBe("https://fojin.app/sources");
+    expect(alternates.get("en")).toBe("https://fojin.app/sources?lang=en");
+    expect(alternates.get("zh-Hant")).toBe("https://fojin.app/sources?lang=zh-Hant");
+  });
+});

--- a/frontend/src/pages/SourcesPage.tsx
+++ b/frontend/src/pages/SourcesPage.tsx
@@ -390,6 +390,8 @@ export default function SourcesPage() {
         <link rel="canonical" href="https://fojin.app/sources" />
         <link rel="alternate" hrefLang="x-default" href="https://fojin.app/sources" />
         <link rel="alternate" hrefLang="zh" href="https://fojin.app/sources" />
+        <link rel="alternate" hrefLang="en" href="https://fojin.app/sources?lang=en" />
+        <link rel="alternate" hrefLang="zh-Hant" href="https://fojin.app/sources?lang=zh-Hant" />
       </Helmet>
       <div className="sources-header">
         <h1 className="sources-title">{t("sources.heading")}</h1>

--- a/frontend/src/pages/SutraLandingPage.tsx
+++ b/frontend/src/pages/SutraLandingPage.tsx
@@ -110,6 +110,8 @@ export default function SutraLandingPage() {
         <link rel="canonical" href={canonicalUrl} />
         <link rel="alternate" hrefLang="x-default" href={canonicalUrl} />
         <link rel="alternate" hrefLang="zh" href={canonicalUrl} />
+        <link rel="alternate" hrefLang="en" href={`${canonicalUrl}?lang=en`} />
+        <link rel="alternate" hrefLang="zh-Hant" href={`${canonicalUrl}?lang=zh-Hant`} />
         <meta property="og:type" content="book" />
         <meta property="og:title" content={sutra.metaTitle} />
         <meta property="og:description" content={sutra.metaDescription} />

--- a/frontend/src/pages/TextDetailPage.test.tsx
+++ b/frontend/src/pages/TextDetailPage.test.tsx
@@ -129,4 +129,22 @@ describe("TextDetailPage", () => {
     expect(screen.getByRole("link", { name: /Read on CBETA/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Export citation/ })).toBeInTheDocument();
   });
+
+  it("emits hreflang alternates for every supported UI language", async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("般若波罗蜜多心经")).toBeInTheDocument());
+    await waitFor(() => expect(document.head.querySelectorAll('link[rel="alternate"]').length).toBeGreaterThan(0));
+
+    const alternates = new Map(
+      Array.from(document.head.querySelectorAll('link[rel="alternate"]')).map((el) => [
+        el.getAttribute("hreflang"),
+        el.getAttribute("href"),
+      ]),
+    );
+    expect(alternates.get("x-default")).toBe("https://fojin.app/texts/1");
+    expect(alternates.get("zh")).toBe("https://fojin.app/texts/1");
+    expect(alternates.get("en")).toBe("https://fojin.app/texts/1?lang=en");
+    expect(alternates.get("zh-Hant")).toBe("https://fojin.app/texts/1?lang=zh-Hant");
+  });
 });

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -90,6 +90,8 @@ export default function TextDetailPage() {
         <link rel="canonical" href={`https://fojin.app/texts/${id}`} />
         <link rel="alternate" hrefLang="x-default" href={`https://fojin.app/texts/${id}`} />
         <link rel="alternate" hrefLang="zh" href={`https://fojin.app/texts/${id}`} />
+        <link rel="alternate" hrefLang="en" href={`https://fojin.app/texts/${id}?lang=en`} />
+        <link rel="alternate" hrefLang="zh-Hant" href={`https://fojin.app/texts/${id}?lang=zh-Hant`} />
         <meta property="og:type" content="book" />
         <meta property="og:title" content={t("textDetail.pageTitle", { title: text.title_zh })} />
         <meta property="og:description" content={shortDescription} />

--- a/frontend/src/pages/WorkDetailPage.test.tsx
+++ b/frontend/src/pages/WorkDetailPage.test.tsx
@@ -172,4 +172,25 @@ describe("WorkDetailPage", () => {
     expect(screen.getByRole("link", { name: /Read/ })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Details/ })).toBeInTheDocument();
   });
+
+  it("emits hreflang alternates for every supported UI language", async () => {
+    mockGetWork.mockResolvedValue(work());
+    mockGetWorkWitnesses.mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getAllByText("妙法蓮華經").length).toBeGreaterThan(0));
+    await waitFor(() => expect(document.head.querySelectorAll('link[rel="alternate"]').length).toBeGreaterThan(0));
+
+    const alternates = new Map(
+      Array.from(document.head.querySelectorAll('link[rel="alternate"]')).map((el) => [
+        el.getAttribute("hreflang"),
+        el.getAttribute("href"),
+      ]),
+    );
+    expect(alternates.get("x-default")).toBe("https://fojin.app/works/lotus-sutra");
+    expect(alternates.get("zh")).toBe("https://fojin.app/works/lotus-sutra");
+    expect(alternates.get("en")).toBe("https://fojin.app/works/lotus-sutra?lang=en");
+    expect(alternates.get("zh-Hant")).toBe("https://fojin.app/works/lotus-sutra?lang=zh-Hant");
+  });
 });

--- a/frontend/src/pages/WorkDetailPage.tsx
+++ b/frontend/src/pages/WorkDetailPage.tsx
@@ -92,6 +92,10 @@ export default function WorkDetailPage() {
         <title>{t("workDetail.pageTitle", { title: work.title_primary })}</title>
         <meta name="description" content={metaDesc} />
         <link rel="canonical" href={canonicalUrl} />
+        <link rel="alternate" hrefLang="x-default" href={canonicalUrl} />
+        <link rel="alternate" hrefLang="zh" href={canonicalUrl} />
+        <link rel="alternate" hrefLang="en" href={`${canonicalUrl}?lang=en`} />
+        <link rel="alternate" hrefLang="zh-Hant" href={`${canonicalUrl}?lang=zh-Hant`} />
         <meta property="og:type" content="book" />
         <meta property="og:title" content={t("workDetail.ogTitle", { title: work.title_primary })} />
         <meta property="og:description" content={metaDesc} />


### PR DESCRIPTION
## Summary
Follows up on issue #711 (i18n roadmap). Its "Supporting work" checklist listed `hreflang` en alternates as blocked on #709 (the `?lang=` param collision) — but #709 actually shipped back in June (commit `8bd67e5`), and `SearchPage` already ships `hreflang="en"`/`"zh-Hant"` alternates in production. The roadmap checklist just never got updated, and no other page ever picked up the same pattern.

- Extended the identical, already-proven pattern to: `HomePage`, `SourcesPage`, `SutraLandingPage`, `TextDetailPage`, `PersonPage`, `WorkDetailPage`.
- `PersonPage` and `WorkDetailPage` were missing hreflang entirely (not even `x-default`/`zh`) — added the full set for consistency with every other page, since `PersonPage` in particular is a major SEO surface (~43k SSR pages per #711).

## Test plan
- [x] `tsc -b`, `eslint`, `i18n:check` all pass
- [x] `vitest run` — 160/160 passing, including 6 new/extended assertions (one per touched page) that check `document.head` after `react-helmet-async` commits, verifying the exact `hreflang`/`href` pairs for every supported UI language
- [x] `vite build` succeeds
- Note: could not do an end-to-end visual check against live prod data locally — Cloudflare's bot detection blocks Node-originated requests (a dev-server-proxied-to-prod setup) regardless of a matching User-Agent header, the same fingerprinting behavior hit earlier testing the homepage's search-suggest endpoint. The `document.head`-assertion tests are the deterministic substitute; will do a quick live spot-check after this deploys.
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)