### PR TITLE
feat(eval): deterministic citation-faithfulness metric ("每一句点回原典")

### DIFF
--- a/backend/eval/README.md
+++ b/backend/eval/README.md
@@ -5,8 +5,9 @@
 | 层 | 是什么 | 需要什么 | 跑在哪 |
 |----|--------|----------|--------|
 | **确定性检索指标** | Recall@K / Hit@K / MRR / Precision@K，对照每题黄金来源，繁简折叠匹配经名（+可选卷号） | 只需语料库 DB（不需 LLM） | prod / cron，可做回归门 |
+| **确定性引用忠实度** | 「每一句都能点回原典」的可度量版：重放线上引用守卫 + 引文核验 + 可信状态管线，算 `citation_grounding_rate` / `verified_rate_of_cited` + 可信状态分布 | DB + LLM key（需生成回答） | prod / cron，可做回归门 |
 | **LLM-as-judge** | 检索相关性 / 引用准确性 / 回答完整性 / 无编造（语义打分） | DB + LLM key | prod / 人工 |
-| **指标逻辑单测** | `retrieval_metrics.py` 的纯函数单测 | 无（纯逻辑） | **CI 自动跑**（`tests/test_retrieval_metrics.py`） |
+| **指标逻辑单测** | `retrieval_metrics.py` / `faithfulness.py` 的纯函数单测 | 无（纯逻辑） | **CI 自动跑**（`tests/test_retrieval_metrics.py` / `tests/test_faithfulness.py`） |
 
 > 全量 eval 需要 678K 向量的语料库 DB，**无法在 GitHub CI 里跑**。所以：度量工具本身的逻辑由 CI 单测护住；全量 eval + 回归门跑在能连到 prod DB 的地方（cron 最合适）。
 
@@ -52,6 +53,31 @@ cd /home/admin/fojin && docker compose exec -T backend eval/run_regression.sh \
 > 而门用到的**指标逻辑**由 CI 单测护住（`test_retrieval_metrics.py` / `test_rag_rerank_merge.py`）。
 > 有意提升质量后，用 `python -m eval.run_eval --no-llm --tag baseline` 重新生成基线并存为新 `BASELINE`。
 
+## 引用忠实度门（`citation_grounding_rate` / `verified_rate_of_cited`）
+
+fojin 的品牌承诺是「每一句都能点回原典」。这层把它从口号变成一个**确定性、可回归**的数字：
+对每道生成回答，重放**线上完全相同**的信任管线 —— `enforce_citation_whitelist`（剥掉检索不到的
+`【《经名》第N卷】`）→ `verify_quoted_content`（标出不是检索片段子串的引文）→ `build_trust_status`
+（收敛成用户在消息上看到的 `ChatTrustState`）—— 然后聚合成：
+
+- **`citation_grounding_rate`**：全部引用中，经守卫核验未被改写的比例（按引用数加权，非按题平均）。
+- **`verified_rate_of_cited`**：**有引用**的回答里，完全核验（无引用改写、无未核实引文）的比例 —— 即「每一句都能点回原典」的题面数字。
+- 可信状态分布（已核验 / 引用被纠正 / 引文未核实 / 有来源未引用 / 无来源）。
+
+在**原始模型输出**（守卫处理前）上度量：数字变差 = 底层模型 grounding 退化的**早期信号**，线上守卫随后在服务时补救此处计到的问题。
+
+```bash
+# 需要生成回答（不能 --no-llm）；忠实度段落会出现在报告里
+python -m eval.run_eval --tag nightly
+
+# 作为门：低于下限即非零退出（仅 LLM-on 运行有意义）
+python -m eval.run_eval --min-citation-grounding 0.98 --min-verified-rate 0.85 --tag gate
+```
+
+> 现有 `run_regression.sh` 用 `--no-llm`（只测检索、省 token），**不含**忠实度门。忠实度需要生成回答，
+> 建议单独排一个**低频 LLM-on** 的 cron 跑上面的门（成本更高），与高频的 `--no-llm` 检索门分开。
+> 对照 `--baseline` 时，若基线与本次**都**生成了回答，忠实度回归也会一并检查。
+
 ## 黄金来源 schema（`test_set.json`）
 
 每题可选两种标注，`gold_sources` 优先：
@@ -93,7 +119,8 @@ python -m eval.from_feedback --window-days 90 --limit 200
 
 ## 文件
 
-- `retrieval_metrics.py` — 确定性指标纯函数（CI 单测覆盖）
+- `retrieval_metrics.py` — 确定性检索指标纯函数（CI 单测覆盖）
+- `faithfulness.py` — 确定性引用忠实度：重放线上信任管线算 grounding 率 + 状态分布（CI 单测 `tests/test_faithfulness.py`）
 - `run_eval.py` — RAG→(LLM)→打分→报告→回归门
 - `scorer.py` — LLM-as-judge + out-of-scope 规则评分
 - `from_feedback.py` — 线上点踩/后台判坏 → 评测候选（CI 单测 `tests/test_from_feedback.py`）

--- a/backend/eval/faithfulness.py
+++ b/backend/eval/faithfulness.py
@@ -1,0 +1,148 @@
+"""Deterministic citation-faithfulness metrics for the AI-chat eval harness.
+
+The eval already scores answers two ways: an LLM judge (subjective, costly,
+non-reproducible) and deterministic *retrieval* metrics (Recall@K/MRR — did we
+fetch the right sources?). Neither measures the property fojin stakes its
+credibility on: does every citation and quote in the *answer* resolve to a
+retrieved source — "每一句都能点回原典"?
+
+That signal already exists at runtime. Production runs each answer through
+``enforce_citation_whitelist`` (strips a hallucinated ``【《title》第N卷】``) and
+``verify_quoted_content`` (flags a quote that isn't a substring of a retrieved
+chunk), then ``build_trust_status`` collapses the result into the same
+``ChatTrustState`` the user sees on the message. This module lifts that exact
+pipeline into the offline eval so the brand claim becomes a measured,
+regression-gate-able number instead of an LLM judge's opinion.
+
+Pure logic — it replays the production guards over an in-memory
+``(answer, sources)`` pair, no DB and no network — so it is unit-tested in CI
+alongside the other deterministic metric layers, while the full eval (which
+needs the corpus DB to *produce* answers) runs on prod/cron with the LLM on.
+
+Measured on the RAW model answer (pre-guard): a rise in mutations is an early
+signal that the underlying model's grounding regressed — the runtime guards then
+remediate at serve time what this metric counts here.
+"""
+
+from __future__ import annotations
+
+from app.schemas.chat import ChatSource
+from app.services.chat_trust import build_trust_status
+from app.services.citation_guard import enforce_citation_whitelist
+from app.services.quote_verifier import verify_quoted_content
+
+# The five states build_trust_status can emit, in descending trust order. Kept
+# explicit (rather than imported from the Literal) so the report renders a
+# stable, ordered distribution even for states absent from a given run.
+TRUST_STATES = (
+    "verified",
+    "sources_available",
+    "citation_corrected",
+    "quote_unverified",
+    "no_sources",
+)
+
+# Grounding rates a regression gate watches. Mirrors retrieval_metrics'
+# _METRIC_PREFIXES convention (bookkeeping counts are excluded).
+_GATED_RATES = ("citation_grounding_rate", "verified_rate_of_cited")
+
+
+def compute_faithfulness(answer: str, sources: list[ChatSource]) -> dict:
+    """Deterministic citation/quote grounding signal for one answer.
+
+    Replays the production trust pipeline (citation guard → quote verifier →
+    trust status) over the raw answer and its retrieved sources. Returns numeric
+    fields plus the ``trust_state`` string; the caller aggregates a run's worth
+    of these with :func:`aggregate_faithfulness`.
+    """
+    corrected, citation_mutations = enforce_citation_whitelist(answer, sources)
+    # The verifier runs *after* the guard by design (see quote_verifier's
+    # module docstring) so quotes attached to already-stripped citations
+    # aren't double-flagged.
+    _, quote_mutations = verify_quoted_content(corrected, sources)
+    trust = build_trust_status(
+        answer,
+        sources,
+        citation_mutations=citation_mutations,
+        quote_mutations=quote_mutations,
+    )
+    citations_grounded = max(0, trust.citation_count - trust.citation_mutation_count)
+    return {
+        "trust_state": trust.state,
+        "citation_count": trust.citation_count,
+        "citation_mutations": trust.citation_mutation_count,
+        "quote_mutations": trust.quote_mutation_count,
+        "citations_grounded": citations_grounded,
+        "has_citations": 1 if trust.citation_count else 0,
+        # "verified" is the only state with ≥1 citation and zero citation/quote
+        # mutations — the literal "every citation and quote checks out" answer.
+        "fully_grounded": 1 if trust.state == "verified" else 0,
+        "quote_unverified": 1 if trust.quote_mutation_count else 0,
+    }
+
+
+def aggregate_faithfulness(rows: list[dict]) -> dict:
+    """Aggregate per-answer faithfulness dicts into headline rates + a state
+    distribution.
+
+    ``rows`` are the dicts from :func:`compute_faithfulness`; falsy entries
+    (skipped/errored questions that produced no answer) are dropped. Returns
+    ``{}`` when nothing is measurable so the report can show "N/A" rather than a
+    misleading 0.
+
+    ``citation_grounding_rate`` is a ratio of sums (an answer that cites ten
+    sources weights ten citations, not one), while the per-answer means are left
+    to the generic :func:`eval.retrieval_metrics.aggregate` when needed.
+    """
+    rows = [r for r in rows if r]
+    if not rows:
+        return {}
+
+    total_citations = sum(r["citation_count"] for r in rows)
+    grounded_citations = sum(r["citations_grounded"] for r in rows)
+    answers_with_citations = sum(r["has_citations"] for r in rows)
+    fully_grounded = sum(r["fully_grounded"] for r in rows)
+
+    distribution = dict.fromkeys(TRUST_STATES, 0)
+    for r in rows:
+        state = r["trust_state"]
+        distribution[state] = distribution.get(state, 0) + 1
+
+    return {
+        "num_answers": len(rows),
+        # Fraction of all emitted citations that survived the guard unmutated.
+        "citation_grounding_rate": (
+            grounded_citations / total_citations if total_citations else None
+        ),
+        # Among answers that cite at all, the fraction fully verified (no
+        # citation or quote mutation) — the headline "每一句都能点回原典" number.
+        "verified_rate_of_cited": (
+            fully_grounded / answers_with_citations if answers_with_citations else None
+        ),
+        "answers_with_unverified_quote": sum(r["quote_unverified"] for r in rows),
+        "total_citations": total_citations,
+        "answers_with_citations": answers_with_citations,
+        "state_distribution": distribution,
+    }
+
+
+def detect_faithfulness_regressions(
+    current: dict, baseline: dict, tolerance: float = 0.02
+) -> list[str]:
+    """Grounding rates that dropped from ``baseline`` by more than ``tolerance``.
+
+    Mirrors :func:`eval.retrieval_metrics.detect_regressions` but over the
+    faithfulness rates. A ``None`` rate (nothing to measure on one side) is
+    skipped rather than treated as a drop to zero.
+    """
+    regressions: list[str] = []
+    for key in _GATED_RATES:
+        cur_val = current.get(key)
+        base_val = baseline.get(key)
+        if not isinstance(cur_val, int | float) or not isinstance(base_val, int | float):
+            continue
+        if base_val - cur_val > tolerance:
+            regressions.append(
+                f"{key}: {cur_val:.3f} < baseline {base_val:.3f} (Δ {cur_val - base_val:+.3f})"
+            )
+    return regressions

--- a/backend/eval/run_eval.py
+++ b/backend/eval/run_eval.py
@@ -29,6 +29,12 @@ from app.config import settings
 from app.database import async_session
 from app.services.chat import _build_llm_messages
 from app.services.rag_retrieval import retrieve_rag_context
+from eval.faithfulness import (
+    TRUST_STATES,
+    aggregate_faithfulness,
+    compute_faithfulness,
+    detect_faithfulness_regressions,
+)
 from eval.retrieval_metrics import (
     aggregate,
     compute_metrics,
@@ -114,6 +120,13 @@ async def run_single_question(question_data: dict, skip_llm: bool = False) -> di
     result["answer"] = answer
     result["model"] = model
 
+    # Deterministic citation-faithfulness: replay the production trust pipeline
+    # (citation guard → quote verifier → trust status) over the raw answer. Needs
+    # the answer, so it is populated only on LLM-on runs and skipped for errored
+    # generations (which carry no citations and would drag the rates down).
+    if not answer.startswith("[ERROR]"):
+        result["faithfulness"] = compute_faithfulness(answer, sources)
+
     # Step 3: Scoring
     if category == "out_of_scope":
         result["scores"] = score_out_of_scope(answer, question_data.get("expected_behavior", "refuse"))
@@ -132,6 +145,48 @@ async def run_single_question(question_data: dict, skip_llm: bool = False) -> di
         "total_s": round(time.monotonic() - t0, 2),
     }
     return result
+
+
+def _fmt_rate(value: object) -> str:
+    """Percent string for a 0..1 rate, or 'N/A' when the rate is unmeasured."""
+    return f"{round(value * 100, 1)}%" if isinstance(value, int | float) else "N/A"
+
+
+def _faithfulness_section(faith_agg: dict) -> list[str]:
+    """Render the deterministic citation-faithfulness block as report lines.
+
+    Empty ``faith_agg`` (a ``--no-llm`` retrieval-only run generates no answers
+    to check) returns an explanatory note instead of misleading zeros.
+    """
+    if not faith_agg:
+        return [
+            "", "## 引用忠实度（确定性 / 每一句可点回原典）", "",
+            "*本次为 --no-llm 检索评测，未生成回答，故无忠实度数据。*", "",
+        ]
+
+    state_names = {
+        "verified": "已核验",
+        "sources_available": "有来源未引用",
+        "citation_corrected": "引用被纠正",
+        "quote_unverified": "引文未核实",
+        "no_sources": "无来源",
+    }
+    dist = faith_agg.get("state_distribution", {})
+    lines = [
+        "", "## 引用忠实度（确定性 / 每一句可点回原典）", "",
+        f"*基于 {faith_agg.get('num_answers', 0)} 道生成回答，重放线上"
+        "「引用守卫 → 引文核验 → 可信状态」管线*", "",
+        "| 指标 | 值 |", "|------|-----|",
+        f"| 引用可核验率 (citation_grounding_rate) | {_fmt_rate(faith_agg.get('citation_grounding_rate'))} |",
+        f"| 有引用回答的完全核验率 (verified_rate_of_cited) | {_fmt_rate(faith_agg.get('verified_rate_of_cited'))} |",
+        f"| 含未核实引文的回答数 | {faith_agg.get('answers_with_unverified_quote', 0)} |",
+        f"| 引用总数 / 有引用回答数 | {faith_agg.get('total_citations', 0)} / {faith_agg.get('answers_with_citations', 0)} |",
+        "", "**可信状态分布**", "",
+        "| 状态 | 数量 |", "|------|------|",
+    ]
+    lines += [f"| {state_names.get(s, s)} | {dist.get(s, 0)} |" for s in TRUST_STATES]
+    lines.append("")
+    return lines
 
 
 def generate_report(results: list[dict], tag: str = "") -> str:
@@ -177,6 +232,9 @@ def generate_report(results: list[dict], tag: str = "") -> str:
         if r.get("retrieval_metrics", {}).get("num_gold", 0) > 0
     )
 
+    # Deterministic citation-faithfulness (replays the runtime trust pipeline).
+    faith_agg = aggregate_faithfulness([r.get("faithfulness") for r in results])
+
     cat_names = {
         "term_explanation": "名相解释", "source_lookup": "经文出处",
         "historical": "人物历史", "comparative": "义理比较",
@@ -203,7 +261,12 @@ def generate_report(results: list[dict], tag: str = "") -> str:
         f"| Hit@5 | {round(retr_agg.get('hit@5', 0), 3)} |",
         f"| MRR | {round(retr_agg.get('mrr', 0), 3)} |",
         f"| Precision@5 | {round(retr_agg.get('precision@5', 0), 3)} |",
-        "", "## 分类得分", "",
+    ]
+
+    lines += _faithfulness_section(faith_agg)
+
+    lines += [
+        "## 分类得分", "",
         "| 分类 | 题数 | 检索 | 引用 | 完整 | 无编造 |",
         "|------|------|------|------|------|--------|",
     ]
@@ -257,6 +320,12 @@ async def main():
                         help="Allowed drop before a metric counts as a regression (default 0.02)")
     parser.add_argument("--min-recall5", type=float,
                         help="Exit non-zero if mean Recall@5 falls below this absolute floor")
+    parser.add_argument("--min-citation-grounding", type=float,
+                        help="Exit non-zero if citation_grounding_rate falls below this floor "
+                             "(LLM-on runs only — needs generated answers)")
+    parser.add_argument("--min-verified-rate", type=float,
+                        help="Exit non-zero if verified_rate_of_cited falls below this floor "
+                             "(LLM-on runs only — needs generated answers)")
     args = parser.parse_args()
 
     test_set = load_test_set()
@@ -320,6 +389,7 @@ async def main():
 
     # Regression gate: usable wherever the corpus DB is reachable (e.g. prod cron).
     current_agg = aggregate([r["retrieval_metrics"] for r in results if r.get("retrieval_metrics")])
+    current_faith = aggregate_faithfulness([r.get("faithfulness") for r in results])
     gate_failed = False
 
     if args.baseline:
@@ -329,6 +399,15 @@ async def main():
                 [r["retrieval_metrics"] for r in baseline_results if r.get("retrieval_metrics")]
             )
             regressions = detect_regressions(current_agg, baseline_agg, args.regression_tolerance)
+            # Faithfulness regressions only when BOTH runs generated answers —
+            # a --no-llm baseline or current run has no rates to compare.
+            baseline_faith = aggregate_faithfulness(
+                [r.get("faithfulness") for r in baseline_results]
+            )
+            if current_faith and baseline_faith:
+                regressions += detect_faithfulness_regressions(
+                    current_faith, baseline_faith, args.regression_tolerance
+                )
             print(f"\n{'='*60}\n回归检查（对照 {args.baseline}）：")
             if regressions:
                 for reg in regressions:
@@ -336,7 +415,7 @@ async def main():
                 if args.fail_on_regression:
                     gate_failed = True
             else:
-                print("  ✓ 检索指标无回归")
+                print("  ✓ 检索/忠实度指标无回归")
         except (OSError, ValueError, KeyError) as exc:
             print(f"\n[baseline 对照失败] {exc}")
 
@@ -344,6 +423,21 @@ async def main():
         recall5 = current_agg.get("recall@5")
         if recall5 is None or recall5 < args.min_recall5:
             print(f"\n  ⚠️  Recall@5 {recall5} 低于下限 {args.min_recall5}")
+            gate_failed = True
+
+    # Faithfulness floors. current_faith is empty on --no-llm runs; treat a
+    # requested floor with no data to check as a failure so a misconfigured
+    # gate (floor set but LLM off) is loud rather than silently passing.
+    for flag_val, key, label in (
+        (args.min_citation_grounding, "citation_grounding_rate", "引用可核验率"),
+        (args.min_verified_rate, "verified_rate_of_cited", "有引用回答完全核验率"),
+    ):
+        if flag_val is None:
+            continue
+        rate = current_faith.get(key)
+        if rate is None or rate < flag_val:
+            shown = f"{rate:.3f}" if isinstance(rate, int | float) else "N/A（本次未生成回答）"
+            print(f"\n  ⚠️  {label} {shown} 低于下限 {flag_val}")
             gate_failed = True
 
     if gate_failed:

--- a/backend/tests/test_faithfulness.py
+++ b/backend/tests/test_faithfulness.py
@@ -1,0 +1,126 @@
+"""Tests for the deterministic citation-faithfulness eval metric.
+
+The metric replays the production trust pipeline (citation guard → quote
+verifier → trust status) over an ``(answer, sources)`` pair, so these tests
+assert that each production failure mode maps to the trust state the eval will
+report — and that the run-level aggregate + regression detector behave.
+
+Pure logic: no DB, no LLM, no network — same tier as test_retrieval_metrics.
+"""
+
+from eval.faithfulness import (
+    aggregate_faithfulness,
+    compute_faithfulness,
+    detect_faithfulness_regressions,
+)
+
+from app.schemas.chat import ChatSource
+
+
+def _src(title: str = "心经", juan: int = 1) -> ChatSource:
+    return ChatSource(
+        text_id=7,
+        juan_num=juan,
+        chunk_index=0,
+        chunk_text="色不异空，空不异色。",
+        score=0.9,
+        title_zh=title,
+    )
+
+
+def test_clean_answer_is_fully_grounded():
+    row = compute_faithfulness("见【《心经》第1卷】。", [_src()])
+    assert row["trust_state"] == "verified"
+    assert row["citation_count"] == 1
+    assert row["citation_mutations"] == 0
+    assert row["fully_grounded"] == 1
+    assert row["citations_grounded"] == 1
+
+
+def test_hallucinated_title_counts_as_corrected_not_grounded():
+    # 大般若經 was never retrieved (only 心经 is in scope) → guard strips it.
+    row = compute_faithfulness("见【《大般若經》第600卷】。", [_src()])
+    assert row["trust_state"] == "citation_corrected"
+    assert row["citation_mutations"] == 1
+    assert row["citations_grounded"] == 0
+    assert row["fully_grounded"] == 0
+
+
+def test_fabricated_quote_counts_as_quote_unverified():
+    # Real citation, invented ≥12-char quote absent from the cited chunk.
+    answer = "经云：「假引文假引文假引文假引文」【《心经》第1卷】"
+    row = compute_faithfulness(answer, [_src()])
+    assert row["trust_state"] == "quote_unverified"
+    assert row["quote_mutations"] >= 1
+    assert row["quote_unverified"] == 1
+    assert row["fully_grounded"] == 0
+
+
+def test_no_sources_is_ungrounded():
+    row = compute_faithfulness("可参看《心经》【《心经》第1卷】。", [])
+    assert row["trust_state"] == "no_sources"
+    assert row["has_citations"] == 1
+    assert row["fully_grounded"] == 0
+
+
+def test_aggregate_uses_ratio_of_sums_and_state_distribution():
+    rows = [
+        {  # verified, 1 grounded citation
+            "trust_state": "verified", "citation_count": 1, "citation_mutations": 0,
+            "quote_mutations": 0, "citations_grounded": 1, "has_citations": 1,
+            "fully_grounded": 1, "quote_unverified": 0,
+        },
+        {  # citation corrected, its 1 citation is not grounded
+            "trust_state": "citation_corrected", "citation_count": 1, "citation_mutations": 1,
+            "quote_mutations": 0, "citations_grounded": 0, "has_citations": 1,
+            "fully_grounded": 0, "quote_unverified": 0,
+        },
+        {  # answer with sources but no citation at all
+            "trust_state": "sources_available", "citation_count": 0, "citation_mutations": 0,
+            "quote_mutations": 0, "citations_grounded": 0, "has_citations": 0,
+            "fully_grounded": 0, "quote_unverified": 0,
+        },
+    ]
+    agg = aggregate_faithfulness(rows)
+    assert agg["num_answers"] == 3
+    assert agg["total_citations"] == 2
+    # 1 of 2 emitted citations survived the guard.
+    assert agg["citation_grounding_rate"] == 0.5
+    # 1 of 2 citing answers is fully verified (the no-citation answer excluded).
+    assert agg["verified_rate_of_cited"] == 0.5
+    assert agg["state_distribution"]["verified"] == 1
+    assert agg["state_distribution"]["citation_corrected"] == 1
+    assert agg["state_distribution"]["sources_available"] == 1
+    assert agg["state_distribution"]["no_sources"] == 0
+
+
+def test_aggregate_empty_and_none_rows_yield_no_data():
+    assert aggregate_faithfulness([]) == {}
+    # --no-llm / errored questions contribute None and must not crash or count.
+    assert aggregate_faithfulness([None, None]) == {}
+
+
+def test_aggregate_rates_are_none_when_no_citations():
+    rows = [{
+        "trust_state": "sources_available", "citation_count": 0, "citation_mutations": 0,
+        "quote_mutations": 0, "citations_grounded": 0, "has_citations": 0,
+        "fully_grounded": 0, "quote_unverified": 0,
+    }]
+    agg = aggregate_faithfulness(rows)
+    assert agg["citation_grounding_rate"] is None
+    assert agg["verified_rate_of_cited"] is None
+
+
+def test_detect_regressions_flags_only_drops_beyond_tolerance():
+    current = {"citation_grounding_rate": 0.90, "verified_rate_of_cited": 0.80}
+    baseline = {"citation_grounding_rate": 0.95, "verified_rate_of_cited": 0.81}
+    regs = detect_faithfulness_regressions(current, baseline, tolerance=0.02)
+    # citation rate dropped 0.05 (> tol); verified rate dropped 0.01 (within tol).
+    assert len(regs) == 1
+    assert "citation_grounding_rate" in regs[0]
+
+
+def test_detect_regressions_skips_none_rates():
+    current = {"citation_grounding_rate": None}
+    baseline = {"citation_grounding_rate": 0.95}
+    assert detect_faithfulness_regressions(current, baseline) == []


### PR DESCRIPTION
## Why

fojin's brand claim — **"每一句都能点回原典"** — was never a measured number. The runtime already runs every answer through `citation_guard` → `quote_verifier` → `build_trust_status` and shows the user a `ChatTrustState`, but the eval only judged faithfulness **subjectively via an LLM judge**. So there was no deterministic, regression-gate-able signal for the property the platform stakes its credibility on.

This is Phase-0 of the "verifiability as the brand" pillar: make the claim a defensible metric before building the MCP server / agentic assistant on top of it.

## What

**`eval/faithfulness.py`** — replays the *exact* production trust pipeline over each eval answer (pure logic: no DB / LLM / network → CI-unit-tested like `retrieval_metrics.py`) and reports:

- **`citation_grounding_rate`** — share of all emitted `【《…》第N卷】` citations the guard left unmutated (ratio of sums, citation-weighted).
- **`verified_rate_of_cited`** — of answers that cite at all, the share fully verified (no citation rewrite, no unverified quote). **The headline "每一句点回原典" number.**
- The runtime `ChatTrustState` distribution (已核验 / 引用被纠正 / 引文未核实 / 有来源未引用 / 无来源).

**`run_eval.py`** — new report section (with an explanatory note on `--no-llm` runs, which generate no answers to check), plus:
- `--min-citation-grounding` / `--min-verified-rate` floor gates (mirror `--min-recall5`).
- baseline faithfulness-regression detection, active only when **both** runs generated answers.

Measured on the **raw model output** (pre-guard): a drop is an early signal that the underlying model's grounding regressed — the runtime guards then remediate at serve time what this metric counts.

## Notes / scope

- **No change to the live SSE chat path** — this is eval-only; it *reuses* the existing guard/verifier/trust functions unchanged.
- Faithfulness needs generated answers, so it does **not** run in the existing `--no-llm` `run_regression.sh` retrieval gate. README documents running it as a separate lower-frequency LLM-on cron. (Follow-up, not in this PR.)
- 9 new unit tests; existing trust/guard/quote tests unchanged. `ruff` clean on `eval/`.

## Test
```
pytest tests/test_faithfulness.py tests/test_chat_trust.py \
  tests/test_citation_guard.py tests/test_quote_verifier.py \
  tests/test_retrieval_metrics.py tests/test_metrics.py -q
# 91 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)