### PR TITLE
feat(rag): attach portable cross-canon URN to chat sources & parallels

### DIFF
--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -76,6 +76,10 @@ class ParallelChunk(BaseModel):
     lang: str
     title: str = ""
     confidence: float = 1.0
+    # Portable cross-canon citation id (fojin:sc/mn10.1 …), None when the
+    # source has no cbeta_id or one that wouldn't round-trip. Optional for
+    # backward compat with chat history stored before this field existed.
+    urn: str | None = None
 
 
 class ChatSource(BaseModel):
@@ -90,6 +94,9 @@ class ChatSource(BaseModel):
     lang: str = "lzh"
     source_id: int | None = None
     parallel_chunks: list[ParallelChunk] = []
+    # Portable cross-canon citation id (fojin:cbeta/T0001.1 …) built from the
+    # source's cbeta_id; None when unavailable. Backward-compatible optional.
+    urn: str | None = None
 
 
 ChatTrustState = Literal[

--- a/backend/app/services/embedding.py
+++ b/backend/app/services/embedding.py
@@ -146,7 +146,7 @@ async def similarity_search(
         "SELECT te.text_id, te.juan_num, te.chunk_index, te.chunk_text, "
         "1 - (te.embedding <=> $1::vector) AS score, "
         "COALESCE(bt.title_zh, '') AS title_zh, "
-        "bt.lang, bt.source_id "
+        "bt.lang, bt.source_id, bt.cbeta_id "
         "FROM text_embeddings te "
         "LEFT JOIN buddhist_texts bt ON bt.id = te.text_id "
         "WHERE te.embedding IS NOT NULL"
@@ -185,6 +185,7 @@ async def similarity_search(
             "title_zh": row[5],
             "lang": row[6] or "lzh",
             "source_id": row[7],
+            "cbeta_id": row[8],
         }
         for row in rows
     ]

--- a/backend/app/services/precise_retrieval.py
+++ b/backend/app/services/precise_retrieval.py
@@ -36,6 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.text import BuddhistText, TextContent
 from app.schemas.chat import ChatSource
+from app.services.urn import build_urn
 
 logger = logging.getLogger(__name__)
 
@@ -356,5 +357,6 @@ async def try_precise_text_retrieval(
             title_zh=bt.title_zh or "",
             lang=tc.lang or bt.lang or "lzh",
             source_id=bt.source_id,
+            urn=build_urn(bt.cbeta_id, juan_num),
         )
     ]

--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -19,6 +19,7 @@ from app.models.dictionary import DictionaryEntry
 from app.schemas.chat import ChatSource
 from app.services.embedding import generate_embedding, similarity_search, source_similarity_search
 from app.services.precise_retrieval import try_precise_text_retrieval
+from app.services.urn import build_urn
 
 logger = logging.getLogger(__name__)
 
@@ -402,7 +403,8 @@ async def _attach_parallel_chunks(db: AsyncSession, results: list[dict]) -> None
                 r.other_lang,
                 r.confidence,
                 te.chunk_text,
-                COALESCE(bt.title_zh, bt.title_sa, bt.title_pi, bt.title_en, '') AS title
+                COALESCE(bt.title_zh, bt.title_sa, bt.title_pi, bt.title_en, '') AS title,
+                bt.cbeta_id
             FROM ranked r
             LEFT JOIN text_embeddings te
                 ON te.text_id = r.other_text_id
@@ -429,6 +431,9 @@ async def _attach_parallel_chunks(db: AsyncSession, results: list[dict]) -> None
                     "lang": row[4] or "lzh",
                     "title": row[7],
                     "confidence": float(row[5]),
+                    # Cross-canon parallels (Pali/Tibetan) are exactly where a
+                    # portable URN matters most; juan-level, None if unbuildable.
+                    "urn": build_urn(row[8], row[2]),
                 }
             )
     except Exception:
@@ -822,7 +827,16 @@ async def retrieve_rag_context(
             await _attach_parallel_chunks(db, search_results)
 
         sources = [
-            ChatSource(**{k: v for k, v in r.items() if k not in ("source_id",)} | {"source_id": r.get("source_id")})
+            ChatSource(
+                **{k: v for k, v in r.items() if k not in ("source_id", "cbeta_id")}
+                | {
+                    "source_id": r.get("source_id"),
+                    # Portable cross-canon citation id, juan-level (line anchors
+                    # aren't indexed yet). build_urn returns None on any id that
+                    # wouldn't round-trip, so this never breaks assembly.
+                    "urn": build_urn(r.get("cbeta_id"), r.get("juan_num")),
+                }
+            )
             for r in search_results
         ]
         context_parts = [_format_context_block(r) for r in search_results]

--- a/backend/app/services/urn.py
+++ b/backend/app/services/urn.py
@@ -71,6 +71,66 @@ _WORK_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _ANCHOR_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
+# Inverse of _SCHEME_PREFIXES for the forward builder: given a stored cbeta_id,
+# pick the ONE canonical scheme to emit. Several schemes can share a prefix
+# (sc/suttacentral → "SC-"); we emit the short canonical name so the URN reads
+# cleanly and still round-trips (resolve_urn re-expands via _SCHEME_PREFIXES).
+# Ordered so the more specific "84K-toh" is tested before any shorter prefix.
+_CANON_PREFIX_SCHEMES: tuple[tuple[str, str], ...] = (
+    ("84K-toh", "84k"),
+    ("GRETIL-", "gretil"),
+    ("SC-", "sc"),
+    ("VRI-", "vri"),
+)
+
+
+def build_urn(
+    cbeta_id: str | None,
+    juan: int | None = None,
+    anchor: str | None = None,
+) -> str | None:
+    """Construct a fojin URN string from a stored cbeta_id — the inverse of
+    :func:`resolve_urn`.
+
+    Returns ``None`` — never raises — when the input can't produce a URN that
+    round-trips cleanly (missing/empty id, or a work_id/anchor with characters
+    the parser rejects). Callers attach the result to a citation as a
+    best-effort portable identifier, so an un-buildable case must degrade to
+    "no URN" silently rather than break answer assembly.
+
+    ``juan``/``anchor`` are emitted only when given; a work-level URN is valid
+    and resolves to the text detail page. Anchors are currently opaque (CBETA
+    line numbers aren't indexed yet — see the module docstring), so callers pass
+    juan-level URNs; the parameter exists so line-level anchoring is a
+    non-breaking add later.
+    """
+    if not isinstance(cbeta_id, str) or not cbeta_id:
+        return None
+
+    scheme = "cbeta"
+    work_id = cbeta_id
+    for prefix, prefix_scheme in _CANON_PREFIX_SCHEMES:
+        if cbeta_id.startswith(prefix):
+            scheme = prefix_scheme
+            work_id = cbeta_id[len(prefix):]
+            break
+
+    # Only emit a URN the parser would accept back — this guarantees the
+    # round-trip parse_urn(build_urn(x)) succeeds and blocks an odd id from
+    # producing a malformed reference a citer might paste into a paper.
+    if not work_id or not _WORK_ID_RE.match(work_id):
+        return None
+    if anchor is not None and not (isinstance(anchor, str) and _ANCHOR_RE.match(anchor)):
+        anchor = None
+
+    urn = f"fojin:{scheme}/{work_id}"
+    if juan is not None and juan >= 1:
+        urn += f".{juan}"
+    if anchor:
+        urn += f"#{anchor}"
+    return urn
+
+
 @dataclass(frozen=True, slots=True)
 class ParsedURN:
     """Structured form of a fojin URN.

--- a/backend/tests/test_rag_parallel_chunks_bulk.py
+++ b/backend/tests/test_rag_parallel_chunks_bulk.py
@@ -43,11 +43,11 @@ async def test_single_bulk_query_for_multiple_primaries():
     # Two parallels for primary 0, one for primary 2, none for the rest.
     # Tuple shape matches the SELECT in _attach_parallel_chunks:
     # (primary_idx, other_text_id, other_juan, other_chunk_idx, other_lang,
-    #  confidence, chunk_text, title)
+    #  confidence, chunk_text, title, cbeta_id)
     fake_rows = [
-        (0, 200, 1, 0, "pi", 0.95, "pali chunk a", "Pali Title"),
-        (0, 300, 1, 0, "bo", 0.88, "tibetan chunk a", "Tib Title"),
-        (2, 201, 1, 2, "pi", 0.77, "pali chunk b", "Pali Title 2"),
+        (0, 200, 1, 0, "pi", 0.95, "pali chunk a", "Pali Title", "SC-mn10"),
+        (0, 300, 1, 0, "bo", 0.88, "tibetan chunk a", "Tib Title", "84K-toh11"),
+        (2, 201, 1, 2, "pi", 0.77, "pali chunk b", "Pali Title 2", "SC-mn11"),
     ]
     db = _make_db_with_rows(fake_rows)
 
@@ -63,6 +63,8 @@ async def test_single_bulk_query_for_multiple_primaries():
         "lang": "pi",
         "title": "Pali Title",
         "confidence": 0.95,
+        # Cross-canon parallel gets a portable URN from its cbeta_id + juan.
+        "urn": "fojin:sc/mn10.1",
     }
     assert primaries[1]["parallel_chunks"] == []
     assert len(primaries[2]["parallel_chunks"]) == 1
@@ -77,8 +79,8 @@ async def test_skips_rows_with_null_chunk_text():
     crash, and not produce a malformed parallel_chunk."""
     primaries = [{"text_id": 1, "juan_num": 1, "chunk_index": 0, "score": 0.9}]
     fake_rows = [
-        (0, 999, 1, 0, "pi", 0.5, None, ""),  # missing text_embedding row
-        (0, 998, 1, 0, "bo", 0.4, "tibetan", "T"),
+        (0, 999, 1, 0, "pi", 0.5, None, "", "SC-x"),  # missing text_embedding row
+        (0, 998, 1, 0, "bo", 0.4, "tibetan", "T", "84K-toh1"),
     ]
     db = _make_db_with_rows(fake_rows)
     await _attach_parallel_chunks(db, primaries)
@@ -91,11 +93,13 @@ async def test_skips_rows_with_null_chunk_text():
 async def test_lang_falls_back_to_lzh_when_null():
     primaries = [{"text_id": 1, "juan_num": 1, "chunk_index": 0, "score": 0.9}]
     fake_rows = [
-        (0, 50, 2, 3, None, 0.6, "chunk", "Title"),
+        (0, 50, 2, 3, None, 0.6, "chunk", "Title", "T1234"),
     ]
     db = _make_db_with_rows(fake_rows)
     await _attach_parallel_chunks(db, primaries)
     assert primaries[0]["parallel_chunks"][0]["lang"] == "lzh"
+    # cbeta_id "T1234" + juan 2 → juan-level cbeta-scheme URN.
+    assert primaries[0]["parallel_chunks"][0]["urn"] == "fojin:cbeta/T1234.2"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_urn.py
+++ b/backend/tests/test_urn.py
@@ -12,9 +12,9 @@ from app.services.urn import (
     ParsedURN,
     URNParseError,
     build_reader_url,
+    build_urn,
     parse_urn,
 )
-
 
 # ──────────────────────────────────────────────────────────────────────
 # parse_urn — happy path
@@ -169,3 +169,63 @@ def test_expand_work_id_applies_scheme_prefix(
     # contain '.' which the parser routes to juan. For the prefix
     # expansion unit test we bypass that and construct ParsedURN by hand.
     assert _expand_work_id(_p(scheme, payload)) == expected_cbeta_id
+
+
+# ──────────────────────────────────────────────────────────────────────
+# build_urn — forward builder (cbeta_id → URN), inverse of resolve_urn
+
+
+@pytest.mark.parametrize("cbeta_id,expected", [
+    ("T0001", "fojin:cbeta/T0001"),
+    ("X0123", "fojin:cbeta/X0123"),
+    ("SC-mn10", "fojin:sc/mn10"),
+    ("84K-toh11", "fojin:84k/11"),
+    ("GRETIL-ramayana", "fojin:gretil/ramayana"),
+    ("VRI-dn1", "fojin:vri/dn1"),
+])
+def test_build_urn_emits_canonical_scheme(cbeta_id: str, expected: str) -> None:
+    assert build_urn(cbeta_id) == expected
+
+
+def test_build_urn_appends_juan_and_anchor() -> None:
+    assert build_urn("T0001", 5) == "fojin:cbeta/T0001.5"
+    assert build_urn("SC-mn10", 2) == "fojin:sc/mn10.2"
+    assert build_urn("T0001", 5, "p0001a01") == "fojin:cbeta/T0001.5#p0001a01"
+
+
+@pytest.mark.parametrize("cbeta_id,juan", [
+    ("T0001", 3),
+    ("X0123", None),
+    ("SC-mn10", 1),
+    ("84K-toh11", 2),
+    ("GRETIL-ramayana", 7),
+    ("VRI-dn1", None),
+])
+def test_build_urn_round_trips_through_parse_and_expand(
+    cbeta_id: str, juan: int | None
+) -> None:
+    """build_urn → parse_urn → _expand_work_id must recover the original
+    cbeta_id (and juan): the whole point of emitting only round-trippable URNs."""
+    from app.services.urn import _expand_work_id
+
+    urn = build_urn(cbeta_id, juan)
+    assert urn is not None
+    parsed = parse_urn(urn)
+    assert _expand_work_id(parsed) == cbeta_id
+    assert parsed.juan == juan
+
+
+@pytest.mark.parametrize("cbeta_id", [None, "", "SC-", "SC-an1.1", "T 0001", "T0001."])
+def test_build_urn_returns_none_when_not_round_trippable(cbeta_id) -> None:
+    """Missing id, empty work payload, or a work_id carrying '.'/space that the
+    parser would reject → None, never a malformed reference or an exception."""
+    assert build_urn(cbeta_id) is None
+
+
+def test_build_urn_drops_invalid_anchor_but_keeps_urn() -> None:
+    """A bad anchor must not sink an otherwise-valid citation id."""
+    assert build_urn("T0001", 5, "has spaces") == "fojin:cbeta/T0001.5"
+
+
+def test_build_urn_ignores_non_positive_juan() -> None:
+    assert build_urn("T0001", 0) == "fojin:cbeta/T0001"


### PR DESCRIPTION
## Why (slice-2 of the "verifiable infrastructure" pillar)

`urn.py` already has a scheme-aware **resolver** (`fojin:sc/mn10.1` → `buddhist_texts` row, with interop for CBETA / SuttaCentral / 84000-Tōhoku / GRETIL / VRI-pali) and a live `GET` endpoint — but **nothing produced URNs**, and `ChatSource` carried only fojin-internal ints (`text_id`/`juan_num`). So external citers, a future MCP tool contract, and any "click a citation → open the exact original" deep-link had **no portable identifier** to hang on.

This attaches the stable id to what the RAG pipeline emits. It's the keystone that unblocks the MCP server (#3) and the agentic assistant (#2), which both need a portable citation contract.

## What

- **`urn.py`** — add `build_urn(cbeta_id, juan, anchor)`, the inverse of `resolve_urn`. Emits the canonical short scheme per `cbeta_id` prefix (`T/X`→`cbeta`, `SC-`→`sc`, `84K-toh`→`84k`, `GRETIL-`→`gretil`, `VRI-`→`vri`) and **only ever returns a URN that round-trips back through `parse_urn`**. Anything un-round-trippable (a `.`/space in the work_id, empty, non-str) → `None`. **Never raises** — a citation id must never break answer assembly.
- **`ChatSource` / `ParallelChunk`** — new **optional** `urn` field (backward-compatible with chat history stored before it).
- **Populated in all three source paths with ZERO extra queries** by selecting the already-joined `bt.cbeta_id`:
  - `similarity_search` (main RAG),
  - `_attach_parallel_chunks` (cross-canon Pali/Tibetan parallels — where a portable id matters *most*),
  - `precise_retrieval` (already holds the full ORM row).
  - **juan-level** for now; line-level anchors are a non-breaking follow-up once CBETA `<lb n>` numbers are indexed (the `anchor` param already exists).

## UX / risk

- **No frontend change** — it's a new optional field the UI can ignore until we wire a feature to it. Users see no difference.
- **No change to the SSE streaming logic** (the flagged repeat-incident area) — this only adds a field and fills it during source assembly.
- `build_urn` degrades to `None` on anything odd, so it can't break an answer.

## Test
```
# affected sweep + full suite
pytest -q            # 855 passed
```
New: `build_urn` canonical-scheme emission, round-trip (`build_urn → parse_urn → _expand_work_id` recovers the original `cbeta_id`+juan), `None`-degradation, and parallel-chunk URN assertions. `ruff` clean on all changed files.

## Sequence
Depends on nothing; independent of #896 (faithfulness metric). Next after this: **#3 MCP server** (thin wrapper exposing search/parallels/entity/dict/passage tools that return this `urn`), then **#2 agent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)