### PR TITLE
feat(research): agentic research assistant — planned multi-step cited retrieval

### DIFF
--- a/backend/app/api/research.py
+++ b/backend/app/api/research.py
@@ -1,0 +1,37 @@
+"""Agentic research assistant endpoint.
+
+POST /api/research/query decomposes a scholarly question into sub-queries,
+retrieves grounded sources for each (with cross-canon parallels + URNs), and
+returns one citation-verified synthesis. It is additive — separate from the
+chat / SSE path — and authenticated, because a single request fans out into
+several LLM + retrieval calls and so must be bounded to signed-in users.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_user
+from app.database import get_db
+from app.models.user import User
+from app.schemas.research import ResearchReport, ResearchRequest
+from app.services.research_agent import build_research_agent
+
+router = APIRouter(prefix="/research", tags=["research"])
+
+
+@router.post("/query", response_model=ResearchReport)
+async def research_query(
+    request: ResearchRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ResearchReport:
+    """Run the multi-step research agent for one question.
+
+    Returns the plan (how the question was decomposed), the deduplicated cited
+    sources (each with a URN), the synthesized answer, and the deterministic
+    trust status of that answer.
+    """
+    agent = build_research_agent(db, user)
+    return await agent.run(request.question, max_steps=request.max_steps)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -74,6 +74,7 @@ from app.api import (
     notification,
     og,
     relations,
+    research,
     rss,
     search,
     search_unified,
@@ -461,6 +462,7 @@ app.include_router(alignment.router, prefix="/api")
 
 # Phase 3 routers
 app.include_router(chat.router, prefix="/api")
+app.include_router(research.router, prefix="/api")
 app.include_router(share.router, prefix="/api")
 app.include_router(og.router, prefix="/api")
 app.include_router(annotations.router, prefix="/api")

--- a/backend/app/schemas/research.py
+++ b/backend/app/schemas/research.py
@@ -1,0 +1,46 @@
+"""Schemas for the agentic research assistant (POST /api/research/query).
+
+The research agent decomposes a scholarly question into sub-queries, retrieves
+grounded sources for each (with cross-canon parallels + portable URNs), then
+synthesizes a single cited answer. These types are the request/response
+contract; the orchestration lives in app.services.research_agent.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from app.schemas.chat import ChatSource, ChatTrustStatus
+
+# The agent's tool vocabulary. v1 dispatches "corpus" (semantic retrieval over
+# the aligned canon, which brings cross-canon parallels along); the field exists
+# so dictionary/entity dispatch is a non-breaking addition.
+ResearchTool = str
+
+
+class ResearchRequest(BaseModel):
+    question: str = Field(..., min_length=2, max_length=500)
+    # Hard cap on planned retrieval steps — bounds LLM+DB cost per request.
+    max_steps: int = Field(default=4, ge=1, le=6)
+
+
+class ResearchStep(BaseModel):
+    """One planned retrieval step: a sub-query the agent ran and how it did."""
+    tool: ResearchTool = "corpus"
+    query: str
+    # Short label for what facet of the question this step investigates.
+    aspect: str = ""
+    num_sources: int = 0
+
+
+class ResearchReport(BaseModel):
+    question: str
+    # The agent's decomposition (post-parse, post-cap) — surfaced so the user
+    # sees how the question was investigated, not just the final answer.
+    plan: list[ResearchStep]
+    answer: str
+    # De-duplicated sources across all steps; each carries a URN (from #897).
+    sources: list[ChatSource]
+    # Deterministic grounding verdict for the synthesized answer, from the same
+    # citation-guard / quote-verifier pipeline the chat path uses.
+    trust_status: ChatTrustStatus | None = None

--- a/backend/app/services/research_agent.py
+++ b/backend/app/services/research_agent.py
@@ -1,0 +1,313 @@
+"""Agentic research assistant — multi-step planned retrieval over the aligned
+corpus, then a grounded, citation-verified synthesis.
+
+This is fojin's killer app: instead of one-shot RAG, a question like "how is
+śūnyatā treated across Prajñāpāramitā vs Madhyamaka vs Yogācāra, with cited
+cross-canon parallels" is *decomposed* into sub-queries, each retrieved
+separately (bringing its own Pali/Tibetan parallels + URNs), then synthesized
+into one answer whose every citation is checked against what was actually
+retrieved. Only fojin's integrated, aligned, URN-addressable corpus makes this
+possible — a single-canon tool can't.
+
+Why it's built *after* the verifiability foundation (PRs #896/#897/#898):
+multi-hop retrieval amplifies hallucination, so the synthesis is put through the
+exact same deterministic guards the chat path uses —
+``enforce_citation_whitelist`` (strip un-retrieved citations),
+``verify_quoted_content`` (flag invented quotes), ``build_trust_status`` — and
+the report carries that trust verdict. The agent can plan, but it cannot cite
+what it didn't retrieve.
+
+Design for testability: the LLM call (``complete``) and each retrieval tool are
+injected callables, so the plan → retrieve → synthesize orchestration is
+unit-tested with fakes — no live LLM or DB. ``build_research_agent`` wires the
+production bindings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from app.schemas.chat import ChatSource, ChatTrustStatus
+from app.schemas.research import ResearchReport, ResearchStep
+from app.services.chat_trust import build_trust_status
+from app.services.citation_guard import enforce_citation_whitelist
+from app.services.quote_verifier import verify_quoted_content
+
+logger = logging.getLogger(__name__)
+
+# Type of an injected LLM text completion: (system, user) -> assistant text.
+CompleteFn = Callable[[str, str], Awaitable[str]]
+# Type of a retrieval tool: query -> retrieved sources (each carrying a URN).
+RetrieveFn = Callable[[str], Awaitable[list[ChatSource]]]
+
+# Absolute ceilings independent of the request's max_steps — defence in depth
+# against a planner that emits a pathological plan.
+_HARD_MAX_STEPS = 6
+_MAX_SOURCES = 24
+_MAX_QUERY_LEN = 200
+
+
+@dataclass
+class PlanStep:
+    tool: str
+    query: str
+    aspect: str = ""
+
+
+@dataclass
+class _Collected:
+    """Accumulator for sources gathered across steps, deduped by (text_id,
+    juan_num) so the same fascicle retrieved by two sub-queries counts once."""
+    sources: list[ChatSource] = field(default_factory=list)
+    _seen: set[tuple[int, int]] = field(default_factory=set)
+
+    def add(self, srcs: list[ChatSource]) -> int:
+        added = 0
+        for s in srcs:
+            if len(self.sources) >= _MAX_SOURCES:
+                break
+            key = (s.text_id, s.juan_num)
+            if s.text_id and s.text_id > 0 and key in self._seen:
+                continue
+            self._seen.add(key)
+            self.sources.append(s)
+            added += 1
+        return added
+
+
+def build_plan_prompt(question: str) -> tuple[str, str]:
+    """(system, user) prompts that ask the LLM to decompose a research question
+    into 2–5 focused sub-queries as strict JSON."""
+    system = (
+        "你是佛教文献研究的检索规划器。把用户的研究问题拆解成 2-5 个聚焦的中文检索子查询，"
+        "每个子查询针对问题的一个方面（如某个宗派、某部经、某个概念的不同侧面），"
+        "以便分别在佛典语料库中检索。\n"
+        "只输出 JSON，格式：{\"steps\":[{\"query\":\"...\",\"aspect\":\"...\"}]}。"
+        "query 是用于检索的关键词式子查询；aspect 是该子查询考察的方面（简短中文）。"
+        "不要输出 JSON 以外的任何文字。"
+    )
+    return system, f"研究问题：{question}"
+
+
+def parse_plan(text: str, question: str, max_steps: int) -> list[PlanStep]:
+    """Parse the planner's JSON into capped PlanSteps.
+
+    Robust to fenced code blocks and trailing prose. On any parse failure or an
+    empty plan, falls back to a single corpus step on the original question — a
+    degraded plan still produces a grounded answer, which beats erroring out.
+    """
+    steps: list[PlanStep] = []
+    obj = _extract_json_object(text)
+    if isinstance(obj, dict):
+        raw_steps = obj.get("steps")
+        if isinstance(raw_steps, list):
+            for item in raw_steps:
+                if not isinstance(item, dict):
+                    continue
+                query = str(item.get("query", "")).strip()[:_MAX_QUERY_LEN]
+                if not query:
+                    continue
+                aspect = str(item.get("aspect", "")).strip()[:80]
+                # tool defaults to corpus; unknown tools coerced to corpus so a
+                # hallucinated tool name never drops a step.
+                tool = str(item.get("tool", "corpus")).strip() or "corpus"
+                if tool != "corpus":
+                    tool = "corpus"
+                steps.append(PlanStep(tool=tool, query=query, aspect=aspect))
+
+    cap = max(1, min(max_steps, _HARD_MAX_STEPS))
+    steps = steps[:cap]
+    if not steps:
+        steps = [PlanStep(tool="corpus", query=question.strip()[:_MAX_QUERY_LEN], aspect="")]
+    return steps
+
+
+def _extract_json_object(text: str) -> object:
+    """Best-effort extraction of the first top-level JSON object from LLM text
+    (which may wrap it in ```json fences or add commentary)."""
+    if not text:
+        return None
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    candidate = fenced.group(1) if fenced else None
+    if candidate is None:
+        start = text.find("{")
+        end = text.rfind("}")
+        candidate = text[start : end + 1] if start != -1 and end > start else None
+    if not candidate:
+        return None
+    try:
+        return json.loads(candidate)
+    except (ValueError, TypeError):
+        return None
+
+
+def build_synthesis_prompt(question: str, sources: list[ChatSource]) -> tuple[str, str]:
+    """(system, user) prompts for the grounded synthesis over collected sources.
+
+    Reuses the chat path's citation contract verbatim — the ``[出处: 《X》第N卷]``
+    context labels and the ``【《X》第N卷】`` clickable-citation rule — so the same
+    citation_guard / quote_verifier that protect chat also protect this answer.
+    """
+    system = (
+        "你是佛教文献研究助手。以下是系统为回答一个研究问题、分多步从佛典语料库中检索到的片段。\n"
+        "请综合这些片段写一篇结构化的研究性回答，比较不同经典/宗派/传承对该问题的处理。\n"
+        "**引用规则（严格）**：\n"
+        "- 只能引用下方 `[出处: 《经名》第N卷]` 标明的经典，格式写作【《经名》第N卷】，"
+        "使用出处行里的原始经名与真实卷号，不要改写或杜撰。\n"
+        "- 严禁把检索片段之外的经典写成【...】引用；那样会生成打不开的链接，严重伤害可信度。"
+        "宁可用散文提及「《X》中说……」。\n"
+        "- 直接引文必须逐字来自检索片段，不要凭记忆杜撰原文。\n"
+        "- 若检索片段含跨藏对读（parallel_chunks / 巴利·藏），可对比不同传承的表述。\n"
+        "- 检索不足以支撑的部分，如实说明，不要编造。"
+    )
+    context = _format_sources_context(sources)
+    user = f"研究问题：{question}\n\n检索到的片段：\n{context}"
+    return system, user
+
+
+def _format_sources_context(sources: list[ChatSource]) -> str:
+    """Render collected sources into the `[出处: …]` context block the citation
+    guard understands, including any cross-canon parallels."""
+    blocks: list[str] = []
+    for s in sources:
+        if s.text_id <= 0:
+            continue
+        label = f"《{s.title_zh}》第{s.juan_num}卷" if s.title_zh else f"text#{s.text_id} 第{s.juan_num}卷"
+        head = f"[出处: {label}]"
+        body = s.chunk_text or ""
+        parallels = s.parallel_chunks or []
+        if parallels:
+            plines = []
+            for p in parallels[:3]:
+                lang = {"pi": "巴利", "bo": "藏", "sa": "梵", "en": "英", "lzh": "汉"}.get(p.lang, p.lang)
+                title = p.title or "其他藏经"
+                plines.append(f"  · [{lang}]《{title}》第{p.juan_num}卷: {p.chunk_text[:200]}")
+            body += "\n[跨藏对读]\n" + "\n".join(plines)
+        blocks.append(f"{head}\n{body}")
+    return "\n\n".join(blocks) if blocks else "（未检索到相关片段）"
+
+
+class ResearchAgent:
+    """Plan → retrieve → synthesize, over injected LLM + retrieval tools."""
+
+    def __init__(self, complete: CompleteFn, corpus_tool: RetrieveFn) -> None:
+        self._complete = complete
+        self._tools: dict[str, RetrieveFn] = {"corpus": corpus_tool}
+
+    async def run(self, question: str, max_steps: int = 4) -> ResearchReport:
+        question = question.strip()
+
+        # 1. Plan (LLM). A planner failure degrades to a single-step plan.
+        try:
+            plan_sys, plan_user = build_plan_prompt(question)
+            plan_text = await self._complete(plan_sys, plan_user)
+        except Exception:
+            logger.warning("research planner LLM call failed; using single-step plan", exc_info=True)
+            plan_text = ""
+        plan = parse_plan(plan_text, question, max_steps)
+
+        # 2. Retrieve (tools), collecting + deduping across steps.
+        collected = _Collected()
+        run_steps: list[ResearchStep] = []
+        for step in plan:
+            tool = self._tools.get(step.tool) or self._tools["corpus"]
+            try:
+                srcs = await tool(step.query)
+            except Exception:
+                logger.warning("research retrieval failed for %r", step.query, exc_info=True)
+                srcs = []
+            added = collected.add(srcs)
+            run_steps.append(
+                ResearchStep(tool=step.tool, query=step.query, aspect=step.aspect, num_sources=added)
+            )
+
+        sources = collected.sources
+
+        # 3. Synthesize (LLM), then ground the answer with the same guards the
+        #    chat path uses. No sources → don't fabricate; return an honest note.
+        if not sources:
+            return ResearchReport(
+                question=question,
+                plan=run_steps,
+                answer="未能检索到与该研究问题相关的佛典片段，无法给出有据可依的回答。",
+                sources=[],
+                trust_status=build_trust_status("", [], citation_mutations=[], quote_mutations=[]),
+            )
+
+        syn_sys, syn_user = build_synthesis_prompt(question, sources)
+        try:
+            answer = await self._complete(syn_sys, syn_user)
+        except Exception:
+            logger.warning("research synthesis LLM call failed", exc_info=True)
+            answer = "抱歉，综合分析阶段的 AI 服务暂时不可用，请稍后重试。"
+
+        answer, trust = ground_answer(answer, sources)
+        return ResearchReport(
+            question=question, plan=run_steps, answer=answer, sources=sources, trust_status=trust
+        )
+
+
+def ground_answer(answer: str, sources: list[ChatSource]) -> tuple[str, ChatTrustStatus]:
+    """Run the synthesis through the deterministic citation guards and return the
+    corrected answer + its trust status — the same machinery as the chat path,
+    so a multi-step answer is held to the same "每一句点回原典" bar."""
+    corrected, cite_muts = enforce_citation_whitelist(answer, sources)
+    corrected, quote_muts = verify_quoted_content(corrected, sources)
+    trust = build_trust_status(
+        corrected, sources, citation_mutations=cite_muts, quote_mutations=quote_muts
+    )
+    return corrected, trust
+
+
+# ── production wiring ────────────────────────────────────────────────────
+
+# Per-step retrieval breadth. Kept modest — the agent runs several steps and
+# dedupes, so a wide per-step fetch mostly adds redundant context + tokens.
+_STEP_PGVECTOR_LIMIT = 8
+_SYNTHESIS_MAX_TOKENS = 2600
+_PLAN_MAX_TOKENS = 400
+
+
+def build_research_agent(db: object, user: object | None) -> ResearchAgent:
+    """Wire a ResearchAgent to the real corpus retriever + the platform/BYOK LLM.
+
+    Imports the heavy retrieval + LLM deps lazily so importing this module (e.g.
+    for unit tests of the pure orchestration) stays cheap and DB-free.
+    """
+    import httpx
+
+    from app.services.llm_client import _resolve_llm_config
+    from app.services.rag_retrieval import retrieve_rag_context
+
+    api_url, api_key, model, _is_byok, _provider = _resolve_llm_config(user)  # type: ignore[arg-type]
+
+    async def complete(system: str, user_msg: str) -> str:
+        # OpenAI-compatible chat/completions — the same call shape eval/run_eval
+        # uses in prod. max_tokens differs per call site (plan vs synthesis) but
+        # the planner prompt is short, so one modest ceiling covers both.
+        messages = [{"role": "system", "content": system}, {"role": "user", "content": user_msg}]
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(
+                f"{api_url}/chat/completions",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={
+                    "model": model,
+                    "messages": messages,
+                    "temperature": 0.5,
+                    "max_tokens": _SYNTHESIS_MAX_TOKENS,
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]["content"] or ""
+
+    async def corpus_tool(query: str) -> list[ChatSource]:
+        sources, _context = await retrieve_rag_context(
+            db, query, pgvector_limit=_STEP_PGVECTOR_LIMIT  # type: ignore[arg-type]
+        )
+        return sources
+
+    return ResearchAgent(complete=complete, corpus_tool=corpus_tool)

--- a/backend/tests/test_research_agent.py
+++ b/backend/tests/test_research_agent.py
@@ -1,0 +1,209 @@
+"""Tests for the agentic research assistant's orchestration.
+
+The LLM (`complete`) and the corpus retriever are injected fakes, so the whole
+plan → retrieve → synthesize → ground loop is exercised deterministically with
+no LLM or DB. Grounding reuses the real citation_guard / quote_verifier, so a
+fabricated citation in the synthesis is really caught here.
+"""
+
+import pytest
+
+from app.schemas.chat import ChatSource, ParallelChunk
+from app.services.research_agent import (
+    ResearchAgent,
+    build_plan_prompt,
+    ground_answer,
+    parse_plan,
+)
+
+
+def _src(text_id: int, title: str, juan: int = 1, text: str = "色不异空，空不异色。") -> ChatSource:
+    return ChatSource(
+        text_id=text_id, juan_num=juan, chunk_index=0, chunk_text=text,
+        score=0.9, title_zh=title, urn=f"fojin:cbeta/T{text_id:04d}.{juan}",
+    )
+
+
+class _ScriptedLLM:
+    """Returns queued responses in order; records the prompts it saw."""
+    def __init__(self, *responses: str) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, str]] = []
+
+    async def __call__(self, system: str, user: str) -> str:
+        self.calls.append((system, user))
+        return self._responses.pop(0) if self._responses else ""
+
+
+# ── parse_plan ───────────────────────────────────────────────────────────
+
+
+def test_parse_plan_reads_steps_and_caps():
+    text = '{"steps":[{"query":"般若 空","aspect":"般若"},{"query":"中观 空","aspect":"中观"},{"query":"唯识 空","aspect":"唯识"}]}'
+    steps = parse_plan(text, "空的三系比较", max_steps=2)
+    assert len(steps) == 2                       # capped to max_steps
+    assert steps[0].query == "般若 空"
+    assert steps[0].aspect == "般若"
+    assert steps[0].tool == "corpus"
+
+
+def test_parse_plan_tolerates_code_fence_and_prose():
+    text = "好的，这是计划：\n```json\n{\"steps\":[{\"query\":\"四念处\"}]}\n```\n希望有帮助"
+    steps = parse_plan(text, "q", max_steps=4)
+    assert len(steps) == 1
+    assert steps[0].query == "四念处"
+
+
+def test_parse_plan_falls_back_to_single_step_on_garbage():
+    steps = parse_plan("not json at all", "如何理解空性", max_steps=4)
+    assert len(steps) == 1
+    assert steps[0].query == "如何理解空性"
+
+
+def test_parse_plan_unknown_tool_coerced_to_corpus():
+    steps = parse_plan('{"steps":[{"query":"x","tool":"web_search"}]}', "q", max_steps=4)
+    assert steps[0].tool == "corpus"
+
+
+def test_parse_plan_drops_empty_queries():
+    steps = parse_plan('{"steps":[{"query":""},{"query":"  "},{"query":"真"}]}', "q", 4)
+    assert len(steps) == 1
+    assert steps[0].query == "真"
+
+
+# ── full agent run ───────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_agent_plans_retrieves_dedupes_and_grounds():
+    plan = '{"steps":[{"query":"般若 空","aspect":"般若"},{"query":"中观 空","aspect":"中观"}]}'
+    # Synthesis cites a real retrieved source → survives the guard intact.
+    synthesis = "般若与中观都讲空【《般若经》第1卷】。"
+    llm = _ScriptedLLM(plan, synthesis)
+
+    calls: list[str] = []
+
+    async def corpus(query: str) -> list[ChatSource]:
+        calls.append(query)
+        # Both sub-queries return the same fascicle (text_id 251) + a unique one,
+        # so dedup must collapse the shared one.
+        shared = _src(251, "般若经")
+        uniq = _src(1509 if "中观" in query else 223, "中论" if "中观" in query else "大智度论")
+        return [shared, uniq]
+
+    agent = ResearchAgent(complete=llm, corpus_tool=corpus)
+    report = await agent.run("空在般若与中观如何处理", max_steps=4)
+
+    # Planned 2 steps, both executed.
+    assert calls == ["般若 空", "中观 空"]
+    assert [s.query for s in report.plan] == ["般若 空", "中观 空"]
+    # Shared fascicle 251 deduped: 3 distinct sources, not 4.
+    ids = sorted(s.text_id for s in report.sources)
+    assert ids == [223, 251, 1509]
+    # Answer grounded; its single citation is to a retrieved title → verified.
+    assert "【《般若经》第1卷】" in report.answer
+    assert report.trust_status is not None
+    assert report.trust_status.state == "verified"
+    # Every source carries a URN (the #897 contract flowing through).
+    assert all(s.urn for s in report.sources)
+
+
+@pytest.mark.anyio
+async def test_agent_strips_fabricated_citation_in_synthesis():
+    plan = '{"steps":[{"query":"心经 空"}]}'
+    # LLM cites a text that was NOT retrieved → guard must strip the 【】.
+    synthesis = "参见【《楞严经》第5卷】的论述。"
+    llm = _ScriptedLLM(plan, synthesis)
+
+    async def corpus(query: str) -> list[ChatSource]:
+        return [_src(251, "般若波罗蜜多心经")]
+
+    report = await ResearchAgent(complete=llm, corpus_tool=corpus).run("q")
+    # The fabricated citation is downgraded to plain 《》 prose.
+    assert "【《楞严经》" not in report.answer
+    assert "《楞严经》" in report.answer
+    assert report.trust_status.state == "citation_corrected"
+
+
+@pytest.mark.anyio
+async def test_agent_no_sources_returns_honest_note_not_fabrication():
+    llm = _ScriptedLLM('{"steps":[{"query":"x"}]}')  # synthesis LLM never called
+
+    async def empty_corpus(query: str) -> list[ChatSource]:
+        return []
+
+    report = await ResearchAgent(complete=llm, corpus_tool=empty_corpus).run("冷僻问题")
+    assert report.sources == []
+    assert "未能检索到" in report.answer
+    assert report.trust_status.state == "no_sources"
+    # Synthesis LLM must NOT have been called (only the planner ran).
+    assert len(llm.calls) == 1
+
+
+@pytest.mark.anyio
+async def test_agent_survives_planner_llm_failure():
+    class _Boom:
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        async def __call__(self, system, user):
+            # First call (plan) raises; second (synthesis) returns text.
+            self.calls.append(1)
+            if len(self.calls) == 1:
+                raise RuntimeError("planner down")
+            return "空即是色【《般若经》第1卷】"
+
+    async def corpus(query: str) -> list[ChatSource]:
+        return [_src(251, "般若经")]
+
+    report = await ResearchAgent(complete=_Boom(), corpus_tool=corpus).run("空性")
+    # Planner failed → single-step fallback plan on the original question.
+    assert len(report.plan) == 1
+    assert report.plan[0].query == "空性"
+    assert report.trust_status.state == "verified"
+
+
+@pytest.mark.anyio
+async def test_agent_survives_retrieval_failure_on_one_step():
+    plan = '{"steps":[{"query":"good"},{"query":"bad"}]}'
+    llm = _ScriptedLLM(plan, "答案【《般若经》第1卷】")
+
+    async def flaky_corpus(query: str) -> list[ChatSource]:
+        if query == "bad":
+            raise RuntimeError("db hiccup")
+        return [_src(251, "般若经")]
+
+    report = await ResearchAgent(complete=llm, corpus_tool=flaky_corpus).run("q")
+    # The failed step contributes 0 sources but doesn't sink the run.
+    assert [s.num_sources for s in report.plan] == [1, 0]
+    assert len(report.sources) == 1
+
+
+# ── prompt + grounding units ─────────────────────────────────────────────
+
+
+def test_synthesis_context_includes_parallels_for_cross_canon():
+    from app.services.research_agent import _format_sources_context
+
+    s = _src(2, "中阿含经")
+    s.parallel_chunks = [ParallelChunk(
+        text_id=272, juan_num=1, chunk_index=0, chunk_text="Right View pali text",
+        lang="pi", title="Majjhima 9", urn="fojin:sc/mn9.1",
+    )]
+    ctx = _format_sources_context([s])
+    assert "[出处: 《中阿含经》第1卷]" in ctx
+    assert "[跨藏对读]" in ctx
+    assert "[巴利]《Majjhima 9》" in ctx
+
+
+def test_build_plan_prompt_asks_for_json():
+    system, user = build_plan_prompt("空性问题")
+    assert "JSON" in system
+    assert "空性问题" in user
+
+
+def test_ground_answer_passes_clean_answer_through():
+    answer = "《心经》讲空【《心经》第1卷】。"
+    out, trust = ground_answer(answer, [_src(251, "心经")])
+    assert out == answer
+    assert trust.state == "verified"


### PR DESCRIPTION
## Why (pillar #2 — the killer app)

Instead of one-shot RAG, a scholarly question — *"how is śūnyatā treated across Prajñāpāramitā vs Madhyamaka vs Yogācāra, with cited cross-canon parallels"* — is **decomposed into sub-queries**, each retrieved separately (bringing its own Pali/Tibetan parallels + URNs), then **synthesized into one answer whose every citation is checked against what was actually retrieved.** Only fojin's integrated, aligned, URN-addressable corpus makes this possible — a single-canon tool can't.

Built **deliberately last**, on the verifiability foundation from #896/#897/#898: multi-hop retrieval amplifies hallucination, so the synthesis is put through the **exact same deterministic guards as the chat path** (`enforce_citation_whitelist` + `verify_quoted_content` + `build_trust_status`) and the report carries that trust verdict. **The agent can plan, but it cannot cite what it didn't retrieve.**

## What

- **`app/services/research_agent.py`** — `plan → retrieve → synthesize → ground`. The LLM (`complete`) and the corpus retriever are **injected callables**, so the orchestration is fully unit-tested with fakes (no LLM/DB). `build_research_agent` wires production bindings: OpenAI-compatible completion via `_resolve_llm_config`, corpus retrieval via `retrieve_rag_context` (which brings cross-canon parallels along).
- **`POST /api/research/query`** — returns the **plan** (how the question was decomposed), the **deduplicated cited sources** (each with a URN), the **synthesized answer**, and its **trust status**.
- **Bounded & robust**: hard step/source caps; planner failure → single-step fallback; a step's retrieval failure doesn't sink the run; **no sources → honest note, not fabrication**.

## UX / risk
- **Additive & isolated**: new endpoint/service/schema; only `main.py` changed (router registration). **Does NOT touch `chat.py` / the SSE path** (the flagged repeat-incident area) — verified in the diff.
- **Authenticated**: a request fans out to several LLM+retrieval calls, so it's bounded to signed-in users.
- **No existing-UX change**: backend-only. A "research mode" frontend is a deliberate follow-up.

## Test
```
pytest tests/test_research_agent.py -q     # 13 passed
pytest -q                                  # 877 passed (full suite)
```
The 13 tests exercise the whole loop with a scripted fake LLM + fake tools, incl. **real citation-guard grounding** — a fabricated citation in the synthesis is really stripped (`trust=citation_corrected`), dedup across steps, planner/retrieval failure fallbacks, and the no-sources honesty path.

## Follow-ups (not in this PR)
- Live end-to-end run for the first real trust/faithfulness numbers needs prod DB (pgvector) + LLM key — an operator step (same as the eval baseline).
- The plan schema carries a `tool` field so **dictionary / KG dispatch** is a non-breaking addition (#2b).
- A **research-mode frontend** panel (gated/optional, doesn't replace chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)