### PR TITLE
fix(cost): quota /research/query and rate-limit paid-inference endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,8 @@ APIFY_TOKEN=apify_api_your-token-here
 # RATE_LIMIT_DEFAULT=200
 # RATE_LIMIT_LOGIN=10
 # RATE_LIMIT_REGISTER=5
+# RATE_LIMIT_SEMANTIC=20
+# RATE_LIMIT_RESEARCH=10
 
 # Prometheus /metrics（默认开启；挂在应用根路径，nginx 不代理 → 仅内网可达。
 # 抓取用可选 overlay：docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d

--- a/backend/app/api/research.py
+++ b/backend/app/api/research.py
@@ -9,13 +9,14 @@ several LLM + retrieval calls and so must be bounded to signed-in users.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_user
 from app.database import get_db
 from app.models.user import User
 from app.schemas.research import ResearchReport, ResearchRequest
+from app.services.chat_quota import check_research_quota
 from app.services.research_agent import build_research_agent
 
 router = APIRouter(prefix="/research", tags=["research"])
@@ -24,6 +25,7 @@ router = APIRouter(prefix="/research", tags=["research"])
 @router.post("/query", response_model=ResearchReport)
 async def research_query(
     request: ResearchRequest,
+    http_request: Request,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ResearchReport:
@@ -33,5 +35,9 @@ async def research_query(
     sources (each with a URN), the synthesized answer, and the deterministic
     trust status of that answer.
     """
+    # A single request fans out into several paid LLM + embedding calls on the
+    # platform key, so enforce a per-user daily budget (BYOK users exempt).
+    redis = getattr(http_request.app.state, "redis", None)
+    await check_research_quota(redis, user)
     agent = build_research_agent(db, user)
     return await agent.run(request.question, max_steps=request.max_steps)

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -170,7 +170,9 @@ async def semantic_search(
     """Semantic search using pgvector embedding similarity.
 
     语义搜索。基于向量相似度在 34.7 万段经文中检索语义最相关的内容。支持按朝代、分类、语言和数据源筛选。"""
-    return await search_semantic(db, q, size, dynasty, category, lang, sources)
+    # Strip first so blank/whitespace-only queries short-circuit before the
+    # paid embedding call and can't each bust the embedding cache.
+    return await search_semantic(db, q.strip(), size, dynasty, category, lang, sources)
 
 
 _filters_cache: dict = {"data": None, "expires": 0}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -92,6 +92,10 @@ class Settings(BaseSettings):
     rate_limit_default: int = 200
     rate_limit_login: int = 10
     rate_limit_register: int = 5
+    # Paid-inference endpoints (platform key): each request triggers embedding
+    # and/or LLM calls, so cap them well below the default per-IP budget.
+    rate_limit_semantic: int = 20
+    rate_limit_research: int = 10
 
     @property
     def database_url(self) -> str:

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -19,6 +19,9 @@ STRICT_PATHS: dict[str, int] = {
     "/api/auth/change-password": 5,
     "/api/search": 60,
     "/api/search/content": 30,
+    # Paid-inference endpoints (embedding / LLM on the platform key).
+    "/api/search/semantic": settings.rate_limit_semantic,
+    "/api/research/query": settings.rate_limit_research,
 }
 
 

--- a/backend/app/services/chat_quota.py
+++ b/backend/app/services/chat_quota.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 # Free daily limits for users without their own API key
 FREE_DAILY_LIMIT_USER = 200      # Logged-in users — effectively unlimited for normal use, caps abuse
 FREE_DAILY_LIMIT_ANONYMOUS = 10  # Anonymous users (encourage registration)
+# Research fans out into several paid LLM + embedding calls per request, so it
+# gets its own daily budget well below the chat limit.
+FREE_DAILY_LIMIT_RESEARCH = 30
 
 
 async def _check_daily_quota(db: AsyncSession, user: User) -> None:
@@ -86,6 +89,42 @@ async def _check_anonymous_quota(redis, client_ip: str) -> None:
         raise
     except Exception:
         logger.warning("Redis anonymous quota check failed", exc_info=True)
+
+
+def _research_quota_key(user_id: int) -> str:
+    """Redis key for per-user daily research quota."""
+    today = date.today().isoformat()
+    return f"research:user:{user_id}:{today}"
+
+
+async def check_research_quota(redis, user: User) -> None:
+    """Check + increment a per-user daily research quota.
+
+    Research runs on the platform key and fans out into several paid LLM +
+    embedding calls per request, so it needs a hard per-user cap. The counter
+    is keyed by ``user.id`` (not IP), so a proxy pool can't widen it. BYOK
+    users pay with their own key and are exempt, mirroring the chat path.
+
+    Fails **closed** (``ServiceError``) when Redis is unavailable — unlike the
+    best-effort chat rate limiter, letting this expensive path run unbounded
+    during a Redis outage would reopen the wallet-DoS it guards against.
+
+    Raises ``QuotaExceededError`` when the daily budget is spent.
+    """
+    if user.encrypted_api_key:  # BYOK — user pays their own key
+        return
+    if not redis:
+        raise ServiceError("研究助手暂时不可用，请稍后重试")
+    key = _research_quota_key(user.id)
+    try:
+        current = await redis.incr(key)
+        if current == 1:
+            await redis.expire(key, 86400)  # 24h TTL
+    except Exception:
+        logger.warning("Redis research quota check failed", exc_info=True)
+        raise ServiceError("研究助手暂时不可用，请稍后重试") from None
+    if current > FREE_DAILY_LIMIT_RESEARCH:
+        raise QuotaExceededError(limit=FREE_DAILY_LIMIT_RESEARCH)
 
 
 def _validate_message(message: str) -> None:

--- a/backend/tests/test_research_quota.py
+++ b/backend/tests/test_research_quota.py
@@ -1,0 +1,91 @@
+"""Tests for the per-user daily research quota (wallet-DoS guard).
+
+The research agent runs on the platform key and fans out into several paid
+LLM + embedding calls per request, but /research/query had no quota — only
+the per-IP default rate limit, which a proxy pool widens trivially. These
+tests pin the per-user cap, BYOK exemption, and fail-closed-on-outage
+behavior.
+"""
+
+import pytest
+
+from app.core.exceptions import QuotaExceededError, ServiceError
+from app.models.user import User
+from app.services.chat_quota import (
+    FREE_DAILY_LIMIT_RESEARCH,
+    check_research_quota,
+)
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict[str, int] = {}
+        self.fail = False
+
+    async def incr(self, key):
+        if self.fail:
+            raise RuntimeError("redis down")
+        self.store[key] = int(self.store.get(key, 0)) + 1
+        return self.store[key]
+
+    async def expire(self, key, ttl):
+        return key in self.store
+
+
+def _user(uid=1, byok=False):
+    return User(id=uid, encrypted_api_key="enc" if byok else None)
+
+
+@pytest.mark.anyio
+async def test_within_limit_passes():
+    r = FakeRedis()
+    for _ in range(FREE_DAILY_LIMIT_RESEARCH):
+        await check_research_quota(r, _user())  # must not raise
+
+
+@pytest.mark.anyio
+async def test_over_limit_raises_quota_exceeded():
+    r = FakeRedis()
+    for _ in range(FREE_DAILY_LIMIT_RESEARCH):
+        await check_research_quota(r, _user())
+    with pytest.raises(QuotaExceededError):
+        await check_research_quota(r, _user())
+
+
+@pytest.mark.anyio
+async def test_byok_user_is_exempt():
+    r = FakeRedis()
+    # Way over the free limit, but BYOK pays their own key → never blocked.
+    for _ in range(FREE_DAILY_LIMIT_RESEARCH * 3):
+        await check_research_quota(r, _user(byok=True))
+    assert r.store == {}  # counter never touched
+
+
+@pytest.mark.anyio
+async def test_quota_is_per_user():
+    r = FakeRedis()
+    for _ in range(FREE_DAILY_LIMIT_RESEARCH):
+        await check_research_quota(r, _user(uid=1))
+    # A different user still has their full budget.
+    await check_research_quota(r, _user(uid=2))
+
+
+@pytest.mark.anyio
+async def test_fails_closed_when_redis_unavailable():
+    with pytest.raises(ServiceError):
+        await check_research_quota(None, _user())
+
+
+@pytest.mark.anyio
+async def test_fails_closed_on_redis_error():
+    r = FakeRedis()
+    r.fail = True
+    with pytest.raises(ServiceError):
+        await check_research_quota(r, _user())
+
+
+def test_cost_endpoints_are_strict_rate_limited():
+    from app.core.rate_limit import STRICT_PATHS
+
+    assert "/api/research/query" in STRICT_PATHS
+    assert "/api/search/semantic" in STRICT_PATHS


### PR DESCRIPTION
## 问题（安全审核 H3，高危 · 成本）

两个端点可耗尽平台 LLM/embedding 预算（denial of wallet）：

- **`POST /research/query`** 已鉴权但**无任何配额**，而单次请求在平台密钥上扇出 ≈2 次 LLM 补全 + 最多 6 次 embedding。唯一约束是按 IP 的默认限流（代理池可绕）。
- **`GET /search/semantic`** **无鉴权**、每次调用付费 embedding，却因不在 `STRICT_PATHS` 落到最宽松的 200/min 档——最贵的接口限流最松。

## 修复

- 新增**每用户每日** research 配额 `FREE_DAILY_LIMIT_RESEARCH=30`，按 `user.id` 计（代理池无法扩大）；**BYOK 用户豁免**（用自己的 key，与 chat 一致）。Redis 不可用时**失败关闭**(503)——昂贵路径在 Redis 故障期不得无界运行（正面回应审计里"fail-open 放大钱包 DoS"的隐患）。
- `/search/semantic` 保持公开（核心功能），但纳入 `STRICT_PATHS`（`rate_limit_semantic=20`）；查询先 `strip()`，空白查询在付费 embedding 前短路、且不能靠加空格逐个击穿 embedding 缓存。
- `/research/query` 纳入 `STRICT_PATHS`（`rate_limit_research=10`）。

## 测试

新增 `tests/test_research_quota.py`（每用户上限、BYOK 豁免、按用户隔离、Redis None/异常均 fail-closed、STRICT_PATHS 成员）。本地全量后端 **895 tests 全绿**，改动文件 ruff 通过。

（已 rebase 到含 #902/#903 的最新 master，config.py/.env.example 的相邻限流配置冲突已合并保留两侧。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)