### PR TITLE
fix(ssrf): pin outbound LLM calls on research + session-title paths

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -205,7 +205,10 @@ async def _generate_session_title(
         {"role": "user", "content": f"用户问：{message[:100]}\n回答：{answer[:200]}"},
     ]
     try:
-        async with httpx.AsyncClient(timeout=10) as client:
+        # Route through the shared client builder so a BYOK "custom" endpoint
+        # gets the same IP-pinned, rebinding-proof transport as the main chat
+        # path — a bare client here would re-resolve DNS and reopen SSRF.
+        async with await _build_llm_http_client(api_url, provider, 10) as client:
             if _is_anthropic(api_url, provider):
                 body = _build_anthropic_body(model, messages, temperature=0.3, max_tokens=_with_reasoning_headroom(model, 64))
                 resp = await client.post(f"{api_url}/messages", headers=_build_anthropic_headers(api_key), json=body)

--- a/backend/app/services/research_agent.py
+++ b/backend/app/services/research_agent.py
@@ -366,17 +366,27 @@ def build_research_agent(db: object, user: object | None) -> ResearchAgent:
     """
     import httpx
 
+    from app.core.url_security import create_pinned_https_transport
     from app.services.llm_client import _resolve_llm_config
     from app.services.rag_retrieval import retrieve_rag_context
 
-    api_url, api_key, model, _is_byok, _provider = _resolve_llm_config(user)  # type: ignore[arg-type]
+    api_url, api_key, model, _is_byok, provider = _resolve_llm_config(user)  # type: ignore[arg-type]
 
     async def complete(system: str, user_msg: str) -> str:
         # OpenAI-compatible chat/completions — the same call shape eval/run_eval
         # uses in prod. max_tokens differs per call site (plan vs synthesis) but
         # the planner prompt is short, so one modest ceiling covers both.
         messages = [{"role": "system", "content": system}, {"role": "user", "content": user_msg}]
-        async with httpx.AsyncClient(timeout=60) as client:
+        # For BYOK "custom" endpoints, pin the outbound connection to a
+        # validated public IP (runtime DNS check + rebinding-proof transport) —
+        # the same guard the chat path applies. Platform/known providers use
+        # fixed, trusted base URLs, so they need no per-request pinning.
+        transport = (
+            await create_pinned_https_transport(api_url, label="自定义 API 地址")
+            if provider == "custom"
+            else None
+        )
+        async with httpx.AsyncClient(timeout=60, transport=transport) as client:
             resp = await client.post(
                 f"{api_url}/chat/completions",
                 headers={"Authorization": f"Bearer {api_key}"},

--- a/backend/tests/test_byok_custom_url_security.py
+++ b/backend/tests/test_byok_custom_url_security.py
@@ -216,6 +216,98 @@ async def test_custom_byok_http_client_uses_pinned_transport(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_session_title_custom_byok_routes_through_pinned_transport(monkeypatch):
+    """Session-title generation must pin BYOK custom endpoints, not use a bare
+    client that re-resolves DNS (SSRF / rebinding). If the pin guard rejects
+    the URL, it returns None without issuing the request."""
+    from app.services import chat
+
+    pin = AsyncMock(side_effect=ValueError("自定义 API 地址 解析到内网地址"))
+    monkeypatch.setattr(chat, "create_pinned_https_transport", pin)
+
+    title = await chat._generate_session_title(
+        "https://llm.example.com/v1", "sk-user", "custom-model",
+        "用户问题", "AI 回答", provider="custom",
+    )
+
+    assert title is None
+    pin.assert_awaited_once_with("https://llm.example.com/v1", label="自定义 API 地址")
+
+
+@pytest.mark.anyio
+async def test_research_agent_custom_byok_routes_through_pinned_transport(monkeypatch):
+    """The research agent's LLM calls must pin BYOK custom endpoints too — this
+    path previously used a bare client with no runtime DNS check at all."""
+    from unittest.mock import MagicMock
+
+    from app.core import url_security
+    from app.services import llm_client, research_agent
+
+    monkeypatch.setattr(
+        llm_client,
+        "_resolve_llm_config",
+        lambda _user: ("https://llm.example.com/v1", "sk-user", "custom-model", True, "custom"),
+    )
+    pin = AsyncMock(side_effect=ValueError("自定义 API 地址 解析到内网地址"))
+    monkeypatch.setattr(url_security, "create_pinned_https_transport", pin)
+
+    agent = research_agent.build_research_agent(db=MagicMock(), user=MagicMock())
+    with pytest.raises(ValueError, match="自定义 API 地址"):
+        await agent._complete("system prompt", "user question")
+
+    pin.assert_awaited_once_with("https://llm.example.com/v1", label="自定义 API 地址")
+
+
+@pytest.mark.anyio
+async def test_research_agent_platform_provider_uses_default_transport(monkeypatch):
+    """Non-custom (platform/known) providers use fixed trusted URLs and must NOT
+    invoke the pinning path (which would add needless DNS work / failure modes)."""
+    from unittest.mock import MagicMock
+
+    from app.core import url_security
+    from app.services import llm_client, research_agent
+
+    monkeypatch.setattr(
+        llm_client,
+        "_resolve_llm_config",
+        lambda _user: ("https://api.deepseek.com/v1", "sk-plat", "deepseek", False, "deepseek"),
+    )
+    pin = AsyncMock()
+    monkeypatch.setattr(url_security, "create_pinned_https_transport", pin)
+
+    captured = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": "答案"}}]}
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            captured["transport"] = kwargs.get("transport", "MISSING")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return _Resp()
+
+    monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+    agent = research_agent.build_research_agent(db=MagicMock(), user=MagicMock())
+    out = await agent._complete("system", "user")
+
+    assert out == "答案"
+    pin.assert_not_awaited()
+    assert captured["transport"] is None
+
+
+@pytest.mark.anyio
 async def test_prepare_chat_rejects_custom_byok_when_runtime_dns_guard_fails(monkeypatch):
     from app.services import chat
 


### PR DESCRIPTION
## 问题（安全审核 M1，中危 · 已登录用户盲 SSRF）

主聊天链路把 BYOK `custom` 端点经 `create_pinned_https_transport`（运行时 DNS 校验 + IP 绑定、防 rebinding）发出，但另外两条出站 LLM 路径用裸 `httpx` 客户端绕过了这道防线：

- **`research_agent.build_research_agent.complete()`** 完全**没有运行时 DNS 校验**——custom URL 的 A 记录直指内网（`169.254.169.254`、`10.0.0.0/8` …）即可被服务器直接请求（任意已登录用户的盲 SSRF，无需 rebinding）。
- **`chat._generate_session_title()`** 在 `_prepare_chat` 一次性校验后用裸客户端**重新解析 DNS**，留下 rebinding 窗口。

## 修复

两处都改为与聊天主链路一致地构造客户端：custom provider → `create_pinned_https_transport`（运行时解析 + 拒绝内网 IP + 绑定）；平台/已知 provider 用其固定可信 URL，不变。研究 Agent 的 plan/synthesis 调用本就包了 try/except，故被拒的 URL 会优雅降级而非 500。

## 测试

扩展 `test_byok_custom_url_security.py`：标题生成与研究 Agent 对 custom URL 都走 pin 守卫（被拒时分别返回 None / 抛错），平台 provider 使用默认 transport（不 pin）。本地相关安全套件 **55 tests 全绿**，改动文件 ruff 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)