### PR TITLE
feat(home): dynamic showcase — turn the 6 hero cards into a live showcase

### DIFF
--- a/backend/app/api/home.py
+++ b/backend/app/api/home.py
@@ -1,0 +1,27 @@
+"""Homepage dynamic content endpoints."""
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.services.home_showcase import SHOWCASE_TTL, get_home_showcase
+
+router = APIRouter(prefix="/home", tags=["home"])
+
+
+@router.get("/showcase")
+async def home_showcase(
+    request: Request,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
+    """Live subtitle content for the 6 hero feature cards.
+
+    Public, Redis-cached, best-effort: each card key may be null, in which case
+    the frontend renders that card's static fallback. Served with a matching
+    Cache-Control so the CDN/browser also caches it briefly.
+    """
+    redis = getattr(request.app.state, "redis", None)
+    showcase = await get_home_showcase(db, redis)
+    response.headers["Cache-Control"] = f"public, max-age={SHOWCASE_TTL}"
+    return showcase

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,6 +69,7 @@ from app.api import (
     feed,
     feedback,
     history,
+    home,
     iiif,
     knowledge_graph,
     notification,
@@ -463,6 +464,7 @@ app.include_router(alignment.router, prefix="/api")
 # Phase 3 routers
 app.include_router(chat.router, prefix="/api")
 app.include_router(research.router, prefix="/api")
+app.include_router(home.router, prefix="/api")
 app.include_router(share.router, prefix="/api")
 app.include_router(og.router, prefix="/api")
 app.include_router(annotations.router, prefix="/api")

--- a/backend/app/services/home_showcase.py
+++ b/backend/app/services/home_showcase.py
@@ -1,0 +1,197 @@
+"""Dynamic homepage showcase — the live content behind the 6 hero feature cards.
+
+The hero cards used to repeat the top nav verbatim (same icon, title, and
+destination), differentiated only by a static example line. This service makes
+them a *showcase* the nav can't be: each card's subtitle is real, rotating
+platform content — live counts, a hot question, a dictionary term, a knowledge-
+graph triple, geography. The 经典专题 card is driven by the frontend's own
+collection content, so it isn't included here.
+
+Two hard constraints, both honoured:
+  - **Cheap**: this is the highest-traffic page. One Redis-cached aggregate
+    (SHOWCASE_TTL) instead of six per-card fetches; every DB query is bounded.
+  - **Degrades independently**: each card's data is best-effort — a failed or
+    empty sub-query yields ``None`` for that card only (the frontend then shows
+    its static fallback), and the whole endpoint never fails the page.
+
+"Rotation" uses a time-bucketed seed so the showcase changes across cache
+periods (feels alive) while staying stable within one (cacheable).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.dictionary import HOT_TERMS
+from app.models.dictionary import DictionaryEntry
+from app.models.knowledge_graph import KGEntity, KGRelation
+from app.models.text import BuddhistText
+from app.services.hot_questions import get_hot_questions
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL for the whole aggregate, and the rotation bucket size. 15 min keeps
+# the homepage lively without hammering the DB.
+SHOWCASE_TTL = 900
+_SHOWCASE_CACHE_KEY = "home:showcase:v1"
+
+# A small candidate pool size for rotation-by-seed queries: fetch a bounded set
+# cheaply, then pick one deterministically per time bucket.
+_POOL = 12
+_GEO_TYPES = ("place", "monastery")
+
+
+def _seed() -> int:
+    """Time-bucketed rotation seed — stable within a cache period, advancing
+    across periods so revisits see fresh content."""
+    return int(time.time() // SHOWCASE_TTL)
+
+
+def _pick(items: list, seed: int):
+    return items[seed % len(items)] if items else None
+
+
+async def _sources_card(db: AsyncSession) -> dict | None:
+    try:
+        texts = (await db.execute(select(func.count(BuddhistText.id)))).scalar() or 0
+        # DataSource import is local to avoid a heavy import at module load.
+        from app.models.source import DataSource
+
+        sources = (
+            await db.execute(
+                select(func.count(DataSource.id)).where(DataSource.is_active.is_(True))
+            )
+        ).scalar() or 0
+        if not texts and not sources:
+            return None
+        return {"sources": int(sources), "texts": int(texts)}
+    except Exception:
+        logger.warning("showcase sources_card failed", exc_info=True)
+        return None
+
+
+async def _chat_card(db: AsyncSession, redis, seed: int) -> dict | None:
+    try:
+        questions = await get_hot_questions(db, redis)
+        q = _pick(questions, seed)
+        return {"question": q} if q else None
+    except Exception:
+        logger.warning("showcase chat_card failed", exc_info=True)
+        return None
+
+
+async def _dictionary_card(db: AsyncSession, seed: int) -> dict | None:
+    try:
+        term = _pick(HOT_TERMS, seed)
+        if not term:
+            return None
+        row = (
+            await db.execute(
+                select(DictionaryEntry.headword, DictionaryEntry.definition)
+                .where(DictionaryEntry.headword == term)
+                .limit(1)
+            )
+        ).first()
+        if row is None:
+            return {"term": term, "definition": None}
+        definition = (row[1] or "").strip().replace("\n", " ")
+        return {"term": row[0], "definition": definition[:60] or None}
+    except Exception:
+        logger.warning("showcase dictionary_card failed", exc_info=True)
+        return None
+
+
+async def _kg_card(db: AsyncSession, seed: int) -> dict | None:
+    """A readable knowledge-graph triple (subject —predicate→ object).
+
+    Bounded: fetches a small pool of relations whose subject is a person (the
+    most human-readable triples: 玄奘 —译→ …) and both endpoints have a name,
+    then rotates. Person-subject filter keeps the sample coherent without an
+    expensive scan."""
+    try:
+        subj = aliased(KGEntity)
+        obj = aliased(KGEntity)
+        rows = (
+            await db.execute(
+                select(subj.name_zh, KGRelation.predicate, obj.name_zh)
+                .join(subj, KGRelation.subject_id == subj.id)
+                .join(obj, KGRelation.object_id == obj.id)
+                .where(
+                    subj.entity_type == "person",
+                    subj.name_zh.is_not(None),
+                    obj.name_zh.is_not(None),
+                )
+                .limit(_POOL)
+            )
+        ).all()
+        picked = _pick(rows, seed)
+        if picked is None:
+            return None
+        return {"subject": picked[0], "predicate": picked[1], "object": picked[2]}
+    except Exception:
+        logger.warning("showcase kg_card failed", exc_info=True)
+        return None
+
+
+async def _geo_card(db: AsyncSession, seed: int) -> dict | None:
+    try:
+        count = (
+            await db.execute(
+                select(func.count(KGEntity.id)).where(KGEntity.entity_type.in_(_GEO_TYPES))
+            )
+        ).scalar() or 0
+        names = (
+            await db.execute(
+                select(KGEntity.name_zh)
+                .where(KGEntity.entity_type.in_(_GEO_TYPES), KGEntity.name_zh.is_not(None))
+                .limit(_POOL)
+            )
+        ).scalars().all()
+        if not count and not names:
+            return None
+        # Rotate the featured slice so the names vary across periods.
+        featured = names[seed % max(1, len(names)) :][:3] or names[:3]
+        return {"count": int(count), "places": list(featured)}
+    except Exception:
+        logger.warning("showcase geo_card failed", exc_info=True)
+        return None
+
+
+async def get_home_showcase(db: AsyncSession, redis=None) -> dict:
+    """Aggregate the live subtitle content for the homepage hero cards.
+
+    Redis-cached for SHOWCASE_TTL. Each card is best-effort and independently
+    nullable — a null card tells the frontend to show its static fallback."""
+    if redis is not None:
+        try:
+            import json
+
+            cached = await redis.get(_SHOWCASE_CACHE_KEY)
+            if cached:
+                return json.loads(cached)
+        except Exception:
+            logger.debug("showcase cache read failed", exc_info=True)
+
+    seed = _seed()
+    showcase = {
+        "sources": await _sources_card(db),
+        "chat": await _chat_card(db, redis, seed),
+        "dictionary": await _dictionary_card(db, seed),
+        "kg": await _kg_card(db, seed),
+        "geo": await _geo_card(db, seed),
+    }
+
+    if redis is not None:
+        try:
+            import json
+
+            await redis.set(_SHOWCASE_CACHE_KEY, json.dumps(showcase), ex=SHOWCASE_TTL)
+        except Exception:
+            logger.debug("showcase cache write failed", exc_info=True)
+
+    return showcase

--- a/backend/tests/test_home_showcase.py
+++ b/backend/tests/test_home_showcase.py
@@ -1,0 +1,114 @@
+"""Tests for the homepage dynamic showcase service.
+
+Uses an in-memory SQLite DB seeded with a few rows so each card's real query
+runs, plus asserts the two guarantees: independent per-card degradation
+(a card with no data → None, page still returns) and time-bucket rotation.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.dictionary import DictionaryEntry
+from app.models.hot_question import HotQuestion
+from app.models.knowledge_graph import KGEntity, KGRelation
+from app.models.source import DataSource
+from app.models.text import BuddhistText
+from app.services import home_showcase
+from app.services.home_showcase import _pick, _seed, get_home_showcase
+
+_MODELS = (BuddhistText, DataSource, DictionaryEntry, HotQuestion, KGEntity, KGRelation)
+
+
+@pytest_asyncio.fixture
+async def seeded_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        for model in _MODELS:
+            await conn.run_sync(model.__table__.create)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        source = DataSource(name_zh="CBETA", code="cbeta", is_active=True)
+        s.add(source)
+        await s.flush()
+        s.add(BuddhistText(cbeta_id="T0001", title_zh="長阿含經", lang="lzh"))
+        s.add(DictionaryEntry(
+            headword="般若", definition="照见诸法实相的智慧。", lang="zh", source_id=source.id
+        ))
+        xuanzang = KGEntity(entity_type="person", name_zh="玄奘")
+        sutra = KGEntity(entity_type="text", name_zh="大般若經")
+        nalanda = KGEntity(entity_type="monastery", name_zh="那烂陀寺")
+        s.add_all([xuanzang, sutra, nalanda])
+        await s.flush()
+        s.add(KGRelation(subject_id=xuanzang.id, predicate="译", object_id=sutra.id))
+        await s.commit()
+        yield s
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_showcase_populates_each_card_from_real_data(seeded_db):
+    out = await get_home_showcase(seeded_db, redis=None)
+    assert out["sources"] == {"sources": 1, "texts": 1}
+    # HOT_TERMS rotates; 般若 is in the list, and its definition is seeded, so
+    # whichever term is picked, the dictionary card is a dict (never crashes).
+    assert isinstance(out["dictionary"], dict)
+    assert out["kg"] == {"subject": "玄奘", "predicate": "译", "object": "大般若經"}
+    assert out["geo"]["count"] == 1
+    assert "那烂陀寺" in out["geo"]["places"]
+    assert isinstance(out["chat"], dict) and out["chat"]["question"]
+
+
+@pytest.mark.anyio
+async def test_empty_db_degrades_each_card_to_none_not_crash():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        for model in _MODELS:
+            await conn.run_sync(model.__table__.create)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        out = await get_home_showcase(s, redis=None)
+    await engine.dispose()
+    # No sources/texts, no KG, no geo → those cards None; chat still has the
+    # DEFAULT_HOT_QUESTIONS fallback; dictionary term exists but no definition row.
+    assert out["sources"] is None
+    assert out["kg"] is None
+    assert out["geo"] is None
+    assert out["chat"]["question"]                      # default hot questions
+    assert out["dictionary"]["definition"] is None      # term w/o seeded entry
+
+
+@pytest.mark.anyio
+async def test_showcase_reads_from_redis_cache_when_present(seeded_db):
+    class _Redis:
+        def __init__(self, payload):
+            self._payload = payload
+        async def get(self, key):
+            return self._payload
+        async def set(self, *a, **k):
+            pass
+
+    import json
+    sentinel = {"sources": {"sources": 999, "texts": 0}, "chat": None,
+                "dictionary": None, "kg": None, "geo": None}
+    out = await get_home_showcase(seeded_db, redis=_Redis(json.dumps(sentinel)))
+    assert out == sentinel                               # served from cache, DB untouched
+
+
+def test_pick_rotates_by_seed():
+    items = ["a", "b", "c"]
+    assert _pick(items, 0) == "a"
+    assert _pick(items, 1) == "b"
+    assert _pick(items, 3) == "a"                        # wraps
+    assert _pick([], 5) is None
+
+
+def test_seed_is_stable_within_bucket(monkeypatch):
+    # Anchor on a bucket boundary so "TTL-1 later" stays in the same bucket.
+    base = home_showcase.SHOWCASE_TTL * 1000
+    monkeypatch.setattr(home_showcase.time, "time", lambda: float(base))
+    s1 = _seed()
+    monkeypatch.setattr(home_showcase.time, "time", lambda: float(base + home_showcase.SHOWCASE_TTL - 1))
+    assert _seed() == s1                                 # same bucket
+    monkeypatch.setattr(home_showcase.time, "time", lambda: float(base + home_showcase.SHOWCASE_TTL))
+    assert _seed() == s1 + 1                             # next bucket

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -395,6 +395,8 @@
   "home.stat_label": "Platform statistics",
   "home.feature_sources_title": "Data Sources",
   "home.feature_sources_desc": "Aggregating CBETA, SuttaCentral and global Buddhist digital resources",
+  "home.sc_sources": "{{sources}} sources · {{texts}} texts",
+  "home.sc_geo": "{{count}} sacred sites · {{places}}",
   "home.feature_kg_title": "Knowledge Graph",
   "home.feature_kg_desc": "e.g. Kumārajīva → translated → Lotus Sutra",
   "home.feature_chat_title": "AI Q&A",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -395,6 +395,8 @@
   "home.stat_label": "平臺資料統計",
   "home.feature_sources_title": "資料來源",
   "home.feature_sources_desc": "匯聚 CBETA、SuttaCentral 等全球數字佛典資源",
+  "home.sc_sources": "{{sources}} 個來源 · {{texts}} 部經典",
+  "home.sc_geo": "{{count}} 處聖跡 · {{places}}",
   "home.feature_kg_title": "知識圖譜",
   "home.feature_kg_desc": "例如：鳩摩羅什 → 譯經 → 《妙法蓮華經》",
   "home.feature_chat_title": "AI 問答",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -395,6 +395,8 @@
   "home.stat_label": "平台数据统计",
   "home.feature_sources_title": "数据源",
   "home.feature_sources_desc": "汇聚 CBETA、SuttaCentral 等全球数字佛典资源",
+  "home.sc_sources": "{{sources}} 个来源 · {{texts}} 部经典",
+  "home.sc_geo": "{{count}} 处圣迹 · {{places}}",
   "home.feature_kg_title": "知识图谱",
   "home.feature_kg_desc": "例如：鸠摩罗什 → 译经 → 《妙法莲华经》",
   "home.feature_chat_title": "AI 问答",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -519,6 +519,21 @@ export async function getStats(): Promise<Stats> {
   return data;
 }
 
+// Homepage dynamic showcase — live subtitle content for the hero feature cards.
+// Every card key is nullable: a null card means "show the static fallback".
+export interface HomeShowcase {
+  sources: { sources: number; texts: number } | null;
+  chat: { question: string } | null;
+  dictionary: { term: string; definition: string | null } | null;
+  kg: { subject: string; predicate: string; object: string } | null;
+  geo: { count: number; places: string[] } | null;
+}
+
+export async function getHomeShowcase(): Promise<HomeShowcase> {
+  const { data } = await api.get<HomeShowcase>("/home/showcase");
+  return data;
+}
+
 // Reader APIs
 export async function getJuanList(textId: number): Promise<JuanListResponse> {
   const { data } = await api.get<JuanListResponse>(`/texts/${textId}/juans`);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useQuery } from "@tanstack/react-query";
@@ -17,7 +17,8 @@ import {
 import { useTranslation } from "react-i18next";
 import { InfoCircleOutlined, CloseOutlined } from "@ant-design/icons";
 import SourceSelector from "../components/SourceSelector";
-import { getStats, getSources, getFilters, getSearchSuggestions } from "../api/client";
+import { getStats, getSources, getFilters, getSearchSuggestions, getHomeShowcase } from "../api/client";
+import { getLocalizedCollections } from "../data/collections";
 import { getLangName } from "../utils/sourceUrls";
 import { getReadingHistory } from "../utils/readingHistory";
 import { useAuthStore } from "../stores/authStore";
@@ -31,7 +32,7 @@ function truncateTitle(title: string, max = 12): string {
 
 export default function HomePage() {
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user } = useAuthStore();
   const [selectedSources, setSelectedSources] = useState<Set<string>>(new Set());
   const [sourceOpen, setSourceOpen] = useState(false);
@@ -44,6 +45,22 @@ export default function HomePage() {
   const { data: stats } = useQuery({ queryKey: ["stats"], queryFn: getStats });
   const { data: sources } = useQuery({ queryKey: ["sources"], queryFn: getSources, enabled: sourceOpen });
   const { data: filters } = useQuery({ queryKey: ["filters"], queryFn: getFilters });
+
+  // Dynamic hero-card content. Best-effort: on error/loading, `showcase` is
+  // undefined and each card renders its static `feature_*_desc` fallback.
+  const { data: showcase } = useQuery({ queryKey: ["homeShowcase"], queryFn: getHomeShowcase, staleTime: 5 * 60_000 });
+
+  // 经典专题 card is driven by the frontend's own collection content (the server
+  // doesn't hold it). Rotate the featured names by a coarse time bucket so the
+  // card feels alive without a backend round-trip. The bucket is captured once
+  // at mount (a lazy initializer is the allowed place for the impure Date.now).
+  const [rotationBucket] = useState(() => Math.floor(Date.now() / (15 * 60_000)));
+  const collectionsDesc = useMemo(() => {
+    const cols = getLocalizedCollections(i18n.language).map((c) => c.name).filter(Boolean);
+    if (cols.length === 0) return null;
+    const start = rotationBucket % cols.length;
+    return [0, 1, 2].map((i) => cols[(start + i) % cols.length]).join(" · ");
+  }, [i18n.language, rotationBucket]);
 
   // 搜索联想：复用 SearchPage 已有的 /search/suggest 接口与防抖模式
   const [acOptions, setAcOptions] = useState<{ value: string }[]>([]);
@@ -205,32 +222,68 @@ export default function HomePage() {
           <div className="home-feature-card" onClick={() => navigate("/sources")}>
             <DatabaseOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_sources_title")}</div>
-            <div className="home-feature-desc">{t("home.feature_sources_desc")}</div>
+            <div className="home-feature-desc">
+              {showcase?.sources
+                ? t("home.sc_sources", {
+                    sources: showcase.sources.sources.toLocaleString(),
+                    texts: showcase.sources.texts.toLocaleString(),
+                  })
+                : t("home.feature_sources_desc")}
+            </div>
           </div>
-          <div className="home-feature-card" onClick={() => navigate("/chat")}>
+          <div
+            className="home-feature-card"
+            onClick={() =>
+              navigate(showcase?.chat?.question ? `/chat?q=${encodeURIComponent(showcase.chat.question)}` : "/chat")
+            }
+          >
             <RobotOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_chat_title")}</div>
-            <div className="home-feature-desc">{t("home.feature_chat_desc")}</div>
+            <div className="home-feature-desc">
+              {showcase?.chat?.question || t("home.feature_chat_desc")}
+            </div>
           </div>
-          <div className="home-feature-card" onClick={() => navigate("/dictionary")}>
+          <div
+            className="home-feature-card"
+            onClick={() =>
+              navigate(showcase?.dictionary?.term ? `/dictionary?q=${encodeURIComponent(showcase.dictionary.term)}` : "/dictionary")
+            }
+          >
             <FileTextOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_dict_title")}</div>
-            <div className="home-feature-desc">{t("home.feature_dict_desc")}</div>
+            <div className="home-feature-desc">
+              {showcase?.dictionary?.term
+                ? `${showcase.dictionary.term}${showcase.dictionary.definition ? ` — ${showcase.dictionary.definition}` : ""}`
+                : t("home.feature_dict_desc")}
+            </div>
           </div>
           <div className="home-feature-card" onClick={() => navigate("/kg")}>
             <ApartmentOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_kg_title")}</div>
-            <div className="home-feature-desc">{t("home.feature_kg_desc")}</div>
+            <div className="home-feature-desc">
+              {showcase?.kg
+                ? `${showcase.kg.subject} → ${showcase.kg.predicate} → ${showcase.kg.object}`
+                : t("home.feature_kg_desc")}
+            </div>
           </div>
           <div className="home-feature-card" onClick={() => navigate("/map")}>
             <GlobalOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_geo_title")}</div>
-            <div className="home-feature-desc">{t("home.feature_geo_desc")}</div>
+            <div className="home-feature-desc">
+              {showcase?.geo && showcase.geo.count > 0
+                ? t("home.sc_geo", {
+                    count: showcase.geo.count.toLocaleString(),
+                    places: showcase.geo.places.slice(0, 3).join("、"),
+                  })
+                : t("home.feature_geo_desc")}
+            </div>
           </div>
           <div className="home-feature-card" onClick={() => navigate("/collections")}>
             <BookOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_collections_title")}</div>
-            <div className="home-feature-desc">{t("home.feature_collections_desc")}</div>
+            <div className="home-feature-desc">
+              {collectionsDesc || t("home.feature_collections_desc")}
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Why

The homepage hero cards **duplicated the top nav verbatim** — same icon, title, and destination — differentiated only by a static example line. This makes them a **showcase the nav can't be**: each card's subtitle is now real, rotating platform content, so the section earns its place instead of cloning the nav.

## What

**Backend** — `GET /api/home/showcase` (public, Redis-cached `SHOWCASE_TTL=15min`, one aggregate query set):

| Card | Dynamic content | Interaction |
|------|-----------------|-------------|
| 数据源 | live source + text counts | → /sources |
| AI问答 | a rotating **hot question** | click deep-links to a **prefilled** `/chat?q=…` |
| 佛学辞典 | a rotating hot **term + definition** | click → `/dictionary?q=…` |
| 知识图谱 | a real KG **triple** (subject —predicate→ object) | → /kg |
| 佛教地理 | place/monastery **count + names** | → /map |
| 经典专题 | rotating collection names (frontend content) | → /collections |

**Two hard guarantees (from the design):**
- **Degrades independently** — each card is best-effort and independently nullable; a null card → the frontend renders its **static `feature_*_desc` fallback**. Worst case = today's page. **Zero risk.**
- **Cheap** — one Redis-cached aggregate on the highest-traffic page, not six per-card fetches; every query bounded. Time-bucketed rotation keeps it lively within the TTL.

**Frontend** — cards render the dynamic subtitle with fallback; 经典专题 rotates the frontend's own collection content client-side. Two new interpolated i18n keys (`sc_sources`/`sc_geo`) in zh/zh-Hant/en; all other dynamic text is **data** (no new strings — hardcoded-Chinese ratchet stays green).

## Test
- Backend: **887** tests (5 new — per-card degradation on empty DB, Redis cache read, seed rotation).
- Frontend: production **build** + **160** vitest + **eslint** + **tsc** + **i18n ratchet** all green.

## Notes
- No change to existing chat/SSE paths. Additive endpoint + a subtitle swap on HomePage.
- A rendered before/after preview is attached in the conversation for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)