### PR TITLE
fix(oauth): ignore unverified Google email for account matching

### DIFF
--- a/backend/app/services/oauth.py
+++ b/backend/app/services/oauth.py
@@ -191,11 +191,21 @@ async def google_callback(code: str, db: AsyncSession) -> TokenResponse:
         user_resp.raise_for_status()
         g_user = user_resp.json()
 
+    # Only trust the email for account matching when Google says it's verified.
+    # _find_or_create_user links a social login to any existing user with the
+    # same email, so an unverified address would let a caller asserting someone
+    # else's email take over that account. Unverified → treat as no email (a
+    # fresh account with a noreply placeholder is created instead). Mirrors the
+    # GitHub path, which only accepts verified emails.
+    email = g_user.get("email")
+    if g_user.get("email_verified") not in (True, "true"):
+        email = None
+
     user = await _find_or_create_user(
         db,
         provider="google",
         provider_user_id=g_user["sub"],
-        email=g_user.get("email"),
+        email=email,
         display_name=g_user.get("name"),
         provider_data={"picture": g_user.get("picture")},
     )

--- a/backend/tests/test_oauth_google_email_verified.py
+++ b/backend/tests/test_oauth_google_email_verified.py
@@ -1,0 +1,99 @@
+"""Google OAuth must not trust an unverified email for account matching.
+
+_find_or_create_user links a social login to any existing user with the same
+email. If the Google userinfo email is unverified, honoring it would let a
+caller asserting someone else's address take over that account. These tests
+pin that only ``email_verified`` emails are used for merging.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _FakeResp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._data
+
+
+class _FakeGoogleClient:
+    """Stands in for httpx.AsyncClient: token POST then userinfo GET."""
+
+    def __init__(self, userinfo):
+        self._userinfo = userinfo
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, **kwargs):
+        return _FakeResp({"access_token": "ya29.fake"})
+
+    async def get(self, url, **kwargs):
+        return _FakeResp(self._userinfo)
+
+
+def _patch(monkeypatch, userinfo):
+    from app.services import oauth
+
+    captured = {}
+
+    async def fake_find_or_create(db, **kwargs):
+        captured.update(kwargs)
+        user = MagicMock()
+        user.id = 1
+        user.password_version = 0
+        return user
+
+    monkeypatch.setattr(oauth, "_find_or_create_user", fake_find_or_create)
+    monkeypatch.setattr(oauth.httpx, "AsyncClient", lambda *a, **k: _FakeGoogleClient(userinfo))
+    return oauth, captured
+
+
+@pytest.mark.anyio
+async def test_verified_email_is_used_for_matching(monkeypatch):
+    oauth, captured = _patch(
+        monkeypatch,
+        {"sub": "g-1", "email": "user@example.com", "email_verified": True, "name": "U"},
+    )
+    await oauth.google_callback("code", AsyncMock())
+    assert captured["email"] == "user@example.com"
+
+
+@pytest.mark.anyio
+async def test_verified_email_as_string_true_is_accepted(monkeypatch):
+    # Some Google responses serialize the flag as the string "true".
+    oauth, captured = _patch(
+        monkeypatch,
+        {"sub": "g-1", "email": "user@example.com", "email_verified": "true", "name": "U"},
+    )
+    await oauth.google_callback("code", AsyncMock())
+    assert captured["email"] == "user@example.com"
+
+
+@pytest.mark.anyio
+async def test_unverified_email_is_dropped(monkeypatch):
+    oauth, captured = _patch(
+        monkeypatch,
+        {"sub": "g-1", "email": "victim@example.com", "email_verified": False, "name": "A"},
+    )
+    await oauth.google_callback("code", AsyncMock())
+    assert captured["email"] is None
+
+
+@pytest.mark.anyio
+async def test_missing_email_verified_is_dropped(monkeypatch):
+    oauth, captured = _patch(
+        monkeypatch,
+        {"sub": "g-1", "email": "victim@example.com", "name": "A"},
+    )
+    await oauth.google_callback("code", AsyncMock())
+    assert captured["email"] is None


### PR DESCRIPTION
## 问题（安全审核 M6，中危 · 跨提供方账号接管）

`_find_or_create_user` 会把社交登录**按 email 关联到已有用户**，但 `google_callback` 直接透传了 userinfo 的 email，**未校验 `email_verified`**。攻击者用一个断言了受害者邮箱、但 `email_verified=false` 的 Google 身份登录，即被 link 到受害者账号并签发其 JWT。GitHub 路径本就只接受 verified 邮箱——Google 分支漏了。

## 修复

仅当 `email_verified` 为 true（布尔或字符串 `"true"`）时才用该 email 做账号匹配；否则丢弃 email，走新建账号（noreply 占位邮箱）路径。

## 测试

`tests/test_oauth_google_email_verified.py`：verified(bool/string) 被接受、unverified 与缺失该字段均丢弃。本地相关套件全绿，ruff 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)