### PR TITLE
fix(nginx): re-apply security headers on header-overriding locations

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,6 +20,7 @@ RUN find dist -type f \( -name '*.js' -o -name '*.css' -o -name '*.html' -o -nam
 FROM nginx:stable-bookworm
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY security-headers.conf /etc/nginx/security-headers.conf
 
 # Run as non-root nginx user
 RUN chown -R nginx:nginx /usr/share/nginx/html && \

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,16 +5,9 @@ server {
     index index.html;
     absolute_redirect off;
 
-    # Security headers — single source of truth.
-    # Backend SecurityHeadersMiddleware was removed in P2-3 cleanup
-    # to avoid duplicate headers on responses proxied through nginx.
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.fojin.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://analytics.fojin.app https://*.cartocdn.com https://api.maptiler.com; font-src 'self' data:; worker-src 'self' blob:;" always;
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    # Security headers — see security-headers.conf. Must be re-included in every
+    # location that sets its own add_header (nginx drops inherited headers there).
+    include /etc/nginx/security-headers.conf;
 
     # Serve pre-compressed .gz files when available
     gzip_static on;
@@ -38,12 +31,14 @@ server {
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        include /etc/nginx/security-headers.conf;
     }
 
     # Font files — long cache
     location /fonts/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        include /etc/nginx/security-headers.conf;
     }
 
     # i18n resource files — un-hashed URLs, so they must revalidate on every
@@ -53,6 +48,7 @@ server {
     # the bundled zh and English users see mixed-language UI.
     location /locales/ {
         add_header Cache-Control "no-cache";
+        include /etc/nginx/security-headers.conf;
     }
 
     # Use Docker DNS resolver so backend can be re-resolved after restarts
@@ -101,6 +97,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         # Don't cache so a frontend redeploy is visible immediately
         add_header Cache-Control "no-cache, no-store, must-revalidate";
+        include /etc/nginx/security-headers.conf;
     }
 
     # SSR-only dictionary headword landing pages. ~300k unique headwords —
@@ -114,6 +111,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         add_header Cache-Control "public, max-age=3600";
+        include /etc/nginx/security-headers.conf;
     }
 
     # SSR-only person landing pages. The SPA has no /persons/:id route,
@@ -126,6 +124,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         add_header Cache-Control "public, max-age=3600";
+        include /etc/nginx/security-headers.conf;
     }
 
     # Shared Q&A deep links — backend injects per-question og:* / og:image
@@ -139,6 +138,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
+        include /etc/nginx/security-headers.conf;
     }
 
     # Pre-built SEO pages — serve their own index.html with correct meta tags
@@ -207,6 +207,7 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
+        include /etc/nginx/security-headers.conf;
     }
 
     # SW registration/update helpers — Cloudflare caches bare .js for hours
@@ -215,12 +216,14 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
+        include /etc/nginx/security-headers.conf;
     }
 
     location = /sw-update.js {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
+        include /etc/nginx/security-headers.conf;
     }
 
     # index.html must not be cached (references hashed assets)
@@ -228,14 +231,8 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
-        # Repeat security headers (nginx add_header in location overrides server-level)
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.fojin.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://analytics.fojin.app https://*.cartocdn.com https://api.maptiler.com; font-src 'self' data:; worker-src 'self' blob:;" always;
-        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header X-Permitted-Cross-Domain-Policies "none" always;
+        # Re-include security headers (nginx add_header in a location overrides server-level)
+        include /etc/nginx/security-headers.conf;
     }
 
     location / {

--- a/frontend/security-headers.conf
+++ b/frontend/security-headers.conf
@@ -1,0 +1,14 @@
+# Security headers — single source of truth.
+#
+# nginx does NOT inherit server-level add_header into a location that sets any
+# add_header of its own, so this snippet is `include`d in the server block AND
+# in every location that adds its own header (cache-control, etc.). Backend
+# SecurityHeadersMiddleware was removed in P2-3 cleanup to keep nginx the only
+# source and avoid duplicate headers on proxied responses.
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.fojin.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://analytics.fojin.app https://*.cartocdn.com https://api.maptiler.com; font-src 'self' data:; worker-src 'self' blob:;" always;
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+add_header X-Permitted-Cross-Domain-Policies "none" always;


### PR DESCRIPTION
## 问题（安全审核 M3，中危 · SSR 页缺安全头）

nginx 规则：location 内出现任何 `add_header`，server 级 add_header **全部失效**。因此每个声明了 `Cache-Control` 的 location——**SSR HTML 页 `/texts` `/dict`(~30万) `/persons`(~4.3万) `/share/qa`**，以及静态资源与 SW 脚本——都在**没有 CSP / X-Frame-Options / HSTS** 的情况下返回，恰是最需要这些头的注入/点击劫持面。此前只有 `/index.html` 靠复制粘贴七个头兜住（易漂移）。

## 修复

把七个安全头抽到 `frontend/security-headers.conf`，在 server 块与每个覆盖了 header 的 location 里 `include`（单一来源），并经 frontend Dockerfile 落盘。SSR 渲染器只输出 `<script type="application/ld+json">`（数据、非可执行，CSP 不拦）且加载与 index.html 相同的 `/assets/` bundle，故 CSP 无回归。

## 验证

`nginx -t` 通过；实际起 nginx 确认一个带自身 add_header 的 location 现在也会输出安全头（此前会丢）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)