### PR TITLE
fix(annotations): scope reads to approved-or-own (stop draft leak)

### DIFF
--- a/backend/app/api/annotations.py
+++ b/backend/app/api/annotations.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.deps import get_current_user
+from app.core.deps import get_current_user, get_optional_user
 from app.core.role_guard import require_role
 from app.database import get_db
 from app.models.user import User
@@ -9,7 +9,7 @@ from app.schemas.annotation import AnnotationCreate, AnnotationResponse, Annotat
 from app.services.annotation import (
     create_annotation,
     delete_annotation,
-    get_annotation,
+    get_visible_annotation,
     list_annotations_for_text,
     review_annotation,
     submit_annotation,
@@ -36,19 +36,23 @@ async def create(
 async def list_by_text(
     text_id: int = Query(...),
     juan_num: int = Query(1),
+    user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """获取指定文本卷的标注列表。"""
-    return await list_annotations_for_text(db, text_id, juan_num)
+    """获取指定文本卷的标注列表（公开的 approved + 本人的全部状态）。"""
+    return await list_annotations_for_text(
+        db, text_id, juan_num, viewer_id=user.id if user else None
+    )
 
 
 @router.get("/{annotation_id}", response_model=AnnotationResponse)
 async def get(
     annotation_id: int,
+    user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """获取标注详情。"""
-    return await get_annotation(db, annotation_id)
+    """获取标注详情（仅 approved 或本人）。"""
+    return await get_visible_annotation(db, annotation_id, viewer_id=user.id if user else None)
 
 
 @router.put("/{annotation_id}", response_model=AnnotationResponse)

--- a/backend/app/services/annotation.py
+++ b/backend/app/services/annotation.py
@@ -1,8 +1,17 @@
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import AccessDeniedError, NotFoundError, ValidationError
 from app.models.annotation import Annotation
+
+
+def _visible_to(viewer_id: int | None):
+    """WHERE clause for annotations a viewer may see: approved ones are public;
+    a signed-in viewer also sees their own (in any status). Anonymous sees only
+    approved. Keeps other users' drafts/pending/rejected private."""
+    if viewer_id is None:
+        return Annotation.status == "approved"
+    return or_(Annotation.status == "approved", Annotation.user_id == viewer_id)
 
 
 async def create_annotation(
@@ -32,6 +41,9 @@ async def create_annotation(
 
 
 async def get_annotation(session: AsyncSession, annotation_id: int) -> Annotation:
+    """Unfiltered lookup — used internally by update/delete/submit/review, which
+    enforce their own ownership/role checks. Do NOT use for read endpoints; use
+    get_visible_annotation so other users' non-approved rows stay private."""
     result = await session.execute(select(Annotation).where(Annotation.id == annotation_id))
     ann = result.scalar_one_or_none()
     if ann is None:
@@ -39,12 +51,28 @@ async def get_annotation(session: AsyncSession, annotation_id: int) -> Annotatio
     return ann
 
 
+async def get_visible_annotation(
+    session: AsyncSession, annotation_id: int, viewer_id: int | None = None
+) -> Annotation:
+    """Fetch a single annotation for a reader, enforcing visibility. Approved is
+    public; the owner also sees their own. Anything else 404s (not 403, so we
+    don't reveal that a hidden annotation exists)."""
+    ann = await get_annotation(session, annotation_id)
+    if ann.status != "approved" and ann.user_id != viewer_id:
+        raise NotFoundError("标注未找到")
+    return ann
+
+
 async def list_annotations_for_text(
-    session: AsyncSession, text_id: int, juan_num: int
+    session: AsyncSession, text_id: int, juan_num: int, viewer_id: int | None = None
 ) -> list[Annotation]:
     result = await session.execute(
         select(Annotation)
-        .where(Annotation.text_id == text_id, Annotation.juan_num == juan_num)
+        .where(
+            Annotation.text_id == text_id,
+            Annotation.juan_num == juan_num,
+            _visible_to(viewer_id),
+        )
         .order_by(Annotation.start_pos)
     )
     return list(result.scalars().all())

--- a/backend/tests/test_annotation_visibility.py
+++ b/backend/tests/test_annotation_visibility.py
@@ -1,0 +1,102 @@
+"""Annotation read-visibility scoping (BOLA fix).
+
+The list/get read paths used to return every annotation for a text
+regardless of owner or status, leaking other users' draft/pending/rejected
+notes. Reads are now scoped to "approved (public) OR owned by the viewer".
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.exceptions import NotFoundError
+from app.services.annotation import (
+    _visible_to,
+    get_visible_annotation,
+    list_annotations_for_text,
+)
+
+
+def _make_annotation(**overrides):
+    ann = MagicMock()
+    ann.id = overrides.get("id", 1)
+    ann.user_id = overrides.get("user_id", 1)
+    ann.status = overrides.get("status", "draft")
+    return ann
+
+
+def _session_returning(ann):
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = ann
+    session.execute.return_value = result
+    return session
+
+
+# ── get_visible_annotation ───────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_approved_visible_to_anonymous():
+    ann = _make_annotation(status="approved", user_id=1)
+    out = await get_visible_annotation(_session_returning(ann), 1, viewer_id=None)
+    assert out is ann
+
+
+@pytest.mark.anyio
+async def test_draft_hidden_from_anonymous():
+    ann = _make_annotation(status="draft", user_id=1)
+    with pytest.raises(NotFoundError):
+        await get_visible_annotation(_session_returning(ann), 1, viewer_id=None)
+
+
+@pytest.mark.anyio
+async def test_draft_hidden_from_other_user():
+    ann = _make_annotation(status="pending", user_id=1)
+    with pytest.raises(NotFoundError):
+        await get_visible_annotation(_session_returning(ann), 1, viewer_id=999)
+
+
+@pytest.mark.anyio
+async def test_own_draft_visible_to_owner():
+    ann = _make_annotation(status="draft", user_id=42)
+    out = await get_visible_annotation(_session_returning(ann), 1, viewer_id=42)
+    assert out is ann
+
+
+# ── list_annotations_for_text query filter ───────────────────────────────
+
+def _compiled_where(viewer_id):
+    # _visible_to returns the SQLAlchemy clause the list query ANDs in.
+    clause = _visible_to(viewer_id)
+    return str(clause.compile(compile_kwargs={"literal_binds": True}))
+
+
+def test_anonymous_filter_is_approved_only():
+    sql = _compiled_where(None)
+    assert "approved" in sql
+    assert "user_id" not in sql
+
+
+def test_viewer_filter_is_approved_or_own():
+    sql = _compiled_where(7)
+    assert "approved" in sql
+    assert "user_id" in sql
+    assert "7" in sql
+
+
+@pytest.mark.anyio
+async def test_list_passes_visibility_filter_into_query():
+    captured = {}
+
+    async def fake_execute(stmt):
+        captured["stmt"] = stmt
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        return result
+
+    session = AsyncMock()
+    session.execute = fake_execute
+    await list_annotations_for_text(session, text_id=100, juan_num=1, viewer_id=7)
+
+    sql = str(captured["stmt"].compile(compile_kwargs={"literal_binds": True}))
+    assert "approved" in sql and "user_id" in sql and "7" in sql


### PR DESCRIPTION
## 问题（安全审核 M7，中危 · BOLA / 私有数据泄露）

`GET /annotations` 与 `GET /annotations/{id}` 无鉴权，且 service 层不按 owner/status 过滤，返回该文本卷的**全部**标注。任意匿名者遍历 `text_id/juan_num` 或 `annotation_id` 即可读到他人 `draft/pending/rejected` 私有批注内容及其 `user_id`。

## 修复

把两条读路径限定为「approved(公开) OR 本人所有」：
- `list_annotations_for_text` 增加 `viewer_id`，AND 进可见性过滤；匿名 → 仅 approved。
- 新增 `get_visible_annotation` 对单条施加同规则，隐藏行返回 **404（非 403）**以不泄露其存在。
- 两端点经 `get_optional_user` 解析 viewer。
- `get_annotation` 保持不过滤，供 update/delete/submit/review 内部调用（它们各自做 owner/role 校验）。

前端标注面板本就是展示「本人草稿 + 公开(approved)」，故对作者 UX 无回归；匿名此后只看到 approved（正确）。

## 测试

`tests/test_annotation_visibility.py`：本人可见自己的草稿；匿名/他人对非公开返回 404、列表仅 approved；列表过滤为 approved-or-own。本地全量后端 **914 tests 全绿**，ruff 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)