### PR TITLE
fix(home): keep showcase cards uniform + polish dynamic content

### DIFF
--- a/backend/app/services/home_showcase.py
+++ b/backend/app/services/home_showcase.py
@@ -45,6 +45,25 @@ _SHOWCASE_CACHE_KEY = "home:showcase:v1"
 _POOL = 12
 _GEO_TYPES = ("place", "monastery")
 
+# Max chars of a dictionary definition shown on the card — kept short so the
+# subtitle stays ~2 lines (the CSS also hard-clamps to 2 lines as a backstop).
+_DEF_MAX_CHARS = 24
+
+# Human-readable Chinese labels for the KG predicate vocabulary, so the card
+# reads "智昇 → 活跃于 → 唐" instead of a raw "active_in" machine code. Covers the
+# full predicate set in the graph; an unmapped predicate falls back to itself.
+_PREDICATE_LABELS = {
+    "teacher_of": "授学",
+    "translated": "译",
+    "translated_at": "译于",
+    "alt_translation": "异译",
+    "cites": "引",
+    "commentary_on": "注",
+    "associated_with": "关联",
+    "active_in": "活跃于",
+    "member_of_school": "属",
+}
+
 
 def _seed() -> int:
     """Time-bucketed rotation seed — stable within a cache period, advancing
@@ -54,6 +73,26 @@ def _seed() -> int:
 
 def _pick(items: list, seed: int):
     return items[seed % len(items)] if items else None
+
+
+def _short_gloss(definition: str | None) -> str | None:
+    """Trim a dictionary definition to a short card-sized gloss.
+
+    Classical-Chinese definitions run long and multi-clause; on the card we want
+    at most ~一句. Take up to the first sentence break, then hard-cap the chars,
+    appending an ellipsis when truncated. Returns None for an empty definition so
+    the card shows just the term."""
+    text = (definition or "").strip().replace("\n", " ")
+    if not text:
+        return None
+    # Prefer cutting at the first sentence/clause boundary if it lands early.
+    for mark in ("。", "；", "！", "，"):
+        idx = text.find(mark)
+        if 0 < idx <= _DEF_MAX_CHARS:
+            return text[:idx]
+    if len(text) <= _DEF_MAX_CHARS:
+        return text
+    return text[:_DEF_MAX_CHARS].rstrip("，、 ") + "…"
 
 
 async def _sources_card(db: AsyncSession) -> dict | None:
@@ -99,8 +138,7 @@ async def _dictionary_card(db: AsyncSession, seed: int) -> dict | None:
         ).first()
         if row is None:
             return {"term": term, "definition": None}
-        definition = (row[1] or "").strip().replace("\n", " ")
-        return {"term": row[0], "definition": definition[:60] or None}
+        return {"term": row[0], "definition": _short_gloss(row[1])}
     except Exception:
         logger.warning("showcase dictionary_card failed", exc_info=True)
         return None
@@ -132,7 +170,8 @@ async def _kg_card(db: AsyncSession, seed: int) -> dict | None:
         picked = _pick(rows, seed)
         if picked is None:
             return None
-        return {"subject": picked[0], "predicate": picked[1], "object": picked[2]}
+        predicate = _PREDICATE_LABELS.get(picked[1], picked[1])
+        return {"subject": picked[0], "predicate": predicate, "object": picked[2]}
     except Exception:
         logger.warning("showcase kg_card failed", exc_info=True)
         return None

--- a/backend/tests/test_home_showcase.py
+++ b/backend/tests/test_home_showcase.py
@@ -15,7 +15,7 @@ from app.models.knowledge_graph import KGEntity, KGRelation
 from app.models.source import DataSource
 from app.models.text import BuddhistText
 from app.services import home_showcase
-from app.services.home_showcase import _pick, _seed, get_home_showcase
+from app.services.home_showcase import _pick, _seed, _short_gloss, get_home_showcase
 
 _MODELS = (BuddhistText, DataSource, DictionaryEntry, HotQuestion, KGEntity, KGRelation)
 
@@ -40,7 +40,7 @@ async def seeded_db():
         nalanda = KGEntity(entity_type="monastery", name_zh="那烂陀寺")
         s.add_all([xuanzang, sutra, nalanda])
         await s.flush()
-        s.add(KGRelation(subject_id=xuanzang.id, predicate="译", object_id=sutra.id))
+        s.add(KGRelation(subject_id=xuanzang.id, predicate="translated", object_id=sutra.id))
         await s.commit()
         yield s
     await engine.dispose()
@@ -53,6 +53,7 @@ async def test_showcase_populates_each_card_from_real_data(seeded_db):
     # HOT_TERMS rotates; 般若 is in the list, and its definition is seeded, so
     # whichever term is picked, the dictionary card is a dict (never crashes).
     assert isinstance(out["dictionary"], dict)
+    # predicate "translated" is mapped to its Chinese label "译".
     assert out["kg"] == {"subject": "玄奘", "predicate": "译", "object": "大般若經"}
     assert out["geo"]["count"] == 1
     assert "那烂陀寺" in out["geo"]["places"]
@@ -93,6 +94,19 @@ async def test_showcase_reads_from_redis_cache_when_present(seeded_db):
                 "dictionary": None, "kg": None, "geo": None}
     out = await get_home_showcase(seeded_db, redis=_Redis(json.dumps(sentinel)))
     assert out == sentinel                               # served from cache, DB untouched
+
+
+def test_short_gloss_trims_long_definitions():
+    # Cuts at the first sentence break when it lands early.
+    assert _short_gloss("法相以唯識為中道，三論以八不為中道，天台以實相為中道") == "法相以唯識為中道"
+    # No early break → hard char cap with an ellipsis.
+    long = "阿" * 40
+    g = _short_gloss(long)
+    assert g.endswith("…") and len(g) <= home_showcase._DEF_MAX_CHARS + 1
+    # Short definition passes through unchanged; empty → None.
+    assert _short_gloss("寂静") == "寂静"
+    assert _short_gloss("") is None
+    assert _short_gloss(None) is None
 
 
 def test_pick_rotates_by_seed():

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -598,6 +598,15 @@
   font-size: 11px;
   color: var(--fj-ink-light);
   line-height: 1.5;
+  /* Clamp to exactly two lines so dynamic showcase content of any length
+     (e.g. a long dictionary definition) can't stretch the card — every card
+     in the row stays the same compact height. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  height: 33px;
 }
 
 /* ---------- 响应式：平板 ---------- */


### PR DESCRIPTION
## Why

The dynamic showcase (#906) shipped with **uncontrolled content lengths**. A long classical-Chinese dictionary definition stretched the 佛学辞典 card to ~8 lines (cut mid-word), and CSS grid then stretched **every** card in the row to match — breaking the clean, uniform layout. The KG card also leaked a raw English predicate (`智昇 → active_in → 唐`).

![before](reported by user)

## Fix

- **`home.css`** — clamp `.home-feature-desc` to **exactly 2 lines** (`-webkit-line-clamp` + fixed height). Content of *any* length now keeps every card the same compact height. This is the robust guarantee — even an unexpectedly long value can't distort the grid.
- **`home_showcase.py`**:
  - Dictionary: trim to a short gloss — cut at the first sentence break, else a ~24-char cap + ellipsis — instead of 60 raw chars ending mid-word.
  - KG: map the predicate vocabulary to Chinese labels (`teacher_of→授学`, `translated→译`, `active_in→活跃于`, `cites→引`, `commentary_on→注`, …) so the card reads **"智昇 → 活跃于 → 唐"**. Full predicate set covered (queried from prod); unknown → passthrough.

## Test
- Backend: 6 showcase tests (added gloss-trimming + predicate-mapping coverage).
- Frontend production build green.

Follows #906; ships promptly to fix the live visible regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)