### PR TITLE
fix(cost): rate-limit + daily-quota public ai-diff (denial of wallet)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,7 @@ APIFY_TOKEN=apify_api_your-token-here
 # RATE_LIMIT_SMS_VERIFY=10
 # RATE_LIMIT_SEMANTIC=20
 # RATE_LIMIT_RESEARCH=10
+# RATE_LIMIT_AI_DIFF=10
 
 # Prometheus /metrics（默认开启；挂在应用根路径，nginx 不代理 → 仅内网可达。
 # 抓取用可选 overlay：docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d

--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -627,6 +627,11 @@ async def get_full_parallel_content(
 
 # === V2: AI difference analysis ===
 
+from fastapi import Request
+
+from app.core.client_ip import get_real_client_ip
+from app.core.deps import get_optional_user
+from app.models.user import User
 from app.schemas.ai_diff import AiDiffRequest, AiDiffResponse
 from app.services.ai_diff import get_or_create_diff
 
@@ -634,10 +639,24 @@ from app.services.ai_diff import get_or_create_diff
 @router.post("/ai-diff", response_model=AiDiffResponse)
 async def ai_diff(
     payload: AiDiffRequest,
+    request: Request,
+    user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ) -> AiDiffResponse:
-    """Generate (or fetch cached) cross-canon difference analysis for 2-4 selected chunks."""
-    cached, prompt_version, model, analysis = await get_or_create_diff(db, payload.chunks)
+    """Generate (or fetch cached) cross-canon difference analysis for 2-4 selected chunks.
+
+    Public, but each fresh (cache-miss) analysis is a platform LLM call, so it's
+    rate-limited (STRICT_PATHS) and counts against a per-caller daily quota.
+    """
+    redis = getattr(request.app.state, "redis", None)
+    identity = f"user:{user.id}" if user else f"ip:{get_real_client_ip(request, default='unknown')}"
+    cached, prompt_version, model, analysis = await get_or_create_diff(
+        db,
+        payload.chunks,
+        redis=redis,
+        quota_identity=identity,
+        quota_is_authenticated=user is not None,
+    )
     return AiDiffResponse(
         cached=cached,
         prompt_version=prompt_version,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -101,6 +101,7 @@ class Settings(BaseSettings):
     # and/or LLM calls, so cap them well below the default per-IP budget.
     rate_limit_semantic: int = 20
     rate_limit_research: int = 10
+    rate_limit_ai_diff: int = 10
 
     @property
     def database_url(self) -> str:

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -24,6 +24,7 @@ STRICT_PATHS: dict[str, int] = {
     # Paid-inference endpoints (embedding / LLM on the platform key).
     "/api/search/semantic": settings.rate_limit_semantic,
     "/api/research/query": settings.rate_limit_research,
+    "/api/alignment/ai-diff": settings.rate_limit_ai_diff,
 }
 
 

--- a/backend/app/services/ai_diff.py
+++ b/backend/app/services/ai_diff.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from datetime import date
 from typing import Any
 
 import httpx
@@ -17,11 +18,38 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.core.exceptions import QuotaExceededError
 from app.models.ai_diff_cache import AiDiffCache
 from app.schemas.ai_diff import AiDiffChunk
 from app.services.ai_diff_prompt import PROMPT_VERSION, SYSTEM_PROMPT
 
 logger = logging.getLogger(__name__)
+
+# Daily budget for *fresh* (cache-miss) analyses, which each cost a platform
+# LLM call. The endpoint stays public, so anonymous callers get a modest daily
+# cap keyed by IP; signed-in users get a higher one keyed by user id.
+FREE_DAILY_AI_DIFF_ANONYMOUS = 20
+FREE_DAILY_AI_DIFF_USER = 100
+
+
+async def _check_ai_diff_quota(redis, identity: str | None, is_authenticated: bool) -> None:
+    """Enforce the daily fresh-analysis budget. Best-effort: the per-IP limit in
+    STRICT_PATHS is the hard backstop, so a Redis outage degrades to rate
+    limiting only rather than blocking this public feature. Raises
+    QuotaExceededError when the budget is spent."""
+    if redis is None or identity is None:
+        return
+    limit = FREE_DAILY_AI_DIFF_USER if is_authenticated else FREE_DAILY_AI_DIFF_ANONYMOUS
+    key = f"ai_diff:{identity}:{date.today().isoformat()}"
+    try:
+        current = await redis.incr(key)
+        if current == 1:
+            await redis.expire(key, 86400)  # 24h TTL
+    except Exception:
+        logger.warning("ai_diff quota check failed; allowing", exc_info=True)
+        return
+    if current > limit:
+        raise QuotaExceededError(limit=limit)
 
 
 def compute_chunks_hash(
@@ -55,12 +83,20 @@ def compute_chunks_hash(
 
 
 async def get_or_create_diff(
-    db: AsyncSession, chunks: list[AiDiffChunk]
+    db: AsyncSession,
+    chunks: list[AiDiffChunk],
+    *,
+    redis=None,
+    quota_identity: str | None = None,
+    quota_is_authenticated: bool = False,
 ) -> tuple[bool, str, str, dict[str, Any]]:
     """Return (cached, prompt_version, model, analysis).
 
     `cached=True` means the row was served from `ai_diff_cache`.
     `cached=False` means a fresh LLM call was made and the row was inserted.
+
+    A fresh call consumes the caller's daily quota (see _check_ai_diff_quota);
+    cache hits are free and never counted.
     """
     model = _resolve_model()
     digest = compute_chunks_hash(chunks, PROMPT_VERSION, model)
@@ -69,6 +105,9 @@ async def get_or_create_diff(
     if cached is not None:
         return True, cached.prompt_version, cached.model, cached.analysis
 
+    # Cache miss → a real platform LLM call. Enforce the daily budget here so
+    # cached re-views stay free.
+    await _check_ai_diff_quota(redis, quota_identity, quota_is_authenticated)
     analysis = await _call_llm(chunks, model)
 
     row = AiDiffCache(

--- a/backend/tests/test_ai_diff_quota.py
+++ b/backend/tests/test_ai_diff_quota.py
@@ -1,0 +1,153 @@
+"""AI-diff cost guard: rate limit + per-caller daily quota on fresh analyses.
+
+/alignment/ai-diff stays public, but each cache-miss is a platform LLM call.
+These tests pin that a fresh analysis consumes the daily budget (anonymous vs
+signed-in limits), that cache hits are free, and that the endpoint is in
+STRICT_PATHS.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.exceptions import QuotaExceededError
+from app.services.ai_diff import (
+    FREE_DAILY_AI_DIFF_ANONYMOUS,
+    FREE_DAILY_AI_DIFF_USER,
+    _check_ai_diff_quota,
+    get_or_create_diff,
+)
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+        self.fail = False
+
+    async def incr(self, key):
+        if self.fail:
+            raise RuntimeError("redis down")
+        self.store[key] = int(self.store.get(key, 0)) + 1
+        return self.store[key]
+
+    async def expire(self, key, ttl):
+        return key in self.store
+
+
+# ── _check_ai_diff_quota ─────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_anonymous_within_and_over_limit():
+    r = FakeRedis()
+    for _ in range(FREE_DAILY_AI_DIFF_ANONYMOUS):
+        await _check_ai_diff_quota(r, "ip:1.2.3.4", is_authenticated=False)
+    with pytest.raises(QuotaExceededError):
+        await _check_ai_diff_quota(r, "ip:1.2.3.4", is_authenticated=False)
+
+
+@pytest.mark.anyio
+async def test_user_gets_higher_limit():
+    r = FakeRedis()
+    # Past the anonymous cap but still within the user cap → allowed.
+    for _ in range(FREE_DAILY_AI_DIFF_ANONYMOUS + 5):
+        await _check_ai_diff_quota(r, "user:7", is_authenticated=True)
+    assert FREE_DAILY_AI_DIFF_USER > FREE_DAILY_AI_DIFF_ANONYMOUS
+
+
+@pytest.mark.anyio
+async def test_no_redis_is_noop():
+    # Best-effort: without Redis the STRICT_PATHS rate limit is the backstop.
+    await _check_ai_diff_quota(None, "ip:1.2.3.4", is_authenticated=False)
+
+
+@pytest.mark.anyio
+async def test_redis_error_allows():
+    r = FakeRedis()
+    r.fail = True
+    await _check_ai_diff_quota(r, "ip:1.2.3.4", is_authenticated=False)  # no raise
+
+
+# ── get_or_create_diff quota wiring ──────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_cache_hit_does_not_consume_quota(monkeypatch):
+    from app.services import ai_diff
+
+    row = MagicMock()
+    row.prompt_version = "v1"
+    row.model = "m"
+    row.analysis = {"summary": "s"}
+    db = MagicMock()
+    db.scalar = AsyncMock(return_value=row)  # cache hit
+
+    called = {"quota": False, "llm": False}
+
+    async def _quota(*a, **k):
+        called["quota"] = True
+
+    async def _llm(*a, **k):
+        called["llm"] = True
+        return {}
+
+    monkeypatch.setattr(ai_diff, "_check_ai_diff_quota", _quota)
+    monkeypatch.setattr(ai_diff, "_call_llm", _llm)
+
+    cached, _, _, _ = await get_or_create_diff(db, [], redis=FakeRedis(), quota_identity="ip:x")
+    assert cached is True
+    assert called == {"quota": False, "llm": False}
+
+
+@pytest.mark.anyio
+async def test_cache_miss_checks_quota_before_llm(monkeypatch):
+    from app.services import ai_diff
+
+    db = MagicMock()
+    db.scalar = AsyncMock(return_value=None)  # cache miss
+
+    order = []
+
+    async def _quota(*a, **k):
+        order.append("quota")
+
+    async def _llm(*a, **k):
+        order.append("llm")
+        return {"summary": "s"}
+
+    monkeypatch.setattr(ai_diff, "_check_ai_diff_quota", _quota)
+    monkeypatch.setattr(ai_diff, "_call_llm", _llm)
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+
+    cached, _, _, _ = await get_or_create_diff(db, [], redis=FakeRedis(), quota_identity="ip:x")
+    assert cached is False
+    assert order == ["quota", "llm"]  # quota enforced before the paid call
+
+
+@pytest.mark.anyio
+async def test_cache_miss_quota_exceeded_blocks_llm(monkeypatch):
+    from app.services import ai_diff
+
+    db = MagicMock()
+    db.scalar = AsyncMock(return_value=None)
+
+    async def _quota(*a, **k):
+        raise QuotaExceededError(limit=FREE_DAILY_AI_DIFF_ANONYMOUS)
+
+    llm_called = {"v": False}
+
+    async def _llm(*a, **k):
+        llm_called["v"] = True
+        return {}
+
+    monkeypatch.setattr(ai_diff, "_check_ai_diff_quota", _quota)
+    monkeypatch.setattr(ai_diff, "_call_llm", _llm)
+
+    with pytest.raises(QuotaExceededError):
+        await get_or_create_diff(db, [], redis=FakeRedis(), quota_identity="ip:x")
+    assert llm_called["v"] is False
+
+
+def test_ai_diff_endpoint_is_strict_rate_limited():
+    from app.core.rate_limit import STRICT_PATHS
+
+    assert "/api/alignment/ai-diff" in STRICT_PATHS


### PR DESCRIPTION
## 问题（安全审核 M8，中危 · 成本）

`POST /alignment/ai-diff` 无鉴权且落在最宽松的 per-IP 限流档，但每次**缓存未命中**都是一次平台付费 LLM 调用。匿名者微调 `chunks[].text` 即可稳定制造缓存 miss、持续消耗平台预算。

前端平行阅读页的 AI-diff 按钮无登录门（属公开功能），故按你的选择**保持公开 + 限流配额**：

- `/api/alignment/ai-diff` 纳入 `STRICT_PATHS`（`rate_limit_ai_diff=10/min/IP`）。
- 仅对**新分析（缓存 miss）**计每日配额，检查点在 `get_or_create_diff` 内、`_call_llm` 之前——缓存命中始终免费、不计配额。匿名按 client IP（20/天），登录按 user id（100/天）。best-effort：Redis 故障时退化为仅限流（端点经 `get_optional_user` 解析调用方）。

## 测试

`tests/test_ai_diff_quota.py`：匿名/登录不同上限、无 Redis/Redis 异常为 no-op、缓存命中跳过配额、缓存 miss 先查配额再调 LLM 且超限拦截、STRICT_PATHS 成员。本地全量后端 **922 tests 全绿**（含既有 ai-diff 端点/service 测试），ruff 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)