### PR TITLE
fix(config): treat unset FOJIN_ENV as production (secure by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ ES_HOST=http://localhost:9200
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
+# 运行环境。未设置时按 production 处理（缺少强密钥即启动失败，secure-by-default）。
+# 本地裸跑（不经 docker-compose）开发时设为 development 放松校验。
+# FOJIN_ENV=production
+
 # JWT（生产环境请更换密钥）
 # Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 JWT_SECRET_KEY=change-me-generate-a-random-secret

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,9 +1,16 @@
 import asyncio
+import os
 import sys
-from pathlib import Path
 from logging.config import fileConfig
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Migrations don't need the app's production secret validation. app.config now
+# fail-fasts when FOJIN_ENV is unset (treated as production) without strong
+# secrets, so default to development here unless the caller (e.g. the prod
+# entrypoint) already set it.
+os.environ.setdefault("FOJIN_ENV", "development")
 
 from alembic import context
 from sqlalchemy import pool
@@ -12,12 +19,24 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 from app.config import settings
 from app.database import Base
 from app.models import (  # noqa: F401
-    BuddhistText, TextContent, User, Bookmark, ReadingHistory,
-    DataSource, TextIdentifier, TextRelation,
-    KGEntity, KGRelation, IIIFManifest,
-    TextEmbedding, ChatSession, ChatMessage,
-    Annotation, AnnotationReview,
-    DictionaryEntry, AdminAuditLog,
+    AdminAuditLog,
+    Annotation,
+    AnnotationReview,
+    Bookmark,
+    BuddhistText,
+    ChatMessage,
+    ChatSession,
+    DataSource,
+    DictionaryEntry,
+    IIIFManifest,
+    KGEntity,
+    KGRelation,
+    ReadingHistory,
+    TextContent,
+    TextEmbedding,
+    TextIdentifier,
+    TextRelation,
+    User,
 )
 
 config = context.config

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -126,9 +126,14 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-_fojin_env = os.environ.get("FOJIN_ENV", "development").lower()
+# Secure by default: an unset FOJIN_ENV is treated as production, so a bare
+# `uvicorn` started outside docker-compose can't silently boot with the
+# insecure default secrets. Local dev, tests, and alembic opt into the relaxed
+# path by setting FOJIN_ENV=development explicitly (see backend/conftest.py and
+# alembic/env.py).
+_fojin_env = os.environ.get("FOJIN_ENV", "production").lower()
 
-if _fojin_env == "production":
+if _fojin_env != "development":
     if settings.jwt_secret_key == _DEFAULT_JWT_SECRET or len(settings.jwt_secret_key) < 32:
         raise RuntimeError(
             "FATAL: In production, JWT_SECRET_KEY must be set and at least 32 characters. "

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,11 @@
+"""Root pytest conftest (loaded before tests/ and tests_integration/).
+
+app.config now treats an unset FOJIN_ENV as production and fail-fasts without
+strong secrets. Tests run without those secrets, so declare the dev
+environment before anything imports app.config. Must stay at the rootdir so it
+applies to every test suite under backend/.
+"""
+
+import os
+
+os.environ.setdefault("FOJIN_ENV", "development")


### PR DESCRIPTION
## 问题（安全审核 M12，中危 · 纵深防御）

生产 fail-fast（强 `JWT_SECRET_KEY` + `API_KEY_ENCRYPTION_KEY`）只在 `FOJIN_ENV=production` 时触发，而默认是 `development`。绕过 docker-compose 的裸 `uvicorn` 生产运行会**静默落入 development**，带着 `dev-only-insecure-default` 的 JWT 密钥启动（仅 warning）。compose 兜住了容器路径，但没兜住 bypass。

## 修复

未设置 `FOJIN_ENV` 时按 **production** 处理（secure-by-default）；放松的 dev 路径需显式 `FOJIN_ENV=development`。为让不带 prod 密钥的测试/迁移仍能跑，在其 import 入口声明 development：
- `backend/conftest.py`（新 rootdir conftest → 覆盖 tests/ 与 tests_integration/）
- `alembic/env.py`（覆盖本地 + alembic dry-run CI）

生产 entrypoint 本就 export `FOJIN_ENV=production`，故 `setdefault` 在 prod 为 no-op。

## 验证

全量单测绿（923）；`import app.config` 在 `FOJIN_ENV` 未设 + 默认密钥下现在**抛 RuntimeError**；production+强密钥、显式 development 均正常启动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)