### PR TITLE
fix(faithfulness): deterministically downgrade paraphrase-as-quote + serve-honest metric

### DIFF
--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -102,6 +102,11 @@ class ChatSource(BaseModel):
 ChatTrustState = Literal[
     "verified",
     "citation_corrected",
+    # A non-verbatim quote was downgraded to prose (deterministic fix) — a
+    # correction tier, not a warning.
+    "quote_relaxed",
+    # Legacy: emitted by the old caveat-only path; retained so diagnostics
+    # persisted before the downgrade change still deserialize.
     "quote_unverified",
     "sources_available",
     "no_sources",

--- a/backend/app/services/chat_trust.py
+++ b/backend/app/services/chat_trust.py
@@ -40,7 +40,11 @@ def build_trust_status(
     if not valid_sources:
         state = "no_sources"
     elif quote_mutations:
-        state = "quote_unverified"
+        # verify_quoted_content now *downgrades* a non-verbatim quote to prose,
+        # so a quote mutation means "we relaxed a paraphrase-as-quote" — the
+        # served answer is honest. This is a correction tier (like
+        # citation_corrected), not the old "unverified" warning.
+        state = "quote_relaxed"
     elif citation_mutations:
         state = "citation_corrected"
     elif citation_count:

--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -32,13 +32,15 @@ The check is deliberately conservative:
   quote inside a 繁-script source citation has already lost the
   attribution chain it claimed to preserve, so failing the check is
   the correct behaviour.
-- On miss we append **one consolidated caveat** at the end of the answer
-  (before any ``[追问]`` block) rather than annotating each quote inline.
-  The earlier per-quote inline ⚠️ markers fired so often on *correct*
-  canonical quotes — retrieval favours dense commentaries over the base
-  sutra that actually contains the line — that they disfigured sound answers
-  mid-sentence and inside tables. The single trailing caveat keeps the
-  unverified-status signal; per-quote detail still reaches the logs.
+- On miss we **downgrade** the quote: strip its open/close marks (or the
+  ``> `` blockquote prefix) so the passage reads as the model's own prose,
+  still followed by its citation. fojin thus never *serves* a false verbatim
+  quote — the earlier design only appended a caveat and left the misquote in
+  place. Each downgrade is recorded as a ``QuoteMutation`` for telemetry (how
+  often the model paraphrases-as-quote is a model-quality signal), and the
+  trust status marks the answer ``quote_relaxed`` (a correction tier, not a
+  warning) rather than ``quote_unverified``. The measured-but-useless prompt
+  approach (PR #901) is why this is done deterministically instead.
 
 The verifier is wired *after* ``enforce_citation_whitelist`` so quotes
 attached to citations the guard already stripped (unverified titles)
@@ -99,12 +101,15 @@ MAX_QUOTE_CITATION_GAP_CHARS = 80
 # in 「」/“”/'' and may span several lines.
 _QUOTE_OPEN = "「『“‘\""
 _QUOTE_CLOSE = "」』”’\""
+# Groups capture every part so a failing quote can be *downgraded* — rebuilt as
+# ``quote + gap + cite`` with the open/close marks dropped, turning a false
+# verbatim quote into honest prose that still cites the source.
 _QUOTE_CITATION_RE = re.compile(
     r"[" + re.escape(_QUOTE_OPEN) + r"]"
     r"(?P<quote>.{" + str(MIN_QUOTE_CHARS) + r",400}?)"
     r"[" + re.escape(_QUOTE_CLOSE) + r"]"
-    r".{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}?"
-    r"【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】",
+    r"(?P<gap>.{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}?)"
+    r"(?P<cite>【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】)",
     re.DOTALL,
 )
 
@@ -130,15 +135,6 @@ _BLOCKQUOTE_CITATION_RE = re.compile(
     r"【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】",
     re.MULTILINE,
 )
-
-# Marker placed at the start of the verifier's own appended caveat
-# blockquote (see ``_QUOTE_CAVEAT``). If the answer is fed back through
-# ``verify_quoted_content`` a second time — or a downstream pipeline
-# concatenates verified answers — the blockquote scanner must skip the
-# caveat itself, otherwise a real ``【《X》】`` citation that follows
-# elsewhere in the answer would pair with the warning blockquote and
-# emit a spurious second mutation.
-_CAVEAT_BLOCK_MARKER = "⚠️ 本回答"
 
 
 # Punctuation we strip from both sides of the substring test. Includes
@@ -235,115 +231,58 @@ def _find_sources(
     return exact or title_only
 
 
-# A single, unobtrusive caveat appended once when ≥1 quote fails verification,
-# replacing the previous per-quote inline ⚠️ markers. Because retrieval favours
-# dense commentaries over base sutras, those inline markers fired on the LLM's
-# *correct* canonical quotes (e.g. 「照见五蕴皆空」 under a 心经 commentary that
-# doesn't contain the line) and disfigured otherwise-sound answers mid-sentence
-# and inside tables. One caveat paragraph (placed before any [追问] block) keeps
-# the scholarly signal without breaking the prose; per-quote detail still goes to
-# the logs via QuoteMutation.
-_QUOTE_CAVEAT = "> ⚠️ 本回答中部分直接引文未能在检索到的经文片段中逐字核实，建议点按引用链接核对原文。"
-
-
-def _append_caveat(answer: str) -> str:
-    """Insert the quote caveat as its own paragraph, before any trailing
-    ``[追问]`` suggestion lines so it reads as part of the answer body rather
-    than after the follow-up buttons (which the frontend renders separately and
-    the backend strips before persistence)."""
-    lines = answer.split("\n")
-    for i, line in enumerate(lines):
-        if line.strip().startswith("[追问]"):
-            head = "\n".join(lines[:i]).rstrip()
-            tail = "\n".join(lines[i:])
-            return f"{head}\n\n{_QUOTE_CAVEAT}\n\n{tail}"
-    return answer.rstrip() + f"\n\n{_QUOTE_CAVEAT}"
-
-
-def _strip_existing_caveat(answer: str) -> str:
-    """Remove a previously-appended caveat blockquote so it can be re-emitted
-    at the correct position below any newly-appearing fabricated content.
-
-    Matches the canonical ``_QUOTE_CAVEAT`` line verbatim (the caveat is a
-    single-line blockquote, so this is unambiguous) and trims one trailing
-    blank line so we don't accumulate paragraph spacing on repeated passes.
-    """
-    if _QUOTE_CAVEAT not in answer:
-        return answer
-    return re.sub(
-        r"\n*" + re.escape(_QUOTE_CAVEAT) + r"\n*",
-        "\n\n",
-        answer,
-    ).rstrip()
+def _quote_failure_reason(
+    quote: str, title: str, juan: int | None, sources: list[ChatSource], *, blockquote: bool
+) -> str | None:
+    """Return a failure reason if ``quote`` is not verbatim in the cited source,
+    else None (verified). Same detection as before — only the *action* changed
+    from flag-and-caveat to downgrade."""
+    candidates = _find_sources(sources, title, juan)
+    if not candidates:
+        return "blockquote_not_in_source" if blockquote else "no_matching_source"
+    normalised = _normalise(quote)
+    if any(normalised in _normalise(c.chunk_text) for c in candidates):
+        return None
+    return "blockquote_not_in_source" if blockquote else "quote_not_in_source"
 
 
 def verify_quoted_content(
     answer: str, sources: list[ChatSource]
 ) -> tuple[str, list[QuoteMutation]]:
-    """Flag quoted segments that aren't substrings of the cited source's
-    chunk_text. Unchanged answers (no quote-citation pairs, or all quotes
-    verified) are returned identical, with an empty mutations list.
+    """Downgrade quoted segments that aren't verbatim in the cited source.
 
-    Implementation: regex scans for ``「…」【《X》第N卷】`` proximity pairs and
-    normalises both sides. Any failing pair is recorded as a QuoteMutation
-    (for logging); if there is at least one, a single consolidated caveat is
-    appended once to the answer (before any ``[追问]`` block). Multiple
-    failures share the one caveat rather than each getting an inline marker.
-    """
+    Detection is unchanged (a ``「…」【《X》第N卷】`` / blockquote pair whose quote
+    isn't a substring of any retrieved chunk of the cited text, 繁→简 folded).
+    The *action* is now deterministic: instead of appending a caveat, the quote
+    marks are stripped so the passage reads as the model's own prose while still
+    citing the source — fojin never *serves* a false verbatim quote. Each
+    downgrade is recorded as a ``QuoteMutation`` for telemetry.
+
+    Returns ``(corrected_answer, mutations)``; an answer with no failing quotes
+    is returned identical with an empty list. Idempotent: a downgraded passage
+    carries no quote marks, so a second pass is a no-op (and returns no
+    mutations — the served answer is already clean)."""
     if not answer or "【《" not in answer:
         return answer, []
 
     mutations: list[QuoteMutation] = []
 
-    for m in _QUOTE_CITATION_RE.finditer(answer):
+    def _downgrade_inline(m: re.Match[str]) -> str:
         quote = m.group("quote").strip()
-        title = m.group("title")
-        juan_str = m.group("juan")
-        juan = int(juan_str) if juan_str else None
         if len(quote) < MIN_QUOTE_CHARS:
-            continue
+            return m.group(0)
+        title = m.group("title")
+        juan = int(m.group("juan")) if m.group("juan") else None
+        reason = _quote_failure_reason(quote, title, juan, sources, blockquote=False)
+        if reason is None:
+            return m.group(0)
+        mutations.append(QuoteMutation(quote=quote, title=title, juan=juan, reason=reason))
+        # Drop the open/close marks: keep the text (now prose) + gap + citation.
+        return m.group("quote") + m.group("gap") + m.group("cite")
 
-        candidates = _find_sources(sources, title, juan)
-        if not candidates:
-            mutations.append(
-                QuoteMutation(
-                    quote=quote, title=title, juan=juan,
-                    reason="no_matching_source",
-                )
-            )
-            continue
-
-        # Pass if the quote is a substring of ANY retrieved chunk for the
-        # cited text — a multi-chunk retrieval scatters the passage across
-        # several chunks of the same juan.
-        normalised_quote = _normalise(quote)
-        if not any(
-            normalised_quote in _normalise(c.chunk_text) for c in candidates
-        ):
-            mutations.append(
-                QuoteMutation(
-                    quote=quote, title=title, juan=juan,
-                    reason="quote_not_in_source",
-                )
-            )
-
-    mutations.extend(_scan_blockquotes(answer, sources))
-
-    if not mutations:
-        return answer, mutations
-
-    # Idempotent caveat: ``chat.py`` calls this verifier twice (once on
-    # the streamed answer, once on the post-correction answer) and the
-    # second input can carry forward a caveat the first pass appended.
-    # Strip any existing caveat so the re-append lands at the bottom of
-    # the current (possibly extended) answer body — this preserves the
-    # single-caveat invariant while still surfacing newly-introduced
-    # fabrications that appear *after* the prior caveat, which a plain
-    # "skip if marker present" check would silently swallow.
-    if _CAVEAT_BLOCK_MARKER in answer:
-        answer = _strip_existing_caveat(answer)
-
-    return _append_caveat(answer), mutations
+    corrected = _QUOTE_CITATION_RE.sub(_downgrade_inline, answer)
+    corrected = _downgrade_blockquotes(corrected, sources, mutations)
+    return corrected, mutations
 
 
 def _strip_blockquote_markers(block: str) -> str:
@@ -369,56 +308,33 @@ def _strip_blockquote_markers(block: str) -> str:
     return " ".join(out_lines).strip()
 
 
-def _scan_blockquotes(
-    answer: str, sources: list[ChatSource]
-) -> list[QuoteMutation]:
-    """Detect ``> …`` blockquote / ``【《X》第N卷】`` pairs and verify them
-    against the cited source's chunk_text with the same substring
-    semantics as the inline scanner.
+def _downgrade_blockquotes(
+    answer: str, sources: list[ChatSource], mutations: list[QuoteMutation]
+) -> str:
+    """Downgrade ``> …`` blockquote / ``【《X》第N卷】`` pairs whose quote isn't
+    verbatim in the cited source: strip the per-line ``> `` markers so the block
+    becomes an ordinary paragraph (still followed by its citation). Appends a
+    QuoteMutation per downgrade to ``mutations``.
 
-    Returns the list of failing mutations (empty if every blockquote
-    verifies, or there are none). The caller decides whether to append
-    the shared caveat — multiple blockquote failures must collapse into
-    the same single caveat as the inline path, so producing inline-style
-    mutations here and letting the caller pool them is the right shape.
-    """
-    out: list[QuoteMutation] = []
-    for m in _BLOCKQUOTE_CITATION_RE.finditer(answer):
+    Same substring detection as the inline path. A verifying blockquote is left
+    untouched. Idempotent: a downgraded block no longer starts with ``>``, so a
+    second pass doesn't match it."""
+    def _sub(m: re.Match[str]) -> str:
         block = m.group("block")
         quote = _strip_blockquote_markers(block)
-        # Skip the verifier's own self-appended caveat blockquote so a
-        # second pass over already-verified output doesn't pair the
-        # warning text with an unrelated downstream citation.
-        if _CAVEAT_BLOCK_MARKER in quote:
-            continue
         if len(quote) < MIN_QUOTE_CHARS:
-            continue
-
+            return m.group(0)
         title = m.group("title")
-        juan_str = m.group("juan")
-        juan = int(juan_str) if juan_str else None
+        juan = int(m.group("juan")) if m.group("juan") else None
+        reason = _quote_failure_reason(quote, title, juan, sources, blockquote=True)
+        if reason is None:
+            return m.group(0)
+        mutations.append(QuoteMutation(quote=quote, title=title, juan=juan, reason=reason))
+        # Replace the blockquote body with its unmarked prose; keep everything
+        # after the block (gap + citation) exactly as matched.
+        return quote + "\n\n" + m.group(0)[len(block):]
 
-        candidates = _find_sources(sources, title, juan)
-        if not candidates:
-            out.append(
-                QuoteMutation(
-                    quote=quote, title=title, juan=juan,
-                    reason="blockquote_not_in_source",
-                )
-            )
-            continue
-
-        normalised_quote = _normalise(quote)
-        if not any(
-            normalised_quote in _normalise(c.chunk_text) for c in candidates
-        ):
-            out.append(
-                QuoteMutation(
-                    quote=quote, title=title, juan=juan,
-                    reason="blockquote_not_in_source",
-                )
-            )
-    return out
+    return _BLOCKQUOTE_CITATION_RE.sub(_sub, answer)
 
 
 def log_quote_mutations(

--- a/backend/eval/faithfulness.py
+++ b/backend/eval/faithfulness.py
@@ -31,20 +31,29 @@ from app.services.chat_trust import build_trust_status
 from app.services.citation_guard import enforce_citation_whitelist
 from app.services.quote_verifier import verify_quoted_content
 
-# The five states build_trust_status can emit, in descending trust order. Kept
+# The states build_trust_status can emit, in descending trust order. Kept
 # explicit (rather than imported from the Literal) so the report renders a
 # stable, ordered distribution even for states absent from a given run.
+# ``quote_unverified`` is legacy (pre-downgrade); new runs emit ``quote_relaxed``.
 TRUST_STATES = (
     "verified",
     "sources_available",
     "citation_corrected",
+    "quote_relaxed",
     "quote_unverified",
     "no_sources",
 )
 
+# Trust states in which the *served* answer contains no misrepresentation — a
+# resolvable citation or honest prose. verified = clean; citation_corrected /
+# quote_relaxed = the guards fixed it. This is the brand number ("what fojin
+# serves is honest"), distinct from verified_rate (raw, zero-correction LLM
+# quality).
+_TRUSTWORTHY_STATES = frozenset({"verified", "citation_corrected", "quote_relaxed"})
+
 # Grounding rates a regression gate watches. Mirrors retrieval_metrics'
 # _METRIC_PREFIXES convention (bookkeeping counts are excluded).
-_GATED_RATES = ("citation_grounding_rate", "verified_rate_of_cited")
+_GATED_RATES = ("citation_grounding_rate", "verified_rate_of_cited", "served_trustworthy_rate")
 
 
 def compute_faithfulness(answer: str, sources: list[ChatSource]) -> dict:
@@ -75,9 +84,16 @@ def compute_faithfulness(answer: str, sources: list[ChatSource]) -> dict:
         "citations_grounded": citations_grounded,
         "has_citations": 1 if trust.citation_count else 0,
         # "verified" is the only state with ≥1 citation and zero citation/quote
-        # mutations — the literal "every citation and quote checks out" answer.
+        # mutations — the strict "every citation and quote checks out first try"
+        # answer (raw LLM quality).
         "fully_grounded": 1 if trust.state == "verified" else 0,
-        "quote_unverified": 1 if trust.quote_mutation_count else 0,
+        # Served-honest: the answer cites and, after the guards, misrepresents
+        # nothing (verified / citation_corrected / quote_relaxed).
+        "served_trustworthy": 1 if (trust.citation_count and trust.state in _TRUSTWORTHY_STATES) else 0,
+        # Number of paraphrase-as-quote passages the verifier downgraded — a
+        # raw model-quality signal, no longer a trust penalty (the served answer
+        # is fixed).
+        "quotes_downgraded": trust.quote_mutation_count,
     }
 
 
@@ -102,6 +118,7 @@ def aggregate_faithfulness(rows: list[dict]) -> dict:
     grounded_citations = sum(r["citations_grounded"] for r in rows)
     answers_with_citations = sum(r["has_citations"] for r in rows)
     fully_grounded = sum(r["fully_grounded"] for r in rows)
+    served_trustworthy = sum(r.get("served_trustworthy", 0) for r in rows)
 
     distribution = dict.fromkeys(TRUST_STATES, 0)
     for r in rows:
@@ -119,7 +136,13 @@ def aggregate_faithfulness(rows: list[dict]) -> dict:
         "verified_rate_of_cited": (
             fully_grounded / answers_with_citations if answers_with_citations else None
         ),
-        "answers_with_unverified_quote": sum(r["quote_unverified"] for r in rows),
+        # The brand number: among citing answers, the fraction whose SERVED text
+        # misrepresents nothing (post-guard). The deterministic quote-downgrade
+        # moves this toward the citation-grounding ceiling.
+        "served_trustworthy_rate": (
+            served_trustworthy / answers_with_citations if answers_with_citations else None
+        ),
+        "answers_with_downgraded_quote": sum(1 for r in rows if r.get("quotes_downgraded")),
         "total_citations": total_citations,
         "answers_with_citations": answers_with_citations,
         "state_distribution": distribution,

--- a/backend/eval/run_eval.py
+++ b/backend/eval/run_eval.py
@@ -57,7 +57,9 @@ def load_test_set() -> dict:
         return json.load(f)
 
 
-async def run_single_question(question_data: dict, skip_llm: bool = False) -> dict:
+async def run_single_question(
+    question_data: dict, skip_llm: bool = False, temperature: float = 0.7
+) -> dict:
     """Run a single question through the RAG + LLM pipeline and score it."""
     qid = question_data["id"]
     question = question_data["question"]
@@ -109,7 +111,7 @@ async def run_single_question(question_data: dict, skip_llm: bool = False) -> di
             resp = await client.post(
                 f"{api_url}/chat/completions",
                 headers={"Authorization": f"Bearer {api_key}"},
-                json={"model": model, "messages": llm_messages, "temperature": 0.7, "max_tokens": 2000},
+                json={"model": model, "messages": llm_messages, "temperature": temperature, "max_tokens": 2000},
             )
             resp.raise_for_status()
             answer = resp.json()["choices"][0]["message"]["content"]
@@ -168,7 +170,8 @@ def _faithfulness_section(faith_agg: dict) -> list[str]:
         "verified": "已核验",
         "sources_available": "有来源未引用",
         "citation_corrected": "引用被纠正",
-        "quote_unverified": "引文未核实",
+        "quote_relaxed": "引文已转述（降级）",
+        "quote_unverified": "引文未核实（旧）",
         "no_sources": "无来源",
     }
     dist = faith_agg.get("state_distribution", {})
@@ -178,8 +181,9 @@ def _faithfulness_section(faith_agg: dict) -> list[str]:
         "「引用守卫 → 引文核验 → 可信状态」管线*", "",
         "| 指标 | 值 |", "|------|-----|",
         f"| 引用可核验率 (citation_grounding_rate) | {_fmt_rate(faith_agg.get('citation_grounding_rate'))} |",
-        f"| 有引用回答的完全核验率 (verified_rate_of_cited) | {_fmt_rate(faith_agg.get('verified_rate_of_cited'))} |",
-        f"| 含未核实引文的回答数 | {faith_agg.get('answers_with_unverified_quote', 0)} |",
+        f"| **服务可信率 (served_trustworthy_rate)** | **{_fmt_rate(faith_agg.get('served_trustworthy_rate'))}** |",
+        f"| 完全核验率·严格 (verified_rate_of_cited) | {_fmt_rate(faith_agg.get('verified_rate_of_cited'))} |",
+        f"| 含转述降级引文的回答数 | {faith_agg.get('answers_with_downgraded_quote', 0)} |",
         f"| 引用总数 / 有引用回答数 | {faith_agg.get('total_citations', 0)} / {faith_agg.get('answers_with_citations', 0)} |",
         "", "**可信状态分布**", "",
         "| 状态 | 数量 |", "|------|------|",
@@ -312,6 +316,9 @@ async def main():
     parser.add_argument("--category", type=str, help="Only run questions from this category")
     parser.add_argument("--limit", type=int, help="Limit number of questions")
     parser.add_argument("--no-llm", action="store_true", help="Skip LLM, only test RAG retrieval")
+    parser.add_argument("--temperature", type=float, default=0.7,
+                        help="LLM sampling temperature. Use 0 for a deterministic, reproducible "
+                             "run when measuring a faithfulness delta (default 0.7 matches prod chat)")
     parser.add_argument("--tag", type=str, default="", help="Tag for the report")
     parser.add_argument("--baseline", type=str, help="Prior raw eval JSON to compare retrieval metrics against")
     parser.add_argument("--fail-on-regression", action="store_true",
@@ -347,7 +354,7 @@ async def main():
     for i, q in enumerate(questions):
         print(f"  [{i+1}/{len(questions)}] {q['id']}: {q['question'][:40]}...", end="", flush=True)
         try:
-            result = await run_single_question(q, skip_llm=args.no_llm)
+            result = await run_single_question(q, skip_llm=args.no_llm, temperature=args.temperature)
             results.append(result)
             score = result["scores"]
             t = result["timing"]["total_s"]

--- a/backend/tests/test_chat_trust.py
+++ b/backend/tests/test_chat_trust.py
@@ -60,15 +60,18 @@ def test_verified_status_counts_citations_and_source_scores():
     assert status.min_source_score == 0.77
 
 
-def test_status_prioritizes_unverified_quotes_over_corrected_citations():
+def test_status_prioritizes_relaxed_quotes_over_corrected_citations():
+    # verify_quoted_content now downgrades a non-verbatim quote, so a quote
+    # mutation → the (fixed) answer is marked quote_relaxed, taking priority
+    # over a citation correction.
     status = build_trust_status(
-        "经云：「假引文假引文假引文」【《心经》第1卷】",
+        "经云：假引文假引文假引文【《心经》第1卷】",
         [_src()],
         citation_mutations=[_citation_mutation()],
         quote_mutations=[_quote_mutation()],
     )
 
-    assert status.state == "quote_unverified"
+    assert status.state == "quote_relaxed"
     assert status.citation_mutation_count == 1
     assert status.quote_mutation_count == 1
 

--- a/backend/tests/test_faithfulness.py
+++ b/backend/tests/test_faithfulness.py
@@ -46,14 +46,17 @@ def test_hallucinated_title_counts_as_corrected_not_grounded():
     assert row["fully_grounded"] == 0
 
 
-def test_fabricated_quote_counts_as_quote_unverified():
-    # Real citation, invented ≥12-char quote absent from the cited chunk.
+def test_fabricated_quote_is_downgraded_and_served_trustworthy():
+    # Real citation, invented ≥12-char quote absent from the cited chunk →
+    # verify_quoted_content downgrades it, so the served answer is honest:
+    # trust=quote_relaxed, NOT verified (a quote was relaxed), but it counts as
+    # served_trustworthy (no misrepresentation remains).
     answer = "经云：「假引文假引文假引文假引文」【《心经》第1卷】"
     row = compute_faithfulness(answer, [_src()])
-    assert row["trust_state"] == "quote_unverified"
-    assert row["quote_mutations"] >= 1
-    assert row["quote_unverified"] == 1
-    assert row["fully_grounded"] == 0
+    assert row["trust_state"] == "quote_relaxed"
+    assert row["quotes_downgraded"] >= 1
+    assert row["fully_grounded"] == 0            # not strictly verified
+    assert row["served_trustworthy"] == 1        # but honest as served
 
 
 def test_no_sources_is_ungrounded():

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -98,31 +98,32 @@ def test_quote_too_short_is_skipped():
 # ──────────────────────────────────────────────────────────────────────
 
 
-def test_quote_not_in_source_gets_annotated():
-    """The flagship case: LLM cites a real source but the quote
-    inside the 「…」 was never in that chunk."""
+def test_quote_not_in_source_is_downgraded_to_prose():
+    """The flagship case: LLM cites a real source but the quote inside the 「…」
+    was never in that chunk. The verifier now DOWNGRADES it — strips the quote
+    marks so it reads as prose — while keeping the citation, and records the
+    mutation. fojin never serves the false verbatim claim."""
     src = _src(7, "心經", 1, "实际原文：般若波罗蜜多，照见五蕴皆空。")
     answer = "经文明示：「众生皆有佛性，如来藏不空妙有」【《心經》第1卷】"
     out, muts = verify_quoted_content(answer, [src])
-    assert "⚠️" in out
-    assert "未能在检索到的经文片段中逐字核实" in out  # single consolidated caveat
+    assert "⚠️" not in out
+    assert "「" not in out and "」" not in out          # marks stripped
+    assert "众生皆有佛性，如来藏不空妙有" in out          # text kept as prose
+    assert "【《心經》第1卷】" in out                     # citation preserved
     assert len(muts) == 1
     assert muts[0].reason == "quote_not_in_source"
     assert muts[0].title == "心經"
     assert muts[0].juan == 1
 
 
-def test_no_matching_source_gets_annotated_differently():
-    """The quote is bound to a citation whose title isn't in sources
-    at all (e.g. citation_guard didn't catch it because it was
-    title-only). The verifier flags as 'no_matching_source' so the
-    audit trail distinguishes 'wrong text' from 'wrong content'."""
+def test_no_matching_source_is_downgraded():
+    """The quote is bound to a citation whose title isn't in sources at all.
+    Still downgraded; the audit mutation keeps the 'wrong text' distinction."""
     src = _src(7, "心經", 1, "...")
     answer = "云：「众生皆有佛性，如来藏不空妙有」【《不存在经》第1卷】"
     out, muts = verify_quoted_content(answer, [src])
-    assert "⚠️" in out  # consolidated caveat present
-    # Both failure reasons now share one user-facing caveat; the distinction
-    # ('wrong text' vs 'wrong content') survives only in the audit mutation.
+    assert "「" not in out                               # marks stripped
+    assert "众生皆有佛性，如来藏不空妙有" in out
     assert len(muts) == 1
     assert muts[0].reason == "no_matching_source"
 
@@ -189,22 +190,23 @@ def test_simplified_answer_quote_verifies_against_traditional_source():
     assert "⚠️" not in out
 
 
-def test_multiple_failing_quotes_share_one_caveat():
-    """Two fabricated quotes in one answer are both logged, but the user
-    sees a single consolidated caveat rather than two inline markers."""
+def test_multiple_failing_quotes_are_all_downgraded():
+    """Two fabricated quotes in one answer are both downgraded (marks stripped)
+    and both logged."""
     src = _src(7, "心經", 1, "无关原文")
     answer = (
         "云：「假引文片段一假引文片段一假引文片段一」【《心經》第1卷】然后："
         "「假引文片段二假引文片段二假引文片段二」【《心經》第1卷】"
     )
     out, muts = verify_quoted_content(answer, [src])
-    assert out.count("⚠️") == 1  # one consolidated caveat regardless of count
-    assert len(muts) == 2  # but every failing quote is still logged
+    assert "「" not in out and "」" not in out           # both downgraded
+    assert "假引文片段一假引文片段一假引文片段一" in out
+    assert "假引文片段二假引文片段二假引文片段二" in out
+    assert len(muts) == 2
 
 
-def test_caveat_inserted_before_followup_block():
-    """The consolidated caveat must sit in the answer body, above any trailing
-    [追问] lines — not after the follow-up buttons (which render separately)."""
+def test_downgrade_leaves_followup_block_intact():
+    """Downgrading an inline fab must not disturb a trailing [追问] block."""
     src = _src(7, "心經", 1, "无关原文")
     answer = (
         "云：「假引文片段一假引文片段一假引文片段一」【《心經》第1卷】\n"
@@ -213,7 +215,8 @@ def test_caveat_inserted_before_followup_block():
     )
     out, muts = verify_quoted_content(answer, [src])
     assert len(muts) == 1
-    assert out.index("⚠️") < out.index("[追问]")  # caveat above the follow-up block
+    assert "「" not in out                               # downgraded
+    assert "[追问] 问题一" in out and "[追问] 问题二" in out
 
 
 def test_distant_quote_and_citation_not_treated_as_pair():
@@ -236,7 +239,8 @@ def test_curly_double_quotes_match_quote_pattern():
     src = _src(7, "心經", 1, "无关原文，没有这段引文。")
     answer = "经云：“色不异空，空不异色，色即是空，色即是色”【《心經》第1卷】"
     out, muts = verify_quoted_content(answer, [src])
-    assert "⚠️" in out
+    assert "“" not in out and "”" not in out            # curly marks stripped
+    assert "色不异空，空不异色" in out
     assert len(muts) == 1
     assert muts[0].reason == "quote_not_in_source"
 
@@ -309,10 +313,9 @@ def test_blockquote_quote_in_source_does_not_annotate():
     assert muts == []
 
 
-def test_blockquote_not_in_source_gets_annotated():
-    """LLM fabricates a blockquote passage and pairs it with a real
-    title. This is the flagship production failure mode for long
-    citations and must produce the consolidated caveat."""
+def test_blockquote_not_in_source_is_downgraded():
+    """LLM fabricates a blockquote passage and pairs it with a real title.
+    The `> ` markers are stripped so it becomes prose; the citation stays."""
     src = _src(7, "心經", 1, "实际原文：般若波罗蜜多，照见五蕴皆空。")
     answer = (
         "经文明示：\n\n"
@@ -321,8 +324,10 @@ def test_blockquote_not_in_source_gets_annotated():
         "【《心經》第1卷】"
     )
     out, muts = verify_quoted_content(answer, [src])
-    assert "⚠️" in out
-    assert "未能在检索到的经文片段中逐字核实" in out
+    assert "⚠️" not in out
+    assert "> 众生皆有佛性" not in out                   # blockquote markers stripped
+    assert "众生皆有佛性，如来藏不空妙有" in out          # text kept as prose
+    assert "【《心經》第1卷】" in out
     assert len(muts) == 1
     assert muts[0].reason == "blockquote_not_in_source"
     assert muts[0].title == "心經"
@@ -382,11 +387,10 @@ def test_blockquote_far_from_citation_not_treated_as_pair():
     assert muts == []
 
 
-def test_self_appended_caveat_blockquote_is_not_rescanned():
-    """The consolidated caveat itself is a `> ⚠️ …` blockquote. If the
-    verifier ran a second pass over its own output it would either
-    inflate the mutation count or recurse — the scanner must skip
-    blockquotes that start with the caveat marker."""
+def test_downgrade_is_idempotent():
+    """A downgraded passage carries no quote marks, so a second pass over the
+    corrected answer is a no-op and reports no further mutations — the served
+    answer is already clean."""
     src = _src(7, "心經", 1, "实际原文：般若波罗蜜多。")
     answer = (
         "经云：\n\n"
@@ -395,45 +399,14 @@ def test_self_appended_caveat_blockquote_is_not_rescanned():
     )
     out, muts = verify_quoted_content(answer, [src])
     assert len(muts) == 1
-    # The caveat blockquote sits in `out`; re-running verify on it must
-    # not produce additional mutations or a second caveat.
     out2, muts2 = verify_quoted_content(out, [src])
-    assert muts2 == muts  # same set of original mutations
-    assert out2.count("⚠️") == 1  # still exactly one caveat
+    assert out2 == out       # no further change
+    assert muts2 == []       # nothing left to downgrade
 
 
-def test_new_fab_after_existing_caveat_still_gets_user_visible_signal():
-    """Regression for a re-entrancy loophole: if an answer already carries
-    a caveat (from a prior pass) AND new fabricated content appears below
-    it, the new fab must remain user-visible — i.e. the caveat must be
-    relocated to the bottom of the answer, not silently kept at its old
-    mid-answer position where the reader would never associate it with the
-    new fab. The earlier behavior (skip append when marker present) hid
-    the new mutation from users while still logging it; correct contract
-    is single caveat AND positioned below the newest fab content.
-    """
-    src = _src(7, "心經", 1, "实际原文：般若波罗蜜多。")
-    answer_with_old_caveat = (
-        "经云：\n\n"
-        "> 众生皆有佛性，如来藏不空妙有，此真实义\n\n"
-        "【《心經》第1卷】\n\n"
-        "> ⚠️ 本回答中部分直接引文未能在检索到的经文片段中逐字核实，建议点按引用链接核对原文。\n\n"
-        "补充又云：「假引文片段二假引文片段二假引文片段二」【《心經》第1卷】"
-    )
-    out, muts = verify_quoted_content(answer_with_old_caveat, [src])
-    assert out.count("⚠️") == 1  # single caveat invariant
-    assert len(muts) == 2  # both fabs surfaced in audit
-    # The relocated caveat must sit AFTER the newly-detected inline fab,
-    # otherwise the user can't tell the warning covers it.
-    new_fab_pos = out.index("假引文片段二")
-    caveat_pos = out.index("⚠️")
-    assert caveat_pos > new_fab_pos
-
-
-def test_blockquote_and_inline_failures_share_one_caveat():
-    """Mixed failure modes (one inline 「…」 fab + one `> …` fab) get
-    one consolidated user-facing caveat, with both failures recorded in
-    the audit list."""
+def test_blockquote_and_inline_failures_both_downgraded():
+    """Mixed failure modes (one inline 「…」 fab + one `> …` fab) are both
+    downgraded, both recorded in the audit list."""
     src = _src(7, "心經", 1, "无关原文")
     answer = (
         "云：「假引文片段一假引文片段一假引文片段一」【《心經》第1卷】\n\n"
@@ -442,7 +415,9 @@ def test_blockquote_and_inline_failures_share_one_caveat():
         "【《心經》第1卷】"
     )
     out, muts = verify_quoted_content(answer, [src])
-    assert out.count("⚠️") == 1
+    assert "「" not in out and "> 假引文片段二" not in out   # both downgraded
+    assert "假引文片段一假引文片段一假引文片段一" in out
+    assert "假引文片段二假引文片段二假引文片段二" in out
     assert len(muts) == 2
     reasons = {m.reason for m in muts}
     assert reasons == {"quote_not_in_source", "blockquote_not_in_source"}

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -960,6 +960,7 @@
   "chat.retry": "Retry",
   "chat.trust.verified": "Citations verified",
   "chat.trust.citation_corrected": "Citations corrected",
+  "chat.trust.quote_relaxed": "Some quotes relaxed to paraphrase",
   "chat.trust.quote_unverified": "Some quotes were not text-verified",
   "chat.trust.sources_available": "Relevant sources retrieved",
   "chat.trust.no_sources": "No clickable sources found",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -960,6 +960,7 @@
   "chat.retry": "重試",
   "chat.trust.verified": "引用已校驗",
   "chat.trust.citation_corrected": "引用已校正",
+  "chat.trust.quote_relaxed": "部分引文已轉述（非逐字）",
   "chat.trust.quote_unverified": "部分引文未逐字核實",
   "chat.trust.sources_available": "已檢索到相關來源",
   "chat.trust.no_sources": "未檢索到可點擊出處",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -960,6 +960,7 @@
   "chat.retry": "重试",
   "chat.trust.verified": "引用已校验",
   "chat.trust.citation_corrected": "引用已校正",
+  "chat.trust.quote_relaxed": "部分引文已转述（非逐字）",
   "chat.trust.quote_unverified": "部分引文未逐字核实",
   "chat.trust.sources_available": "已检索到相关来源",
   "chat.trust.no_sources": "未检索到可点击出处",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1600,6 +1600,7 @@ export interface ChatSessionItem {
 export type ChatTrustState =
   | "verified"
   | "citation_corrected"
+  | "quote_relaxed"
   | "quote_unverified"
   | "sources_available"
   | "no_sources";

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -137,6 +137,10 @@ function trustStatusColor(status?: ChatTrustStatus | null): string {
   switch (status?.state) {
     case "verified":
       return "#3f7d20";
+    case "quote_relaxed":
+      // A paraphrase-as-quote was relaxed to prose (fixed) — a correction, not
+      // a warning, so use the accent tone rather than the legacy amber.
+      return "var(--fj-accent)";
     case "quote_unverified":
       return "#a66300";
     case "no_sources":


### PR DESCRIPTION
## Why

fojin's first prod faithfulness baseline: **citations resolve 99%** but the LLM often **presents paraphrases as verbatim quotes**. The prompt-only fix (#901) was *measured* and did nothing (20.6%→11.1%, noise-dominated). This is the **deterministic** fix flagged as the fallback — it makes "每一句都能点回原典" actually true for what fojin *serves*.

## What

- **`quote_verifier`** — on a non-verbatim quote, **downgrade** it: strip the `「」`/`""`/`''` marks (or the `> ` blockquote prefix) so the passage reads as the model's own prose, still followed by its citation. fojin now **never serves a false verbatim quote** (the old path only appended a caveat and left the misquote in place). Detection unchanged; idempotent (a downgraded passage has no marks to re-match); mutations still recorded for telemetry.
- **Trust** — new `quote_relaxed` state (a *correction* tier, not the amber `quote_unverified` warning). Frontend + i18n (zh/zh-Hant/en) render it neutrally. `quote_unverified` kept in the Literal so pre-change diagnostics still deserialize.
- **Eval faithfulness** — add **`served_trustworthy_rate`**: among citing answers, the fraction whose *served* text misrepresents nothing (verified / citation_corrected / quote_relaxed). This is the brand number the downgrade moves toward the citation-grounding ceiling; `verified_rate_of_cited` stays as the strict raw-LLM-quality measure. Added a gate flag.
- **Eval `run_eval`** — `--temperature` flag (default 0.7; use **0** for a deterministic, reproducible faithfulness delta — a single temp-0.7 run can't measure a ~10pt change).

## Risk
- Touches the live chat path's `verify_quoted_content`, but it's a strict honesty improvement (served answers no longer misquote) and heavily tested. The SSE streaming/session logic is untouched.

## Test
```
pytest -q            # 922 passed
# frontend: eslint + tsc + i18n ratchet + vitest all green
```
Rewrote the quote_verifier tests (caveat → downgrade assertions), the trust-state test, and the faithfulness test; added served_trustworthy coverage.

## Follow-up (this is #4 of a 4-part plan)
After deploy: re-run before/after at **temperature=0** to confirm the real `served_trustworthy_rate` delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)