### PR TITLE
ci(mcp): make the fojin-mcp package publishable (CI + PyPI release + docs)

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,47 @@
+name: Publish fojin-mcp
+
+# Publishes the fojin-mcp package to PyPI when a version tag is pushed
+# (e.g. `git tag mcp-v0.1.0 && git push origin mcp-v0.1.0`), or on manual
+# dispatch. Everything is prepared so publishing is a one-step action for the
+# maintainer — it only needs credentials, set up ONE of:
+#
+#   1. Trusted Publishing (recommended, no secret): on PyPI, add a
+#      "pending publisher" for project `fojin-mcp`, repo `xr843/fojin`,
+#      workflow `mcp-publish.yml`, environment `pypi`. Then this runs as-is.
+#   2. API token: create a repo secret `PYPI_API_TOKEN` with a PyPI token
+#      scoped to `fojin-mcp`, and uncomment the `password:` line below.
+on:
+  push:
+    tags: ["mcp-v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build + publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for Trusted Publishing
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist + wheel
+        run: pip install build && python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: mcp-server/dist/
+          # Trusted Publishing needs no password. For token auth instead,
+          # set the PYPI_API_TOKEN secret and uncomment the next line:
+          # password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -1,0 +1,41 @@
+name: MCP server
+
+# Lints + tests the standalone fojin-mcp package. Scoped to its own path so it
+# only runs when the package changes (the package is independent of the backend
+# and frontend). Mirrors the backend job's Python + ruff + pytest shape.
+on:
+  push:
+    branches: [main, master]
+    paths: ["mcp-server/**", ".github/workflows/mcp-server.yml"]
+  pull_request:
+    branches: [main, master]
+    paths: ["mcp-server/**", ".github/workflows/mcp-server.yml"]
+
+permissions:
+  contents: read
+
+jobs:
+  mcp:
+    name: MCP server tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install package + dev deps
+        run: pip install -e '.[dev]'
+
+      - name: Lint (ruff)
+        run: pip install ruff==0.9.7 && ruff check fojin_mcp/ tests/
+
+      - name: Run tests
+        run: python -m pytest -q
+
+      - name: Build distribution (sdist + wheel)
+        run: pip install build && python -m build

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -27,35 +27,50 @@ directly.
 
 ## Install & run
 
+Once published to PyPI, no clone needed — run it with `uvx` (nothing to
+install) or `pip`:
+
 ```bash
-cd mcp-server
-pip install -e .
-python -m fojin_mcp          # stdio transport (the MCP default)
+uvx fojin-mcp                 # zero-install, stdio transport (the MCP default)
+# or
+pip install fojin-mcp && fojin-mcp
+```
+
+From a checkout (development):
+
+```bash
+cd mcp-server && pip install -e . && python -m fojin_mcp
 ```
 
 By default it talks to `https://fojin.app/api`. Point it elsewhere (self-host,
 staging) with an env var:
 
 ```bash
-FOJIN_API_BASE_URL=http://localhost:8000/api python -m fojin_mcp
+FOJIN_API_BASE_URL=http://localhost:8000/api uvx fojin-mcp
 ```
 
 ### Claude Desktop
 
-Add to `claude_desktop_config.json`:
+Add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
 
 ```json
 {
   "mcpServers": {
     "fojin": {
-      "command": "python",
-      "args": ["-m", "fojin_mcp"]
+      "command": "uvx",
+      "args": ["fojin-mcp"]
     }
   }
 }
 ```
 
-(or use the installed `fojin-mcp` console script as `"command"`.)
+(or `"command": "fojin-mcp"` if you `pip install`ed it, or `python -m fojin_mcp`
+from a checkout.) Restart Claude Desktop; the six fojin tools then appear.
+
+### ChatGPT / other MCP clients
+
+Any client that speaks MCP over stdio can launch `uvx fojin-mcp` (or the
+`fojin-mcp` console script) and will discover the six tools automatically.
 
 ## Design
 
@@ -78,6 +93,22 @@ Add to `claude_desktop_config.json`:
 pip install -e '.[dev]'
 pytest -q          # unit tests (no network)
 ```
+
+## Publishing (maintainer)
+
+CI (`.github/workflows/mcp-server.yml`) lints, tests, and builds the package on
+every change under `mcp-server/`. To release to PyPI, bump `version` in
+`pyproject.toml`, then push a tag:
+
+```bash
+git tag mcp-v0.1.0 && git push origin mcp-v0.1.0
+```
+
+`.github/workflows/mcp-publish.yml` builds and uploads. It needs credentials
+once — set up **either** PyPI Trusted Publishing (recommended; no secret) for
+project `fojin-mcp` / repo `xr843/fojin` / workflow `mcp-publish.yml` /
+environment `pypi`, **or** a `PYPI_API_TOKEN` repo secret (then uncomment the
+`password:` line in the workflow).
 
 ## License
 

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -9,10 +9,25 @@ description = "MCP server exposing fojin's verified cross-canon Buddhist corpus 
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
+authors = [{ name = "fojin (佛津)" }]
+keywords = ["mcp", "buddhism", "cbeta", "digital-humanities", "rag", "llm-tools"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Religion",
+    "Topic :: Text Processing :: Linguistic",
+]
 dependencies = [
     "mcp>=1.2",
     "httpx>=0.27",
 ]
+
+[project.urls]
+Homepage = "https://fojin.app"
+Repository = "https://github.com/xr843/fojin"
+Issues = "https://github.com/xr843/fojin/issues"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Why (pillar #3)

Shipping the MCP server (#898) into the repo wasn't enough — for ChatGPT/Claude/research tools to actually **call** fojin's verified corpus, the package has to be **discoverable and installable**. This makes it so.

## What

- **`.github/workflows/mcp-server.yml`** — path-scoped CI that lints (ruff), tests (pytest), and builds the sdist+wheel on every `mcp-server/` change. The package was previously **outside CI entirely**.
- **`.github/workflows/mcp-publish.yml`** — tag-triggered (`mcp-v*`) PyPI publish via `pypa/gh-action-pypi-publish`. **One-step release for the maintainer**: needs only Trusted Publishing setup (no secret) *or* a `PYPI_API_TOKEN` — both documented.
- **`pyproject`** — authors, project URLs, keywords, PyPI classifiers for a real listing.
- **`fojin_mcp/py.typed`** — ship type info to consumers (verified present in the built wheel).
- **README** — `uvx` / `pip install`, Claude Desktop + ChatGPT connect steps, and a maintainer *Publishing* section.

## Result
```bash
uvx fojin-mcp                    # zero-install once published
```
Claude Desktop config:
```json
{ "mcpServers": { "fojin": { "command": "uvx", "args": ["fojin-mcp"] } } }
```

## Test
- 28 package tests pass; `python -m build` produces a clean sdist + wheel (all modules + `py.typed`).
- No tool code changed.

## Maintainer step (yours — needs your credentials)
Once merged, publish with `git tag mcp-v0.1.0 && git push origin mcp-v0.1.0` after setting up PyPI Trusted Publishing (or the token secret). I can't create the PyPI project or hold credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)