### PR TITLE
feat(alignment): cross-canon alignment flywheel — mine, review, promote (slice 1)

### DIFF
--- a/backend/alembic/versions/0167_add_alignment_candidates.py
+++ b/backend/alembic/versions/0167_add_alignment_candidates.py
@@ -1,0 +1,53 @@
+"""Staging table for the cross-canon alignment flywheel.
+
+Revision ID: 0167
+Revises: 0166
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0167"
+down_revision = "0166"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "alignment_candidates",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("text_a_id", sa.Integer(), sa.ForeignKey("buddhist_texts.id"), nullable=False),
+        sa.Column("text_a_juan_num", sa.Integer(), nullable=False),
+        sa.Column("text_a_chunk_index", sa.Integer(), nullable=False),
+        sa.Column("text_a_lang", sa.String(10), nullable=False),
+        sa.Column("text_b_id", sa.Integer(), sa.ForeignKey("buddhist_texts.id"), nullable=False),
+        sa.Column("text_b_juan_num", sa.Integer(), nullable=False),
+        sa.Column("text_b_chunk_index", sa.Integer(), nullable=False),
+        sa.Column("text_b_lang", sa.String(10), nullable=False),
+        sa.Column("similarity", sa.Float(), nullable=False),
+        sa.Column("source", sa.String(40), server_default="knn-bootstrap", nullable=False),
+        sa.Column("status", sa.String(12), server_default="pending", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reviewed_by", sa.Integer(), sa.ForeignKey("users.id"), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_alignment_candidates_text_a_id", "alignment_candidates", ["text_a_id"])
+    op.create_index("ix_alignment_candidates_text_b_id", "alignment_candidates", ["text_b_id"])
+    op.create_index("ix_alignment_candidates_status", "alignment_candidates", ["status"])
+    op.create_index(
+        "uq_alignment_candidate_pair",
+        "alignment_candidates",
+        ["text_a_id", "text_a_juan_num", "text_a_chunk_index",
+         "text_b_id", "text_b_juan_num", "text_b_chunk_index"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_alignment_candidate_pair", table_name="alignment_candidates")
+    op.drop_index("ix_alignment_candidates_status", table_name="alignment_candidates")
+    op.drop_index("ix_alignment_candidates_text_b_id", table_name="alignment_candidates")
+    op.drop_index("ix_alignment_candidates_text_a_id", table_name="alignment_candidates")
+    op.drop_table("alignment_candidates")

--- a/backend/app/api/alignment_review.py
+++ b/backend/app/api/alignment_review.py
@@ -1,0 +1,91 @@
+"""Admin review surface for the cross-canon alignment flywheel.
+
+Lists mined candidates and lets an admin accept (→ promoted into the
+ground-truth ``alignment_pairs``) or reject each. Mining itself (the pgvector
+kNN batch) is a prod/cron operation via
+``app.services.alignment_flywheel.mine_candidates`` — deliberately not an HTTP
+endpoint, since it's long-running.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.role_guard import require_role
+from app.database import get_db
+from app.models.alignment_candidate import AlignmentCandidate
+from app.models.text import BuddhistText
+from app.services.alignment_flywheel import list_pending, review_candidate
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+class AlignmentCandidateOut(BaseModel):
+    id: int
+    text_a_id: int
+    text_a_title: str | None
+    text_a_juan_num: int
+    text_a_lang: str
+    text_b_id: int
+    text_b_title: str | None
+    text_b_juan_num: int
+    text_b_lang: str
+    similarity: float
+    source: str
+    status: str
+
+
+class ReviewRequest(BaseModel):
+    accept: bool
+
+
+async def _titles(db: AsyncSession, ids: set[int]) -> dict[int, str]:
+    if not ids:
+        return {}
+    rows = (await db.execute(
+        select(BuddhistText.id, BuddhistText.title_zh).where(BuddhistText.id.in_(ids))
+    )).all()
+    return {r[0]: r[1] for r in rows}
+
+
+def _to_out(c: AlignmentCandidate, titles: dict[int, str]) -> AlignmentCandidateOut:
+    return AlignmentCandidateOut(
+        id=c.id,
+        text_a_id=c.text_a_id, text_a_title=titles.get(c.text_a_id),
+        text_a_juan_num=c.text_a_juan_num, text_a_lang=c.text_a_lang,
+        text_b_id=c.text_b_id, text_b_title=titles.get(c.text_b_id),
+        text_b_juan_num=c.text_b_juan_num, text_b_lang=c.text_b_lang,
+        similarity=c.similarity, source=c.source, status=c.status,
+    )
+
+
+@router.get("/alignment-candidates", response_model=list[AlignmentCandidateOut])
+async def alignment_candidates(
+    limit: int = Query(50, ge=1, le=200),
+    _user=Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Pending cross-canon alignment candidates, highest-similarity first."""
+    pending = await list_pending(db, limit=limit)
+    titles = await _titles(db, {c.text_a_id for c in pending} | {c.text_b_id for c in pending})
+    return [_to_out(c, titles) for c in pending]
+
+
+@router.post("/alignment-candidates/{candidate_id}/review", response_model=AlignmentCandidateOut)
+async def review(
+    candidate_id: int,
+    body: ReviewRequest,
+    user=Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Accept (→ promote into alignment_pairs) or reject a candidate."""
+    c = await review_candidate(db, candidate_id, accept=body.accept, user_id=getattr(user, "id", None))
+    if c is None:
+        raise HTTPException(status_code=404, detail="candidate not found")
+    await db.commit()
+    await db.refresh(c)
+    titles = await _titles(db, {c.text_a_id, c.text_b_id})
+    return _to_out(c, titles)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,6 +59,7 @@ from datetime import UTC
 from app.api import (
     admin,
     alignment,
+    alignment_review,
     annotations,
     auth,
     bookmarks,
@@ -502,6 +503,7 @@ app.include_router(feedback.router, prefix="/api")
 
 # Admin dashboard
 app.include_router(admin.router, prefix="/api")
+app.include_router(alignment_review.router, prefix="/api")
 
 # Notifications
 app.include_router(notification.router, prefix="/api")

--- a/backend/app/models/alignment_candidate.py
+++ b/backend/app/models/alignment_candidate.py
@@ -1,0 +1,55 @@
+"""Staging table for the cross-canon alignment flywheel.
+
+fojin's moat is verified cross-canon alignment, but it sits at only ~3K
+chunk pairs. Growing it safely means a pipeline, not a bulk import: mine
+*candidates* automatically (cheap, high-recall, low-precision), then let a
+human accept/reject before anything reaches ``alignment_pairs`` (which RAG and
+the reader trust as ground truth). This table is the middle stage — candidates
+awaiting review — so a bad automatic match never silently becomes a served
+"parallel".
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class AlignmentCandidate(Base):
+    __tablename__ = "alignment_candidates"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # The two aligned chunks, keyed the same way as alignment_pairs so an
+    # accepted candidate promotes directly.
+    text_a_id: Mapped[int] = mapped_column(Integer, ForeignKey("buddhist_texts.id"), index=True)
+    text_a_juan_num: Mapped[int] = mapped_column(Integer)
+    text_a_chunk_index: Mapped[int] = mapped_column(Integer)
+    text_a_lang: Mapped[str] = mapped_column(String(10))
+    text_b_id: Mapped[int] = mapped_column(Integer, ForeignKey("buddhist_texts.id"), index=True)
+    text_b_juan_num: Mapped[int] = mapped_column(Integer)
+    text_b_chunk_index: Mapped[int] = mapped_column(Integer)
+    text_b_lang: Mapped[str] = mapped_column(String(10))
+
+    # Cosine similarity from the bootstrap kNN mine (0..1).
+    similarity: Mapped[float] = mapped_column(Float)
+    # How the candidate was produced (e.g. "knn-bootstrap").
+    source: Mapped[str] = mapped_column(String(40), server_default="knn-bootstrap")
+    # pending | accepted | rejected
+    status: Mapped[str] = mapped_column(String(12), server_default="pending", index=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    reviewed_by: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"))
+
+    __table_args__ = (
+        # One candidate per directed chunk pair — the miner dedups on this.
+        Index(
+            "uq_alignment_candidate_pair",
+            "text_a_id", "text_a_juan_num", "text_a_chunk_index",
+            "text_b_id", "text_b_juan_num", "text_b_chunk_index",
+            unique=True,
+        ),
+    )

--- a/backend/app/services/alignment_flywheel.py
+++ b/backend/app/services/alignment_flywheel.py
@@ -1,0 +1,264 @@
+"""Cross-canon alignment flywheel — mine candidates, stage, human-review, promote.
+
+The moat (verified cross-canon alignment) grows through a pipeline, not a bulk
+import:
+
+  1. **mine** (cheap, high-recall): for source-language chunks, find the nearest
+     cross-language chunk by embedding cosine similarity (fojin embeds all langs
+     in one space, so lzh↔pi↔bo nearest-neighbour is meaningful). Stage those
+     above a threshold — that aren't already aligned — as *pending* candidates.
+  2. **review** (human, high-precision): an admin accepts or rejects each.
+  3. **promote**: an accepted candidate is written into ``alignment_pairs`` —
+     the table RAG and the reader trust as ground truth. A bad automatic match
+     therefore never becomes a served "parallel" without a human in the loop.
+
+This module keeps the *decision* logic pure (threshold + dedup) and unit-tested;
+the kNN mine needs the corpus DB + pgvector and runs on prod/cron like the eval.
+This is slice 1 — candidate generation + review + promote. Later slices add
+LLM pre-verification, batch review UX, and provenance/quality scoring.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.alignment_candidate import AlignmentCandidate
+
+logger = logging.getLogger(__name__)
+
+# Default cosine-similarity floor for a chunk pair to be worth a human's time.
+# Deliberately conservative — the miner is high-recall, review is the precision
+# stage, but staging near-random pairs just wastes review effort.
+DEFAULT_SIMILARITY_THRESHOLD = 0.62
+# Cross-canon target languages a source (lzh) chunk is matched against.
+DEFAULT_TARGET_LANGS = ("pi", "bo", "sa")
+
+
+@dataclass(frozen=True)
+class ChunkRef:
+    """A retrieved chunk keyed the same way as alignment_pairs."""
+    text_id: int
+    juan_num: int
+    chunk_index: int
+    lang: str
+
+
+def pair_key(a: ChunkRef, b: ChunkRef) -> tuple:
+    """Directed dedup key for a candidate pair (source a → target b)."""
+    return (a.text_id, a.juan_num, a.chunk_index, b.text_id, b.juan_num, b.chunk_index)
+
+
+def select_new_candidates(
+    source: ChunkRef,
+    neighbours: list[tuple[ChunkRef, float]],
+    existing_keys: set[tuple],
+    *,
+    threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+) -> list[tuple[ChunkRef, ChunkRef, float]]:
+    """Pure decision step: from a source chunk's cross-language neighbours, pick
+    the (source, target, similarity) triples worth staging.
+
+    A neighbour is kept iff its similarity ≥ threshold, it's a different text,
+    and the directed pair isn't already known (in alignment_pairs *or* already
+    staged — the caller passes both in ``existing_keys``). Within one call the
+    same target is de-duplicated too."""
+    out: list[tuple[ChunkRef, ChunkRef, float]] = []
+    seen: set[tuple] = set()
+    for target, sim in neighbours:
+        if sim < threshold:
+            continue
+        if target.text_id == source.text_id:
+            continue
+        key = pair_key(source, target)
+        if key in existing_keys or key in seen:
+            continue
+        seen.add(key)
+        out.append((source, target, sim))
+    return out
+
+
+async def _existing_pair_keys(db: AsyncSession, source: ChunkRef) -> set[tuple]:
+    """Directed keys already known for this source chunk — from the ground-truth
+    ``alignment_pairs`` (either direction) and from prior candidates — so the
+    miner never re-stages a pair."""
+    keys: set[tuple] = set()
+    rows = (await db.execute(
+        text(
+            "SELECT text_b_id, text_b_juan_num, text_b_chunk_index "
+            "FROM alignment_pairs "
+            "WHERE text_a_id = :tid AND text_a_juan_num = :juan AND text_a_chunk_index = :cidx"
+        ),
+        {"tid": source.text_id, "juan": source.juan_num, "cidx": source.chunk_index},
+    )).all()
+    for r in rows:
+        if r[0] is not None:
+            keys.add((source.text_id, source.juan_num, source.chunk_index, r[0], r[1], r[2]))
+    prior = (await db.execute(
+        select(
+            AlignmentCandidate.text_b_id,
+            AlignmentCandidate.text_b_juan_num,
+            AlignmentCandidate.text_b_chunk_index,
+        ).where(
+            AlignmentCandidate.text_a_id == source.text_id,
+            AlignmentCandidate.text_a_juan_num == source.juan_num,
+            AlignmentCandidate.text_a_chunk_index == source.chunk_index,
+        )
+    )).all()
+    for r in prior:
+        keys.add((source.text_id, source.juan_num, source.chunk_index, r[0], r[1], r[2]))
+    return keys
+
+
+async def stage_candidates(
+    db: AsyncSession,
+    source: ChunkRef,
+    triples: list[tuple[ChunkRef, ChunkRef, float]],
+    *,
+    source_name: str = "knn-bootstrap",
+) -> int:
+    """Insert new candidate rows (pending). Returns how many were added.
+
+    Skips any pair already known for this source (defence in depth over the
+    unique index). Commit is the caller's."""
+    if not triples:
+        return 0
+    existing = await _existing_pair_keys(db, source)
+    added = 0
+    for a, b, sim in triples:
+        if pair_key(a, b) in existing:
+            continue
+        db.add(AlignmentCandidate(
+            text_a_id=a.text_id, text_a_juan_num=a.juan_num,
+            text_a_chunk_index=a.chunk_index, text_a_lang=a.lang,
+            text_b_id=b.text_id, text_b_juan_num=b.juan_num,
+            text_b_chunk_index=b.chunk_index, text_b_lang=b.lang,
+            similarity=round(float(sim), 4), source=source_name, status="pending",
+        ))
+        added += 1
+    return added
+
+
+async def _cross_lang_neighbours(
+    db: AsyncSession, source: ChunkRef, target_langs: tuple[str, ...], k: int
+) -> list[tuple[ChunkRef, float]]:
+    """Top-k nearest cross-language chunks to ``source`` by embedding cosine
+    similarity (pgvector). fojin embeds all languages in one space, so this is a
+    meaningful lzh↔pi↔bo match. Correlated on the source chunk's own embedding."""
+    lang_list = ",".join(f"'{lg}'" for lg in target_langs if lg.isalpha())  # nosec B608 — whitelist langs
+    rows = (await db.execute(
+        text(
+            "WITH src AS ("
+            "  SELECT embedding FROM text_embeddings "
+            "  WHERE text_id = :tid AND juan_num = :juan AND chunk_index = :cidx"
+            ") "
+            "SELECT te.text_id, te.juan_num, te.chunk_index, bt.lang, "
+            "       1 - (te.embedding <=> (SELECT embedding FROM src)) AS sim "
+            "FROM text_embeddings te JOIN buddhist_texts bt ON bt.id = te.text_id "
+            f"WHERE bt.lang IN ({lang_list}) AND te.embedding IS NOT NULL "
+            "  AND (SELECT embedding FROM src) IS NOT NULL "
+            "ORDER BY te.embedding <=> (SELECT embedding FROM src) "
+            "LIMIT :k"
+        ),
+        {"tid": source.text_id, "juan": source.juan_num, "cidx": source.chunk_index, "k": k},
+    )).all()
+    return [
+        (ChunkRef(text_id=r[0], juan_num=r[1], chunk_index=r[2], lang=r[3] or "lzh"), float(r[4]))
+        for r in rows
+    ]
+
+
+async def mine_candidates(
+    db: AsyncSession,
+    *,
+    limit: int = 200,
+    per_source_k: int = 3,
+    threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    target_langs: tuple[str, ...] = DEFAULT_TARGET_LANGS,
+    source_lang: str = "lzh",
+) -> int:
+    """Mine cross-canon candidates for a bounded batch of source-language chunks.
+
+    Needs the corpus DB + pgvector (run on prod/cron). For up to ``limit`` source
+    chunks, finds their nearest target-language chunks, stages new ones above
+    ``threshold``. Returns total staged. Best-effort per source — one failure is
+    logged and skipped, not fatal."""
+    source_rows = (await db.execute(
+        text(
+            "SELECT te.text_id, te.juan_num, te.chunk_index "
+            "FROM text_embeddings te JOIN buddhist_texts bt ON bt.id = te.text_id "
+            "WHERE bt.lang = :lang AND te.embedding IS NOT NULL "
+            "ORDER BY te.text_id, te.juan_num, te.chunk_index "
+            "LIMIT :limit"
+        ),
+        {"lang": source_lang, "limit": limit},
+    )).all()
+
+    total = 0
+    for sr in source_rows:
+        source = ChunkRef(text_id=sr[0], juan_num=sr[1], chunk_index=sr[2], lang=source_lang)
+        try:
+            neighbours = await _cross_lang_neighbours(db, source, target_langs, per_source_k)
+            existing = await _existing_pair_keys(db, source)
+            triples = select_new_candidates(source, neighbours, existing, threshold=threshold)
+            total += await stage_candidates(db, source, triples)
+        except Exception:
+            logger.warning("mine_candidates failed for %s", source, exc_info=True)
+    await db.commit()
+    return total
+
+
+async def list_pending(db: AsyncSession, limit: int = 50) -> list[AlignmentCandidate]:
+    """Highest-similarity pending candidates first — review the most promising."""
+    rows = await db.execute(
+        select(AlignmentCandidate)
+        .where(AlignmentCandidate.status == "pending")
+        .order_by(AlignmentCandidate.similarity.desc())
+        .limit(limit)
+    )
+    return list(rows.scalars().all())
+
+
+async def _promote_to_alignment_pairs(db: AsyncSession, c: AlignmentCandidate) -> None:
+    """Write an accepted candidate into the ground-truth alignment_pairs table."""
+    await db.execute(
+        text(
+            "INSERT INTO alignment_pairs "
+            "(text_a_id, text_a_juan_num, text_a_chunk_index, text_a_lang, "
+            " text_b_id, text_b_juan_num, text_b_chunk_index, text_b_lang, "
+            " confidence, method) "
+            "VALUES (:ta, :taj, :tac, :tal, :tb, :tbj, :tbc, :tbl, :conf, 'flywheel-verified')"
+        ),
+        {
+            "ta": c.text_a_id, "taj": c.text_a_juan_num, "tac": c.text_a_chunk_index, "tal": c.text_a_lang,
+            "tb": c.text_b_id, "tbj": c.text_b_juan_num, "tbc": c.text_b_chunk_index, "tbl": c.text_b_lang,
+            "conf": c.similarity,
+        },
+    )
+
+
+async def review_candidate(
+    db: AsyncSession, candidate_id: int, *, accept: bool, user_id: int | None
+) -> AlignmentCandidate | None:
+    """Accept (→ promote into alignment_pairs) or reject a pending candidate.
+
+    Idempotent-ish: a candidate already reviewed is returned unchanged (no
+    double-promote). Returns None if the id doesn't exist. Commit is the
+    caller's."""
+    c = (await db.execute(
+        select(AlignmentCandidate).where(AlignmentCandidate.id == candidate_id)
+    )).scalar_one_or_none()
+    if c is None or c.status != "pending":
+        return c
+    if accept:
+        await _promote_to_alignment_pairs(db, c)
+        c.status = "accepted"
+    else:
+        c.status = "rejected"
+    c.reviewed_at = datetime.now(UTC)
+    c.reviewed_by = user_id
+    return c

--- a/backend/tests/test_alignment_flywheel.py
+++ b/backend/tests/test_alignment_flywheel.py
@@ -1,0 +1,135 @@
+"""Tests for the alignment flywheel.
+
+The pgvector mine needs the corpus DB, so it isn't unit-tested here (like the
+eval). What IS tested: the pure candidate-selection decision (threshold / dedup /
+same-text skip) and the review state machine (accept → promote into
+alignment_pairs, reject, no double-review) over in-memory SQLite.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.alignment_candidate import AlignmentCandidate
+from app.services.alignment_flywheel import (
+    ChunkRef,
+    list_pending,
+    pair_key,
+    review_candidate,
+    select_new_candidates,
+)
+
+
+def _ref(tid, juan=1, cidx=0, lang="lzh"):
+    return ChunkRef(text_id=tid, juan_num=juan, chunk_index=cidx, lang=lang)
+
+
+# ── pure decision logic ──────────────────────────────────────────────────
+
+
+def test_select_keeps_only_above_threshold():
+    src = _ref(1)
+    neighbours = [(_ref(10, lang="pi"), 0.9), (_ref(11, lang="bo"), 0.5)]
+    out = select_new_candidates(src, neighbours, set(), threshold=0.62)
+    assert [t[1].text_id for t in out] == [10]     # 0.5 dropped
+
+
+def test_select_skips_same_text_and_existing_and_dupes():
+    src = _ref(1)
+    existing = {pair_key(src, _ref(20, lang="pi"))}
+    neighbours = [
+        (_ref(1, lang="pi"), 0.99),    # same text_id → skip
+        (_ref(20, lang="pi"), 0.95),   # already known → skip
+        (_ref(30, lang="pi"), 0.8),    # keep
+        (_ref(30, lang="pi"), 0.8),    # duplicate in-call → skip
+    ]
+    out = select_new_candidates(src, neighbours, existing, threshold=0.62)
+    assert [t[1].text_id for t in out] == [30]
+
+
+def test_pair_key_is_directed():
+    a, b = _ref(1), _ref(2)
+    assert pair_key(a, b) != pair_key(b, a)
+
+
+# ── review state machine (SQLite) ────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(AlignmentCandidate.__table__.create)
+        # Minimal alignment_pairs table — only the columns the promote inserts.
+        await conn.execute(text(
+            "CREATE TABLE alignment_pairs ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " text_a_id INT, text_a_juan_num INT, text_a_chunk_index INT, text_a_lang TEXT,"
+            " text_b_id INT, text_b_juan_num INT, text_b_chunk_index INT, text_b_lang TEXT,"
+            " confidence FLOAT, method TEXT)"
+        ))
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _add(db, **kw):
+    defaults = dict(
+        text_a_id=1, text_a_juan_num=1, text_a_chunk_index=0, text_a_lang="lzh",
+        text_b_id=2, text_b_juan_num=1, text_b_chunk_index=0, text_b_lang="pi",
+        similarity=0.8, source="knn-bootstrap", status="pending",
+    )
+    defaults.update(kw)
+    c = AlignmentCandidate(**defaults)
+    db.add(c)
+    await db.flush()
+    return c
+
+
+@pytest.mark.anyio
+async def test_accept_promotes_into_alignment_pairs(db):
+    c = await _add(db, similarity=0.91)
+    out = await review_candidate(db, c.id, accept=True, user_id=7)
+    assert out.status == "accepted"
+    assert out.reviewed_by == 7
+    # A ground-truth alignment_pairs row now exists with method flywheel-verified.
+    row = (await db.execute(text(
+        "SELECT text_a_id, text_b_id, confidence, method FROM alignment_pairs"
+    ))).all()
+    assert len(row) == 1
+    assert row[0] == (1, 2, 0.91, "flywheel-verified")
+
+
+@pytest.mark.anyio
+async def test_reject_does_not_promote(db):
+    c = await _add(db)
+    out = await review_candidate(db, c.id, accept=False, user_id=7)
+    assert out.status == "rejected"
+    n = (await db.execute(text("SELECT COUNT(*) FROM alignment_pairs"))).scalar()
+    assert n == 0
+
+
+@pytest.mark.anyio
+async def test_already_reviewed_is_noop(db):
+    c = await _add(db, status="accepted")
+    out = await review_candidate(db, c.id, accept=True, user_id=7)
+    assert out.status == "accepted"
+    # No second promote row.
+    n = (await db.execute(text("SELECT COUNT(*) FROM alignment_pairs"))).scalar()
+    assert n == 0
+
+
+@pytest.mark.anyio
+async def test_missing_candidate_returns_none(db):
+    assert await review_candidate(db, 9999, accept=True, user_id=1) is None
+
+
+@pytest.mark.anyio
+async def test_list_pending_orders_by_similarity_desc(db):
+    await _add(db, text_b_id=2, similarity=0.7)
+    await _add(db, text_b_id=3, similarity=0.95)
+    await _add(db, text_b_id=4, similarity=0.5, status="rejected")  # excluded
+    pending = await list_pending(db, limit=10)
+    assert [c.similarity for c in pending] == [0.95, 0.7]

--- a/docs/ALIGNMENT_FLYWHEEL.md
+++ b/docs/ALIGNMENT_FLYWHEEL.md
@@ -1,0 +1,60 @@
+# Cross-canon alignment flywheel
+
+fojin's moat is **verified cross-canon alignment** — but it sits at only ~3K
+chunk pairs. Growing it safely means a pipeline, not a bulk import, so a bad
+automatic match never becomes a served "parallel" without a human in the loop.
+
+```
+mine (cheap, high-recall)  →  review (human, high-precision)  →  promote
+   pgvector kNN                admin accept / reject             alignment_pairs
+   → alignment_candidates                                        (ground truth)
+```
+
+This is **slice 1**: candidate generation + review + promote. Later slices:
+LLM pre-verification (auto-reject obvious mismatches before a human sees them),
+batch review UX, provenance/quality scoring, bootstrap from BuddhaNexus / MITRA
+open alignment output.
+
+## 1. Mine (prod / cron — needs the corpus DB + pgvector)
+
+`app.services.alignment_flywheel.mine_candidates` embeds each source-language
+(default `lzh`) chunk against the cross-canon target languages (`pi`/`bo`/`sa`)
+in fojin's shared embedding space, and stages new pairs above a similarity
+threshold that aren't already in `alignment_pairs`.
+
+```bash
+# inside the backend container, cwd /app
+docker compose exec -T backend python - <<'PY'
+import asyncio
+from app.database import async_session
+from app.services.alignment_flywheel import mine_candidates
+async def main():
+    async with async_session() as db:
+        n = await mine_candidates(db, limit=500, threshold=0.62)
+        print("staged", n, "candidates")
+asyncio.run(main())
+PY
+```
+
+Bounded per run (`limit` source chunks); re-runnable — it skips pairs already
+staged or aligned. Good cron cadence: a modest `limit` nightly so the review
+queue never floods.
+
+## 2. Review (admin API)
+
+```
+GET  /api/admin/alignment-candidates?limit=50      # pending, highest-similarity first
+POST /api/admin/alignment-candidates/{id}/review   # body: {"accept": true|false}
+```
+
+Accept promotes the pair into `alignment_pairs` with `method='flywheel-verified'`
+and `confidence` = the mined similarity; reject just marks it. Both are
+idempotent (an already-reviewed candidate is a no-op, so no double-promote).
+
+## 3. Effect
+
+Every accepted candidate immediately widens what the trilingual RAG and the
+reader's 多语对读 panel can surface — the moat grows one verified pair at a
+time, and the `/admin/alignment-coverage` dashboard (PR #895) shows where the
+biggest gaps still are, to steer the next mine.
+```


### PR DESCRIPTION
## Why (pillar #1 — the moat)

fojin's differentiator is **verified cross-canon alignment**, but it sits at only **~3K chunk pairs**. Growing it safely needs a *pipeline*, not a bulk import — so a bad automatic match never becomes a served "parallel" without a human in the loop.

```
mine (cheap, high-recall)  →  review (human, high-precision)  →  promote
   pgvector kNN                 admin accept / reject             alignment_pairs
   → alignment_candidates                                          (ground truth)
```

## What (slice 1)

- **`alignment_candidates`** staging table (migration `0167`) + model.
- **`services/alignment_flywheel.py`**:
  - `mine_candidates` — embeds each source (`lzh`) chunk against `pi`/`bo`/`sa` in fojin's **shared embedding space** and stages new pairs above a similarity threshold that aren't already aligned. The candidate-selection **decision** (threshold / dedup / same-text skip) is **pure + unit-tested**; the pgvector kNN is a prod/cron op.
  - `review_candidate` — accept (→ **promotes** into `alignment_pairs` with `method='flywheel-verified'`, `confidence` = mined similarity) or reject. Idempotent — an already-reviewed candidate is a no-op (no double-promote).
- **Admin API** — `GET /admin/alignment-candidates` (pending, highest-sim first) + `POST .../{id}/review`.
- **`docs/ALIGNMENT_FLYWHEEL.md`** — how to run the mine on prod + the review loop.

## Test
- 8 unit tests: pure candidate-selection + the review state machine over SQLite (incl. the promote-into-`alignment_pairs` path).
- Full backend suite **930** green.

## Scope
- **Additive**; no live-path change. Mining is deliberately not an HTTP endpoint (long-running).
- **Slice 1 of a long effort** — later slices: LLM pre-verification (auto-reject obvious mismatches), batch review UX, bootstrap from BuddhaNexus / MITRA open alignment output. Every accepted pair immediately widens trilingual RAG + the reader's 多语对读 panel; `/admin/alignment-coverage` (#895) shows where the next gaps are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)