### PR TITLE
feat(home): randomize showcase cards per refresh via cached candidate pools

### DIFF
--- a/backend/app/services/home_showcase.py
+++ b/backend/app/services/home_showcase.py
@@ -21,7 +21,6 @@ periods (feels alive) while staying stable within one (cacheable).
 from __future__ import annotations
 
 import logging
-import time
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,7 +37,7 @@ logger = logging.getLogger(__name__)
 # Cache TTL for the whole aggregate, and the rotation bucket size. 15 min keeps
 # the homepage lively without hammering the DB.
 SHOWCASE_TTL = 900
-_SHOWCASE_CACHE_KEY = "home:showcase:v1"
+_SHOWCASE_CACHE_KEY = "home:showcase:v2"  # v2: pools (not single picks)
 
 # A small candidate pool size for rotation-by-seed queries: fetch a bounded set
 # cheaply, then pick one deterministically per time bucket.
@@ -65,14 +64,11 @@ _PREDICATE_LABELS = {
 }
 
 
-def _seed() -> int:
-    """Time-bucketed rotation seed — stable within a cache period, advancing
-    across periods so revisits see fresh content."""
-    return int(time.time() // SHOWCASE_TTL)
-
-
-def _pick(items: list, seed: int):
-    return items[seed % len(items)] if items else None
+# Each card returns a POOL of candidates (cached SHOWCASE_TTL); the frontend
+# picks one at random on every page load, so the card varies per refresh while
+# the DB work stays cached. Pool sizes are small — enough variety, tiny payload.
+_CHAT_POOL = 8
+_GEO_POOL = 8
 
 
 def _short_gloss(definition: str | None) -> str | None:
@@ -114,43 +110,43 @@ async def _sources_card(db: AsyncSession) -> dict | None:
         return None
 
 
-async def _chat_card(db: AsyncSession, redis, seed: int) -> dict | None:
+async def _chat_card(db: AsyncSession, redis) -> dict | None:
+    """A pool of hot questions; the frontend shows one at random per load."""
     try:
         questions = await get_hot_questions(db, redis)
-        q = _pick(questions, seed)
-        return {"question": q} if q else None
+        pool = [q for q in questions if q][:_CHAT_POOL]
+        return {"questions": pool} if pool else None
     except Exception:
         logger.warning("showcase chat_card failed", exc_info=True)
         return None
 
 
-async def _dictionary_card(db: AsyncSession, seed: int) -> dict | None:
+async def _dictionary_card(db: AsyncSession) -> dict | None:
+    """A pool of hot terms + short glosses (one batched query over HOT_TERMS)."""
     try:
-        term = _pick(HOT_TERMS, seed)
-        if not term:
-            return None
-        row = (
+        rows = (
             await db.execute(
                 select(DictionaryEntry.headword, DictionaryEntry.definition)
-                .where(DictionaryEntry.headword == term)
-                .limit(1)
+                .where(DictionaryEntry.headword.in_(HOT_TERMS))
             )
-        ).first()
-        if row is None:
-            return {"term": term, "definition": None}
-        return {"term": row[0], "definition": _short_gloss(row[1])}
+        ).all()
+        # One gloss per headword (first row wins), preserving HOT_TERMS order.
+        by_term: dict[str, str | None] = {}
+        for headword, definition in rows:
+            if headword not in by_term:
+                by_term[headword] = _short_gloss(definition)
+        terms = [{"term": t, "definition": by_term[t]} for t in HOT_TERMS if t in by_term]
+        return {"terms": terms} if terms else None
     except Exception:
         logger.warning("showcase dictionary_card failed", exc_info=True)
         return None
 
 
-async def _kg_card(db: AsyncSession, seed: int) -> dict | None:
-    """A readable knowledge-graph triple (subject —predicate→ object).
+async def _kg_card(db: AsyncSession) -> dict | None:
+    """A pool of readable knowledge-graph triples (subject —predicate→ object).
 
-    Bounded: fetches a small pool of relations whose subject is a person (the
-    most human-readable triples: 玄奘 —译→ …) and both endpoints have a name,
-    then rotates. Person-subject filter keeps the sample coherent without an
-    expensive scan."""
+    Person-subject filter keeps the sample human-readable (玄奘 —译→ …) without
+    an expensive scan; the frontend shows one triple at random per load."""
     try:
         subj = aliased(KGEntity)
         obj = aliased(KGEntity)
@@ -167,17 +163,22 @@ async def _kg_card(db: AsyncSession, seed: int) -> dict | None:
                 .limit(_POOL)
             )
         ).all()
-        picked = _pick(rows, seed)
-        if picked is None:
-            return None
-        predicate = _PREDICATE_LABELS.get(picked[1], picked[1])
-        return {"subject": picked[0], "predicate": predicate, "object": picked[2]}
+        triples = [
+            {
+                "subject": r[0],
+                "predicate": _PREDICATE_LABELS.get(r[1], r[1]),
+                "object": r[2],
+            }
+            for r in rows
+        ]
+        return {"triples": triples} if triples else None
     except Exception:
         logger.warning("showcase kg_card failed", exc_info=True)
         return None
 
 
-async def _geo_card(db: AsyncSession, seed: int) -> dict | None:
+async def _geo_card(db: AsyncSession) -> dict | None:
+    """Site count + a pool of place names; the frontend samples a few per load."""
     try:
         count = (
             await db.execute(
@@ -188,14 +189,12 @@ async def _geo_card(db: AsyncSession, seed: int) -> dict | None:
             await db.execute(
                 select(KGEntity.name_zh)
                 .where(KGEntity.entity_type.in_(_GEO_TYPES), KGEntity.name_zh.is_not(None))
-                .limit(_POOL)
+                .limit(_GEO_POOL)
             )
         ).scalars().all()
         if not count and not names:
             return None
-        # Rotate the featured slice so the names vary across periods.
-        featured = names[seed % max(1, len(names)) :][:3] or names[:3]
-        return {"count": int(count), "places": list(featured)}
+        return {"count": int(count), "places": list(names)}
     except Exception:
         logger.warning("showcase geo_card failed", exc_info=True)
         return None
@@ -216,13 +215,12 @@ async def get_home_showcase(db: AsyncSession, redis=None) -> dict:
         except Exception:
             logger.debug("showcase cache read failed", exc_info=True)
 
-    seed = _seed()
     showcase = {
         "sources": await _sources_card(db),
-        "chat": await _chat_card(db, redis, seed),
-        "dictionary": await _dictionary_card(db, seed),
-        "kg": await _kg_card(db, seed),
-        "geo": await _geo_card(db, seed),
+        "chat": await _chat_card(db, redis),
+        "dictionary": await _dictionary_card(db),
+        "kg": await _kg_card(db),
+        "geo": await _geo_card(db),
     }
 
     if redis is not None:

--- a/backend/tests/test_home_showcase.py
+++ b/backend/tests/test_home_showcase.py
@@ -1,8 +1,8 @@
 """Tests for the homepage dynamic showcase service.
 
 Uses an in-memory SQLite DB seeded with a few rows so each card's real query
-runs, plus asserts the two guarantees: independent per-card degradation
-(a card with no data → None, page still returns) and time-bucket rotation.
+runs, and asserts: per-card POOLS (the frontend picks one at random per load),
+independent per-card degradation (no data → None), and cache passthrough.
 """
 
 import pytest
@@ -15,7 +15,7 @@ from app.models.knowledge_graph import KGEntity, KGRelation
 from app.models.source import DataSource
 from app.models.text import BuddhistText
 from app.services import home_showcase
-from app.services.home_showcase import _pick, _seed, _short_gloss, get_home_showcase
+from app.services.home_showcase import _short_gloss, get_home_showcase
 
 _MODELS = (BuddhistText, DataSource, DictionaryEntry, HotQuestion, KGEntity, KGRelation)
 
@@ -47,17 +47,18 @@ async def seeded_db():
 
 
 @pytest.mark.anyio
-async def test_showcase_populates_each_card_from_real_data(seeded_db):
+async def test_showcase_returns_pools_per_card(seeded_db):
     out = await get_home_showcase(seeded_db, redis=None)
     assert out["sources"] == {"sources": 1, "texts": 1}
-    # HOT_TERMS rotates; 般若 is in the list, and its definition is seeded, so
-    # whichever term is picked, the dictionary card is a dict (never crashes).
-    assert isinstance(out["dictionary"], dict)
-    # predicate "translated" is mapped to its Chinese label "译".
-    assert out["kg"] == {"subject": "玄奘", "predicate": "译", "object": "大般若經"}
+    # KG returns a POOL of triples; the seeded translated→译 triple is in it.
+    assert {"subject": "玄奘", "predicate": "译", "object": "大般若經"} in out["kg"]["triples"]
+    # Dictionary returns a POOL of {term, definition}; 般若 (seeded) is present.
+    terms = {e["term"] for e in out["dictionary"]["terms"]}
+    assert "般若" in terms
     assert out["geo"]["count"] == 1
     assert "那烂陀寺" in out["geo"]["places"]
-    assert isinstance(out["chat"], dict) and out["chat"]["question"]
+    # Chat returns a non-empty pool of questions.
+    assert isinstance(out["chat"]["questions"], list) and out["chat"]["questions"]
 
 
 @pytest.mark.anyio
@@ -70,13 +71,13 @@ async def test_empty_db_degrades_each_card_to_none_not_crash():
     async with factory() as s:
         out = await get_home_showcase(s, redis=None)
     await engine.dispose()
-    # No sources/texts, no KG, no geo → those cards None; chat still has the
-    # DEFAULT_HOT_QUESTIONS fallback; dictionary term exists but no definition row.
+    # No sources/texts, no KG, no geo, no dictionary rows → those cards None;
+    # chat still has the DEFAULT_HOT_QUESTIONS fallback pool.
     assert out["sources"] is None
     assert out["kg"] is None
     assert out["geo"] is None
-    assert out["chat"]["question"]                      # default hot questions
-    assert out["dictionary"]["definition"] is None      # term w/o seeded entry
+    assert out["dictionary"] is None                     # no HOT_TERMS entries seeded
+    assert out["chat"]["questions"]                      # default hot questions
 
 
 @pytest.mark.anyio
@@ -107,22 +108,3 @@ def test_short_gloss_trims_long_definitions():
     assert _short_gloss("寂静") == "寂静"
     assert _short_gloss("") is None
     assert _short_gloss(None) is None
-
-
-def test_pick_rotates_by_seed():
-    items = ["a", "b", "c"]
-    assert _pick(items, 0) == "a"
-    assert _pick(items, 1) == "b"
-    assert _pick(items, 3) == "a"                        # wraps
-    assert _pick([], 5) is None
-
-
-def test_seed_is_stable_within_bucket(monkeypatch):
-    # Anchor on a bucket boundary so "TTL-1 later" stays in the same bucket.
-    base = home_showcase.SHOWCASE_TTL * 1000
-    monkeypatch.setattr(home_showcase.time, "time", lambda: float(base))
-    s1 = _seed()
-    monkeypatch.setattr(home_showcase.time, "time", lambda: float(base + home_showcase.SHOWCASE_TTL - 1))
-    assert _seed() == s1                                 # same bucket
-    monkeypatch.setattr(home_showcase.time, "time", lambda: float(base + home_showcase.SHOWCASE_TTL))
-    assert _seed() == s1 + 1                             # next bucket

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -521,11 +521,13 @@ export async function getStats(): Promise<Stats> {
 
 // Homepage dynamic showcase — live subtitle content for the hero feature cards.
 // Every card key is nullable: a null card means "show the static fallback".
+// Each card is a POOL (cached ~15min); the frontend picks one at random per page
+// load so the card varies on every refresh without extra backend load.
 export interface HomeShowcase {
   sources: { sources: number; texts: number } | null;
-  chat: { question: string } | null;
-  dictionary: { term: string; definition: string | null } | null;
-  kg: { subject: string; predicate: string; object: string } | null;
+  chat: { questions: string[] } | null;
+  dictionary: { terms: { term: string; definition: string | null }[] } | null;
+  kg: { triples: { subject: string; predicate: string; object: string }[] } | null;
   geo: { count: number; places: string[] } | null;
 }
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -50,17 +50,42 @@ export default function HomePage() {
   // undefined and each card renders its static `feature_*_desc` fallback.
   const { data: showcase } = useQuery({ queryKey: ["homeShowcase"], queryFn: getHomeShowcase, staleTime: 5 * 60_000 });
 
+  // One random value per pool, fixed once at mount (a lazy initializer is the
+  // allowed place for the impure Math.random). So every page load / refresh
+  // shows a different pick from each cached pool — the cards feel alive without
+  // any extra backend round-trip.
+  const [rand] = useState(() => ({
+    chat: Math.random(), dict: Math.random(), kg: Math.random(),
+    geo: Math.random(), col: Math.random(),
+  }));
+
+  // Pick one item from each cached pool using the per-mount random values.
+  const sc = useMemo(() => {
+    const at = (r: number, len: number) => Math.floor(r * len) % Math.max(1, len);
+    const q = showcase?.chat?.questions ?? [];
+    const terms = showcase?.dictionary?.terms ?? [];
+    const triples = showcase?.kg?.triples ?? [];
+    const places = showcase?.geo?.places ?? [];
+    return {
+      sources: showcase?.sources ?? null,
+      chat: q.length ? q[at(rand.chat, q.length)] : null,
+      dict: terms.length ? terms[at(rand.dict, terms.length)] : null,
+      kg: triples.length ? triples[at(rand.kg, triples.length)] : null,
+      geo: showcase?.geo && showcase.geo.count > 0
+        ? { count: showcase.geo.count, places: places.length
+            ? [0, 1, 2].map((i) => places[(at(rand.geo, places.length) + i) % places.length]) : [] }
+        : null,
+    };
+  }, [showcase, rand]);
+
   // 经典专题 card is driven by the frontend's own collection content (the server
-  // doesn't hold it). Rotate the featured names by a coarse time bucket so the
-  // card feels alive without a backend round-trip. The bucket is captured once
-  // at mount (a lazy initializer is the allowed place for the impure Date.now).
-  const [rotationBucket] = useState(() => Math.floor(Date.now() / (15 * 60_000)));
+  // doesn't hold it). Pick a random featured slice per load, same as the pools.
   const collectionsDesc = useMemo(() => {
     const cols = getLocalizedCollections(i18n.language).map((c) => c.name).filter(Boolean);
     if (cols.length === 0) return null;
-    const start = rotationBucket % cols.length;
+    const start = Math.floor(rand.col * cols.length) % cols.length;
     return [0, 1, 2].map((i) => cols[(start + i) % cols.length]).join(" · ");
-  }, [i18n.language, rotationBucket]);
+  }, [i18n.language, rand.col]);
 
   // 搜索联想：复用 SearchPage 已有的 /search/suggest 接口与防抖模式
   const [acOptions, setAcOptions] = useState<{ value: string }[]>([]);
@@ -223,10 +248,10 @@ export default function HomePage() {
             <DatabaseOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_sources_title")}</div>
             <div className="home-feature-desc">
-              {showcase?.sources
+              {sc.sources
                 ? t("home.sc_sources", {
-                    sources: showcase.sources.sources.toLocaleString(),
-                    texts: showcase.sources.texts.toLocaleString(),
+                    sources: sc.sources.sources.toLocaleString(),
+                    texts: sc.sources.texts.toLocaleString(),
                   })
                 : t("home.feature_sources_desc")}
             </div>
@@ -234,26 +259,26 @@ export default function HomePage() {
           <div
             className="home-feature-card"
             onClick={() =>
-              navigate(showcase?.chat?.question ? `/chat?q=${encodeURIComponent(showcase.chat.question)}` : "/chat")
+              navigate(sc.chat ? `/chat?q=${encodeURIComponent(sc.chat)}` : "/chat")
             }
           >
             <RobotOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_chat_title")}</div>
             <div className="home-feature-desc">
-              {showcase?.chat?.question || t("home.feature_chat_desc")}
+              {sc.chat || t("home.feature_chat_desc")}
             </div>
           </div>
           <div
             className="home-feature-card"
             onClick={() =>
-              navigate(showcase?.dictionary?.term ? `/dictionary?q=${encodeURIComponent(showcase.dictionary.term)}` : "/dictionary")
+              navigate(sc.dict ? `/dictionary?q=${encodeURIComponent(sc.dict.term)}` : "/dictionary")
             }
           >
             <FileTextOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_dict_title")}</div>
             <div className="home-feature-desc">
-              {showcase?.dictionary?.term
-                ? `${showcase.dictionary.term}${showcase.dictionary.definition ? ` — ${showcase.dictionary.definition}` : ""}`
+              {sc.dict
+                ? `${sc.dict.term}${sc.dict.definition ? ` — ${sc.dict.definition}` : ""}`
                 : t("home.feature_dict_desc")}
             </div>
           </div>
@@ -261,8 +286,8 @@ export default function HomePage() {
             <ApartmentOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_kg_title")}</div>
             <div className="home-feature-desc">
-              {showcase?.kg
-                ? `${showcase.kg.subject} → ${showcase.kg.predicate} → ${showcase.kg.object}`
+              {sc.kg
+                ? `${sc.kg.subject} → ${sc.kg.predicate} → ${sc.kg.object}`
                 : t("home.feature_kg_desc")}
             </div>
           </div>
@@ -270,10 +295,10 @@ export default function HomePage() {
             <GlobalOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_geo_title")}</div>
             <div className="home-feature-desc">
-              {showcase?.geo && showcase.geo.count > 0
+              {sc.geo
                 ? t("home.sc_geo", {
-                    count: showcase.geo.count.toLocaleString(),
-                    places: showcase.geo.places.slice(0, 3).join("、"),
+                    count: sc.geo.count.toLocaleString(),
+                    places: sc.geo.places.join("、"),
                   })
                 : t("home.feature_geo_desc")}
             </div>


### PR DESCRIPTION
## Why

The hero cards looked **fixed on refresh**. Three layers pinned them for 15 min — a time-bucketed pick seed, the Redis response cache, and HTTP `max-age`. So content rotated only every 15 minutes, not per visit (as the user noticed).

## Fix (keeps the performance win)

Each card now returns a **pool** of candidates (still cached ~15 min in Redis), and the **frontend picks one at random on every page load**. DB work stays cached; each refresh varies.

- **`home_showcase.py`**: `chat → {questions:[…]}`, `dictionary → {terms:[{term,definition}…]}` (one **batched** query over `HOT_TERMS`), `kg → {triples:[…]}`, `geo → {count, places:[…]}`. Dropped the time-bucket seed / `_pick`. Cache key **v1→v2** (shape change).
- **`HomePage`**: one `Math.random()` per pool captured at mount (lazy `useState` initializer — the eslint-allowed place for impurity), used to index each pool; every mount / refresh re-picks. 经典专题 likewise picks a random slice per load. Static `feature_*_desc` fallback still applies when a pool is empty.
- **`client.ts`** `HomeShowcase` type → pools.

## Test
- Backend showcase tests updated to the pool shape (+ removed the seed/pick tests); 11 pass.
- Frontend production **build** + **160** vitest + **eslint** (Math.random purity ok) + **tsc** + **i18n ratchet** green.

## Note
On deploy I'll flush the Redis `home:showcase:*` key so the new pool shape takes effect immediately (else the v1 cache lingers ≤15 min — though the v2 key means it just repopulates fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)