### PR TITLE
fix(home): keep legacy single-pick showcase fields for one release (backward-compat)

### DIFF
--- a/backend/app/services/home_showcase.py
+++ b/backend/app/services/home_showcase.py
@@ -115,7 +115,10 @@ async def _chat_card(db: AsyncSession, redis) -> dict | None:
     try:
         questions = await get_hot_questions(db, redis)
         pool = [q for q in questions if q][:_CHAT_POOL]
-        return {"questions": pool} if pool else None
+        # `question` (first of pool) is a legacy field kept for one release so a
+        # PWA-cached old frontend (which reads .question) still works during the
+        # service-worker update window. Safe to drop once SWs have propagated.
+        return {"questions": pool, "question": pool[0]} if pool else None
     except Exception:
         logger.warning("showcase chat_card failed", exc_info=True)
         return None
@@ -136,7 +139,10 @@ async def _dictionary_card(db: AsyncSession) -> dict | None:
             if headword not in by_term:
                 by_term[headword] = _short_gloss(definition)
         terms = [{"term": t, "definition": by_term[t]} for t in HOT_TERMS if t in by_term]
-        return {"terms": terms} if terms else None
+        if not terms:
+            return None
+        # Legacy single-pick fields (see _chat_card) for PWA-cached old frontends.
+        return {"terms": terms, "term": terms[0]["term"], "definition": terms[0]["definition"]}
     except Exception:
         logger.warning("showcase dictionary_card failed", exc_info=True)
         return None
@@ -171,7 +177,10 @@ async def _kg_card(db: AsyncSession) -> dict | None:
             }
             for r in rows
         ]
-        return {"triples": triples} if triples else None
+        if not triples:
+            return None
+        # Legacy single-pick fields (see _chat_card) for PWA-cached old frontends.
+        return {"triples": triples, **triples[0]}
     except Exception:
         logger.warning("showcase kg_card failed", exc_info=True)
         return None

--- a/backend/tests/test_home_showcase.py
+++ b/backend/tests/test_home_showcase.py
@@ -59,6 +59,10 @@ async def test_showcase_returns_pools_per_card(seeded_db):
     assert "那烂陀寺" in out["geo"]["places"]
     # Chat returns a non-empty pool of questions.
     assert isinstance(out["chat"]["questions"], list) and out["chat"]["questions"]
+    # Legacy single-pick fields coexist (backward-compat for PWA-cached old FE).
+    assert out["chat"]["question"] == out["chat"]["questions"][0]
+    assert out["kg"]["subject"] == out["kg"]["triples"][0]["subject"]
+    assert out["dictionary"]["term"] == out["dictionary"]["terms"][0]["term"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Why

#917 changed the showcase response from single picks → pools. A **PWA service-worker-cached OLD frontend** (reading `.chat.question` / `.kg.subject` / `.dictionary.term`) then rendered **"undefined → undefined → undefined"** against the new pool response until its SW updated — a transient but ugly regression for returning visitors (caught live in the browser).

## Fix (expand-then-contract)

The backend now returns the new **pools AND the legacy single fields** (first pool item), so **both** old-cached and new frontends work. Drop the legacy fields in a later cleanup once SWs have propagated.

## Test
Backend showcase tests assert the legacy fields coexist with the pools; 4 pass, ruff clean.