### PR TITLE
feat(home): make all 5 showcase cards vary per refresh

### DIFF
--- a/backend/app/services/home_showcase.py
+++ b/backend/app/services/home_showcase.py
@@ -68,7 +68,8 @@ _PREDICATE_LABELS = {
 # picks one at random on every page load, so the card varies per refresh while
 # the DB work stays cached. Pool sizes are small — enough variety, tiny payload.
 _CHAT_POOL = 8
-_GEO_POOL = 8
+_GEO_POOL = 12
+_SOURCES_POOL = 12
 
 
 def _short_gloss(definition: str | None) -> str | None:
@@ -102,9 +103,19 @@ async def _sources_card(db: AsyncSession) -> dict | None:
                 select(func.count(DataSource.id)).where(DataSource.is_active.is_(True))
             )
         ).scalar() or 0
+        # A pool of active source names so the card varies per load (the raw
+        # counts alone never change — and are already shown in the hero stats).
+        names = (
+            await db.execute(
+                select(DataSource.name_zh)
+                .where(DataSource.is_active.is_(True), DataSource.name_zh.is_not(None))
+                .limit(_SOURCES_POOL)
+            )
+        ).scalars().all()
         if not texts and not sources:
             return None
-        return {"sources": int(sources), "texts": int(texts)}
+        # texts kept for backward compat (PWA-cached old frontend reads it).
+        return {"sources": int(sources), "texts": int(texts), "names": list(names)}
     except Exception:
         logger.warning("showcase sources_card failed", exc_info=True)
         return None

--- a/backend/tests/test_home_showcase.py
+++ b/backend/tests/test_home_showcase.py
@@ -49,7 +49,8 @@ async def seeded_db():
 @pytest.mark.anyio
 async def test_showcase_returns_pools_per_card(seeded_db):
     out = await get_home_showcase(seeded_db, redis=None)
-    assert out["sources"] == {"sources": 1, "texts": 1}
+    assert out["sources"]["sources"] == 1 and out["sources"]["texts"] == 1
+    assert out["sources"]["names"] == ["CBETA"]          # active source name pool
     # KG returns a POOL of triples; the seeded translated→译 triple is in it.
     assert {"subject": "玄奘", "predicate": "译", "object": "大般若經"} in out["kg"]["triples"]
     # Dictionary returns a POOL of {term, definition}; 般若 (seeded) is present.

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -414,6 +414,7 @@
   "home.feature_sources_title": "Data Sources",
   "home.feature_sources_desc": "Aggregating CBETA, SuttaCentral and global Buddhist digital resources",
   "home.sc_sources": "{{sources}} sources · {{texts}} texts",
+  "home.sc_sources_names": "{{sources}} sources · {{names}}",
   "home.sc_geo": "{{count}} sacred sites · {{places}}",
   "home.feature_kg_title": "Knowledge Graph",
   "home.feature_kg_desc": "e.g. Kumārajīva → translated → Lotus Sutra",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -414,6 +414,7 @@
   "home.feature_sources_title": "資料來源",
   "home.feature_sources_desc": "匯聚 CBETA、SuttaCentral 等全球數字佛典資源",
   "home.sc_sources": "{{sources}} 個來源 · {{texts}} 部經典",
+  "home.sc_sources_names": "{{sources}} 個來源 · {{names}}",
   "home.sc_geo": "{{count}} 處聖跡 · {{places}}",
   "home.feature_kg_title": "知識圖譜",
   "home.feature_kg_desc": "例如：鳩摩羅什 → 譯經 → 《妙法蓮華經》",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -414,6 +414,7 @@
   "home.feature_sources_title": "数据源",
   "home.feature_sources_desc": "汇聚 CBETA、SuttaCentral 等全球数字佛典资源",
   "home.sc_sources": "{{sources}} 个来源 · {{texts}} 部经典",
+  "home.sc_sources_names": "{{sources}} 个来源 · {{names}}",
   "home.sc_geo": "{{count}} 处圣迹 · {{places}}",
   "home.feature_kg_title": "知识图谱",
   "home.feature_kg_desc": "例如：鸠摩罗什 → 译经 → 《妙法莲华经》",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -524,7 +524,7 @@ export async function getStats(): Promise<Stats> {
 // Each card is a POOL (cached ~15min); the frontend picks one at random per page
 // load so the card varies on every refresh without extra backend load.
 export interface HomeShowcase {
-  sources: { sources: number; texts: number } | null;
+  sources: { sources: number; texts: number; names?: string[] } | null;
   chat: { questions: string[] } | null;
   dictionary: { terms: { term: string; definition: string | null }[] } | null;
   kg: { triples: { subject: string; predicate: string; object: string }[] } | null;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -55,25 +55,40 @@ export default function HomePage() {
   // shows a different pick from each cached pool — the cards feel alive without
   // any extra backend round-trip.
   const [rand] = useState(() => ({
-    chat: Math.random(), dict: Math.random(), kg: Math.random(),
-    geo: Math.random(), col: Math.random(),
+    sources: Math.random(), chat: Math.random(), dict: Math.random(),
+    kg: Math.random(), geo: Math.random(), col: Math.random(),
   }));
 
   // Pick one item from each cached pool using the per-mount random values.
   const sc = useMemo(() => {
     const at = (r: number, len: number) => Math.floor(r * len) % Math.max(1, len);
+    // Deterministic seeded shuffle → take n. Uses only the passed seed (pure),
+    // so multi-item cards (source names, geo places) get a fully-random distinct
+    // sample per load, not an overlapping sliding window.
+    const sample = (arr: string[], n: number, seed: number): string[] => {
+      const a = arr.slice();
+      let s = Math.floor(seed * 2 ** 31) || 1;
+      const rnd = () => { s = (s * 1103515245 + 12345) & 0x7fffffff; return s / 0x7fffffff; };
+      for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(rnd() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+      }
+      return a.slice(0, n);
+    };
     const q = showcase?.chat?.questions ?? [];
     const terms = showcase?.dictionary?.terms ?? [];
     const triples = showcase?.kg?.triples ?? [];
     const places = showcase?.geo?.places ?? [];
+    const srcNames = showcase?.sources?.names ?? [];
     return {
-      sources: showcase?.sources ?? null,
+      sources: showcase?.sources
+        ? { count: showcase.sources.sources, names: sample(srcNames, 3, rand.sources) }
+        : null,
       chat: q.length ? q[at(rand.chat, q.length)] : null,
       dict: terms.length ? terms[at(rand.dict, terms.length)] : null,
       kg: triples.length ? triples[at(rand.kg, triples.length)] : null,
       geo: showcase?.geo && showcase.geo.count > 0
-        ? { count: showcase.geo.count, places: places.length
-            ? [0, 1, 2].map((i) => places[(at(rand.geo, places.length) + i) % places.length]) : [] }
+        ? { count: showcase.geo.count, places: sample(places, 3, rand.geo) }
         : null,
     };
   }, [showcase, rand]);
@@ -248,10 +263,10 @@ export default function HomePage() {
             <DatabaseOutlined className="home-feature-icon" />
             <div className="home-feature-title">{t("home.feature_sources_title")}</div>
             <div className="home-feature-desc">
-              {sc.sources
-                ? t("home.sc_sources", {
-                    sources: sc.sources.sources.toLocaleString(),
-                    texts: sc.sources.texts.toLocaleString(),
+              {sc.sources && sc.sources.names.length > 0
+                ? t("home.sc_sources_names", {
+                    sources: sc.sources.count.toLocaleString(),
+                    names: sc.sources.names.join("、"),
                   })
                 : t("home.feature_sources_desc")}
             </div>


### PR DESCRIPTION
## Why
Two cards still looked fixed on refresh: **数据源** showed only counts (no pool — never varies, and the counts already appear in the hero stats row), and **佛教地理** used a sliding-window slice of its places pool so adjacent refreshes overlapped.

## What
- **`home_showcase.py`**: the sources card now also returns a **pool of active source names** (`texts` kept for backward compat); geo pool bumped to 12.
- **HomePage**: a deterministic **seeded shuffle** (pure — uses only the per-mount random seed) gives `sources.names` and `geo.places` a fully-random **distinct 3-sample** per load instead of an overlapping window. 数据源 now shows "617 个来源 · <3 random source names>" via a new i18n key.

Now **all 5 dynamic cards change on every refresh**. Backend showcase tests + frontend eslint/tsc/i18n/build green.