### PR TITLE
fix(home): bump showcase cache key v2→v3 (sources.names shape change)

### DIFF
--- a/backend/app/services/home_showcase.py
+++ b/backend/app/services/home_showcase.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 # Cache TTL for the whole aggregate, and the rotation bucket size. 15 min keeps
 # the homepage lively without hammering the DB.
 SHOWCASE_TTL = 900
-_SHOWCASE_CACHE_KEY = "home:showcase:v2"  # v2: pools (not single picks)
+_SHOWCASE_CACHE_KEY = "home:showcase:v3"  # v3: sources.names pool added
 
 # A small candidate pool size for rotation-by-seed queries: fetch a bounded set
 # cheaply, then pick one deterministically per time bucket.


### PR DESCRIPTION
#919 added `sources.names` but didn't bump the cache key, so the new code served the stale v2 cache (no names) until its 15-min TTL. Bumping to v3 makes the deploy recompute fresh — the source-name pool appears immediately, no redis flush needed. (Lesson: any response-shape change bumps the key.)