### PR TITLE
fix(alignment): force seq-scan for cross-lingual kNN (HNSW returned 0)

### DIFF
--- a/backend/app/services/alignment_flywheel.py
+++ b/backend/app/services/alignment_flywheel.py
@@ -169,10 +169,18 @@ async def _cross_lang_neighbours(
         return []
     emb = src[0]  # asyncpg returns the pgvector column as a '[...]' string
 
-    # A filtered cross-lingual kNN scans more than a normal query; give it room
-    # so it isn't cancelled by the default statement_timeout (SET LOCAL scopes it
-    # to this transaction only).
-    await raw.exec_driver_sql("SET LOCAL statement_timeout = 25000")
+    # Cross-lingual kNN can't use the HNSW index: an lzh chunk's nearest
+    # neighbours are overwhelmingly other lzh chunks (same-language dominance),
+    # so an index scan's top-ef_search candidates contain no pi/bo/sa and the
+    # lang filter returns nothing. Force a sequential scan of the target-language
+    # subset — correct (all distances computed), but O(target rows) per source
+    # chunk (~1min over 246K), so this is an OFFLINE/cron miner, not on-demand.
+    # (SCALE follow-up: a per-language embedding index would make this fast.)
+    # Fetched the source embedding above WITH indexes on; disable them only now
+    # so that lookup stayed fast.
+    await raw.exec_driver_sql("SET LOCAL enable_indexscan = off")
+    await raw.exec_driver_sql("SET LOCAL enable_bitmapscan = off")
+    await raw.exec_driver_sql("SET LOCAL statement_timeout = 120000")
     rows = (await raw.exec_driver_sql(
         "SELECT te.text_id, te.juan_num, te.chunk_index, bt.lang, "
         "       1 - (te.embedding <=> $1::vector) AS sim "


### PR DESCRIPTION
Root cause of the mine staging 0: an lzh chunk's nearest neighbours are overwhelmingly **other lzh chunks** (same-language dominance in the shared embedding space), so the HNSW index scan's top candidates contain no pi/bo/sa → the lang filter yields nothing. **Validated on prod**: a forced sequential scan of the target-language subset *does* find real cross-canon neighbours (Tibetan chunks at cosine ~0.6), but takes **~60s per source chunk** over 246K target embeddings. Fix: disable index/bitmap scan + raise statement timeout for the kNN (source-embedding lookup stays indexed since `SET LOCAL` only affects later statements). Correct now, but an **offline/cron miner** — not on-demand. **Scale follow-up (slice-2): a per-language embedding index makes this fast.** Pure tests (8) pass.