### PR TITLE
fix(compose): umami least-privilege DB account + pin image (M9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,11 @@ OAUTH_REDIRECT_BASE=http://localhost:3000
 # Umami Analytics（自托管，隐私友好，无 cookie）
 # Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 UMAMI_APP_SECRET=change-me-generate-a-random-secret
+# umami 专用低权数据库账号（只能访问 umami 库，碰不到主 fojin 库）。留空则回退到
+# 主 POSTGRES 账号（旧行为）。建议：CREATE ROLE umami LOGIN PASSWORD '…'; 让它拥有
+# umami 库对象，并 REVOKE CONNECT ON DATABASE fojin FROM PUBLIC。
+# UMAMI_DB_USER=umami
+# UMAMI_DB_PASSWORD=
 
 # 前端 Umami 注入（构建期 build args）— 两者都为空时前端不发任何遥测脚本，
 # 这是 self-host 默认。设置后浏览器会加载 <VITE_UMAMI_URL> 并以 <VITE_UMAMI_WEBSITE_ID>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,14 +217,21 @@ services:
         condition: service_healthy
 
   umami:
-    image: ghcr.io/umami-software/umami:postgresql-latest
+    # Pinned by digest (v3.0.3) instead of the floating postgresql-latest tag,
+    # so a pull can't silently swap in unreviewed code or run a surprise
+    # schema migration. Bump deliberately.
+    image: ghcr.io/umami-software/umami:postgresql-latest@sha256:28f263fe06f79ebffa5a6a6e9bd33b7a278e9342a88e0bdac812416c9f9e4361
     container_name: fojin-umami
     restart: always
     logging: *default-logging
     mem_limit: 384m
     cpus: 0.5
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-fojin}:${POSTGRES_PASSWORD}@postgres:5432/umami
+      # Use a dedicated least-privilege role that can only reach the umami DB,
+      # so a compromise of this third-party container can't read/write the main
+      # fojin database (user table, BYOK ciphertexts). Falls back to the main
+      # postgres account when UMAMI_DB_* are unset (backward compatible).
+      DATABASE_URL: postgresql://${UMAMI_DB_USER:-${POSTGRES_USER:-fojin}}:${UMAMI_DB_PASSWORD:-${POSTGRES_PASSWORD}}@postgres:5432/umami
       APP_SECRET: ${UMAMI_APP_SECRET:?Set UMAMI_APP_SECRET in .env}
       BASE_PATH: /umami
     ports:


### PR DESCRIPTION
## 问题（安全审核 M9，中危 · 第三方容器握主库全权）

umami 分析容器以主 `POSTGRES_USER`（超级账号）连库，能完整读写 `fojin` 主库（用户表、BYOK 密文）。叠加 `postgresql-latest` 浮动标签，这个第三方容器一旦被供应链投毒/RCE 即可拖库。

## 修复

- `DATABASE_URL` 改用专用 `${UMAMI_DB_USER}/${UMAMI_DB_PASSWORD}` 低权账号；未设时回退主账号（嵌套插值向后兼容，已在 Compose 2.27 验证）。
- 镜像**按 digest 固定**到 v3.0.3，杜绝浮动标签带来的不可复现/意外迁移。

## 服务器侧（已在 prod 执行并验证）

已建 `umami` 角色、把 umami 库对象属主转给它、`REVOKE CONNECT ON DATABASE fojin FROM PUBLIC`——已验证该角色访问主库被拒（`permission denied for database fojin`），且主应用与 analytics 均 200。`.env` 已写入 `UMAMI_DB_USER/PASSWORD`。本 PR 合并后在服务器 `docker compose up -d umami` 让容器切到新账号（仅分析短暂中断）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)