### PR TITLE
fix(backup): gpg-encrypt pg dump + secrets tarball before OSS upload (M11)

### DIFF
--- a/fojin-backup.sh
+++ b/fojin-backup.sh
@@ -23,6 +23,7 @@ PG_FILE="fojin_pg_${TIMESTAMP}.sql.gz"
 CFG_FILE="fojin_configs_${TIMESTAMP}.tar.gz"
 CRON_FILE="fojin_cron_${TIMESTAMP}.txt"
 BUCKET="oss://fojin-prod-backup"
+GPG_RECIPIENT="C8D283D7427137C35D1D086AAE6F12A74AB34DB5"  # fojin-backup pubkey; private key held off-server (see SECURITY.md)
 
 mkdir -p "$BACKUP_DIR"
 
@@ -38,7 +39,7 @@ if [ "$PG_SIZE" -lt 1048576 ]; then
 fi
 echo "[$(date)] Local pg backup: ${BACKUP_DIR}/${PG_FILE} (${PG_SIZE} bytes)"
 
-if /usr/local/bin/ossutil cp "${BACKUP_DIR}/${PG_FILE}" "${BUCKET}/pg/${PG_FILE}"; then
+if gpg --batch --yes --trust-model always -r "$GPG_RECIPIENT" -o "${BACKUP_DIR}/${PG_FILE}.gpg" --encrypt "${BACKUP_DIR}/${PG_FILE}" && /usr/local/bin/ossutil cp "${BACKUP_DIR}/${PG_FILE}.gpg" "${BUCKET}/pg/${PG_FILE}.gpg" && rm -f "${BACKUP_DIR}/${PG_FILE}.gpg"; then
     echo "[$(date)] OSS pg upload success: ${BUCKET}/pg/${PG_FILE}"
 else
     echo "[$(date)] WARNING: OSS pg upload failed, local backup kept"
@@ -74,7 +75,7 @@ if [ "$CFG_SIZE" -lt 1024 ]; then
     echo "[$(date)] WARNING: configs tarball too small (${CFG_SIZE} bytes)"
 else
     echo "[$(date)] Local configs backup: ${BACKUP_DIR}/${CFG_FILE} (${CFG_SIZE} bytes)"
-    if /usr/local/bin/ossutil cp "${BACKUP_DIR}/${CFG_FILE}" "${BUCKET}/configs/${CFG_FILE}"; then
+    if gpg --batch --yes --trust-model always -r "$GPG_RECIPIENT" -o "${BACKUP_DIR}/${CFG_FILE}.gpg" --encrypt "${BACKUP_DIR}/${CFG_FILE}" && /usr/local/bin/ossutil cp "${BACKUP_DIR}/${CFG_FILE}.gpg" "${BUCKET}/configs/${CFG_FILE}.gpg" && rm -f "${BACKUP_DIR}/${CFG_FILE}.gpg"; then
         echo "[$(date)] OSS configs upload success: ${BUCKET}/configs/${CFG_FILE}"
     else
         echo "[$(date)] WARNING: OSS configs upload failed"


### PR DESCRIPTION
## 问题（安全审核 M11，中危 · 备份明文密钥外泄面）

`fojin-backup.sh` 把 pg dump 和 configs/secrets tarball（含 `.env` —— JWT/Fernet/DB/LLM/OAuth/SMS 全部凭据）**明文**传 OSS，留存 14–60 天。OSS bucket 或其凭据一旦泄露 = 全量密钥泄露。

## 修复

上传前用专用 gpg 收件人（`fojin-backup`, ed25519）**加密**两者，只传 `.gpg`，上传后删本地 `.gpg`。**私钥保存在服务器之外**，故 OSS 副本无私钥不可解密。OSS 保留策略的文件名 glob 仍匹配（`fojin_pg_/configs_` 子串保留）。

本 PR 是 host cron 脚本的版本控制副本；改动已在 host 上应用并做过加解密**往返验证**。

> 收尾：私钥当前仍在服务器 keyring（加密用公钥即可），待用户把私钥取到服务器之外妥存后，删除服务器私钥即完成密钥托管闭环。

🤖 Generated with [Claude Code](https://claude.com/claude-code)