### PR TITLE
fix(research): stop the assistant timing out at 15s on a 60-90s request

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -171,6 +171,21 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Research assistant: one request fans out into a plan + several retrievals
+    # + a synthesis on a (reasoning-class) LLM, so it routinely runs 60-90s —
+    # well past nginx's 60s default read timeout. Give this path more headroom
+    # (still under the ~100s upstream CDN ceiling). More specific prefix than
+    # /api/ below, so it wins for /api/research/*.
+    location /api/research/ {
+        proxy_pass $upstream_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 180s;
+        proxy_send_timeout 180s;
+    }
+
     location /api/ {
         proxy_pass $upstream_backend;
         proxy_set_header Host $host;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1645,11 +1645,16 @@ export interface ResearchReport {
   trust_status?: ChatTrustStatus | null;
 }
 
-export async function runResearch(question: string, maxSteps = 4): Promise<ResearchReport> {
-  const { data } = await api.post<ResearchReport>("/research/query", {
-    question,
-    max_steps: maxSteps,
-  });
+export async function runResearch(question: string, maxSteps = 3): Promise<ResearchReport> {
+  // The agent fans out into a plan + several retrievals + a synthesis, all on a
+  // (often reasoning-class) LLM, so a single call routinely runs 60-90s — far
+  // past the 15s axios default. Give it a 3-minute ceiling so the client waits
+  // instead of aborting with a spurious "research failed".
+  const { data } = await api.post<ResearchReport>(
+    "/research/query",
+    { question, max_steps: maxSteps },
+    { timeout: 180000 },
+  );
   return data;
 }
 

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -48,7 +48,9 @@ export default function ResearchPage() {
   const [question, setQuestion] = useState("");
 
   const mutation = useMutation<ResearchReport, Error, string>({
-    mutationFn: (q: string) => runResearch(q, 4),
+    // 3 steps already yields ~10 cited sources; 4 pushes total latency toward
+    // the ~100s upstream (Cloudflare) ceiling, so keep the default at 3.
+    mutationFn: (q: string) => runResearch(q, 3),
   });
 
   const submit = () => {


### PR DESCRIPTION
## Symptom
`/research` shows **「研究请求失败，请稍后重试。」** on every query (reported for 「菩提心」).

## Root cause (diagnosed on prod, not guessed)
Running the agent **as the reporting user (id 3, DeepSeek BYOK)** completed fine — **~74s, 10 cited sources**. The pipeline works. The failure was **timeouts too short for a legitimately long request**:

| Layer | Timeout | vs ~74s request |
|---|---|---|
| frontend axios (research call had no override) | **15s default** | aborts first → the error users saw |
| nginx `location /api/` (no `proxy_read_timeout`) | **60s default** | would also cut it |
| Cloudflare (upstream) | ~100s | 74s fits, but 4-step had no margin |

The loading hint already told users to wait *"30–90 秒"* — but the HTTP client gave up at 15s. Classic mismatch.

(Aside: several *other* BYOK users have expired DashScope keys → 401; unrelated to this report, and correctly handled by graceful degradation.)

## Fix
- **frontend**: `runResearch` gets a **180s** timeout (was the 15s axios default).
- **nginx**: dedicated **`location /api/research/`** with `proxy_read_timeout 180s` / `proxy_send_timeout 180s`, placed before `/api/` so the more specific prefix wins.
- **default steps 4 → 3**: already yields ~10 cited sources; 4 pushed latency toward the ~100s CDN ceiling.

## Deploy note
Touches `frontend/` (bundle) + `frontend/nginx.conf` → merging triggers a **frontend rebuild + redeploy**. No backend change.

## Follow-ups (not in this PR)
- Bigger latency win: use a faster (non-reasoning) model for the planning step, and/or parallelize per-step retrievals — would bring this well under 30s.
- The prod DB is currently taking heavy crawler load on `seo_dict`/`sitemap` (statement timeouts in logs); worth rate-limiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)