### PR TITLE
fix(redis): require a password (M10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ ES_HOST=http://localhost:9200
 # Redis
 REDIS_HOST=localhost
 REDIS_PORT=6379
+# Redis 密码。留空=无认证（旧行为）。生产建议设置，避免同网络容器无凭据读写/清空 Redis。
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(24))"
+REDIS_PASSWORD=
 
 # 运行环境。未设置时按 production 处理（缺少强密钥即启动失败，secure-by-default）。
 # 本地裸跑（不经 docker-compose）开发时设为 development 放松校验。

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     # Redis
     redis_host: str = "localhost"
     redis_port: int = 6379
+    redis_password: str = ""
 
     # JWT
     jwt_secret_key: str = os.environ.get("JWT_SECRET_KEY", _DEFAULT_JWT_SECRET)
@@ -119,7 +120,8 @@ class Settings(BaseSettings):
 
     @property
     def redis_url(self) -> str:
-        return f"redis://{self.redis_host}:{self.redis_port}/0"
+        auth = f":{self.redis_password}@" if self.redis_password else ""
+        return f"redis://{auth}{self.redis_host}:{self.redis_port}/0"
 
     model_config = {"env_file": ("../.env", ".env"), "env_file_encoding": "utf-8", "extra": "ignore"}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,12 +68,18 @@ services:
     logging: *default-logging
     mem_limit: 256m
     cpus: 0.5
+    # Require a password when REDIS_PASSWORD is set (empty → no auth, backward
+    # compatible). Read from the container env, not interpolated into argv.
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+    command: sh -c 'exec redis-server --requirepass "$$REDIS_PASSWORD"'
     ports:
       - "127.0.0.1:${REDIS_PORT:-6379}:6379"
     volumes:
       - redisdata:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      # Works with or without a password: auth ping first, else plain ping.
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" --no-auth-warning ping 2>/dev/null | grep -q PONG || redis-cli ping 2>/dev/null | grep -q PONG"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -96,6 +102,7 @@ services:
       ES_HOST: http://elasticsearch:9200
       REDIS_HOST: redis
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:?Set JWT_SECRET_KEY in .env (32+ chars)}
       # P0-1: BYOK encryption key, independent of JWT_SECRET_KEY.
       API_KEY_ENCRYPTION_KEY: ${API_KEY_ENCRYPTION_KEY:?Set API_KEY_ENCRYPTION_KEY in .env (Fernet.generate_key() output)}
@@ -171,6 +178,7 @@ services:
       ES_HOST: http://elasticsearch:9200
       REDIS_HOST: redis
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:?Set JWT_SECRET_KEY in .env (32+ chars)}
       API_KEY_ENCRYPTION_KEY: ${API_KEY_ENCRYPTION_KEY:?Set API_KEY_ENCRYPTION_KEY in .env (Fernet.generate_key() output)}
       FOJIN_ENV: ${FOJIN_ENV:-production}


### PR DESCRIPTION
## 问题（安全审核 M10 之一，中危）

Redis 在共享 compose 网络内**无鉴权**，任一容器（尤其第三方 umami）都能读取或 `FLUSHALL`——清空支撑 H1/H3/M8/限流 的 `ratelimit:*`、`sms_attempt:*`、配额键。

## 修复

- redis 以 `--requirepass "$REDIS_PASSWORD"` 启动（空=无认证，向后兼容）；healthcheck 先 authed ping、否则 plain ping。
- backend/backend2 传入 `REDIS_PASSWORD`；`config.redis_url` 内嵌之。

`.env` 设置 `REDIS_PASSWORD` 即启用。已验证 redis_url 带/不带认证正确、全量后端 929 测试绿。服务器侧：.env 已设强密码，合并后协调重建 redis+backend（几秒、限流优雅降级）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)