### PR TITLE
fix(es): require authentication (M10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ POSTGRES_PASSWORD=change-me-to-a-strong-password
 
 # Elasticsearch
 ES_HOST=http://localhost:9200
+# Elasticsearch 认证。ES_PASSWORD 留空=无认证（旧行为）。启用时需在 compose 打开
+# xpack.security 并为 elastic 用户设密码（elasticsearch-reset-password -u elastic）。
+ES_USER=elastic
+ES_PASSWORD=
 
 # Redis
 REDIS_HOST=localhost

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,6 +18,8 @@ class Settings(BaseSettings):
 
     # Elasticsearch
     es_host: str = "http://localhost:9200"
+    es_user: str = "elastic"
+    es_password: str = ""  # empty → connect without auth (backward compatible)
 
     # Redis
     redis_host: str = "localhost"

--- a/backend/app/core/elasticsearch.py
+++ b/backend/app/core/elasticsearch.py
@@ -127,7 +127,12 @@ CONTENT_INDEX_SETTINGS = {
 
 async def init_es() -> AsyncElasticsearch:
     global es_client
-    es_client = AsyncElasticsearch(settings.es_host)
+    if settings.es_password:
+        es_client = AsyncElasticsearch(
+            settings.es_host, basic_auth=(settings.es_user, settings.es_password)
+        )
+    else:
+        es_client = AsyncElasticsearch(settings.es_host)
     return es_client
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,10 @@ services:
     cpus: 1.5
     environment:
       - discovery.type=single-node
-      - xpack.security.enabled=false
+      # Require auth. HTTP TLS stays off — ES is bound to 127.0.0.1 only, so
+      # basic auth over plaintext http on the loopback is the intended model.
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=false
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
     ports:
       - "127.0.0.1:${ES_PORT:-9200}:9200"
@@ -103,6 +106,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      ES_USER: ${ES_USER:-elastic}
+      ES_PASSWORD: ${ES_PASSWORD:-}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:?Set JWT_SECRET_KEY in .env (32+ chars)}
       # P0-1: BYOK encryption key, independent of JWT_SECRET_KEY.
       API_KEY_ENCRYPTION_KEY: ${API_KEY_ENCRYPTION_KEY:?Set API_KEY_ENCRYPTION_KEY in .env (Fernet.generate_key() output)}
@@ -179,6 +184,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      ES_USER: ${ES_USER:-elastic}
+      ES_PASSWORD: ${ES_PASSWORD:-}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:?Set JWT_SECRET_KEY in .env (32+ chars)}
       API_KEY_ENCRYPTION_KEY: ${API_KEY_ENCRYPTION_KEY:?Set API_KEY_ENCRYPTION_KEY in .env (Fernet.generate_key() output)}
       FOJIN_ENV: ${FOJIN_ENV:-production}


### PR DESCRIPTION
## 问题（安全审核 M10 之一，中危）

Elasticsearch `xpack.security.enabled=false`，同网络任一容器无需凭据即可读/覆盖搜索索引。

## 修复

启用 basic auth（HTTP TLS 保持关闭——ES 仅绑 127.0.0.1，回环上明文 basic-auth 即预期模型）：
- compose：`xpack.security.enabled=true` + `http.ssl.enabled=false`。
- backend/backend2 传入 `ES_USER/ES_PASSWORD`；`init_es()` 在 `ES_PASSWORD` 非空时带 `basic_auth`（空=无认证，向后兼容）。

线上启用是手动协调步骤（重建 ES→重置 elastic 密码→`.env` 设 ES_PASSWORD→重建 backend，搜索约 1 分钟中断），合并本 PR 本身不改变运行状态。已验证全量 929 测试绿、ruff 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)