### PR TITLE
fix(es): make healthcheck auth-agnostic (prep for ES security)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,10 @@ services:
     volumes:
       - esdata:/usr/share/elasticsearch/data
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      # Auth-agnostic: ES is up whether it answers 200 (no security) or 401
+      # (security on, no creds). A down node yields 000. Avoids embedding the
+      # password in the healthcheck.
+      test: ["CMD-SHELL", "c=$$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9200/_cluster/health); [ \"$$c\" = 200 ] || [ \"$$c\" = 401 ]"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
ES healthcheck 用无认证 curl，一旦 xpack.security 开启会 401→节点被判 unhealthy→依赖它的服务全部起不来。改为 200 或 401 都算健康（都表示 ES 在应答），只有真正宕机(000)才失败。无需在 healthcheck 里放密码。M10 ES 鉴权的前置修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)