### PR TITLE
fix(chat): 修复空流导致的 AI 问答静默卡死

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -939,6 +939,26 @@ async def send_message_stream(
         provider,
     )
 
+    # Empty-completion guard: the stream finished without ever producing an
+    # answer token AND without emitting an error (an error path sets
+    # ``full_answer = full_answer or error_msg``, so a still-empty
+    # ``full_answer`` uniquely identifies "silent empty completion"). Left
+    # alone we'd fall through to a bare ``done`` while the bubble is still on
+    # the thinking placeholder — the frontend then hangs on "正在检索…"
+    # forever with no answer, no error, and no retry. Surface it as an
+    # ``error`` (mirrors the prep-error path above) so the client shows its
+    # retry affordance, then close the stream. Nothing to citation-guard or
+    # persist, so return early.
+    if not received_first_token and not full_answer:
+        logger.warning(
+            "chat/stream produced no tokens and no error (session_id=%s, provider=%s)",
+            chat_session_id, provider,
+        )
+        empty_msg = "抱歉，本次未能生成任何回答内容，请重试。"
+        yield f"data: {json.dumps({'type': 'error', 'message': empty_msg}, ensure_ascii=False)}\n\n"
+        yield f"data: {json.dumps({'type': 'done'})}\n\n"
+        return
+
     # Citation guard: rewrite any 【《X》第N卷】 not anchored in the
     # retrieved sources. The user has already seen the raw stream; we
     # emit a final 'citation_correction' event so the frontend can swap

--- a/backend/tests/test_chat_stream_empty_completion.py
+++ b/backend/tests/test_chat_stream_empty_completion.py
@@ -1,0 +1,145 @@
+"""Regression test for the empty-completion silent-hang bug.
+
+When the LLM stream completes without ever yielding an answer token (and
+without raising — an "empty but successful" completion), ``send_message_stream``
+used to fall through to a bare ``done`` event. The frontend, which only leaves
+its "正在检索经文并生成回答…" placeholder on a ``token`` or ``error`` event, then
+hung on that fake-loading state forever — no answer, no error, no retry. This
+was reproducible against production.
+
+The guard emits an ``error`` event (so the client shows its retry affordance)
+before ``done`` whenever the stream produced neither a token nor an error.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.chat import ChatSource
+
+
+def _make_fake_sources() -> list[ChatSource]:
+    return [
+        ChatSource(text_id=1, juan_num=1, chunk_text="色不异空", score=0.9, title_zh="心经"),
+    ]
+
+
+def _make_prepare_chat_return(sources: list[ChatSource]):
+    fake_session = MagicMock()
+    fake_session.id = 42
+    llm_messages = [{"role": "user", "content": "测试"}]
+    return (
+        fake_session, "https://api.example.com/v1", "fake-key", "test-model",
+        False, "openai", sources, llm_messages, [],
+    )
+
+
+def _make_mock_httpx_client(tokens: list[str]):
+    """Mock httpx.AsyncClient whose stream yields ``tokens`` then ``[DONE]``.
+
+    Passing an empty list reproduces an "empty but successful" completion:
+    the SSE stream carries only the terminal ``data: [DONE]`` and no content
+    deltas, so ``_stream_llm_once`` yields nothing and never raises.
+    """
+    lines = [f"data: {json.dumps({'choices': [{'delta': {'content': t}}]})}" for t in tokens]
+    lines.append("data: [DONE]")
+    mock_resp = MagicMock()
+
+    async def aiter_lines():
+        for line in lines:
+            yield line
+
+    mock_resp.aiter_lines = aiter_lines
+    mock_resp.raise_for_status = MagicMock()
+
+    class _StreamCM:
+        async def __aenter__(self): return mock_resp
+        async def __aexit__(self, *_): return False
+
+    class _ClientInstance:
+        def stream(self, *args, **kwargs): return _StreamCM()
+
+    class _ClientCM:
+        async def __aenter__(self): return _ClientInstance()
+        async def __aexit__(self, *_): return False
+
+    return MagicMock(return_value=_ClientCM())
+
+
+class _FakeSessionmaker:
+    """Minimal ``async with sessionmaker() as db`` producing an AsyncMock db."""
+
+    def __call__(self):
+        class _SessCM:
+            async def __aenter__(self_inner): return AsyncMock()
+            async def __aexit__(self_inner, *_): return False
+
+        return _SessCM()
+
+
+def _events(chunks: list[str]) -> list[dict]:
+    """Parse SSE ``data: {json}`` frames, skipping ``: keepalive`` comments."""
+    out: list[dict] = []
+    for c in chunks:
+        c = c.strip()
+        if not c.startswith("data: "):
+            continue
+        try:
+            out.append(json.loads(c[len("data: "):]))
+        except json.JSONDecodeError:
+            pass
+    return out
+
+
+async def _run_stream(tokens: list[str]) -> list[dict]:
+    prepare_return = _make_prepare_chat_return(_make_fake_sources())
+    mock_client_cls = _make_mock_httpx_client(tokens)
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
+         patch("app.services.chat._mark_attachments_consumed", new_callable=AsyncMock), \
+         patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
+        from app.services.chat import send_message_stream
+
+        chunks: list[str] = []
+        async for chunk in send_message_stream(
+            user_id=1, message="测试", sessionmaker=_FakeSessionmaker(),
+        ):
+            chunks.append(chunk)
+    return _events(chunks)
+
+
+@pytest.mark.anyio
+async def test_empty_completion_emits_error_not_bare_done():
+    """An empty (token-less, error-less) stream must surface an ``error``
+    event so the client can recover — never a silent bare ``done``."""
+    events = await _run_stream(tokens=[])
+
+    types = [e.get("type") for e in events]
+    assert "token" not in types, f"empty completion must yield no token; got {types}"
+    assert "error" in types, (
+        f"empty completion must emit an 'error' event (not a silent done); got {types}"
+    )
+    # The error must precede done (client leaves the placeholder on 'error').
+    assert types.index("error") < types.index("done"), (
+        f"'error' must be emitted before 'done'; got {types}"
+    )
+    err = next(e for e in events if e.get("type") == "error")
+    assert "回答" in err["message"] or "重试" in err["message"], err
+
+
+@pytest.mark.anyio
+async def test_normal_completion_is_unaffected():
+    """Guard regression: a stream that does yield tokens still completes
+    normally with token events and no spurious empty-completion error."""
+    events = await _run_stream(tokens=["般", "若"])
+
+    types = [e.get("type") for e in events]
+    assert types.count("token") == 2, f"expected 2 token events; got {types}"
+    assert "done" in types
+    # No empty-completion error should be injected on the happy path.
+    empty_errors = [
+        e for e in events
+        if e.get("type") == "error" and "未能生成任何回答内容" in e.get("message", "")
+    ]
+    assert not empty_errors, f"no empty-completion error expected on happy path; got {empty_errors}"

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -980,6 +980,20 @@ export default function ChatPage() {
         abortRef.current = null;
         setStreamingId(0);
         setSending(false);
+        // Empty completion: the stream ended without ever delivering a token
+        // (and without an error frame — e.g. a bare `done`). If the bubble is
+        // still the thinking placeholder, nothing will ever replace it and it
+        // hangs on the fake "正在检索…" state forever. Convert it to the failure
+        // sentinel so the existing retry button renders (mirrors onError). When
+        // the backend already sent an `error`, onError ran first and the content
+        // is no longer THINKING_SENTINEL, so this is a no-op — safe either way.
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId && m.content === THINKING_SENTINEL
+              ? { ...m, content: REQUEST_FAILED_SENTINEL }
+              : m,
+          ),
+        );
         // Clear attachment chips only after successful stream completion.
         // On error the chips stay so the user can retry without re-uploading.
         if (attachmentIdsForSend.length > 0) {


### PR DESCRIPTION
## 问题（线上可复现）

在 `/chat` 实测发现:当 LLM 流**跑完却没吐出任何回答 token、也没有抛错**（"空但成功"的 completion）时，`send_message_stream` 会直接走到裸 `done` 事件。而前端只在收到 `token` 或 `error` 时才会替换 "正在检索经文并生成回答…" 占位符——于是气泡**永久卡在假加载态：没有答案、没有报错、没有重试**。发送按钮已复位（生成已结束），但占位符再也不会消失。这打在使用量最大的 AI 问答功能上。

## 修复

**后端** `backend/app/services/chat.py` — 在 LLM 流阶段结束后加一道空完成守卫：当整轮既没产生 token、`full_answer` 也仍为空（错误路径会把 `full_answer` 置为错误文案，所以"仍为空"唯一对应"静默空完成"）时，发出一个 `error` 事件（随后 `done` 并 `return`），让前端弹出重试入口，而不是挂死。逻辑与已有的 prep-error 早返回范式一致；空内容无需 citation-guard/落库，故提前返回。

**前端** `frontend/src/pages/ChatPage.tsx` — 作为"后端发裸 `done`"等其它路径的兜底：`onDone` 里若气泡仍是 thinking 占位符，则转成失败态，复用现成的重试按钮（与上方 `onError` 同款写法）。当后端已先发 `error` 时，`onError` 已把内容改掉，这段即为 no-op，两条路径叠加安全。

## 验证

- **后端**:新增回归测试 `backend/tests/test_chat_stream_empty_completion.py`（TDD red-first：无修复时确认失败）。空流 → 断言发出 `error` 且在 `done` 之前、且无任何 `token`；happy path 回归不受影响。`pytest` 该文件 **2 passed**；`test_chat_stream_*` / `test_chat_trust` / `test_citations` 回归 **32 passed**。
- **前端**:`tsc -b` **exit 0**;`MessageBubble.test.tsx` **9 passed**（无回归）。前端改动为防御性兜底，主恢复路径（后端 `error` → `onError`）已被后端测试覆盖。

## 范围说明（有意收窄）

本 PR **只修静默卡死这一个确认仍存在的 bug**。我此前审计里提的"逐字引用/可信度"改进，复核当前 `master` 后发现**上游已经做掉了**，故**不再重复**：
- `prompt_builder.py` 的 `SYSTEM_PROMPT` 已含规则 4c（直接引号内文字必须逐字来自检索片段）；
- `quote_verifier.verify_quoted_content` 已从"标 caveat"改为**降级去引号**（非逐字引文直接去掉引号当作模型自己的话，仍附出处）。

## 后续（本 PR 未含，建议各自独立 PR）

- 同 provider 一次重试（在 fallback 之前），降低瞬时故障导致的可见失败；
- `quote_verifier` 给失败引文分桶 `near_miss`/`absent`（difflib 相似度）——用于观测上述"降级"是否会误伤**本来正确、只是不在本次检索窗口里**的引文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
