### PR TITLE
feat(quote-verify): 失败引文分桶 near_miss/absent（纯测量）

### DIFF
--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -52,6 +52,7 @@ import re
 import unicodedata
 from collections.abc import Iterable
 from dataclasses import dataclass
+from difflib import SequenceMatcher
 
 from opencc import OpenCC
 
@@ -71,6 +72,19 @@ _t2s = OpenCC("t2s")
 # LLMs routinely shorten "色不异空，空不异色" to "色不异空" and we don't
 # want to flag that.
 MIN_QUOTE_CHARS = 12
+
+# Fuzzy-classification of a FAILED quote (measurement only — never changes
+# the served answer). A failed quote whose best windowed similarity to the
+# cited chunk is >= this is bucketed "near_miss" (almost verbatim: a variant
+# character, edition/punctuation difference, or a correct quote the retriever
+# didn't surface — i.e. likely-correct text the downgrade wrongly strips);
+# below it is "absent" (a paraphrase or fabrication). 0.85 keeps 1–2 differing
+# chars in a ~12-char quote on the near_miss side while excluding paraphrases.
+NEAR_MISS_THRESHOLD = 0.85
+
+# Cap on how many sliding windows _windowed_ratio evaluates, so a
+# pathologically long chunk can't make failure-classification quadratic.
+_MAX_RATIO_WINDOWS = 256
 
 # Maximum distance (chars) between the closing quote and the start of
 # the trailing 【《X》第N卷】 reference for them to count as bound. A
@@ -159,6 +173,15 @@ class QuoteMutation:
     # have different LLM root causes and different downstream prompt
     # mitigations.
     reason: str
+    # Fuzzy-match telemetry for the failed quote (measurement only — does NOT
+    # affect the served answer). ``similarity`` is the best windowed
+    # SequenceMatcher ratio of the normalised quote against the cited chunk
+    # (0.0 when the cite matched no retrieved chunk). ``bucket`` is
+    # "near_miss" (>= NEAR_MISS_THRESHOLD — a likely-correct quote the
+    # retriever missed) or "absent" (paraphrase / fabrication). Defaulted so
+    # every existing construction site and consumer stays valid.
+    similarity: float = 0.0
+    bucket: str = "absent"
 
 
 def _normalise(s: str) -> str:
@@ -246,6 +269,64 @@ def _quote_failure_reason(
     return "blockquote_not_in_source" if blockquote else "quote_not_in_source"
 
 
+def _windowed_ratio(needle: str, haystack: str) -> float:
+    """Best ``SequenceMatcher`` ratio of ``needle`` against any same-length
+    window of ``haystack``. Windowing stops a short quote's score from being
+    diluted by a long (~500-char) chunk. Both inputs must already be
+    ``_normalise``d. Coarse step + a window cap keep it O(reasonable); the
+    tail window is always included so a match at the very end isn't missed."""
+    if not needle or not haystack:
+        return 0.0
+    nlen = len(needle)
+    if len(haystack) <= nlen:
+        return SequenceMatcher(None, needle, haystack, autojunk=False).ratio()
+    step = max(1, nlen // 4)
+    starts = list(range(0, len(haystack) - nlen + 1, step))
+    tail = len(haystack) - nlen
+    if starts[-1] != tail:
+        starts.append(tail)
+    if len(starts) > _MAX_RATIO_WINDOWS:
+        # Evenly subsample to bound cost on pathologically long chunks.
+        stride = len(starts) / _MAX_RATIO_WINDOWS
+        starts = [starts[int(i * stride)] for i in range(_MAX_RATIO_WINDOWS)]
+    best = 0.0
+    for s in starts:
+        r = SequenceMatcher(None, needle, haystack[s : s + nlen], autojunk=False).ratio()
+        if r > best:
+            best = r
+            if best >= 0.999:
+                break
+    return best
+
+
+def _classify_failure(
+    quote: str, title: str, juan: int | None, sources: list[ChatSource]
+) -> tuple[float, str]:
+    """Best fuzzy similarity + bucket for a quote that already FAILED the
+    verbatim substring test. Measurement only — never changes the answer.
+
+    ``similarity`` is the max windowed ratio of the normalised quote against
+    any candidate chunk of the cited text (0.0 when the cite matched no
+    retrieved chunk at all). ``bucket`` splits the two very different failure
+    modes that a flat verified_rate conflates:
+      * ``near_miss`` (>= ``NEAR_MISS_THRESHOLD``): almost verbatim — a variant
+        character, an edition/punctuation difference, or a correct quote whose
+        source chunk the retriever didn't surface. A likely-correct quote the
+        downgrade wrongly strips.
+      * ``absent``: nowhere near the source — a paraphrase or fabrication.
+    """
+    candidates = _find_sources(sources, title, juan)
+    if not candidates:
+        return 0.0, "absent"
+    nq = _normalise(quote)
+    similarity = max(
+        (_windowed_ratio(nq, _normalise(c.chunk_text)) for c in candidates),
+        default=0.0,
+    )
+    bucket = "near_miss" if similarity >= NEAR_MISS_THRESHOLD else "absent"
+    return similarity, bucket
+
+
 def verify_quoted_content(
     answer: str, sources: list[ChatSource]
 ) -> tuple[str, list[QuoteMutation]]:
@@ -276,12 +357,27 @@ def verify_quoted_content(
         reason = _quote_failure_reason(quote, title, juan, sources, blockquote=False)
         if reason is None:
             return m.group(0)
-        mutations.append(QuoteMutation(quote=quote, title=title, juan=juan, reason=reason))
+        similarity, bucket = _classify_failure(quote, title, juan, sources)
+        mutations.append(QuoteMutation(
+            quote=quote, title=title, juan=juan, reason=reason,
+            similarity=similarity, bucket=bucket,
+        ))
         # Drop the open/close marks: keep the text (now prose) + gap + citation.
         return m.group("quote") + m.group("gap") + m.group("cite")
 
     corrected = _QUOTE_CITATION_RE.sub(_downgrade_inline, answer)
     corrected = _downgrade_blockquotes(corrected, sources, mutations)
+    if mutations:
+        near_miss = sum(1 for m in mutations if m.bucket == "near_miss")
+        absent = len(mutations) - near_miss
+        # One structured line per answer so a `grep quote_verify` over logs
+        # shows how much of the (post-downgrade) "unverified" volume is
+        # likely-correct near-misses vs. real paraphrase/fabrication —
+        # i.e. how much of the low verified_rate is a measurement artifact.
+        logger.info(
+            "quote_verify buckets: near_miss=%d absent=%d total_failed=%d",
+            near_miss, absent, len(mutations),
+        )
     return corrected, mutations
 
 
@@ -329,7 +425,11 @@ def _downgrade_blockquotes(
         reason = _quote_failure_reason(quote, title, juan, sources, blockquote=True)
         if reason is None:
             return m.group(0)
-        mutations.append(QuoteMutation(quote=quote, title=title, juan=juan, reason=reason))
+        similarity, bucket = _classify_failure(quote, title, juan, sources)
+        mutations.append(QuoteMutation(
+            quote=quote, title=title, juan=juan, reason=reason,
+            similarity=similarity, bucket=bucket,
+        ))
         # Replace the blockquote body with its unmarked prose; keep everything
         # after the block (gap + citation) exactly as matched.
         return quote + "\n\n" + m.group(0)[len(block):]

--- a/backend/tests/test_quote_verifier_buckets.py
+++ b/backend/tests/test_quote_verifier_buckets.py
@@ -1,0 +1,150 @@
+"""Tests for the failed-quote bucket classifier (measurement only).
+
+``verify_quoted_content`` downgrades any 「」/blockquote quote that isn't a
+verbatim substring of the cited chunk. That flat "unverified" signal conflates
+two very different failure modes:
+
+  * a genuinely correct canonical quote whose source chunk the retriever simply
+    didn't surface (or that differs by a variant char / edition) — a
+    *measurement artifact*, wrongly stripped by the downgrade; vs.
+  * a paraphrase or fabrication that is nowhere near the source — the real
+    problem.
+
+Each ``QuoteMutation`` now carries ``similarity`` + ``bucket``
+("near_miss" / "absent") so the two can be told apart. These tests pin that
+classification and confirm the served answer is byte-identical to before.
+"""
+
+import logging
+
+from app.schemas.chat import ChatSource
+from app.services.quote_verifier import (
+    NEAR_MISS_THRESHOLD,
+    QuoteMutation,
+    verify_quoted_content,
+)
+
+
+def _src(text_id: int, title: str, juan: int, chunk_text: str) -> ChatSource:
+    return ChatSource(
+        text_id=text_id,
+        juan_num=juan,
+        chunk_index=0,
+        chunk_text=chunk_text,
+        score=0.9,
+        title_zh=title,
+        lang="lzh",
+    )
+
+
+# The canonical passage used as the retrieved source across tests.
+_HEART = "色不異空空不異色色即是空空即是色受想行識亦復如是"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# near_miss: almost-verbatim quote wrongly downgraded
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_near_miss_when_quote_almost_matches_source():
+    """A quote identical to the source but for one trailing character fails
+    the exact-substring test yet is ~verbatim — it must bucket as near_miss
+    (the downgrade is likely stripping a correct quote)."""
+    src = _src(1, "心經", 1, _HEART)
+    # Same as the source's opening but with an extra 「也」 the chunk lacks.
+    answer = "经文说「色不異空空不異色色即是空空即是色也」【《心經》第1卷】"
+    _out, muts = verify_quoted_content(answer, [src])
+
+    assert len(muts) == 1
+    assert muts[0].reason == "quote_not_in_source"
+    assert muts[0].bucket == "near_miss"
+    assert muts[0].similarity >= NEAR_MISS_THRESHOLD
+
+
+# ──────────────────────────────────────────────────────────────────────
+# absent: paraphrase / fabrication
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_absent_when_quote_is_a_paraphrase():
+    """A modern-language paraphrase shares almost nothing with the source
+    verbatim — it must bucket as absent with low similarity."""
+    src = _src(1, "心經", 1, _HEART)
+    answer = "经文大意是「這段話闡述諸法本無自性的空性道理」【《心經》第1卷】"
+    _out, muts = verify_quoted_content(answer, [src])
+
+    assert len(muts) == 1
+    assert muts[0].reason == "quote_not_in_source"
+    assert muts[0].bucket == "absent"
+    assert muts[0].similarity < NEAR_MISS_THRESHOLD
+
+
+def test_absent_when_no_matching_source():
+    """A quote cited to a title absent from the retrieved set has no candidate
+    chunk to compare against — similarity 0.0, bucket absent."""
+    src = _src(1, "心經", 1, _HEART)
+    # Cited to a sutra that was never retrieved.
+    answer = "论中说「這是一段並不存在於檢索結果中的長引文內容」【《楞嚴經》第3卷】"
+    _out, muts = verify_quoted_content(answer, [src])
+
+    assert len(muts) == 1
+    assert muts[0].reason == "no_matching_source"
+    assert muts[0].bucket == "absent"
+    assert muts[0].similarity == 0.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# verified quotes never produce a mutation (bucket path never runs)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_exact_quote_produces_no_mutation():
+    src = _src(1, "心經", 1, _HEART)
+    answer = "经文说「色不異空空不異色色即是空」【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+
+    assert muts == []
+    assert out == answer
+
+
+# ──────────────────────────────────────────────────────────────────────
+# summary log + answer-unchanged guarantee
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_summary_log_reports_bucket_counts(caplog):
+    """One near_miss + one absent in the same answer → a single structured
+    summary line with per-bucket counts."""
+    src = _src(1, "心經", 1, _HEART)
+    answer = (
+        "一「色不異空空不異色色即是空空即是色也」【《心經》第1卷】"
+        "二「這段話闡述諸法本無自性的空性道理」【《心經》第1卷】"
+    )
+    with caplog.at_level(logging.INFO, logger="app.services.quote_verifier"):
+        _out, muts = verify_quoted_content(answer, [src])
+
+    buckets = sorted(m.bucket for m in muts)
+    assert buckets == ["absent", "near_miss"]
+    assert "quote_verify buckets: near_miss=1 absent=1 total_failed=2" in caplog.text
+
+
+def test_bucketing_does_not_change_served_answer():
+    """Instrumentation only: the corrected answer for a failing quote must be
+    exactly the downgraded prose (quote marks stripped), unaffected by the new
+    similarity/bucket fields."""
+    src = _src(1, "心經", 1, _HEART)
+    answer = "经文说「這段話闡述諸法本無自性的空性道理」【《心經》第1卷】"
+    out, _muts = verify_quoted_content(answer, [src])
+
+    # Marks dropped, text + citation preserved (the pre-instrumentation shape).
+    assert "「" not in out and "」" not in out
+    assert "這段話闡述諸法本無自性的空性道理" in out
+    assert "【《心經》第1卷】" in out
+
+
+def test_default_similarity_and_bucket_are_backward_compatible():
+    """Existing construction sites / callers that don't pass the new fields
+    still work, with conservative defaults."""
+    m = QuoteMutation(quote="x" * 12, title="心經", juan=1, reason="quote_not_in_source")
+    assert m.similarity == 0.0
+    assert m.bucket == "absent"


### PR DESCRIPTION
## 背景

`verify_quoted_content` 会把任何**非逐字**的 `「」`/blockquote 引文降级去引号(当作模型自己的话，仍附出处)。但这个"未逐字"信号把两种性质完全不同的失败混在一起：

- **near_miss** — 本来正确的经典引文，只是**检索没把对应 chunk 召回**，或只差一个异体字/版本/标点。这类是被降级**误伤**的正确引文，是拉低 verified_rate 的**测量假象**。
- **absent** — 改写或编造，跟原文八竿子打不着。这才是**真问题**。

在没把这两者分开前，我们无法判断"低 verified_rate"里到底有多少是真该修的，有多少只是检索覆盖不足的噪音。

## 改动（纯测量，不改答案）

给 `QuoteMutation` 增加两个**带默认值**的字段：
- `similarity: float` — 归一化后的引文对被引 chunk 的**最佳滑窗 `SequenceMatcher` 比率**（窗口化，避免短引文被长 chunk 稀释；引文命中不到任何检索 chunk 时为 0.0）。
- `bucket: str` — `"near_miss"`（`similarity >= 0.85`）或 `"absent"`。

并在 `verify_quoted_content` 末尾输出一行结构化汇总日志 `quote_verify buckets: near_miss=N absent=M total_failed=K`，方便 `grep` 直接看生产上两类占比。

**严格仅测量**：返回的答案字符串、失败检测逻辑、`(answer, mutations)` 返回结构**全部不变**——只在失败分支追加分类、加一行日志。字段带默认值，所有既有构造点/消费者(`chat_trust`/`persist_answer_diagnostic`)不受影响。

## 判别效果（本地实测）

| 引文 | similarity | bucket |
|---|---|---|
| 与原文仅差一个尾字 | **0.941** | near_miss |
| 现代语改写 | **0.062** | absent |

## 验证

- 新增 `test_quote_verifier_buckets.py`：near_miss / absent / 无匹配源 / 精确命中不产生 mutation / 汇总日志 / **答案字节不变** / 字段向后兼容 —— **7 passed**。
- 回归：`test_quote_verifier.py` **28 passed**；下游 `test_chat_trust` + `test_citations` + `test_chat_stream_session_lifecycle` **21 passed**。

## 用途（为什么现在做这个）

上游已把非逐字引文从"标 caveat"改成"降级去引号"。这个 PR 不改那套行为，而是**先量化它的副作用**：上线后看 `near_miss` 占比，就能判断是否值得投入下一步（把失败引文的核对范围从"本次检索的 5 个 chunk"扩大到**被引整卷**，从而救回被误伤的 near_miss 引文并让引用抽屉能高亮定位）。先测量，再决定要不要修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
