### PR TITLE
feat(chat): 瞬时故障时同 provider 重试一次（BYOK 唯一韧性）

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -100,6 +100,15 @@ logger = logging.getLogger(__name__)
 # browsers per spec, so this is invisible to the frontend consumer.
 LLM_STREAM_HEARTBEAT_INTERVAL_S = 25.0
 
+# Fixed backoff before a single same-provider retry of a transient
+# pre-first-token stream failure (see _stream_attempt). Kept short: the goal
+# is to ride out a one-off blip (connection reset, upstream 5xx/429/timeout),
+# not to wait out a sustained outage — that's what the platform fallback is
+# for. No jitter: a per-request single retry doesn't need thundering-herd
+# spread, and this module avoids time.monotonic-based randomness in the hot
+# path.
+LLM_STREAM_RETRY_BACKOFF_S = 0.5
+
 # Provider → base URL mapping (most are OpenAI-compatible; Anthropic uses its own format)
 
 
@@ -858,6 +867,44 @@ async def send_message_stream(
                     except (json.JSONDecodeError, IndexError, KeyError):
                         continue
 
+    async def _stream_attempt(u: str, k: str, m: str, p: str):
+        """One provider's stream, retried ONCE on a *transient* failure that
+        happens *before* any token is yielded.
+
+        Retrying after tokens have already streamed would duplicate output, so
+        we only retry while this attempt has produced nothing (``yielded`` is
+        False). Only transient failures are retried — a connection reset or an
+        upstream 5xx/429/timeout usually succeeds on an immediate second try;
+        a 4xx (bad key, model-not-found, invalid request) will just fail again,
+        so we surface it straight away. This is the only resilience a BYOK
+        request gets — it has no cross-provider fallback.
+        """
+        retried = False
+        while True:
+            yielded = False
+            try:
+                async for chunk in _stream_llm_once(u, k, m, p):
+                    yielded = True
+                    yield chunk
+                return
+            except (httpx.TimeoutException, httpx.HTTPStatusError, httpx.RequestError) as exc:
+                status = getattr(getattr(exc, "response", None), "status_code", None)
+                transient = (
+                    status in (429, 500, 502, 503, 504)
+                    if isinstance(exc, httpx.HTTPStatusError)
+                    # TimeoutException / ConnectError / ReadError etc. are all
+                    # network-level and worth one retry.
+                    else True
+                )
+                if yielded or retried or not transient:
+                    raise
+                retried = True
+                logger.warning(
+                    "LLM stream transient failure (%s, status=%s); retrying %s/%s once after %.1fs",
+                    type(exc).__name__, status, p, m, LLM_STREAM_RETRY_BACKOFF_S,
+                )
+                await asyncio.sleep(LLM_STREAM_RETRY_BACKOFF_S)
+
     # Build attempt list: primary first, then platform fallback (only for non-BYOK)
     attempts: list[tuple[str, str, str, str, bool]] = [(api_url, api_key, model, provider, False)]
     if not is_byok:
@@ -872,7 +919,7 @@ async def send_message_stream(
         for idx, (att_url, att_key, att_model, att_provider, is_fb) in enumerate(attempts):
             try:
                 async for kind, content in _interleave_heartbeat(
-                    _stream_llm_once(att_url, att_key, att_model, att_provider),
+                    _stream_attempt(att_url, att_key, att_model, att_provider),
                     heartbeat_interval=LLM_STREAM_HEARTBEAT_INTERVAL_S,
                 ):
                     if kind == "ping":

--- a/backend/tests/test_chat_stream_retry.py
+++ b/backend/tests/test_chat_stream_retry.py
@@ -1,0 +1,185 @@
+"""Tests for the same-provider transient retry in send_message_stream.
+
+``_stream_attempt`` wraps each provider's stream with ONE retry, fired only
+when the failure is transient (network / timeout / 5xx / 429) AND no token has
+been yielded yet. This is the only resilience a BYOK request gets (it has no
+cross-provider fallback). The invariants under test:
+
+  * a transient pre-token failure retries the SAME provider once and succeeds;
+  * a failure AFTER the first token is NOT retried (would duplicate output);
+  * a non-transient 4xx is NOT retried (it would just fail again).
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.schemas.chat import ChatSource
+
+
+def _make_prepare_chat_return(sources: list[ChatSource], *, is_byok: bool):
+    fake_session = MagicMock()
+    fake_session.id = 42
+    llm_messages = [{"role": "user", "content": "测试"}]
+    return (
+        fake_session, "https://api.example.com/v1", "fake-key", "test-model",
+        is_byok, "openai", sources, llm_messages, [],
+    )
+
+
+def _fake_sources() -> list[ChatSource]:
+    return [ChatSource(text_id=1, juan_num=1, chunk_text="色不异空", score=0.9, title_zh="心经")]
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+    resp = httpx.Response(status, request=req)
+    return httpx.HTTPStatusError(f"{status}", request=req, response=resp)
+
+
+def _scripted_httpx(script: list, call_log: list):
+    """Patched httpx.AsyncClient whose every ``client.stream(...)`` consumes the
+    next behavior from ``script`` (shared across attempts):
+
+      * list[str]                 -> yields those content deltas + [DONE]
+      * Exception                 -> raised before any yield (pre-token failure)
+      * (list[str], Exception)    -> yields the tokens, THEN raises (mid-stream)
+
+    Each ``stream()`` call appends to ``call_log`` so tests can count attempts.
+    """
+    def _norm(b):
+        if isinstance(b, tuple):
+            return b
+        if isinstance(b, Exception):
+            return [], b
+        return b, None
+
+    def _make_resp(behavior):
+        tokens, exc = _norm(behavior)
+        mock_resp = MagicMock()
+
+        async def aiter_lines():
+            for t in tokens:
+                yield f"data: {json.dumps({'choices': [{'delta': {'content': t}}]})}"
+            if exc is not None:
+                raise exc
+            yield "data: [DONE]"
+
+        mock_resp.aiter_lines = aiter_lines
+        mock_resp.raise_for_status = MagicMock()
+        return mock_resp
+
+    class _StreamCM:
+        def __init__(self, behavior):
+            self._behavior = behavior
+
+        async def __aenter__(self):
+            return _make_resp(self._behavior)
+
+        async def __aexit__(self, *_):
+            return False
+
+    class _ClientInstance:
+        def stream(self, *args, **kwargs):
+            behavior = script.pop(0)
+            call_log.append(1)
+            return _StreamCM(behavior)
+
+    class _ClientCM:
+        async def __aenter__(self):
+            return _ClientInstance()
+
+        async def __aexit__(self, *_):
+            return False
+
+    return MagicMock(return_value=_ClientCM())
+
+
+class _FakeSessionmaker:
+    def __call__(self):
+        class _SessCM:
+            async def __aenter__(self_inner):
+                return AsyncMock()
+
+            async def __aexit__(self_inner, *_):
+                return False
+
+        return _SessCM()
+
+
+def _events(chunks: list[str]) -> list[dict]:
+    out: list[dict] = []
+    for c in chunks:
+        c = c.strip()
+        if not c.startswith("data: "):
+            continue
+        try:
+            out.append(json.loads(c[len("data: "):]))
+        except json.JSONDecodeError:
+            pass
+    return out
+
+
+async def _run(script: list, *, is_byok: bool):
+    call_log: list = []
+    prepare_return = _make_prepare_chat_return(_fake_sources(), is_byok=is_byok)
+    mock_client_cls = _scripted_httpx(script, call_log)
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock, return_value=prepare_return), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
+         patch("app.services.chat._mark_attachments_consumed", new_callable=AsyncMock), \
+         patch("app.services.chat.asyncio.sleep", new_callable=AsyncMock), \
+         patch("app.services.chat.httpx.AsyncClient", mock_client_cls):
+        from app.services.chat import send_message_stream
+
+        chunks: list[str] = []
+        async for chunk in send_message_stream(user_id=1, message="测试", sessionmaker=_FakeSessionmaker()):
+            chunks.append(chunk)
+    return _events(chunks), call_log
+
+
+@pytest.mark.anyio
+async def test_transient_pretoken_failure_retries_same_provider():
+    """A ConnectError before any token → one same-provider retry that succeeds.
+    BYOK (no fallback), so 2 stream() calls prove it was a retry, not a fallback."""
+    script = [httpx.ConnectError("boom"), ["般", "若"]]
+    events, call_log = await _run(script, is_byok=True)
+
+    assert len(call_log) == 2, f"expected exactly one retry (2 stream calls); got {len(call_log)}"
+    tokens = [e["content"] for e in events if e.get("type") == "token"]
+    assert tokens == ["般", "若"], tokens
+    assert not [e for e in events if e.get("type") == "error"], "retry succeeded; no error expected"
+
+
+@pytest.mark.anyio
+async def test_no_retry_after_first_token():
+    """A failure AFTER a token has streamed must NOT retry (would duplicate)."""
+    script = [(["般"], httpx.ReadError("mid-stream"))]
+    events, call_log = await _run(script, is_byok=True)
+
+    assert len(call_log) == 1, f"must not retry after a token; got {len(call_log)} stream calls"
+    tokens = [e["content"] for e in events if e.get("type") == "token"]
+    assert tokens == ["般"], tokens
+    assert any(e.get("type") == "error" for e in events), "mid-stream break should surface an error"
+
+
+@pytest.mark.anyio
+async def test_non_transient_4xx_is_not_retried():
+    """A 401 (bad key) is permanent — surface immediately, no retry."""
+    script = [_http_status_error(401)]
+    events, call_log = await _run(script, is_byok=True)
+
+    assert len(call_log) == 1, f"4xx must not be retried; got {len(call_log)} stream calls"
+    assert any(e.get("type") == "error" for e in events), "the 401 must surface as an error event"
+
+
+@pytest.mark.anyio
+async def test_transient_5xx_is_retried():
+    """A 503 before any token is transient → one retry that then succeeds."""
+    script = [_http_status_error(503), ["四", "圣", "谛"]]
+    events, call_log = await _run(script, is_byok=True)
+
+    assert len(call_log) == 2, f"5xx should be retried once; got {len(call_log)} stream calls"
+    tokens = [e["content"] for e in events if e.get("type") == "token"]
+    assert tokens == ["四", "圣", "谛"], tokens


### PR DESCRIPTION
## 问题

LLM 流连接上一次**瞬时抖动**（连接重置、上游 5xx/429、超时）目前会直接变成整个请求的硬失败。非 BYOK 请求还能落到平台 fallback，但 **BYOK 请求完全没有 fallback**——一次抖动 = 一次失败的回答。

## 改动

把每个 provider 的流包一层 `_stream_attempt`，对**同一个 provider 重试一次**，但仅当同时满足：

- **失败是瞬时的**——网络 / 超时 / 5xx / 429；而 **4xx**（错误的 key、模型不存在、非法请求）直接抛出不重试（重试也只会再失败一次）；
- **尚未吐出任何 token**——已经流式输出后再重试会**重复输出**，所以只在本次尝试零产出时重试。

与既有的跨 provider fallback 自然组合(主 provider 先自重试一次，再 fallback；fallback 同样自重试一次)。固定 0.5s 退避，无 jitter(单请求单次重试不需要打散惊群)。这是 **BYOK 请求唯一的韧性来源**。

## 验证

新增 `test_chat_stream_retry.py`（TDD red-first）:
- 首 token 前 `ConnectError` / `503` → **恰好一次**同 provider 重试并成功(断言 stream 调用数=2，且未走 fallback);
- **已吐 token 后**失败 → **不重试**(断言 stream 调用数=1，无重复 token);
- `401` → 不重试。

**4 passed**；全量 chat-stream 回归(lifecycle / heartbeat / auth / sources-order / byok-errors / trust)**52 passed**，无回归。

## 与 #935 的关系

本 PR 与 #935（空流静默卡死修复）都改 `send_message_stream`，但在**不同代码区、无文本重叠**（#935 在流循环**之后**加空完成守卫；本 PR 在循环**之前**加 `_stream_attempt` 并改一行调用），两者可**任意顺序干净合并**，语义上也正交(重试只在异常路径触发,空流守卫只在"成功但零 token"触发)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
