### PR TITLE
feat(rate-limit): 给 chat(AI 问答)端点加严格限流

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -105,6 +105,11 @@ class Settings(BaseSettings):
     rate_limit_semantic: int = 20
     rate_limit_research: int = 10
     rate_limit_ai_diff: int = 10
+    # Chat (AI Q&A) — the most expensive endpoint: RAG retrieval always uses the
+    # platform embedding key (even for BYOK users) plus a long streaming LLM
+    # call and a DB pool slot. 30/min/IP is generous for real use (a stream
+    # takes seconds) while capping abuse far below the 200 default.
+    rate_limit_chat: int = 30
 
     @property
     def database_url(self) -> str:

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -25,6 +25,13 @@ STRICT_PATHS: dict[str, int] = {
     "/api/search/semantic": settings.rate_limit_semantic,
     "/api/research/query": settings.rate_limit_research,
     "/api/alignment/ai-diff": settings.rate_limit_ai_diff,
+    # Chat / AI Q&A — the most expensive endpoint (platform-key RAG embedding +
+    # streaming LLM + a held DB pool slot), previously left at the loose
+    # default. Exact-path map (STRICT_PATHS.get(path)), so both routes are
+    # listed; each gets its own per-IP window at the same limit (production
+    # traffic is effectively all /stream).
+    "/api/chat": settings.rate_limit_chat,
+    "/api/chat/stream": settings.rate_limit_chat,
 }
 
 

--- a/backend/tests/test_chat_rate_limit.py
+++ b/backend/tests/test_chat_rate_limit.py
@@ -1,0 +1,29 @@
+"""The chat (AI Q&A) endpoints must be strict-rate-limited.
+
+Chat is the most expensive endpoint: RAG retrieval always spends the platform
+embedding key (even for BYOK users), then a long streaming LLM call holds a DB
+pool slot. It was previously left at the loose per-IP default (200/min) while
+cheaper paid-inference endpoints (semantic search, research, ai-diff) were
+capped. These tests lock chat into STRICT_PATHS at its configured, far-lower
+limit so a future refactor can't silently drop the protection.
+"""
+
+from app.config import settings
+from app.core.rate_limit import STRICT_PATHS
+
+
+def test_chat_endpoints_are_strict_rate_limited():
+    """Both the sync twin and the streaming path must be strict-limited."""
+    assert "/api/chat" in STRICT_PATHS
+    assert "/api/chat/stream" in STRICT_PATHS
+
+
+def test_chat_limit_uses_configured_value():
+    assert STRICT_PATHS["/api/chat"] == settings.rate_limit_chat
+    assert STRICT_PATHS["/api/chat/stream"] == settings.rate_limit_chat
+
+
+def test_chat_limit_is_far_below_the_default():
+    """The whole point is to cap the expensive endpoint well under the loose
+    per-IP default — otherwise adding it to STRICT_PATHS buys nothing."""
+    assert settings.rate_limit_chat < settings.rate_limit_default


### PR DESCRIPTION
## 问题

`STRICT_PATHS` 已经收紧了 auth / search / semantic / research / ai-diff，**唯独 `/api/chat` 和 `/api/chat/stream` 仍落在宽松的默认 200/min/IP**——而 chat 恰恰是**最贵的端点**：RAG 检索的 embedding **始终走平台 key**(BYOK 用户也一样)，随后一次长时流式 LLM 调用还会占住一个 DB 连接池槽位直到结束。这是最大的成本/DoS 敞口，却几乎不设防。

## 改动

把两个 chat 路由加入 `STRICT_PATHS`，用新的可配置项 `rate_limit_chat`(默认 **30/min/IP**)——对真实使用足够宽松(一次流式回答要数秒)，同时把滥用压到远低于 200。

- **按 IP** 限流，与既有的**按用户每日配额**正交叠加；
- **对 BYOK 同样生效**——BYOK 仍消耗平台 embedding + DB 资源，必须限；
- 限流器在 Redis 挂掉时**仍 fail-open**(行为不变)；
- `STRICT_PATHS` 是精确路径匹配，故两个路由分别列出、各自独立 per-IP 窗口(生产流量实际全走 `/stream`)。

## 验证

新增 `test_chat_rate_limit.py`(TDD red-first：无此条目时失败):两个 chat 路由在 `STRICT_PATHS` 中、取配置值、且低于默认值。限流相邻回归(sms 爆破 / ai-diff / research 配额)**21 passed**。

## 范围

只碰 `config.py` + `rate_limit.py`(+测试)，**与已开的 #935/#936/#937 零文件重叠**。这是主线3 里唯一"小、独立、低风险"的一项。其余三项经核实性质不同：cross-encoder 重排是**运维开关**(prod `.env` 设 `RERANKER_API_URL`，非 PR)；句读切块是**整库重嵌迁移**(非快 PR)；Redis 答案缓存需先定缓存范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
