### PR TITLE
fix(admin): stop dashboard white-screening on a transient stats 503

### DIFF
--- a/frontend/src/pages/AdminDashboardPage.resilience.test.tsx
+++ b/frontend/src/pages/AdminDashboardPage.resilience.test.tsx
@@ -1,0 +1,131 @@
+import { Component, type ReactElement, type ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import AdminDashboardPage from "./AdminDashboardPage";
+import {
+  getAdminOverview,
+  getAdminTrends,
+  getAdminActiveUsers,
+  getAdminModuleUsage,
+  type AdminOverview,
+} from "../api/client";
+import { getPlatformActivity } from "../api/feed";
+
+// The dashboard's trend chart is a heavy canvas component; stub it out.
+vi.mock("@ant-design/charts", () => ({
+  DualAxes: () => <div data-testid="dual-axes" />,
+}));
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    getAdminOverview: vi.fn(),
+    getAdminTrends: vi.fn(),
+    getAdminActiveUsers: vi.fn(),
+    getAdminModuleUsage: vi.fn(),
+  };
+});
+
+vi.mock("../api/feed", () => ({
+  getPlatformActivity: vi.fn(),
+}));
+
+// Mirrors the app-level ErrorBoundary that, in production, caught the crash and
+// rendered "加载失败" over the whole admin route. If AdminDashboardPage throws
+// during render, this boundary trips and shows the sentinel.
+class CrashSentinel extends Component<{ children: ReactNode }, { crashed: boolean }> {
+  state = { crashed: false };
+  static getDerivedStateFromError() {
+    return { crashed: true };
+  }
+  render() {
+    return this.state.crashed ? <div data-testid="crashed" /> : this.props.children;
+  }
+}
+
+function renderWithProviders(ui: ReactElement, client: QueryClient) {
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <CrashSentinel>{ui}</CrashSentinel>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+}
+
+const overview: AdminOverview = {
+  total_users: 10,
+  new_users_today: 2,
+  new_users_yesterday: 1,
+  total_sessions: 20,
+  new_sessions_today: 3,
+  new_sessions_yesterday: 2,
+  total_messages: 50,
+  new_messages_today: 4,
+  new_messages_yesterday: 3,
+  pending_suggestions: 0,
+  pending_annotations: 0,
+  last_updated: "2026-07-08T00:00:00Z",
+};
+
+describe("AdminDashboardPage resilience to transient stats failures", () => {
+  beforeEach(() => {
+    // Sub-cards only mount once the main content renders (which it never does in
+    // these tests), so these queries are never actually invoked — keep the mocks
+    // harmless and correctly typed just in case.
+    vi.mocked(getAdminActiveUsers).mockResolvedValue({ date: "2026-07-08", total: 0, users: [] });
+    vi.mocked(getAdminModuleUsage).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof getAdminModuleUsage>>,
+    );
+    vi.mocked(getPlatformActivity).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof getPlatformActivity>>,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression for the prod incident: a burst of backend 503s left the trends
+  // query neither loading nor error yet with undefined data — React Query
+  // status:'pending' + fetchStatus:'idle', so isLoading (=isPending && isFetching)
+  // is false and isError is false, but data is still undefined. The old code did
+  // `const trends = trendsQuery.data!` and then `trends.messages.map(...)`, which
+  // threw and took the whole admin route down via the ErrorBoundary ("加载失败，
+  // 请刷新后重试"). The page must instead degrade to a spinner and never crash.
+  //
+  // We reproduce that exact pending+idle window deterministically: hold the trends
+  // fetch open, let overview resolve, then cancel the in-flight trends query.
+  it("does not crash while the trends query is pending with no data (transient 503 window)", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(getAdminOverview).mockResolvedValue(overview);
+    // Never resolves on its own -> stays fetching until we cancel it.
+    vi.mocked(getAdminTrends).mockReturnValue(
+      new Promise<never>(() => {}) as ReturnType<typeof getAdminTrends>,
+    );
+
+    renderWithProviders(<AdminDashboardPage />, client);
+
+    // Overview has resolved; trends is still in flight -> spinner, no crash yet.
+    await waitFor(() => expect(getAdminTrends).toHaveBeenCalled());
+    expect(screen.queryByTestId("crashed")).toBeNull();
+
+    // Cancel the in-flight trends fetch: the query is now status:'pending' +
+    // fetchStatus:'idle' with undefined data — the precise state the 503 burst
+    // produced, and the one that used to throw at `trends.messages`.
+    await act(async () => {
+      await client.cancelQueries({ queryKey: ["adminTrends", 30] });
+    });
+
+    // Must not have white-screened; degrades to a spinner instead.
+    expect(screen.queryByTestId("crashed")).toBeNull();
+    expect(document.querySelector(".ant-spin")).not.toBeNull();
+  });
+});

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -222,8 +222,23 @@ export default function AdminDashboardPage() {
     );
   }
 
-  const overview = overviewQuery.data!;
-  const trends = trendsQuery.data!;
+  // React Query can report a query as neither loading nor error while its data is
+  // still undefined — status:'pending' + fetchStatus:'idle' (e.g. the gap after a
+  // transient 503, before a retry lands). `isLoading` is `isPending && isFetching`,
+  // so it reads false there. Guarding on the actual payload (instead of a `!`
+  // assertion) keeps a momentary backend blip from throwing at `trends.messages`
+  // and taking the whole admin route down via the ErrorBoundary; the page shows a
+  // spinner and recovers once the data arrives.
+  const overview = overviewQuery.data;
+  const trends = trendsQuery.data;
+
+  if (!overview || !trends) {
+    return (
+      <div style={{ textAlign: "center", padding: 80 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
 
   // Dual Y-axis: 消息数 (tens~hundreds) on the left, 新增用户 + 活跃用户
   // (single digits ~ teens) on the right. On a shared axis the two


### PR DESCRIPTION
## 现象

`fojin.app/admin` 间歇性显示 **"加载失败，请刷新后重试"**(app 级 ErrorBoundary 兜底页),仪表盘白屏。

## 根因

浏览器实测:一次刷新时 admin 的 5 个 stats API(`/api/admin/stats/*` 等)**同时返回 503**(后端双副本滚动重启窗口的典型表现),随后重试转 200。控制台报:

```
TypeError: Cannot read properties of undefined (reading 'messages')
    at AdminDashboardPage (…:208 → trends.messages.map)
```

`AdminDashboardPage` 用非空断言拿数据:

```tsx
const trends = trendsQuery.data!;
const messagesData = trends.messages.map(...)   // ← 崩溃
```

React Query v5 里,查询可处于 `status:'pending'` + `fetchStatus:'idle'` 的瞬态(如瞬时 503 后、下一次重试落地前):`isLoading (= isPending && isFetching)` 读作 **false**、`isError` 也 **false**,但 `data` 仍是 `undefined`。于是 `isLoading` 守卫和 `isError` 守卫**都放行**,`trends.messages` 直接抛错,被 ErrorBoundary 捕获 → 整个 `/admin` 白屏。**后端一个瞬时抖动就击穿整个后台,而非优雅降级。**

## 修复

去掉两个 `!` 非空断言,改为对**实际负载**加守卫:任一 stats 查询尚无数据时显示 Spin。React Query 会持续重试 503,数据到达后页面自动恢复渲染——正是手动刷新时自愈的行为。

```tsx
const overview = overviewQuery.data;
const trends = trendsQuery.data;
if (!overview || !trends) {
  return <div style={{ textAlign: "center", padding: 80 }}><Spin size="large" /></div>;
}
```

移除 `!` 后 `tsc` 仍通过 = 守卫正确收窄了类型(否则会报 `trends` possibly undefined)。

## 测试

新增 `AdminDashboardPage.resilience.test.tsx`:通过**取消在途 trends 查询**确定性复现 `pending+idle+undefined` 窗口,断言页面降级为 Spin 而非触发 ErrorBoundary。

- 修复前:测试红(CrashSentinel 触发)
- 修复后:测试绿
- 完整前端套件:**161 / 161 通过**,无回归

## 备注

后端 503 本身是瞬时的(当前 curl 20/20 健康,判断为部署滚动重启窗口)。本 PR 只解决前端韧性——让瞬时后端抖动不再白屏。后端 503 来源另行在服务器侧核实。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
