### PR TITLE
feat(chat): 每条答案下常驻可点「参考经文」源列表

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -960,6 +960,7 @@
   "chat.upload_failed": "Upload failed, please try again later",
   "chat.thinking": "Searching scriptures and generating an answer",
   "chat.request_failed": "Request failed, please retry",
+  "chat.reference_sources": "Sources",
   "chat.export_empty": "No conversation to export",
   "chat.export_time": "Exported: {{time}}",
   "chat.export_role_user": "User",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -960,6 +960,7 @@
   "chat.upload_failed": "上傳失敗，請稍後重試",
   "chat.thinking": "正在檢索經文並生成回答",
   "chat.request_failed": "請求失敗，請重試",
+  "chat.reference_sources": "參考經文",
   "chat.export_empty": "暫無對話內容可匯出",
   "chat.export_time": "匯出時間: {{time}}",
   "chat.export_role_user": "用戶",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -960,6 +960,7 @@
   "chat.upload_failed": "上传失败，请稍后重试",
   "chat.thinking": "正在检索经文并生成回答",
   "chat.request_failed": "请求失败，请重试",
+  "chat.reference_sources": "参考经文",
   "chat.export_empty": "暂无对话内容可导出",
   "chat.export_time": "导出时间: {{time}}",
   "chat.export_role_user": "用户",

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -432,7 +432,7 @@ function MessageBubbleInner({
                         onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.16)"; e.currentTarget.style.color = "var(--fj-accent)"; }}
                         onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.06)"; e.currentTarget.style.color = "var(--fj-ink-muted)"; }}
                       >
-                        {`《${s.title_zh}》${s.juan_num ? ` 第${s.juan_num}卷` : ""}`}
+                        {t("reader.citation.title_with_juan", { title: s.title_zh, n: s.juan_num })}
                       </button>
                     ))}
                   </div>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -313,6 +313,7 @@ interface MessageBubbleProps {
   onShare: (m: ChatMessageItem) => void;
   onRetry: (m: ChatMessageItem) => void;
   onFeedback: (m: ChatMessageItem, dir: "up" | "down") => void;
+  onSourceClick: (source: ChatSource) => void;
 }
 
 /** One chat message row, memoised on (m, isStreaming, sending, user). A streaming
@@ -323,7 +324,7 @@ interface MessageBubbleProps {
     which was the dominant "越聊越卡" jank in long conversations. */
 function MessageBubbleInner({
   m, isStreaming, sending, user, markdownComponents,
-  onSuggestionClick, onShare, onRetry, onFeedback,
+  onSuggestionClick, onShare, onRetry, onFeedback, onSourceClick,
 }: MessageBubbleProps) {
   // Read t here (not as a prop): on a mid-conversation language switch, i18next's
   // subscription re-renders the bubble — which memo does NOT block, since memo
@@ -346,6 +347,25 @@ function MessageBubbleInner({
     () => (isAssistantText ? tightenLists(injectCitationLinks(cleanContent, m.sources)) + (isStreaming ? " ▌" : "") : ""),
     [isAssistantText, cleanContent, m.sources, isStreaming],
   );
+
+  // Distinct retrieved sources (deduped by text + fascicle) shown as a
+  // persistent "参考经文" list under the answer. Inline 【…】 citations only
+  // appear when the LLM names the sutra in prose; this surfaces EVERY retrieved
+  // source, so any of them can be opened in the citation drawer and checked
+  // against the original one click away — even when the model paraphrased.
+  const sourceChips = useMemo(() => {
+    if (!isAssistantText || !m.sources) return [] as ChatSource[];
+    const seen = new Set<string>();
+    const out: ChatSource[] = [];
+    for (const s of m.sources) {
+      if (!s.title_zh) continue; // no title → nothing meaningful to label the chip with
+      const key = `${s.text_id}:${s.juan_num}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(s);
+    }
+    return out;
+  }, [isAssistantText, m.sources]);
   const trustLabelKey = trustStatusLabelKey(m.trust_status);
 
   return (
@@ -393,6 +413,28 @@ function MessageBubbleInner({
                     }}
                   >
                     {t(trustLabelKey)}
+                  </div>
+                )}
+                {sourceChips.length > 0 && (
+                  <div style={{ marginTop: 8, display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center" }}>
+                    <span style={{ fontSize: 12, color: "var(--fj-ink-muted)" }}>{t("chat.reference_sources")}</span>
+                    {sourceChips.map((s) => (
+                      <button
+                        key={`${s.text_id}:${s.juan_num}`}
+                        type="button"
+                        onClick={() => onSourceClick(s)}
+                        style={{
+                          display: "inline-flex", alignItems: "center", gap: 4,
+                          padding: "3px 10px", borderRadius: 12,
+                          border: "1px solid rgba(176,141,87,0.5)", background: "rgba(176,141,87,0.06)",
+                          color: "var(--fj-ink-muted)", fontSize: 12, lineHeight: 1.6, cursor: "pointer", transition: "all 0.2s",
+                        }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.16)"; e.currentTarget.style.color = "var(--fj-accent)"; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.06)"; e.currentTarget.style.color = "var(--fj-ink-muted)"; }}
+                      >
+                        {`《${s.title_zh}》${s.juan_num ? ` 第${s.juan_num}卷` : ""}`}
+                      </button>
+                    ))}
                   </div>
                 )}
                 {suggestions.length > 0 && !sending && (
@@ -1051,6 +1093,27 @@ export default function ChatPage() {
     }
   }, [messages, handleSendMessage]);
 
+  const handleSourceClick = useCallback((s: ChatSource) => {
+    // Behavioural signal, mirroring inline citation clicks: opening a source
+    // from the persistent list is engagement with / trust in the retrieved text.
+    if (typeof umami !== "undefined") {
+      umami.track("source_click", { text_id: s.text_id });
+    }
+    const chunkIndex = s.chunk_index ?? -1;
+    if (chunkIndex < 0) {
+      // No chunk anchor (legacy / non-chunked source) — fall back to the reader,
+      // same as the inline-citation legacy path.
+      navigate(`/texts/${s.text_id}/read?juan=${s.juan_num}`);
+      return;
+    }
+    setCitationTarget({
+      textId: s.text_id,
+      juanNum: s.juan_num,
+      chunkIndex,
+      titleZh: s.title_zh ?? "",
+    });
+  }, [navigate]);
+
   const handleFeedbackMessage = useCallback((m: ChatMessageItem, dir: "up" | "down") => {
     const newFeedback = m.feedback === dir ? null : dir;
     setMessages((prev) => prev.map((x) => x.id === m.id ? { ...x, feedback: newFeedback } : x));
@@ -1397,6 +1460,7 @@ export default function ChatPage() {
                 onShare={handleShareMessage}
                 onRetry={handleRetryMessage}
                 onFeedback={handleFeedbackMessage}
+                onSourceClick={handleSourceClick}
               />
             ))}
             {/* Streaming cursor is shown inline via ▌ in the message bubble */}

--- a/frontend/src/pages/MessageBubble.test.tsx
+++ b/frontend/src/pages/MessageBubble.test.tsx
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeAll } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { Components } from "react-markdown";
 import { MessageBubble } from "./ChatPage";
-import type { ChatMessageItem } from "../api/client";
+import type { ChatMessageItem, ChatSource } from "../api/client";
+import type { TextId } from "../types/branded";
 
 // antd (Button/Tooltip) reads matchMedia via useBreakpoint under jsdom.
 beforeAll(() => {
@@ -21,11 +22,24 @@ function msg(o: Partial<ChatMessageItem> = {}): ChatMessageItem {
   return { id: 1, role: "assistant", content: "answer", sources: null, created_at: "2026-06-18", ...o };
 }
 
+function src(o: Partial<ChatSource> = {}): ChatSource {
+  return {
+    text_id: 1 as TextId,
+    juan_num: 1,
+    chunk_index: 0,
+    chunk_text: "色不異空",
+    score: 0.9,
+    title_zh: "心經",
+    ...o,
+  };
+}
+
 function renderBubble(props: Partial<React.ComponentProps<typeof MessageBubble>> = {}) {
   const onSuggestionClick = vi.fn();
   const onShare = vi.fn();
   const onRetry = vi.fn();
   const onFeedback = vi.fn();
+  const onSourceClick = vi.fn();
   render(
     <MessageBubble
       m={msg()}
@@ -37,10 +51,11 @@ function renderBubble(props: Partial<React.ComponentProps<typeof MessageBubble>>
       onShare={onShare}
       onRetry={onRetry}
       onFeedback={onFeedback}
+      onSourceClick={onSourceClick}
       {...props}
     />,
   );
-  return { onSuggestionClick, onShare, onRetry, onFeedback };
+  return { onSuggestionClick, onShare, onRetry, onFeedback, onSourceClick };
 }
 
 describe("MessageBubble", () => {
@@ -54,7 +69,7 @@ describe("MessageBubble", () => {
       <MessageBubble
         m={msg({ content: "正在生成" })} isStreaming sending user={null}
         markdownComponents={markdownComponents}
-        onSuggestionClick={vi.fn()} onShare={vi.fn()} onRetry={vi.fn()} onFeedback={vi.fn()}
+        onSuggestionClick={vi.fn()} onShare={vi.fn()} onRetry={vi.fn()} onFeedback={vi.fn()} onSourceClick={vi.fn()}
       />,
     );
     expect(container.textContent).toContain("▌");
@@ -123,5 +138,40 @@ describe("MessageBubble", () => {
     expect(buttons).toHaveLength(4);
     fireEvent.click(buttons[2]); // like
     expect(onFeedback).toHaveBeenCalledWith(expect.objectContaining({ id: 42 }), "up");
+  });
+
+  it("renders a persistent 参考经文 source list and fires onSourceClick", () => {
+    const s = src({ text_id: 5 as TextId, juan_num: 16, title_zh: "雜阿含經" });
+    const { onSourceClick } = renderBubble({ m: msg({ sources: [s] }) });
+    // Label + a clickable chip for the retrieved source, even though the answer
+    // text never named it inline.
+    expect(screen.getByText("参考经文")).toBeInTheDocument();
+    const chip = screen.getByText("《雜阿含經》 第16卷");
+    fireEvent.click(chip);
+    expect(onSourceClick).toHaveBeenCalledWith(expect.objectContaining({ text_id: 5, juan_num: 16 }));
+  });
+
+  it("dedupes the source list by text + fascicle", () => {
+    renderBubble({
+      m: msg({
+        sources: [
+          src({ text_id: 1 as TextId, juan_num: 1, chunk_index: 0, title_zh: "心經" }),
+          src({ text_id: 1 as TextId, juan_num: 1, chunk_index: 3, title_zh: "心經" }), // same 卷, other chunk
+          src({ text_id: 2 as TextId, juan_num: 1, title_zh: "金剛經" }),
+        ],
+      }),
+    });
+    expect(screen.getAllByText("《心經》 第1卷")).toHaveLength(1);
+    expect(screen.getByText("《金剛經》 第1卷")).toBeInTheDocument();
+  });
+
+  it("shows no source list when the answer has no retrieved sources", () => {
+    renderBubble({ m: msg({ sources: null }) });
+    expect(screen.queryByText("参考经文")).toBeNull();
+  });
+
+  it("skips sources without a title (nothing to label the chip with)", () => {
+    renderBubble({ m: msg({ sources: [src({ title_zh: undefined })] }) });
+    expect(screen.queryByText("参考经文")).toBeNull();
   });
 });

--- a/frontend/src/pages/MessageBubble.test.tsx
+++ b/frontend/src/pages/MessageBubble.test.tsx
@@ -146,7 +146,7 @@ describe("MessageBubble", () => {
     // Label + a clickable chip for the retrieved source, even though the answer
     // text never named it inline.
     expect(screen.getByText("参考经文")).toBeInTheDocument();
-    const chip = screen.getByText("《雜阿含經》 第16卷");
+    const chip = screen.getByText("《雜阿含經》· 第 16 卷");
     fireEvent.click(chip);
     expect(onSourceClick).toHaveBeenCalledWith(expect.objectContaining({ text_id: 5, juan_num: 16 }));
   });
@@ -161,8 +161,8 @@ describe("MessageBubble", () => {
         ],
       }),
     });
-    expect(screen.getAllByText("《心經》 第1卷")).toHaveLength(1);
-    expect(screen.getByText("《金剛經》 第1卷")).toBeInTheDocument();
+    expect(screen.getAllByText("《心經》· 第 1 卷")).toHaveLength(1);
+    expect(screen.getByText("《金剛經》· 第 1 卷")).toBeInTheDocument();
   });
 
   it("shows no source list when the answer has no retrieved sources", () => {


### PR DESCRIPTION
## 问题:很强的核对抽屉,只对一部分答案生效

检索到的 RAG 源**只有当模型在正文里点名了经名**(`injectCitationLinks` 把 `【…】` 改写成可点链接)才可点。模型**转述**了、或**没点名**的源,对用户是**隐形**的——那套很强的 CitationDrawer(逐字原文 + 汉/巴/梵/藏 对读 + 高亮)只对一部分答案可达,"每条回答均附经文原文引用 / 可验证"的承诺打了折扣。

## 改动:每条答案下常驻「参考经文」

把**每一条检索到的源**渲染成答案下方常驻、**按(经 text_id + 卷)去重**的「参考经文」chip。点击任一 chip 就在同一个 CitationDrawer 里打开该段落(无 chunk 锚点的旧源回退到阅读器),完全**复用行内引用的点击路径**(含 `source_click` 埋点)。于是**即便答案是转述**,每一条检索源也都离原文一键之遥。

- `MessageBubble`:新增 `onSourceClick` prop + 去重的 `sourceChips` 列表。
- 父层:`handleSourceClick` 从 `ChatSource` 构造 `CitationTarget`,镜像行内引用行为(umami 埋点 / `chunk_index<0` 回退阅读器 / 否则 `setCitationTarget`)。
- i18n:`chat.reference_sources`(参考经文 / 參考經文 / Sources),三语对称。

## 为什么是它
这是把整个交流主线"**可验证**"**直接交付给用户**的一步:激活已有的强核对基础设施,覆盖**所有**答案而非仅模型点名的那部分。纯加法 UI,不碰后端/流式热路径,风险低。

## 验证
- `MessageBubble.test.tsx` 新增 4 例(渲染「参考经文」+ 点击触发 `onSourceClick`、按 text+卷去重、无源不显示、无标题源跳过)→ **13 passed**(9 现有回归 + 4 新)。
- `tsc -b` **exit 0**;i18n 一致性 `RemainingPageI18n.test.tsx` **9 passed**;三语 JSON 有效、键对称。
- 现有 button-count 断言不受影响(其 fixture 均无 sources → 不产生 chip)。

## 范围
仅前端 5 文件(+121/−4),`base master`,与在途/已合并的后端改动零重叠。子代理当前受 403 限制,故本次为**严格自审 + tsc + 单测**验证(未跑独立复审代理)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
