### PR TITLE
fix(home): 佛教地理卡片正名并策展示例地名（圣迹→寺院、去外文名）

### DIFF
--- a/backend/app/services/home_showcase.py
+++ b/backend/app/services/home_showcase.py
@@ -68,8 +68,20 @@ _PREDICATE_LABELS = {
 # picks one at random on every page load, so the card varies per refresh while
 # the DB work stays cached. Pool sizes are small — enough variety, tiny payload.
 _CHAT_POOL = 8
-_GEO_POOL = 12
 _SOURCES_POOL = 12
+
+# Curated example names for the geo card. The geo layer is a global OSM/Wikidata
+# harvest, so most rows' name_zh holds a foreign native name (고경사, "Chùa …",
+# even a typo'd "Tibetian Budist Temple"). Sampling arbitrary rows put those on
+# the homepage. This card is a storefront: show a fixed pool of well-known
+# Chinese temples and sacred mountains instead. The real total (~60k) still
+# comes from the live count; only these example names are curated. The frontend
+# samples a few of these per page load.
+_GEO_FEATURED = (
+    "少林寺", "灵隐寺", "白马寺", "寒山寺", "法门寺", "大慈恩寺",
+    "国清寺", "栖霞寺", "南普陀寺", "金山寺", "大昭寺", "扎什伦布寺",
+    "五台山", "普陀山", "峨眉山", "九华山",
+)
 
 
 def _short_gloss(definition: str | None) -> str | None:
@@ -198,23 +210,22 @@ async def _kg_card(db: AsyncSession) -> dict | None:
 
 
 async def _geo_card(db: AsyncSession) -> dict | None:
-    """Site count + a pool of place names; the frontend samples a few per load."""
+    """Live site count + a curated pool of well-known temple names.
+
+    The count is the real total over the geo entity types; the example names are
+    the curated ``_GEO_FEATURED`` pool (not sampled from the DB, which would
+    surface foreign native names). The frontend samples a few names per load.
+    Returns None when there is no geo data so the card degrades cleanly.
+    """
     try:
         count = (
             await db.execute(
                 select(func.count(KGEntity.id)).where(KGEntity.entity_type.in_(_GEO_TYPES))
             )
         ).scalar() or 0
-        names = (
-            await db.execute(
-                select(KGEntity.name_zh)
-                .where(KGEntity.entity_type.in_(_GEO_TYPES), KGEntity.name_zh.is_not(None))
-                .limit(_GEO_POOL)
-            )
-        ).scalars().all()
-        if not count and not names:
+        if not count:
             return None
-        return {"count": int(count), "places": list(names)}
+        return {"count": int(count), "places": list(_GEO_FEATURED)}
     except Exception:
         logger.warning("showcase geo_card failed", exc_info=True)
         return None

--- a/backend/tests/test_home_showcase.py
+++ b/backend/tests/test_home_showcase.py
@@ -56,8 +56,13 @@ async def test_showcase_returns_pools_per_card(seeded_db):
     # Dictionary returns a POOL of {term, definition}; 般若 (seeded) is present.
     terms = {e["term"] for e in out["dictionary"]["terms"]}
     assert "般若" in terms
+    # count is the live geo total (1 seeded monastery); places are the CURATED
+    # featured pool (not sampled from the DB, so foreign native names never leak
+    # onto the homepage). The seeded 那烂陀寺 therefore does NOT appear.
     assert out["geo"]["count"] == 1
-    assert "那烂陀寺" in out["geo"]["places"]
+    assert out["geo"]["places"] == list(home_showcase._GEO_FEATURED)
+    assert "少林寺" in out["geo"]["places"]
+    assert "那烂陀寺" not in out["geo"]["places"]
     # Chat returns a non-empty pool of questions.
     assert isinstance(out["chat"]["questions"], list) and out["chat"]["questions"]
     # Legacy single-pick fields coexist (backward-compat for PWA-cached old FE).
@@ -100,6 +105,18 @@ async def test_showcase_reads_from_redis_cache_when_present(seeded_db):
                 "dictionary": None, "kg": None, "geo": None}
     out = await get_home_showcase(seeded_db, redis=_Redis(json.dumps(sentinel)))
     assert out == sentinel                               # served from cache, DB untouched
+
+
+def test_geo_featured_pool_is_pure_chinese():
+    """The whole point of curating the pool: no latin/hangul/kana names ever
+    reach the homepage. Each featured name must be CJK-Han only (a handful of
+    well-known temples / sacred mountains)."""
+    import re
+
+    non_han = re.compile(r"[A-Za-z가-힣぀-ヿ]")  # latin / hangul / kana
+    assert home_showcase._GEO_FEATURED, "featured pool must be non-empty"
+    for name in home_showcase._GEO_FEATURED:
+        assert not non_han.search(name), f"featured name not pure-Chinese: {name!r}"
 
 
 def test_short_gloss_trims_long_definitions():

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -415,7 +415,7 @@
   "home.feature_sources_desc": "Aggregating CBETA, SuttaCentral and global Buddhist digital resources",
   "home.sc_sources": "{{sources}} sources · {{texts}} texts",
   "home.sc_sources_names": "{{sources}} sources · {{names}}",
-  "home.sc_geo": "{{count}} sacred sites · {{places}}",
+  "home.sc_geo": "{{count}} Buddhist temples worldwide · {{places}}",
   "home.feature_kg_title": "Knowledge Graph",
   "home.feature_kg_desc": "e.g. Kumārajīva → translated → Lotus Sutra",
   "home.feature_chat_title": "AI Q&A",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -415,7 +415,7 @@
   "home.feature_sources_desc": "匯聚 CBETA、SuttaCentral 等全球數字佛典資源",
   "home.sc_sources": "{{sources}} 個來源 · {{texts}} 部經典",
   "home.sc_sources_names": "{{sources}} 個來源 · {{names}}",
-  "home.sc_geo": "{{count}} 處聖跡 · {{places}}",
+  "home.sc_geo": "{{count}} 座佛教寺院 · {{places}}",
   "home.feature_kg_title": "知識圖譜",
   "home.feature_kg_desc": "例如：鳩摩羅什 → 譯經 → 《妙法蓮華經》",
   "home.feature_chat_title": "AI 問答",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -415,7 +415,7 @@
   "home.feature_sources_desc": "汇聚 CBETA、SuttaCentral 等全球数字佛典资源",
   "home.sc_sources": "{{sources}} 个来源 · {{texts}} 部经典",
   "home.sc_sources_names": "{{sources}} 个来源 · {{names}}",
-  "home.sc_geo": "{{count}} 处圣迹 · {{places}}",
+  "home.sc_geo": "{{count}} 座佛教寺院 · {{places}}",
   "home.feature_kg_title": "知识图谱",
   "home.feature_kg_desc": "例如：鸠摩罗什 → 译经 → 《妙法莲华经》",
   "home.feature_chat_title": "AI 问答",


### PR DESCRIPTION
## 问题
首页「佛教地理」卡片副标题 `60,174 处圣迹 · 龍興寺、고경사、德林寺` 有两处问题：

1. **「圣迹」不准**：`60,174` = 寺院(monastery `59,836`) + 地点(place `338`)，**99.4% 是活寺院不是圣迹**。
2. **示例名夹外文/拼写错**：`_geo_card` 取 `name_zh` 前 12 条**无语言过滤、无排序**；全球采集的 `name_zh` 约 17% 是原文名（`고경사`、`Chùa Chúc Thánh`、拼错的 `Tibetian Budist Temple`），前端随机抽 3 条常命中它们。

## 改动
- **后端 `_geo_card`**：示例名从「DB 堆序前 12 条」换成手选知名寺院/名山固定池 `_GEO_FEATURED`（少林寺、灵隐寺、白马寺、五台山…共 16 条）；`count` 仍查真实 live 值；省掉一次 name 查询；降级条件改为仅 `if not count`。
- **3 处 locale `home.sc_geo`**：`处圣迹/處聖跡/sacred sites` → `座佛教寺院/座佛教寺院/Buddhist temples worldwide`。
- 数字保留真实 `60,174`（未圆整；精确值本就是数据集规模，且已在 hero stats 出现）。

## 效果
`60,174 处圣迹 · 龍興寺、고경사、德林寺` → `60,174 座佛教寺院 · 少林寺、峨眉山、白马寺`（前端每刷新从 16 条策展池随机抽 3）。

## 测试
- 更新 `test_home_showcase` geo 断言为策展池、断言种子 `那烂陀寺` 不再出现。
- 新增 `test_geo_featured_pool_is_pure_chinese`（无拉丁/韩文/假名）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)