### PR TITLE
fix(home): 三个「文案配不上数据」卡片 bug（词典生英文/图谱单一谓词/geo残留）

### DIFF
--- a/backend/app/services/home_showcase.py
+++ b/backend/app/services/home_showcase.py
@@ -21,6 +21,7 @@ periods (feels alive) while staying stable within one (cacheable).
 from __future__ import annotations
 
 import logging
+from itertools import zip_longest
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -42,7 +43,14 @@ _SHOWCASE_CACHE_KEY = "home:showcase:v3"  # v3: sources.names pool added
 # A small candidate pool size for rotation-by-seed queries: fetch a bounded set
 # cheaply, then pick one deterministically per time bucket.
 _POOL = 12
-_GEO_TYPES = ("place", "monastery")
+
+# KG card: query each of these predicates separately and round-robin the results
+# so the pool spans relation types instead of whatever the physical scan hits
+# first (which was 100% active_in). translated (译) + teacher_of (授学) are the
+# illustrative person→X edges; active_in (活跃于) is filler. All three have
+# person subjects.
+_KG_FEATURED_PREDICATES = ("translated", "teacher_of", "active_in")
+_KG_PER_PREDICATE = 5
 
 # Max chars of a dictionary definition shown on the card — kept short so the
 # subtitle stays ~2 lines (the CSS also hard-clamps to 2 lines as a backstop).
@@ -74,13 +82,13 @@ _SOURCES_POOL = 12
 # harvest, so most rows' name_zh holds a foreign native name (고경사, "Chùa …",
 # even a typo'd "Tibetian Budist Temple"). Sampling arbitrary rows put those on
 # the homepage. This card is a storefront: show a fixed pool of well-known
-# Chinese temples and sacred mountains instead. The real total (~60k) still
-# comes from the live count; only these example names are curated. The frontend
-# samples a few of these per page load.
+# Chinese temples instead. All entries are monasteries (寺院) so they match the
+# card's "座佛教寺院" label — no sacred mountains, which aren't temples. The real
+# total comes from the live monastery count; only these names are curated.
 _GEO_FEATURED = (
     "少林寺", "灵隐寺", "白马寺", "寒山寺", "法门寺", "大慈恩寺",
     "国清寺", "栖霞寺", "南普陀寺", "金山寺", "大昭寺", "扎什伦布寺",
-    "五台山", "普陀山", "峨眉山", "九华山",
+    "隆兴寺", "广济寺", "华严寺", "归元寺",
 )
 
 
@@ -147,6 +155,12 @@ async def _chat_card(db: AsyncSession, redis) -> dict | None:
         return None
 
 
+def _has_cjk(s: str | None) -> bool:
+    """True if the string contains at least one CJK ideograph — used to tell a
+    real Chinese gloss from a bare English/Sanskrit transliteration."""
+    return any("一" <= c <= "鿿" for c in (s or ""))
+
+
 async def _dictionary_card(db: AsyncSession) -> dict | None:
     """A pool of hot terms + short glosses (one batched query over HOT_TERMS)."""
     try:
@@ -156,12 +170,26 @@ async def _dictionary_card(db: AsyncSession) -> dict | None:
                 .where(DictionaryEntry.headword.in_(HOT_TERMS))
             )
         ).all()
-        # One gloss per headword (first row wins), preserving HOT_TERMS order.
+        # Prefer a Chinese gloss per headword. A single-entry term (e.g. 如来 whose
+        # only entry defines it as "Tathagata") would otherwise deterministically
+        # surface a bare transliteration, which reads as broken on a 佛学辞典 card.
+        # Keep the first gloss seen, but upgrade to a Chinese one if a later row
+        # has it.
         by_term: dict[str, str | None] = {}
         for headword, definition in rows:
-            if headword not in by_term:
-                by_term[headword] = _short_gloss(definition)
-        terms = [{"term": t, "definition": by_term[t]} for t in HOT_TERMS if t in by_term]
+            gloss = _short_gloss(definition)
+            if not gloss:
+                continue
+            cur = by_term.get(headword)
+            if cur is None or (not _has_cjk(cur) and _has_cjk(gloss)):
+                by_term[headword] = gloss
+        # Only surface terms whose chosen gloss is actually Chinese — drop any
+        # term left with only a non-Chinese gloss rather than show it.
+        terms = [
+            {"term": t, "definition": by_term[t]}
+            for t in HOT_TERMS
+            if by_term.get(t) and _has_cjk(by_term[t])
+        ]
         if not terms:
             return None
         # Legacy single-pick fields (see _chat_card) for PWA-cached old frontends.
@@ -174,24 +202,35 @@ async def _dictionary_card(db: AsyncSession) -> dict | None:
 async def _kg_card(db: AsyncSession) -> dict | None:
     """A pool of readable knowledge-graph triples (subject —predicate→ object).
 
-    Person-subject filter keeps the sample human-readable (玄奘 —译→ …) without
-    an expensive scan; the frontend shows one triple at random per load."""
+    Person-subject filter keeps the sample human-readable (玄奘 —译→ …). We query
+    each featured predicate separately and round-robin the results so the pool
+    spans relation TYPES: a single ``LIMIT`` over the physical scan returned 100%
+    ``active_in→唐`` and hid the 22k teacher_of / 2.8k translated edges. The
+    frontend shows one triple at random per load."""
     try:
         subj = aliased(KGEntity)
         obj = aliased(KGEntity)
-        rows = (
-            await db.execute(
-                select(subj.name_zh, KGRelation.predicate, obj.name_zh)
-                .join(subj, KGRelation.subject_id == subj.id)
-                .join(obj, KGRelation.object_id == obj.id)
-                .where(
-                    subj.entity_type == "person",
-                    subj.name_zh.is_not(None),
-                    obj.name_zh.is_not(None),
+
+        async def _pred_rows(pred: str) -> list:
+            return (
+                await db.execute(
+                    select(subj.name_zh, KGRelation.predicate, obj.name_zh)
+                    .join(subj, KGRelation.subject_id == subj.id)
+                    .join(obj, KGRelation.object_id == obj.id)
+                    .where(
+                        subj.entity_type == "person",
+                        KGRelation.predicate == pred,
+                        subj.name_zh.is_not(None),
+                        obj.name_zh.is_not(None),
+                    )
+                    .limit(_KG_PER_PREDICATE)
                 )
-                .limit(_POOL)
-            )
-        ).all()
+            ).all()
+
+        # translated (译) + teacher_of (授学) are the illustrative ones; active_in
+        # (活跃于) is kept as filler but no longer allowed to dominate.
+        per_pred = [await _pred_rows(p) for p in _KG_FEATURED_PREDICATES]
+        rows = [r for tier in zip_longest(*per_pred) for r in tier if r]
         triples = [
             {
                 "subject": r[0],
@@ -212,15 +251,16 @@ async def _kg_card(db: AsyncSession) -> dict | None:
 async def _geo_card(db: AsyncSession) -> dict | None:
     """Live site count + a curated pool of well-known temple names.
 
-    The count is the real total over the geo entity types; the example names are
-    the curated ``_GEO_FEATURED`` pool (not sampled from the DB, which would
-    surface foreign native names). The frontend samples a few names per load.
-    Returns None when there is no geo data so the card degrades cleanly.
+    The count is the live monastery total — monasteries only, to match the
+    "座佛教寺院" label (the ``place`` rows, ~0.6%, aren't temples). The example
+    names are the curated ``_GEO_FEATURED`` pool (not sampled from the DB, which
+    would surface foreign native names). The frontend samples a few names per
+    load. Returns None when there is no geo data so the card degrades cleanly.
     """
     try:
         count = (
             await db.execute(
-                select(func.count(KGEntity.id)).where(KGEntity.entity_type.in_(_GEO_TYPES))
+                select(func.count(KGEntity.id)).where(KGEntity.entity_type == "monastery")
             )
         ).scalar() or 0
         if not count:

--- a/backend/tests/test_home_showcase.py
+++ b/backend/tests/test_home_showcase.py
@@ -109,14 +109,65 @@ async def test_showcase_reads_from_redis_cache_when_present(seeded_db):
 
 def test_geo_featured_pool_is_pure_chinese():
     """The whole point of curating the pool: no latin/hangul/kana names ever
-    reach the homepage. Each featured name must be CJK-Han only (a handful of
-    well-known temples / sacred mountains)."""
+    reach the homepage. Each featured name must be CJK-Han only (well-known
+    temples — matching the card's 座佛教寺院 label)."""
     import re
 
     non_han = re.compile(r"[A-Za-z가-힣぀-ヿ]")  # latin / hangul / kana
     assert home_showcase._GEO_FEATURED, "featured pool must be non-empty"
     for name in home_showcase._GEO_FEATURED:
         assert not non_han.search(name), f"featured name not pure-Chinese: {name!r}"
+
+
+@pytest.mark.anyio
+async def test_dictionary_card_prefers_chinese_gloss_over_transliteration():
+    """A term whose only gloss is a bare transliteration (如来 → "Tathagata")
+    must be dropped, not shown; a term with both keeps the Chinese gloss."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(DictionaryEntry.__table__.create)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        s.add(DictionaryEntry(headword="如来", definition="Tathagata", lang="en"))
+        s.add(DictionaryEntry(headword="般若", definition="prajñā", lang="sa"))
+        s.add(DictionaryEntry(headword="般若", definition="照见诸法实相的智慧。", lang="zh"))
+        await s.commit()
+        card = await home_showcase._dictionary_card(s)
+    await engine.dispose()
+
+    terms = {t["term"]: t["definition"] for t in (card or {}).get("terms", [])}
+    assert "如来" not in terms                       # English-only → dropped
+    assert terms.get("般若") == "照见诸法实相的智慧"    # Chinese gloss chosen over prajñā
+
+
+@pytest.mark.anyio
+async def test_kg_card_pool_spans_multiple_predicates():
+    """Regression for the "100% active_in→唐" bug: with translated + teacher_of
+    + active_in data present, the pool must span more than one relation type."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(KGEntity.__table__.create)
+        await conn.run_sync(KGRelation.__table__.create)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        kj = KGEntity(entity_type="person", name_zh="鸠摩罗什")
+        dx = KGEntity(entity_type="person", name_zh="道宣")
+        xz = KGEntity(entity_type="person", name_zh="玄奘")
+        lotus = KGEntity(entity_type="text", name_zh="妙法莲华经")
+        wg = KGEntity(entity_type="person", name_zh="文纲")
+        tang = KGEntity(entity_type="dynasty", name_zh="唐")
+        s.add_all([kj, dx, xz, lotus, wg, tang])
+        await s.flush()
+        s.add(KGRelation(subject_id=kj.id, predicate="translated", object_id=lotus.id))
+        s.add(KGRelation(subject_id=dx.id, predicate="teacher_of", object_id=wg.id))
+        s.add(KGRelation(subject_id=xz.id, predicate="active_in", object_id=tang.id))
+        await s.commit()
+        card = await home_showcase._kg_card(s)
+    await engine.dispose()
+
+    preds = {t["predicate"] for t in (card or {}).get("triples", [])}
+    assert len(preds) >= 2, f"pool should span multiple predicates, got {preds}"
+    assert "译" in preds and "授学" in preds
 
 
 def test_short_gloss_trims_long_definitions():

--- a/backend/tests/test_home_showcase.py
+++ b/backend/tests/test_home_showcase.py
@@ -125,12 +125,19 @@ async def test_dictionary_card_prefers_chinese_gloss_over_transliteration():
     must be dropped, not shown; a term with both keeps the Chinese gloss."""
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
+        await conn.run_sync(DataSource.__table__.create)
         await conn.run_sync(DictionaryEntry.__table__.create)
     factory = async_sessionmaker(engine, expire_on_commit=False)
     async with factory() as s:
-        s.add(DictionaryEntry(headword="如来", definition="Tathagata", lang="en"))
-        s.add(DictionaryEntry(headword="般若", definition="prajñā", lang="sa"))
-        s.add(DictionaryEntry(headword="般若", definition="照见诸法实相的智慧。", lang="zh"))
+        src = DataSource(name_zh="测试辞典", code="test-dict", is_active=True)
+        s.add(src)
+        await s.flush()
+        s.add(DictionaryEntry(headword="如来", definition="Tathagata", lang="en",
+                              source_id=src.id, external_id="t1"))
+        s.add(DictionaryEntry(headword="般若", definition="prajñā", lang="sa",
+                              source_id=src.id, external_id="t2"))
+        s.add(DictionaryEntry(headword="般若", definition="照见诸法实相的智慧。", lang="zh",
+                              source_id=src.id, external_id="t3"))
         await s.commit()
         card = await home_showcase._dictionary_card(s)
     await engine.dispose()


### PR DESCRIPTION
走查(真实打开首页+代码/数据交叉核对)发现三处卡片展示与实际数据不符，均与已修的 geo「圣迹」同类。

## 1. 词典卡片弹生英文释义
`_dictionary_card` 取首行不分语言 → 单条目术语「如来 → Tathagata」「菩萨 → bodhisattva」必现英文转写，像坏了。**改为优先含 CJK 的中文释义，只有非中文释义的术语不上卡。** 生产核实：般若/涅槃/菩提/三昧/中道/佛性/慈悲 保留；如来/菩萨（仅英文）剔除。

## 2. 图谱卡片永远「XX → 活跃于 → 唐」
`_kg_card` 对 person 三元组 `LIMIT 12` 无排序 → 堆序 100% 命中 `active_in`，藏了 22k `teacher_of` / 2.8k `translated` 边。**改为按谓词（译/授学/活跃于）分桶取 + round-robin 交错**，轮流展示不同关系类型。三谓词均有丰富 person 主语数据（已核实）。

## 3. geo 残留（上个 PR 引入）
「60,174 座佛教寺院」把 338 个 `place` + 示例池里五台山等四大名山都算作寺院。**count 改为仅 monastery（59,836）；示例池去名山、换 4 座寺院**（隆兴寺/广济寺/华严寺/归元寺），名副其实。

## 测试
新增 `test_dictionary_card_prefers_chinese_gloss_over_transliteration`、`test_kg_card_pool_spans_multiple_predicates`；更新 geo 断言。部署后浏览器复验卡片渲染。

🤖 Generated with [Claude Code](https://claude.com/claude-code)