### PR TITLE
perf(pwa): SW 预缓存真正用的 webp、排除 577K 死 PNG

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -208,7 +208,12 @@ export default defineConfig({
       registerType: "autoUpdate",
       manifest: false, // We provide our own manifest.json in public/
       workbox: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
+        // Include webp so the real hero (landscape-bg.webp, ~19KB) is precached;
+        // exclude landscape-bg.png (577KB) — it's only the og:image for social
+        // crawlers, which don't run a service worker, so precaching it into every
+        // PWA install just wastes ~577KB the user never sees.
+        globPatterns: ["**/*.{js,css,html,ico,png,svg,webp}"],
+        globIgnores: ["**/landscape-bg.png"],
         navigateFallbackDenylist: [/^\/api\//],
         skipWaiting: true,
         clientsClaim: true,


### PR DESCRIPTION
vite PWA `globPatterns` 含 png 不含 webp：把 `landscape-bg.png`(577K)预缓存进每个 PWA 但用户从不显示（页面用 webp，PNG 仅供社交爬虫 og:image，爬虫不跑 SW）；真正显示的 `landscape-bg.webp`(19K)反而没被预缓存。

改：glob 加 `webp`，`globIgnores` 排除 `landscape-bg.png`。每个 PWA 首装预缓存净减 ~558K。部署后验证 sw.js 预缓存清单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)