### PR TITLE
fix(copy+cache): chat 承诺文案对齐实际能力 + 图标/favicon 缓存头

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -64,6 +64,21 @@ server {
         include /etc/nginx/security-headers.conf;
     }
 
+    # PWA icons + favicon — small, near-static, un-hashed root assets that
+    # otherwise fall through to `location /` with no Cache-Control and get
+    # re-validated every load. Long max-age (not immutable, since filenames
+    # aren't content-hashed — rename if one ever changes).
+    location /icons/ {
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000";
+        include /etc/nginx/security-headers.conf;
+    }
+    location = /favicon.svg {
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000";
+        include /etc/nginx/security-headers.conf;
+    }
+
     # Use Docker DNS resolver so backend can be re-resolved after restarts
     resolver 127.0.0.11 valid=30s;
     set $upstream_backend http://backend:8000;

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -694,7 +694,7 @@
   "chat.page_title": "AI Buddhist Q&A — FoJin",
   "chat.title": "AI Buddhist Q&A",
   "chat.subtitle": "Ask about Buddhist scriptures, history, translations, and more",
-  "chat.subtitle2": "Every answer includes citations from original texts",
+  "chat.subtitle2": "Answers cite scriptural sources — open any to verify",
   "chat.new_chat": "New Chat",
   "chat.configure_key": "Configure API Key",
   "chat.key_configured": "Key Configured",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -694,7 +694,7 @@
   "chat.page_title": "小津 AI 佛典問答 — 佛津 FoJin",
   "chat.title": "小津 AI 佛典問答",
   "chat.subtitle": "可以問我關於佛經內容、佛教歷史、經典翻譯等問題",
-  "chat.subtitle2": "每條回答均附經文原文引用",
+  "chat.subtitle2": "答案標註經文出處，可點開核對原文",
   "chat.new_chat": "新對話",
   "chat.configure_key": "配置 API Key",
   "chat.key_configured": "已配置 Key",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -694,7 +694,7 @@
   "chat.page_title": "小津 AI 佛典问答 — 佛津 FoJin",
   "chat.title": "小津 AI 佛典问答",
   "chat.subtitle": "可以问我关于佛经内容、佛教历史、经典翻译等问题",
-  "chat.subtitle2": "每条回答均附经文原文引用",
+  "chat.subtitle2": "答案标注经文出处，可点开核对原文",
   "chat.new_chat": "新对话",
   "chat.configure_key": "配置 API Key",
   "chat.key_configured": "已配置 Key",


### PR DESCRIPTION
收口两项。

## 1. 文案诚实对齐
`chat.subtitle2`「每条回答均附经文原文引用」是过度承诺——实测 54% 逐字引文被降级成白话（quote_relaxed），且 meta 问答（你是谁）本就无引用。改为不含绝对量词、准确的说法：
- zh: 答案标注经文出处，可点开核对原文
- zh-Hant: 答案標註經文出處，可點開核對原文
- en: Answers cite scriptural sources — open any to verify

出处标注 100% 真实、「可点开核对」描述 CitationDrawer，保留「可验证」价值而不虚标逐字引用。

## 2. 图标/favicon 缓存头
nginx 给 `/icons/` 与 `/favicon.svg` 加 30d 缓存（此前落 `location /` 无 Cache-Control）。锚定明确、不碰 /assets/ immutable。`nginx -t` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)