### PR TITLE
feat(rag): MITRA 平行按句相关度择优(修检索平行不对题)

### DIFF
--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -52,7 +52,7 @@ ENABLE_PARALLEL_RAG = settings.enable_parallel_rag if hasattr(settings, "enable_
 ENABLE_MITRA_RAG_PARALLELS = (
     settings.enable_mitra_rag_parallels if hasattr(settings, "enable_mitra_rag_parallels") else True
 )
-MITRA_PARALLEL_K = 3   # max MITRA rows fetched per primary chunk
+MITRA_CANDIDATE_K = 8  # MITRA rows fetched per primary chunk to rank (candidate pool)
 MITRA_PARALLEL_SHOW = 2  # max MITRA parallels rendered per primary (new langs only)
 
 # Display labels for parallel-language annotations in the [跨藏对读] block.
@@ -458,31 +458,68 @@ def _group_mitra_rows(rows) -> dict[int, list[dict]]:
     foreign-parallel dicts. Pure (no I/O) so it's unit-testable.
 
     Row shape matches the SELECT in ``_attach_mitra_parallels``:
-    ``(primary_idx, foreign_lang, foreign_text, confidence)``. Rows with empty
+    ``(primary_idx, foreign_lang, foreign_text, zh_text, confidence)``. ``zh_text``
+    is the 汉 side of the aligned sentence, kept for relevance ranking (see
+    ``_rank_mitra_by_relevance``); it is not rendered. Rows with empty
     ``foreign_text`` are skipped (nothing to show the model).
     """
     grouped: dict[int, list[dict]] = {}
     for row in rows:
-        primary_idx, lang, foreign_text, confidence = row[0], row[1], row[2], row[3]
+        primary_idx, lang, foreign_text, zh_text, confidence = row[0], row[1], row[2], row[3], row[4]
         if not foreign_text:
             continue
         grouped.setdefault(primary_idx, []).append(
             {
                 "lang": lang or "",
                 "chunk_text": foreign_text,
+                "zh_text": zh_text or "",
                 "confidence": float(confidence) if confidence is not None else 1.0,
             }
         )
     return grouped
 
 
-async def _attach_mitra_parallels(db: AsyncSession, results: list[dict]) -> None:
+def _cjk_overlap(query: str, text: str) -> int:
+    """Count of distinct CJK characters shared between ``query`` and ``text``.
+
+    A cheap, dependency-free relevance signal (same spirit as _keyword_rerank's
+    character overlap): Buddhist doctrinal phrases are distinctive character
+    sequences, so a MITRA sentence whose 汉 side shares more of the question's
+    characters is the one the user actually asked about.
+    """
+    q = {c for c in query if "一" <= c <= "鿿"}
+    if not q:
+        return 0
+    z = {c for c in text if "一" <= c <= "鿿"}
+    return len(q & z)
+
+
+def _rank_mitra_by_relevance(items: list[dict], query: str) -> list[dict]:
+    """Re-order a primary's MITRA parallels so the sentence most relevant to the
+    question comes first — instead of the previous highest-confidence-first.
+
+    A chunk anchors many MITRA sentences (whole 500-char window); picking by
+    confidence surfaced an arbitrary one (e.g. 「受想行识亦复如是」 for a 「色即是空」
+    question). Rank by (汉-side overlap with the query) desc, then confidence
+    desc as tie-breaker. Pure — no I/O. ``_format_context_block`` then dedups by
+    language over this order, so the most relevant sentence per language wins.
+    """
+    return sorted(
+        items,
+        key=lambda it: (_cjk_overlap(query, it.get("zh_text", "")), it.get("confidence", 0.0)),
+        reverse=True,
+    )
+
+
+async def _attach_mitra_parallels(db: AsyncSession, results: list[dict], query: str) -> None:
     """Attach MITRA cross-lingual parallels to each result's ``mitra_parallels``.
 
     Mirrors ``_attach_parallel_chunks``' single-bulk-query shape, but reads
     ``mitra_alignments`` (chunk-anchored on the 汉 side by (text_id, juan_num,
-    chunk_index) — indexed by ix_mitra_align_chunk). Top-``MITRA_PARALLEL_K`` per
-    primary by confidence.
+    chunk_index) — indexed by ix_mitra_align_chunk). Fetches the top-
+    ``MITRA_CANDIDATE_K`` per primary by confidence, then re-ranks that pool by
+    relevance to ``query`` (see ``_rank_mitra_by_relevance``) so the sentence the
+    user actually asked about wins, not an arbitrary high-confidence one.
 
     Kept in a SEPARATE ``mitra_parallels`` key (not ``parallel_chunks``): MITRA's
     foreign side is inline source text with no ingested chunk, so it can't carry
@@ -510,6 +547,7 @@ async def _attach_mitra_parallels(db: AsyncSession, results: list[dict]) -> None
                     p.idx AS primary_idx,
                     ma.foreign_lang,
                     ma.foreign_text,
+                    ma.zh_text,
                     ma.confidence,
                     ROW_NUMBER() OVER (
                         PARTITION BY p.idx ORDER BY ma.confidence DESC, ma.id
@@ -520,14 +558,17 @@ async def _attach_mitra_parallels(db: AsyncSession, results: list[dict]) -> None
                    AND ma.juan_num = p.juan
                    AND ma.chunk_index = p.cidx
             )
-            SELECT primary_idx, foreign_lang, foreign_text, confidence
+            SELECT primary_idx, foreign_lang, foreign_text, zh_text, confidence
             FROM ranked
-            WHERE rn <= {MITRA_PARALLEL_K}
+            WHERE rn <= {MITRA_CANDIDATE_K}
             ORDER BY primary_idx, rn
         """)
         rows = (await db.execute(bulk_sql)).fetchall()
         for idx, items in _group_mitra_rows(rows).items():
-            results[idx]["mitra_parallels"] = items
+            # Re-rank the confidence-fetched pool by relevance to the question so
+            # the sentence the user asked about surfaces (format then dedups by
+            # language over this order and shows the top MITRA_PARALLEL_SHOW).
+            results[idx]["mitra_parallels"] = _rank_mitra_by_relevance(items, query)
     except Exception:
         logger.exception("Failed to attach mitra parallels")
 
@@ -940,7 +981,7 @@ async def retrieve_rag_context(
             # LLM — reader panel already shows them; this brings them to the
             # answer side. Separate mitra_parallels key, LLM-context-only.
             if ENABLE_MITRA_RAG_PARALLELS:
-                await _attach_mitra_parallels(db, search_results)
+                await _attach_mitra_parallels(db, search_results, query)
 
         sources = [
             ChatSource(

--- a/backend/tests/test_rag_mitra_parallels.py
+++ b/backend/tests/test_rag_mitra_parallels.py
@@ -1,18 +1,12 @@
 """Tests for feeding MITRA parallels into the chat RAG context.
 
 `mitra_alignments` (~908K Skt/Tib↔汉 sentence pairs, chunk-anchored on the 汉
-side) was previously only surfaced in the reader panel. `_attach_mitra_parallels`
-now also brings it to the answer side as an LLM-context-only `mitra_parallels`
-field, and `_format_context_block` renders it in the [跨藏对读] block for
-languages the small self-built alignment_pairs table didn't cover.
-
-Asserts:
-  1. _group_mitra_rows groups by primary + skips empty foreign_text (pure).
-  2. _attach_mitra_parallels: one bulk query, populates mitra_parallels,
-     empty input = no DB call, DB error is swallowed.
-  3. _format_context_block: renders MITRA parallels, dedups languages already
-     covered by alignment_pairs, caps at MITRA_PARALLEL_SHOW, and is unchanged
-     when there are no MITRA parallels.
+side) is surfaced to the answer side as an LLM-context-only `mitra_parallels`
+field. A chunk anchors many MITRA sentences, so `_attach_mitra_parallels` fetches
+a confidence pool then re-ranks it by relevance to the question
+(`_rank_mitra_by_relevance`) — so 「色即是空」's Sanskrit wins over an arbitrary
+「受想行识」 sentence in the same chunk. `_format_context_block` renders the top
+results in [跨藏对读], deduped by language.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -22,8 +16,10 @@ import pytest
 from app.services.rag_retrieval import (
     MITRA_PARALLEL_SHOW,
     _attach_mitra_parallels,
+    _cjk_overlap,
     _format_context_block,
     _group_mitra_rows,
+    _rank_mitra_by_relevance,
 )
 
 
@@ -38,18 +34,47 @@ def _make_db_with_rows(rows):
 # ── _group_mitra_rows (pure) ──────────────────────────────────────────
 
 def test_group_mitra_rows_groups_and_skips_empty():
-    # row shape: (primary_idx, foreign_lang, foreign_text, confidence)
+    # row shape: (primary_idx, foreign_lang, foreign_text, zh_text, confidence)
     rows = [
-        (0, "sa", "sanskrit A", 0.99),
-        (0, "bo", "tibetan A", 0.90),
-        (0, "sa", "", 0.80),          # empty foreign_text → skipped
-        (2, "bo", "tibetan B", 0.70),
+        (0, "sa", "sanskrit A", "汉A", 0.99),
+        (0, "bo", "tibetan A", "汉B", 0.90),
+        (0, "sa", "", "汉C", 0.80),        # empty foreign_text → skipped
+        (2, "bo", "tibetan B", "汉D", 0.70),
     ]
     grouped = _group_mitra_rows(rows)
     assert set(grouped.keys()) == {0, 2}
     assert [p["chunk_text"] for p in grouped[0]] == ["sanskrit A", "tibetan A"]
-    assert grouped[0][0] == {"lang": "sa", "chunk_text": "sanskrit A", "confidence": 0.99}
+    assert grouped[0][0] == {"lang": "sa", "chunk_text": "sanskrit A", "zh_text": "汉A", "confidence": 0.99}
     assert grouped[2][0]["lang"] == "bo"
+
+
+# ── relevance ranking (pure) ──────────────────────────────────────────
+
+def test_cjk_overlap_counts_shared_characters():
+    assert _cjk_overlap("色即是空的梵文", "色即是空空即是色") == 4  # 色即是空
+    assert _cjk_overlap("色即是空的梵文", "受想行识亦复如是") == 1  # 是
+    assert _cjk_overlap("", "色即是空") == 0
+    assert _cjk_overlap("rūpaṃ", "śūnyatā") == 0  # no CJK either side
+
+
+def test_rank_prefers_query_relevant_sentence_over_higher_confidence():
+    """The whole point: a 「受想行识」 sentence with HIGHER confidence must lose to
+    the 「色即是空」 sentence the user actually asked about."""
+    items = [
+        {"lang": "sa", "chunk_text": "Evam eva vedanā", "zh_text": "受想行识亦复如是", "confidence": 0.99},
+        {"lang": "sa", "chunk_text": "rūpaṃ śūnyatā", "zh_text": "色即是空空即是色", "confidence": 0.80},
+    ]
+    ranked = _rank_mitra_by_relevance(items, "《心经》「色即是空」的梵文是什么")
+    assert ranked[0]["chunk_text"] == "rūpaṃ śūnyatā", "the query-relevant sentence must rank first"
+
+
+def test_rank_falls_back_to_confidence_when_no_overlap():
+    items = [
+        {"lang": "sa", "chunk_text": "low", "zh_text": "毫不相关", "confidence": 0.40},
+        {"lang": "bo", "chunk_text": "high", "zh_text": "另一无关", "confidence": 0.90},
+    ]
+    ranked = _rank_mitra_by_relevance(items, "色即是空")
+    assert ranked[0]["chunk_text"] == "high"  # overlap tie (0) → confidence desc
 
 
 # ── _attach_mitra_parallels (bulk) ────────────────────────────────────
@@ -58,24 +83,25 @@ def test_group_mitra_rows_groups_and_skips_empty():
 async def test_empty_results_no_db_call():
     db = _make_db_with_rows([])
     results: list[dict] = []
-    await _attach_mitra_parallels(db, results)
+    await _attach_mitra_parallels(db, results, "任意问题")
     assert db.execute.await_count == 0
     assert results == []
 
 
 @pytest.mark.asyncio
-async def test_single_bulk_query_populates_mitra_parallels():
+async def test_single_bulk_query_ranks_relevant_sentence_first():
     primaries = [{"text_id": 100 + i, "juan_num": 1, "chunk_index": i} for i in range(3)]
+    # primary 0 has two Sanskrit sentences; the 受想行识 one has higher confidence
+    # but the query asks about 色即是空 — relevance must reorder them.
     rows = [
-        (0, "sa", "sanskrit", 0.98),
-        (0, "bo", "tibetan", 0.91),
-        (2, "sa", "sanskrit c", 0.60),
+        (0, "sa", "Evam eva vedanā", "受想行识亦复如是", 0.99),
+        (0, "sa", "rūpaṃ śūnyatā", "色即是空空即是色", 0.80),
+        (2, "sa", "prajñā", "般若", 0.60),
     ]
     db = _make_db_with_rows(rows)
-    await _attach_mitra_parallels(db, primaries)
+    await _attach_mitra_parallels(db, primaries, "「色即是空」的梵文原文")
     assert db.execute.await_count == 1, "must be a single bulk query"
-    assert len(primaries[0]["mitra_parallels"]) == 2
-    assert primaries[0]["mitra_parallels"][0]["chunk_text"] == "sanskrit"
+    assert primaries[0]["mitra_parallels"][0]["chunk_text"] == "rūpaṃ śūnyatā"
     assert primaries[1]["mitra_parallels"] == []
     assert primaries[2]["mitra_parallels"][0]["lang"] == "sa"
 
@@ -85,7 +111,7 @@ async def test_db_error_is_swallowed():
     db = MagicMock()
     db.execute = AsyncMock(side_effect=RuntimeError("boom"))
     primaries = [{"text_id": 1, "juan_num": 1, "chunk_index": 0}]
-    await _attach_mitra_parallels(db, primaries)  # must not raise
+    await _attach_mitra_parallels(db, primaries, "问题")  # must not raise
     assert primaries[0]["mitra_parallels"] == []
 
 
@@ -109,9 +135,6 @@ def test_mitra_only_renders_in_block():
 
 
 def test_mitra_dedups_language_already_covered_by_alignment_pairs():
-    """If alignment_pairs already gave a Tibetan (bo) parallel, the MITRA
-    Tibetan is skipped, but MITRA Sanskrit (sa) — which alignment_pairs lacks —
-    is still added."""
     r = _result(
         parallel_chunks=[{"lang": "bo", "chunk_text": "藏文对读", "juan_num": 2, "title": "甘珠尔"}],
         mitra_parallels=[


### PR DESCRIPTION
## 问题(实测截图暴露)

一个 500 字 chunk 挂着 MITRA 的**很多句**平行。#949 是**按对齐置信度**取前几条,结果挑出的是**任意一句**——问「色即是空」的梵文,拿到的却是**「受想行识亦复如是」**的梵文平行(线上实测确认),因为那条置信度碰巧更高。检索平行**没对上用户问的那句**。

## 改动:按"与问题的相关度"择优

`_attach_mitra_parallels` 现在先取 `MITRA_CANDIDATE_K=8` 的置信度候选池(并带上每句的**汉文侧 `zh_text`**),再用 `_rank_mitra_by_relevance` **按"汉文侧 ↔ query 的 CJK 字符重叠"降序**、置信度做 tie-break 重排。`_format_context_block` 在此顺序上按语言去重,于是**每种语言里最相关的那句**胜出。

**strictly better-or-equal**:字符零重叠时**回退到原来的置信度顺序**(即 #949 的行为),只会改善"挑哪一句",不会更差。

用字符重叠(而非 embedding)作信号:零成本、同步、佛教义理短句是**高辨识度的字符序列**,与库内既有的 `_keyword_rerank` 一致。仍只喂 LLM、仍去重封顶、仍受 flag 控、DB 错仍吞掉。

## 前后差别

| 问「色即是空的梵文」 | 改前(#949) | 改后 |
|---|---|---|
| 挂上的平行 | 「受想行识」那句(置信度高但不对题) | **「色即是空」那句的梵文** |

## 验证

- `_cjk_overlap` 计数正确;`_rank` 在"低相关但高置信 vs 高相关低置信"时**让高相关句排第一**、无重叠时回退置信度;`_attach` 经 bulk 路径把相关句排首;既有 group/dedup/cap/unchanged 用例按新 `(…, zh_text, confidence)` row + query 参数更新。**11 passed**。
- 回归:parallel-chunks-bulk / rerank-merge / precise-retrieval **79 passed**。

## 范围
后端 1 文件(+测试),base master(9bb93a3,#949 之上),与在途改动零重叠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
