### PR TITLE
fix(quote-verify): 引文抽取器把中文强调号「」当引用,吞掉整段散文

### DIFF
--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -115,17 +115,60 @@ MAX_QUOTE_CITATION_GAP_CHARS = 80
 # in 「」/“”/'' and may span several lines.
 _QUOTE_OPEN = "「『“‘\""
 _QUOTE_CLOSE = "」』”’\""
+# Which close mark closes which open mark. An unpaired match (「…” ) is not a
+# quotation — it is two unrelated marks the scanner happened to straddle.
+_QUOTE_PAIRS = {"「": "」", "『": "』", "“": "”", "‘": "’", '"': '"'}
+
+# A quote body runs to the **first** mark that closes its own opener, and never
+# across a line break. Both bounds are load-bearing, and both were missing:
+#
+# - Unbounded by its closing mark, the lazy body walked *past* it to whichever
+#   later mark happened to sit within the gap window of a citation. CJK prose
+#   uses 「」 for emphasis constantly (「念」「寻」), so an answer that emphasised
+#   two terms and cited a source three lines down had the entire span between
+#   them captured as one "quote" and then downgraded as fabricated.
+# - Unbounded by the line, that walk crossed paragraphs, swallowing bullet
+#   lists and markdown bold. Blockquotes are a separate multi-line construct
+#   with their own scanner below; an inline quote is single-line.
+#
+# Prod diagnostics 2026-07-09 (chat_answer_diagnostics): 69% of the quotes
+# bucketed ``absent`` contained a newline and 45% contained ``**``, mean length
+# 145 chars — against 36 chars and zero newlines for the ``near_miss`` (real)
+# ones. The verifier was mostly measuring itself.
+#
+# Only the *paired* mark terminates the body. Excluding every close mark from
+# every body would trade over-capture for under-verification: U+2019 is both a
+# closing single quote and the English apostrophe, so “the Buddha’s words” would
+# stop being checked at all.
+_QUOTE_PAIRS = {"「": "」", "『": "』", "“": "”", "‘": "’", '"': '"'}
+
 # Groups capture every part so a failing quote can be *downgraded* — rebuilt as
 # ``quote + gap + cite`` with the open/close marks dropped, turning a false
-# verbatim quote into honest prose that still cites the source.
+# verbatim quote into honest prose that still cites the source. One alternation
+# branch per mark family, since stdlib ``re`` forbids reusing a group name and
+# cannot backreference across two different characters.
 _QUOTE_CITATION_RE = re.compile(
-    r"[" + re.escape(_QUOTE_OPEN) + r"]"
-    r"(?P<quote>.{" + str(MIN_QUOTE_CHARS) + r",400}?)"
-    r"[" + re.escape(_QUOTE_CLOSE) + r"]"
-    r"(?P<gap>.{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}?)"
+    r"(?:"
+    + r"|".join(
+        r"(?P<open" + str(i) + r">" + re.escape(o) + r")"
+        r"(?P<quote" + str(i) + r">[^\n" + re.escape(c) + r"]"
+        r"{" + str(MIN_QUOTE_CHARS) + r",400})"
+        + re.escape(c)
+        for i, (o, c) in enumerate(_QUOTE_PAIRS.items())
+    )
+    + r")"
+    r"(?P<gap>[^\n]{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}?)"
     r"(?P<cite>【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】)",
-    re.DOTALL,
 )
+
+
+def _matched_quote(m: re.Match[str]) -> str:
+    """The body of whichever mark-family branch matched."""
+    for i in range(len(_QUOTE_PAIRS)):
+        q = m.group("quote" + str(i))
+        if q is not None:
+            return q
+    raise AssertionError("no quote branch matched")  # pragma: no cover
 
 # Match a contiguous Markdown blockquote block followed (within the
 # usual gap window of subsequent non-blockquote text) by a
@@ -349,7 +392,7 @@ def verify_quoted_content(
     mutations: list[QuoteMutation] = []
 
     def _downgrade_inline(m: re.Match[str]) -> str:
-        quote = m.group("quote").strip()
+        quote = _matched_quote(m).strip()
         if len(quote) < MIN_QUOTE_CHARS:
             return m.group(0)
         title = m.group("title")
@@ -363,7 +406,7 @@ def verify_quoted_content(
             similarity=similarity, bucket=bucket,
         ))
         # Drop the open/close marks: keep the text (now prose) + gap + citation.
-        return m.group("quote") + m.group("gap") + m.group("cite")
+        return _matched_quote(m) + m.group("gap") + m.group("cite")
 
     corrected = _QUOTE_CITATION_RE.sub(_downgrade_inline, answer)
     corrected = _downgrade_blockquotes(corrected, sources, mutations)

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -421,3 +421,106 @@ def test_blockquote_and_inline_failures_both_downgraded():
     assert len(muts) == 2
     reasons = {m.reason for m in muts}
     assert reasons == {"quote_not_in_source", "blockquote_not_in_source"}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Over-capture: 「」 as CJK emphasis, not quotation
+#
+# Prod evidence (chat_answer_diagnostics, 2026-07-09): of 75 quotes the
+# verifier bucketed ``absent``, 69% contained a newline, 45% contained
+# markdown bold, mean length 145 chars — while the 3 ``near_miss`` (real)
+# quotes averaged 36 chars with no newlines. The inline regex was walking
+# past nested marks and across paragraphs to reach any citation within the
+# gap window, so ordinary emphasis got downgraded as a fabricated quote.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_emphasis_marks_are_not_extracted_as_a_quote():
+    """CJK 「」 used for emphasis must not be captured as a quotation.
+
+    The passage below quotes nothing verbatim; every 「…」 is emphasis and
+    each is shorter than MIN_QUOTE_CHARS. Nothing should be downgraded, and
+    the served answer must keep its emphasis marks intact."""
+    src = _src(3, "瑜伽師地論", 3, "必与舍受相应，能持寻伺。")
+    answer = (
+        "「念」的功能正是维持、把持这种「寻」，如果伴随苦乐，寻就会波动。\n\n"
+        "逐句消文：\n"
+        "- **「第二依地门」**：这是论中分析此种心所的第二门。\n"
+        "- 论中说必与舍受相应【《瑜伽師地論》第3卷】。\n"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert muts == []
+    assert out == answer
+    assert "「念」" in out and "「寻」" in out
+
+
+def test_quote_capture_stops_at_the_first_closing_mark():
+    """A quote must not swallow a later 「…」 pair to reach a citation."""
+    src = _src(3, "瑜伽師地論", 3, "无关原文")
+    answer = "「甲」中间夹了很多很多很多的散文字句「乙」【《瑜伽師地論》第3卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert muts == []
+    assert out == answer
+
+
+def test_quote_does_not_span_a_newline():
+    """An inline quote is a single-line construct; blockquotes have their own
+    scanner. A 「 that never closes on its line must not capture across lines."""
+    src = _src(7, "心經", 1, "无关原文")
+    answer = "开头出现一个孤立的「引号但这一行没有闭合\n下一行才闭合了引号」【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert muts == []
+    assert out == answer
+
+
+def test_mismatched_open_and_close_marks_do_not_pair():
+    """「 must be closed by 」 — not by ” or a straight quote."""
+    src = _src(7, "心經", 1, "无关原文")
+    answer = '云：「这是一段足够长的假引文内容啊”【《心經》第1卷】'
+    out, muts = verify_quoted_content(answer, [src])
+    assert muts == []
+    assert out == answer
+
+
+def test_real_paraphrase_as_quote_is_still_downgraded():
+    """Regression guard: the actual feature must survive the precision fix."""
+    src = _src(7, "心經", 1, "五陰覆蓋，使昏迷故。")
+    answer = "论云：「五阴覆盖般若灵明，使众生心识昏蒙」【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert len(muts) == 1
+    assert "「" not in out
+    assert "五阴覆盖般若灵明，使众生心识昏蒙" in out
+
+
+def test_real_verbatim_quote_still_verifies():
+    """Regression guard: a genuine verbatim quote is left alone."""
+    src = _src(7, "心經", 1, "舍利子，色不异空，空不异色，色即是空。")
+    answer = "经云：「色不异空，空不异色，色即是空」【《心經》第1卷】"
+    out, muts = verify_quoted_content(answer, [src])
+    assert muts == []
+    assert out == answer
+
+
+def test_quote_does_not_bind_to_a_citation_across_paragraphs():
+    """The gap window is 80 chars of *the same line*, per the module docstring:
+    a quote separated from the citation by commentary isn't attributable to it."""
+    src = _src(7, "心經", 1, "无关原文")
+    answer = (
+        "论中说：「一段足够长的十二字以上引文」，此处先不展开。\n\n"
+        "下面这段解说与上文无关【《心經》第1卷】"
+    )
+    out, muts = verify_quoted_content(answer, [src])
+    assert muts == []
+    assert out == answer
+
+
+def test_english_quote_with_typographic_apostrophe_is_still_checked():
+    """U+2019 doubles as a closing single quote *and* an English apostrophe.
+    Excluding it from every quote body would silently stop verifying English
+    quotes (84000 / SuttaCentral translations), trading over-capture for
+    under-verification. Only the mark that *pairs* with the opener may end it."""
+    src = _src(9, "Dhammapada", 1, "Unrelated canonical text.")
+    answer = '“the Buddha’s own words, plainly stated”【《Dhammapada》第1卷】'
+    _, muts = verify_quoted_content(answer, [src])
+    assert len(muts) == 1
+    assert muts[0].quote == "the Buddha’s own words, plainly stated"


### PR DESCRIPTION
## 问题

生产 `chat_answer_diagnostics` 实测(2026-07-09):被判 `absent` 的引文里 **69% 含换行、45% 含 markdown 粗体,平均 145 字**;而 `near_miss`(真引文)平均 **36 字、零换行**。

**引文核验器主要在测量它自己。**

`_QUOTE_CITATION_RE` 有两处无界:

1. **引文体不受自己闭合符约束。** 惰性匹配会越过本该闭合的 `」`,一路找到 gap 窗口内跟着引用标记的下一个闭合符。中文用 「」 做强调极其常见(`「念」`、`「寻」`),于是「强调两个词 + 三行后引一部经」的答案,整段被当成一条引文,再被当作伪造引文降级。
2. **`re.DOTALL` 让这次游走跨越段落**,吞进项目符号与粗体。blockquote 是独立的多行构造(有自己的扫描器);inline 引文本就是单行构造。

复现:

```python
answer = "「念」的功能正是维持、把持这种「寻」，如果伴随苦乐，寻就会波动。\n\n逐句消文：\n- 论中说必与舍受相应【《瑜伽師地論》第3卷】。"
# 抓到的 "引文":'念」的功能正是维持、把持这种「寻'   ← 纯散文,没有一个字是引用
```

后果有三层,一层比一层重:

- 用户看到的答案里,**普通强调号被无故抹掉**(`quote_relaxed` 按设计会剥离开闭标记)。
- `verified_rate` 测的是抽取器的 bug,不是模型的诚实度。
- **#949 / #950 / #951 的 RAG 与提示词工作,一直按这个坏掉的量尺在导航。**

## 修复

每个引号家族一个分支,引文体只排除**与自己配对**的闭合符,并禁止跨换行。

不排除全部闭合符是刻意的:`U+2019` 既是右单引号也是英文撇号,一刀切会让 `“the Buddha’s words”` 彻底不再被核验——那是拿**欠核验**去换**过度捕获**。新增测试 `test_english_quote_with_typographic_apostrophe_is_still_checked` 锁住这一点(我第一版修复正是栽在这里,被这条测试抓住)。

## 在 537 条真实生产答案上回放

| | 修复前 | 修复后 |
|---|---|---|
| 引号被无故抹掉的答案 | 260 (48.4%) | **135 (25.1%)** |
| inline 失败引文 | 633 | **210** |
| ↳ 其中含换行 | 469 | **0** |
| ↳ 中位长度 | 157 字 | **38 字** |
| 逐字核验通过率¹ | **1.9%** | **36.8%** |

¹ 分母 = 真正含可抽取引文的答案(修复前 265,修复后 212)。

**真实的逐字引用保真度约为 37%,而不是旧仪表显示的 ~2%。**

## 测试

TDD:6 条新测试先失败(理由各自正确),再实现。`ruff check` 干净。

```
tests/test_quote_verifier.py tests/test_quote_verifier_buckets.py tests/test_chat_trust.py
48 passed
```

回归保护:`test_real_paraphrase_as_quote_is_still_downgraded` 与 `test_real_verbatim_quote_still_verifies` 确保精度修复没有把功能本身改坏。

## 附带发现(本 PR 未处理)

`chat_trust.build_trust_status` 的 `verified` 只要求「有引用标记 且 无 quote_mutation」——**一句引文都没有的答案也会被标 `verified`**。回放数据里修复前 40 个 `verified` 中有 35 个属于此类。上表 36.8% 用的是「确实含可抽取引文」的分母,绕开了这个空洞通过,但它本身值得单独修。
