### PR TITLE
fix(eval): 「没有证据」正被当成「证据核验通过」——修好导航用的那把尺

### DIFF
--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -424,6 +424,36 @@ def verify_quoted_content(
     return corrected, mutations
 
 
+def count_checked_quotes(answer: str, sources: list[ChatSource]) -> int:
+    """How many quoted passages :func:`verify_quoted_content` actually examines.
+
+    Zero mutations means one of two very different things — every quote checked
+    out, or the answer quoted nothing at all — and callers that score an answer
+    cannot tell them apart from the mutation list alone. ``verified`` therefore
+    used to be awarded to an answer that cited a source and quoted none of it:
+    "no evidence" scored as "evidence checked out", and the metric rewarded a
+    model for quoting the canon *less*.
+
+    Counted here, not returned from ``verify_quoted_content``, so the existing
+    two-tuple contract and its call sites stay untouched. The candidate
+    predicate (paired marks, ``MIN_QUOTE_CHARS``) is the one both scanners
+    apply before they verify anything, and ``test_count_checked_quotes_matches``
+    pins the two together."""
+    if not answer or "【《" not in answer:
+        return 0
+    inline = sum(
+        1
+        for m in _QUOTE_CITATION_RE.finditer(answer)
+        if len(_matched_quote(m).strip()) >= MIN_QUOTE_CHARS
+    )
+    blocks = sum(
+        1
+        for m in _BLOCKQUOTE_CITATION_RE.finditer(answer)
+        if len(_strip_blockquote_markers(m.group("block"))) >= MIN_QUOTE_CHARS
+    )
+    return inline + blocks
+
+
 def _strip_blockquote_markers(block: str) -> str:
     """Strip the per-line ``> `` Markdown prefix from a blockquote so we
     can hand the joined body to the substring test.

--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -115,9 +115,6 @@ MAX_QUOTE_CITATION_GAP_CHARS = 80
 # in 「」/“”/'' and may span several lines.
 _QUOTE_OPEN = "「『“‘\""
 _QUOTE_CLOSE = "」』”’\""
-# Which close mark closes which open mark. An unpaired match (「…” ) is not a
-# quotation — it is two unrelated marks the scanner happened to straddle.
-_QUOTE_PAIRS = {"「": "」", "『": "』", "“": "”", "‘": "’", '"': '"'}
 
 # A quote body runs to the **first** mark that closes its own opener, and never
 # across a line break. Both bounds are load-bearing, and both were missing:

--- a/backend/eval/faithfulness.py
+++ b/backend/eval/faithfulness.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from app.schemas.chat import ChatSource
 from app.services.chat_trust import build_trust_status
 from app.services.citation_guard import enforce_citation_whitelist
-from app.services.quote_verifier import verify_quoted_content
+from app.services.quote_verifier import count_checked_quotes, verify_quoted_content
 
 # The states build_trust_status can emit, in descending trust order. Kept
 # explicit (rather than imported from the Literal) so the report renders a
@@ -53,7 +53,12 @@ _TRUSTWORTHY_STATES = frozenset({"verified", "citation_corrected", "quote_relaxe
 
 # Grounding rates a regression gate watches. Mirrors retrieval_metrics'
 # _METRIC_PREFIXES convention (bookkeeping counts are excluded).
-_GATED_RATES = ("citation_grounding_rate", "verified_rate_of_cited", "served_trustworthy_rate")
+_GATED_RATES = (
+    "citation_grounding_rate",
+    "verified_rate_of_cited",
+    "served_trustworthy_rate",
+    "verbatim_quote_rate",
+)
 
 
 def compute_faithfulness(answer: str, sources: list[ChatSource]) -> dict:
@@ -68,6 +73,7 @@ def compute_faithfulness(answer: str, sources: list[ChatSource]) -> dict:
     # The verifier runs *after* the guard by design (see quote_verifier's
     # module docstring) so quotes attached to already-stripped citations
     # aren't double-flagged.
+    quote_count = count_checked_quotes(corrected, sources)
     _, quote_mutations = verify_quoted_content(corrected, sources)
     trust = build_trust_status(
         answer,
@@ -83,10 +89,18 @@ def compute_faithfulness(answer: str, sources: list[ChatSource]) -> dict:
         "quote_mutations": trust.quote_mutation_count,
         "citations_grounded": citations_grounded,
         "has_citations": 1 if trust.citation_count else 0,
-        # "verified" is the only state with ≥1 citation and zero citation/quote
-        # mutations — the strict "every citation and quote checks out first try"
-        # answer (raw LLM quality).
-        "fully_grounded": 1 if trust.state == "verified" else 0,
+        # How many quoted passages the verifier examined. Zero means the answer
+        # quoted nothing, which is NOT the same as "its quotes checked out".
+        "quote_count": quote_count,
+        "has_checked_quotes": 1 if quote_count else 0,
+        # ≥1 citation, ≥1 quote, and zero citation/quote mutations — the strict
+        # "every citation and quote checks out first try" answer (raw LLM
+        # quality). The ``quote_count`` term is what stops an answer that cites
+        # a source and quotes none of it from passing vacuously: ``verified``
+        # only asserts "no mutation", and no quotes produce no mutations.
+        "fully_grounded": 1 if (trust.state == "verified" and quote_count) else 0,
+        # Of the answers that did quote, did every quote hold up verbatim?
+        "quotes_all_verbatim": 1 if (quote_count and not quote_mutations) else 0,
         # Served-honest: the answer cites and, after the guards, misrepresents
         # nothing (verified / citation_corrected / quote_relaxed).
         "served_trustworthy": 1 if (trust.citation_count and trust.state in _TRUSTWORTHY_STATES) else 0,
@@ -119,6 +133,8 @@ def aggregate_faithfulness(rows: list[dict]) -> dict:
     answers_with_citations = sum(r["has_citations"] for r in rows)
     fully_grounded = sum(r["fully_grounded"] for r in rows)
     served_trustworthy = sum(r.get("served_trustworthy", 0) for r in rows)
+    answers_with_quotes = sum(r.get("has_checked_quotes", 0) for r in rows)
+    quotes_all_verbatim = sum(r.get("quotes_all_verbatim", 0) for r in rows)
 
     distribution = dict.fromkeys(TRUST_STATES, 0)
     for r in rows:
@@ -131,11 +147,20 @@ def aggregate_faithfulness(rows: list[dict]) -> dict:
         "citation_grounding_rate": (
             grounded_citations / total_citations if total_citations else None
         ),
-        # Among answers that cite at all, the fraction fully verified (no
-        # citation or quote mutation) — the headline "每一句都能点回原典" number.
+        # Among answers that cite at all, the fraction that also quoted and had
+        # every citation and quote hold up. An answer that cites without quoting
+        # scores 0 here, not 1 — it verified nothing.
         "verified_rate_of_cited": (
             fully_grounded / answers_with_citations if answers_with_citations else None
         ),
+        # The quote-fidelity number, denominated in answers that actually quoted:
+        # "when the model puts canon in quote marks, how often is it verbatim?"
+        # Kept separate from verified_rate_of_cited so a run cannot improve by
+        # quoting less — the two move independently and both are reported.
+        "verbatim_quote_rate": (
+            quotes_all_verbatim / answers_with_quotes if answers_with_quotes else None
+        ),
+        "answers_with_quotes": answers_with_quotes,
         # The brand number: among citing answers, the fraction whose SERVED text
         # misrepresents nothing (post-guard). The deterministic quote-downgrade
         # moves this toward the citation-grounding ceiling.

--- a/backend/eval/run_eval.py
+++ b/backend/eval/run_eval.py
@@ -311,6 +311,40 @@ def generate_report(results: list[dict], tag: str = "") -> str:
     return "\n".join(lines)
 
 
+def compare_baseline(
+    baseline_path: str,
+    current_agg: dict,
+    current_faith: dict,
+    tolerance: float = 0.02,
+) -> tuple[list[str], str | None]:
+    """Compare this run against a prior raw eval JSON.
+
+    Returns ``(regressions, error)``. ``error`` is a message when the baseline
+    could not be read or parsed — a state the caller must not confuse with "no
+    regressions found", which is why the two are separate return values rather
+    than an empty list. Extracted from ``main`` so the distinction is testable
+    without a corpus DB.
+    """
+    try:
+        baseline_results = json.loads(Path(baseline_path).read_text(encoding="utf-8"))
+        baseline_agg = aggregate(
+            [r["retrieval_metrics"] for r in baseline_results if r.get("retrieval_metrics")]
+        )
+        regressions = detect_regressions(current_agg, baseline_agg, tolerance)
+        # Faithfulness regressions only when BOTH runs generated answers —
+        # a --no-llm baseline or current run has no rates to compare.
+        baseline_faith = aggregate_faithfulness(
+            [r.get("faithfulness") for r in baseline_results]
+        )
+        if current_faith and baseline_faith:
+            regressions += detect_faithfulness_regressions(
+                current_faith, baseline_faith, tolerance
+            )
+        return regressions, None
+    except (OSError, ValueError, KeyError) as exc:
+        return [], str(exc)
+
+
 async def main():
     parser = argparse.ArgumentParser(description="Run AI Chat evaluation")
     parser.add_argument("--category", type=str, help="Only run questions from this category")
@@ -400,31 +434,24 @@ async def main():
     gate_failed = False
 
     if args.baseline:
-        try:
-            baseline_results = json.loads(Path(args.baseline).read_text(encoding="utf-8"))
-            baseline_agg = aggregate(
-                [r["retrieval_metrics"] for r in baseline_results if r.get("retrieval_metrics")]
-            )
-            regressions = detect_regressions(current_agg, baseline_agg, args.regression_tolerance)
-            # Faithfulness regressions only when BOTH runs generated answers —
-            # a --no-llm baseline or current run has no rates to compare.
-            baseline_faith = aggregate_faithfulness(
-                [r.get("faithfulness") for r in baseline_results]
-            )
-            if current_faith and baseline_faith:
-                regressions += detect_faithfulness_regressions(
-                    current_faith, baseline_faith, args.regression_tolerance
-                )
-            print(f"\n{'='*60}\n回归检查（对照 {args.baseline}）：")
-            if regressions:
-                for reg in regressions:
-                    print(f"  ⚠️  {reg}")
-                if args.fail_on_regression:
-                    gate_failed = True
-            else:
-                print("  ✓ 检索/忠实度指标无回归")
-        except (OSError, ValueError, KeyError) as exc:
-            print(f"\n[baseline 对照失败] {exc}")
+        regressions, error = compare_baseline(
+            args.baseline, current_agg, current_faith, args.regression_tolerance
+        )
+        print(f"\n{'='*60}\n回归检查（对照 {args.baseline}）：")
+        if error is not None:
+            # A baseline we could not read is not a baseline we passed. Falling
+            # through here left gate_failed False, so --fail-on-regression exited
+            # 0 on a corrupt or missing file — the gate silently stopped gating.
+            print(f"  ⚠️  [baseline 对照失败] {error}")
+            if args.fail_on_regression:
+                gate_failed = True
+        elif regressions:
+            for reg in regressions:
+                print(f"  ⚠️  {reg}")
+            if args.fail_on_regression:
+                gate_failed = True
+        else:
+            print("  ✓ 检索/忠实度指标无回归")
 
     if args.min_recall5 is not None:
         recall5 = current_agg.get("recall@5")

--- a/backend/tests/test_eval_regression_wrapper.py
+++ b/backend/tests/test_eval_regression_wrapper.py
@@ -87,3 +87,40 @@ def test_gate_fail_with_partial_creds_skips_alert_but_still_fails(tmp_path):
     proc, calls = _run(tmp_path, gate_exit=1, chat_id=None)
     assert proc.returncode == 1, "partial creds must not mask the regression"
     assert calls == "", "incomplete creds → no curl attempt"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# run_eval's own baseline gate had the very failure this wrapper guards
+# against: an unreadable or corrupt --baseline printed a note and fell
+# through with gate_failed still False, so --fail-on-regression exited 0.
+# "Could not compare" is not "no regression".
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_missing_baseline_file_reports_an_error_not_a_clean_comparison(tmp_path):
+    from eval.run_eval import compare_baseline
+
+    regressions, error = compare_baseline(
+        str(tmp_path / "does-not-exist.json"), current_agg={}, current_faith={}
+    )
+    assert error is not None
+    assert regressions == []
+
+
+def test_corrupt_baseline_json_reports_an_error(tmp_path):
+    from eval.run_eval import compare_baseline
+
+    bad = tmp_path / "baseline.json"
+    bad.write_text("{ this is not json", encoding="utf-8")
+    regressions, error = compare_baseline(str(bad), current_agg={}, current_faith={})
+    assert error is not None
+
+
+def test_readable_baseline_compares_cleanly(tmp_path):
+    from eval.run_eval import compare_baseline
+
+    good = tmp_path / "baseline.json"
+    good.write_text("[]", encoding="utf-8")
+    regressions, error = compare_baseline(str(good), current_agg={}, current_faith={})
+    assert error is None
+    assert regressions == []

--- a/backend/tests/test_faithfulness.py
+++ b/backend/tests/test_faithfulness.py
@@ -17,24 +17,54 @@ from eval.faithfulness import (
 from app.schemas.chat import ChatSource
 
 
-def _src(title: str = "心经", juan: int = 1) -> ChatSource:
+# A chunk long enough to hold a quote at or above MIN_QUOTE_CHARS (12), so a
+# test can exercise a quote the verifier actually checks rather than one it
+# skips as too short to distinguish from normalisation noise.
+_LONG_CHUNK = "舍利子，色不异空，空不异色，色即是空，空即是色。"
+
+
+def _src(title: str = "心经", juan: int = 1, chunk_text: str = "色不异空，空不异色。") -> ChatSource:
     return ChatSource(
         text_id=7,
         juan_num=juan,
         chunk_index=0,
-        chunk_text="色不异空，空不异色。",
+        chunk_text=chunk_text,
         score=0.9,
         title_zh=title,
     )
 
 
-def test_clean_answer_is_fully_grounded():
-    row = compute_faithfulness("见【《心经》第1卷】。", [_src()])
+def test_clean_answer_with_a_checked_quote_is_fully_grounded():
+    """The positive case: a citation *and* a verbatim quote the verifier checked.
+
+    This test used to pass the answer "见【《心经》第1卷】。" — a citation with no
+    quote at all — and assert ``fully_grounded == 1``. It was asserting the
+    vacuous pass: zero quote mutations because zero quotes were examined. The
+    quote below is 14 chars, above MIN_QUOTE_CHARS, so it is actually verified.
+    """
+    row = compute_faithfulness(
+        "经云：「色不异空，空不异色，色即是空」【《心经》第1卷】",
+        [_src(chunk_text=_LONG_CHUNK)],
+    )
     assert row["trust_state"] == "verified"
     assert row["citation_count"] == 1
     assert row["citation_mutations"] == 0
+    assert row["quote_count"] == 1
     assert row["fully_grounded"] == 1
     assert row["citations_grounded"] == 1
+
+
+def test_citation_without_a_quote_keeps_the_badge_but_not_the_metric():
+    """The user-facing trust badge and the eval gauge deliberately diverge here.
+
+    ``trust_state`` stays ``verified`` (nothing the answer served is false — it
+    cited a real source and misquoted nothing), but ``fully_grounded`` is 0
+    because no quote was ever checked. Conflating the two is what let the gauge
+    reward a model for quoting the canon less."""
+    row = compute_faithfulness("见【《心经》第1卷】。", [_src()])
+    assert row["trust_state"] == "verified"
+    assert row["quote_count"] == 0
+    assert row["fully_grounded"] == 0
 
 
 def test_hallucinated_title_counts_as_corrected_not_grounded():
@@ -127,3 +157,59 @@ def test_detect_regressions_skips_none_rates():
     current = {"citation_grounding_rate": None}
     baseline = {"citation_grounding_rate": 0.95}
     assert detect_faithfulness_regressions(current, baseline) == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Vacuous pass: "no evidence" was being scored as "evidence checked out"
+#
+# `verified` only means "≥1 citation and zero mutations". An answer that cites
+# a source but quotes nothing has zero quote mutations vacuously, so it scored
+# as fully grounded. Replaying 537 prod answers, 124 of 202 `verified` answers
+# contained no checkable quote at all — and the metric rewards a model for
+# quoting the canon *less*, which is the opposite of what fojin sells.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_answer_that_cites_but_never_quotes_is_not_fully_grounded():
+    """Citing a source without quoting it is honest, but nothing was verified."""
+    row = compute_faithfulness("本经讲的是空性的道理【《心经》第1卷】。", [_src()])
+    assert row["citation_count"] == 1
+    assert row["quote_count"] == 0
+    assert row["fully_grounded"] == 0
+
+
+def test_quote_below_min_length_is_not_checked_and_not_fully_grounded():
+    """MIN_QUOTE_CHARS exists because short fragments are normalisation noise.
+    A sub-threshold quote is therefore *unverified*, not *verified* — the same
+    absence-of-evidence the vacuous pass turned into a pass."""
+    row = compute_faithfulness("经云：「色不异空」【《心经》第1卷】", [_src()])
+    assert row["quote_count"] == 0
+    assert row["fully_grounded"] == 0
+
+
+def test_verbatim_quote_rate_denominator_is_answers_that_quoted():
+    """Answers that never quoted must not dilute the quote-fidelity rate."""
+    src = _src(chunk_text=_LONG_CHUNK)
+    quoted_ok = compute_faithfulness(
+        "经云：「色不异空，空不异色，色即是空」【《心经》第1卷】", [src]
+    )
+    quoted_bad = compute_faithfulness(
+        "经云：「五阴覆盖般若灵明，使众生心识昏蒙」【《心经》第1卷】", [src]
+    )
+    never_quoted = compute_faithfulness("本经讲的是空性的道理【《心经》第1卷】。", [src])
+
+    agg = aggregate_faithfulness([quoted_ok, quoted_bad, never_quoted])
+    assert agg["answers_with_quotes"] == 2
+    assert agg["verbatim_quote_rate"] == 0.5      # 1 of the 2 that quoted
+    # …and the citation-level rate sees all three.
+    assert agg["answers_with_citations"] == 3
+
+
+def test_a_drop_in_verbatim_quote_rate_is_a_regression():
+    """The new quote-fidelity number must gate, not merely decorate the report."""
+    regressions = detect_faithfulness_regressions(
+        {"verbatim_quote_rate": 0.30},
+        {"verbatim_quote_rate": 0.50},
+        tolerance=0.02,
+    )
+    assert any("verbatim_quote_rate" in r for r in regressions)

--- a/backend/tests/test_quote_verifier.py
+++ b/backend/tests/test_quote_verifier.py
@@ -524,3 +524,25 @@ def test_english_quote_with_typographic_apostrophe_is_still_checked():
     _, muts = verify_quoted_content(answer, [src])
     assert len(muts) == 1
     assert muts[0].quote == "the Buddha’s own words, plainly stated"
+
+
+def test_count_checked_quotes_matches_the_verifier():
+    """The counter and the verifier must agree on what counts as a quote:
+    when every quote fails, one mutation is recorded per checked quote."""
+    from app.services.quote_verifier import count_checked_quotes
+
+    src = _src(7, "心經", 1, "无关原文")
+    answer = (
+        "云：「假引文片段一假引文片段一」【《心經》第1卷】\n"
+        "又：「假引文片段二假引文片段二」【《心經》第1卷】"
+    )
+    _, muts = verify_quoted_content(answer, [src])
+    assert count_checked_quotes(answer, [src]) == len(muts) == 2
+
+
+def test_count_checked_quotes_ignores_emphasis_and_short_fragments():
+    from app.services.quote_verifier import count_checked_quotes
+
+    src = _src(3, "瑜伽師地論", 3, "必与舍受相应。")
+    answer = "「念」维持「寻」，论中说必与舍受相应【《瑜伽師地論》第3卷】。"
+    assert count_checked_quotes(answer, [src]) == 0


### PR DESCRIPTION
## 问题:三处独立的空洞通过,同一个缺陷

**缺少证据被记为证据充分。**

### 1. `eval/faithfulness.py` — 头号指标在骗人

```python
"fully_grounded": 1 if trust.state == "verified" else 0,
```

而 `verified` 只要求「≥1 个引用标记 **且** 零 `quote_mutation`」。一条**一句引文都没有**的答案,零 mutation 是**因为没检查**,不是因为检查通过。于是「引用了来源、但一个字都不引原文」的答案被记为"完全核验"。

这个指标**奖励模型少引用原典**。一个彻底不引经据典的模型能刷到 100% —— 而 fojin 卖的恰恰是引经据典且可核对。

### 2. `tests/test_faithfulness.py` — 测试把 bug 固化成了契约

```python
def test_clean_answer_is_fully_grounded():
    row = compute_faithfulness("见【《心经》第1卷】。", [_src()])   # ← 没有引文
    assert row["fully_grounded"] == 1                              # ← 却断言完全核验
```

### 3. `eval/run_eval.py` — gate 悄悄停止 gating

```python
except (OSError, ValueError, KeyError) as exc:
    print(f"\n[baseline 对照失败] {exc}")     # gate_failed 仍为 False
```

`--baseline` 损坏或读不到时,`--fail-on-regression` **退出 0**。「无法比较」不是「没有回归」。讽刺的是,`test_eval_regression_wrapper.py` 的 docstring 明写它存在的意义就是防止「gate quietly stops working」。

## 修复

- `quote_verifier.count_checked_quotes()` — 核验器**实际检查过**几条引文。不改 `verify_quoted_content` 的二元组契约与任何调用点;`test_count_checked_quotes_matches_the_verifier` 把计数器与核验器的口径钉在一起。
- `fully_grounded` 追加 `quote_count > 0`。
- 新增 **`verbatim_quote_rate`**,分母是「真的引用了原文的答案」:*模型把原典放进引号里时,有多少次是逐字的?* 与 `verified_rate_of_cited` **独立移动**,所以一次 run 无法靠少引用来刷分。已接入 `_GATED_RATES` —— 否则它只是报表上的装饰。
- `compare_baseline()` 抽成纯函数,返回 `(regressions, error)`;`error` 非空且 `--fail-on-regression` 时,gate 失败。抽出来是为了让这条不变式**可被测试**(原逻辑埋在需要语料库 DB 的 `async def main()` 里)。

**用户可见的 `trust_state` 徽章未改动**(`ChatPage.tsx:415` 渲染它)。是否该在无引文的答案上显示「已核验」,是独立的 UX/i18n 决定,不该夹带在指标修复里。新增的 `test_citation_without_a_quote_keeps_the_badge_but_not_the_metric` 明确记录了这处**故意的分叉**。

## 在 537 条真实生产答案上(均已应用 #952)

| 指标 | 值 |
|---|---|
| 旧口径 `verified_rate_of_cited` | **55.0%** (165/300) ← 含零引文空洞通过 |
| 新 `verified_rate_of_cited` | **27.7%** (83/300) |
| 新 `verbatim_quote_rate` | **38.1%** (83/218) |

**这是本 PR 存在的理由:** 合了 #952 之后直接跑 baseline,旧仪表会报 **55%**,让人得出「引用忠实度已大获全胜」的结论(此前是 ~13%)。真实的逐字引用保真度是 **38.1%**。

## 测试

TDD:每条新测试先失败、且失败理由逐条核对过,再实现。

```
tests/test_faithfulness.py tests/test_quote_verifier.py tests/test_quote_verifier_buckets.py
tests/test_chat_trust.py tests/test_eval_regression_wrapper.py tests/test_retrieval_metrics.py
94 passed
```

`ruff check app/ eval/` 干净(`app/core/metrics.py` 的 UP047 在 master 上同样报,是新版 ruff 的规则,CI 钉的是 0.9.7)。

## 之后

合并后跑 baseline,**务必带 `--temperature 0`**(`run_eval.py` 默认 0.7)。上一轮 baseline 前后对比是 temp=0.7、n=1,~10 个百分点的摆动约等于 2 个标准误——那是噪声。#951 已于本轮之前合入 master,其效果无法再单独归因;这条 baseline 是**面向未来**的参照线。
