### PR TITLE
fix(eval): 把 verbatim_quote_rate 渲染进报告,并说清每个比率的分母

### DIFF
--- a/backend/eval/README.md
+++ b/backend/eval/README.md
@@ -61,18 +61,43 @@ fojin 的品牌承诺是「每一句都能点回原典」。这层把它从口�
 （收敛成用户在消息上看到的 `ChatTrustState`）—— 然后聚合成：
 
 - **`citation_grounding_rate`**：全部引用中，经守卫核验未被改写的比例（按引用数加权，非按题平均）。
-- **`verified_rate_of_cited`**：**有引用**的回答里，完全核验（无引用改写、无未核实引文）的比例 —— 即「每一句都能点回原典」的题面数字。
+- **`verified_rate_of_cited`**：**有引用**的回答里，完全核验的比例。分母是有引用的回答；**引用了来源却一个字都不引原文的回答记 0，不记 1** —— 它什么都没核验。
+- **`verbatim_quote_rate`**：**真的引用了原文**的回答里，每条引文都逐字对上的比例 —— 「模型把原典放进引号里时，有多少次是逐字的」。
 - 可信状态分布（已核验 / 引用被纠正 / 引文未核实 / 有来源未引用 / 无来源）。
+
+后两个指标**分母不同、独立移动**，必须一起看。只看 `verified_rate_of_cited` 会奖励模型**少引用原典**（不引用 → 无引文可失败）；只看 `verbatim_quote_rate` 会忽略「压根不引用」这一整类失败。
+
+> **注意分母只覆盖到哪里。** `verify_quoted_content` 目前在答案不含 `【《…》】` 标记时**整条跳过核验**
+> （见其首行早退）。生产实测 544 条答案中 237 条（43.6%）无此标记 → 上述所有比率都只统计了另外
+> 56%。修好之前，别把这些数字当成"全部答案"的质量。
 
 在**原始模型输出**（守卫处理前）上度量：数字变差 = 底层模型 grounding 退化的**早期信号**，线上守卫随后在服务时补救此处计到的问题。
 
 ```bash
-# 需要生成回答（不能 --no-llm）；忠实度段落会出现在报告里
-python -m eval.run_eval --tag nightly
+# 需要生成回答（不能 --no-llm）。⚠️ 必须 --temperature 0：
+# 默认 0.7 下 n=1 的前后对比，~10 个百分点的摆动约等于 2 个标准误，是噪声不是信号。
+python -m eval.run_eval --tag nightly --temperature 0
 
 # 作为门：低于下限即非零退出（仅 LLM-on 运行有意义）
-python -m eval.run_eval --min-citation-grounding 0.98 --min-verified-rate 0.85 --tag gate
+python -m eval.run_eval --temperature 0 --min-citation-grounding 0.95 --min-verified-rate 0.40 --tag gate
 ```
+
+### 当前基线（2026-07-09，90 题，`--temperature 0`）
+
+| 指标 | 值 | 分母 |
+|------|-----|------|
+| `citation_grounding_rate` | 97.8% | 314 条引用 |
+| `verified_rate_of_cited` | 48.4% | 62 条有引用回答 |
+| `verbatim_quote_rate` | **56.6%** | 53 条含可核验引文的回答 |
+
+原始 JSON：`eval/reports/eval-20260709-045853-baseline-temp0.json`（宿主机 `backend/eval/reports/`，bind mount 进容器）。
+把它传给 `--baseline` 才能比较忠实度；`baseline.json` 是 `--no-llm` 检索基线，**不含 faithfulness 行**，只能门检索指标。
+
+同一套指标在 537 条**真实生产答案**上回放得到 `verbatim_quote_rate = 38.1%` —— **题库比生产宽容约 20 个百分点**，不要拿 eval 数字代表线上质量。
+
+> 报告写入 `eval/reports/`。容器以 `app(999)` 运行而该目录属主是 `admin(1000)`，若权限不对，
+> run_eval 会退到 **ephemeral 的 `/tmp`**（重启即丢）并打印警告。修复：
+> `chgrp 999 backend/eval/reports && chmod g+w backend/eval/reports`
 
 > 现有 `run_regression.sh` 用 `--no-llm`（只测检索、省 token），**不含**忠实度门。忠实度需要生成回答，
 > 建议单独排一个**低频 LLM-on** 的 cron 跑上面的门（成本更高），与高频的 `--no-llm` 检索门分开。

--- a/backend/eval/run_eval.py
+++ b/backend/eval/run_eval.py
@@ -179,13 +179,23 @@ def _faithfulness_section(faith_agg: dict) -> list[str]:
         "", "## 引用忠实度（确定性 / 每一句可点回原典）", "",
         f"*基于 {faith_agg.get('num_answers', 0)} 道生成回答，重放线上"
         "「引用守卫 → 引文核验 → 可信状态」管线*", "",
-        "| 指标 | 值 |", "|------|-----|",
-        f"| 引用可核验率 (citation_grounding_rate) | {_fmt_rate(faith_agg.get('citation_grounding_rate'))} |",
-        f"| **服务可信率 (served_trustworthy_rate)** | **{_fmt_rate(faith_agg.get('served_trustworthy_rate'))}** |",
-        f"| 完全核验率·严格 (verified_rate_of_cited) | {_fmt_rate(faith_agg.get('verified_rate_of_cited'))} |",
-        f"| 含转述降级引文的回答数 | {faith_agg.get('answers_with_downgraded_quote', 0)} |",
-        f"| 引用总数 / 有引用回答数 | {faith_agg.get('total_citations', 0)} / {faith_agg.get('answers_with_citations', 0)} |",
-        "", "**可信状态分布**", "",
+        "| 指标 | 值 | 分母 |", "|------|-----|------|",
+        f"| 引用可核验率 (citation_grounding_rate) | {_fmt_rate(faith_agg.get('citation_grounding_rate'))} "
+        f"| {faith_agg.get('total_citations', 0)} 条引用 |",
+        f"| **服务可信率 (served_trustworthy_rate)** | **{_fmt_rate(faith_agg.get('served_trustworthy_rate'))}** "
+        f"| {faith_agg.get('answers_with_citations', 0)} 条有引用回答 |",
+        f"| 完全核验率·严格 (verified_rate_of_cited) | {_fmt_rate(faith_agg.get('verified_rate_of_cited'))} "
+        f"| {faith_agg.get('answers_with_citations', 0)} 条有引用回答 |",
+        f"| **逐字引用保真度 (verbatim_quote_rate)** | **{_fmt_rate(faith_agg.get('verbatim_quote_rate'))}** "
+        f"| {faith_agg.get('answers_with_quotes', 0)} 条含可核验引文的回答 |",
+        f"| 含转述降级引文的回答数 | {faith_agg.get('answers_with_downgraded_quote', 0)} | — |",
+        "",
+        "> `verified_rate_of_cited` 的分母是**有引用**的回答:引用了来源却一个字都不引原文的",
+        "> 回答记 0,不记 1 —— 它什么都没核验。`verbatim_quote_rate` 的分母是**真的引用了",
+        "> 原文**的回答,回答「模型把原典放进引号里时,有多少次是逐字的」。两者独立移动,",
+        "> 所以一次 run 无法靠少引用来刷分。",
+        "",
+        "**可信状态分布**", "",
         "| 状态 | 数量 |", "|------|------|",
     ]
     lines += [f"| {state_names.get(s, s)} | {dist.get(s, 0)} |" for s in TRUST_STATES]
@@ -415,14 +425,22 @@ async def main():
         raw_path = REPORTS_DIR / f"eval-{timestamp}{tag_suffix}.json"
         raw_path.write_text(json.dumps(results, ensure_ascii=False, indent=2), encoding="utf-8")
         saved = f"\nReport: {report_path}\nRaw: {raw_path}"
-    except OSError:
-        # Fallback: write to /tmp when running inside Docker
+    except OSError as exc:
+        # Fallback: /tmp is ephemeral — it dies with the container, taking the
+        # run's raw JSON (and thus any future --baseline) with it. In prod
+        # ``eval/reports`` is a bind mount of ``backend/eval/reports`` on the
+        # host, owned by admin(1000) while the container runs as app(999), so an
+        # unwritable dir silently downgraded every report to a temp file. Say so.
         fallback = Path("/tmp")
         report_path = fallback / f"eval-{timestamp}{tag_suffix}.md"
         report_path.write_text(report, encoding="utf-8")
         raw_path = fallback / f"eval-{timestamp}{tag_suffix}.json"
         raw_path.write_text(json.dumps(results, ensure_ascii=False, indent=2), encoding="utf-8")
-        saved = f"\nReport: {report_path}\nRaw: {raw_path}"
+        saved = (
+            f"\n⚠️  {REPORTS_DIR} 不可写（{exc}）——报告写到了 EPHEMERAL 的 /tmp，"
+            f"容器重启即丢失。\n    修复：chgrp 999 backend/eval/reports && chmod g+w backend/eval/reports"
+            f"\nReport: {report_path}\nRaw: {raw_path}"
+        )
 
     print(f"\n{'='*60}")
     print(report)

--- a/backend/tests/test_faithfulness.py
+++ b/backend/tests/test_faithfulness.py
@@ -213,3 +213,57 @@ def test_a_drop_in_verbatim_quote_rate_is_a_regression():
         tolerance=0.02,
     )
     assert any("verbatim_quote_rate" in r for r in regressions)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# The report is where a human reads these numbers. A metric that exists
+# only in the aggregate dict — and in the regression gate — is invisible
+# to the person deciding what to work on next. verbatim_quote_rate was
+# added in #953 and never rendered; the 2026-07-09 baseline had to be
+# recomputed by hand from the raw JSON to read it.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_report_renders_verbatim_quote_rate():
+    from eval.run_eval import _faithfulness_section
+
+    lines = _faithfulness_section(
+        {
+            "num_answers": 90,
+            "answers_with_citations": 62,
+            "answers_with_quotes": 53,
+            "total_citations": 314,
+            "citation_grounding_rate": 0.978,
+            "verified_rate_of_cited": 0.484,
+            "verbatim_quote_rate": 0.566,
+            "served_trustworthy_rate": 0.968,
+            "answers_with_downgraded_quote": 23,
+            "state_distribution": {},
+        }
+    )
+    body = "\n".join(lines)
+    assert "verbatim_quote_rate" in body
+    assert "56.6%" in body
+    assert "53" in body          # answers_with_quotes, the honest denominator
+
+
+def test_report_shows_na_when_no_answer_quoted():
+    """verbatim_quote_rate is None when nothing quoted — render N/A, not 0%."""
+    from eval.run_eval import _faithfulness_section
+
+    lines = _faithfulness_section(
+        {
+            "num_answers": 5,
+            "answers_with_citations": 3,
+            "answers_with_quotes": 0,
+            "verbatim_quote_rate": None,
+            "citation_grounding_rate": 1.0,
+            "verified_rate_of_cited": 0.0,
+            "served_trustworthy_rate": 1.0,
+            "total_citations": 3,
+            "answers_with_downgraded_quote": 0,
+            "state_distribution": {},
+        }
+    )
+    body = "\n".join(lines)
+    assert "N/A" in body


### PR DESCRIPTION
## 问题

**#953 加了 `verbatim_quote_rate`,接进了回归门,却没接进人看的地方。**

2026-07-09 的 baseline 跑完后,报告里只有 `verified_rate_of_cited = 48.4%`。真正重要的那个数字(`verbatim_quote_rate = 56.6%`)是我从原始 JSON 里**手算**出来的。明天任何人打开报告,都看不到它。

**指标不可见 = 指标不存在。** 这是我在 #953 里留下的缺口。

## 改动

**1. 报告表格加「分母」列 + `verbatim_quote_rate` 一行**

```
| 指标 | 值 | 分母 |
|------|-----|------|
| 引用可核验率 (citation_grounding_rate) | 97.8% | 314 条引用 |
| **服务可信率 (served_trustworthy_rate)** | **96.8%** | 62 条有引用回答 |
| 完全核验率·严格 (verified_rate_of_cited) | 48.4% | 62 条有引用回答 |
| **逐字引用保真度 (verbatim_quote_rate)** | **56.6%** | 53 条含可核验引文的回答 |
```

表下附一段说明:`verified_rate_of_cited` 的分母是**有引用**的回答(引用了来源却一个字都不引原文的记 0);`verbatim_quote_rate` 的分母是**真的引用了原文**的回答。两者独立移动,所以一次 run 无法靠少引用来刷分。

**2. 报告落盘失败时大声警告(而不是静默降级)**

生产上 `eval/reports` 是宿主机 `backend/eval/reports` 的 bind mount,属主 `admin(1000)`,而容器以 `app(999)` 运行 → **目录不可写** → `except OSError` 静默退到 `/tmp`。`/tmp` 随容器重启消失。

今天这次 baseline 就是这么差点丢掉的 —— 我是手动 `docker cp` 抢救出来的。现在会打印不可写的原因和修复命令。

**3. `eval/README.md`**

- 记录当前基线(90 题,`--temperature 0`)及其原始 JSON 路径。
- 写明 **`--temperature 0` 是强制的**:默认 0.7 下 n=1 的前后对比,~10 个百分点的摆动约等于 2 个标准误,是噪声不是信号。
- `--min-verified-rate` 的示例从**不可达的 0.85** 改成 0.40(真实值 48.4%)。README 里放一个永远达不到的门限,等于教人关掉它。
- 提醒 eval 题库比生产**宽容约 20 个百分点**(56.6% vs 生产回放的 38.1%),别拿 eval 数字代表线上质量。

## 同时记录一个**尚未修复**的覆盖洞

`verify_quoted_content` 首行:

```python
if not answer or "【《" not in answer:
    return answer, []      # 整条答案跳过引文核验
```

生产 544 条答案中 **237 条(43.6%)不含 `【《…》】` 标记 → 整条跳过核验**,其中 74 条含 ≥12 字的 `「…」` 引文。**上述所有比率都只统计了另外 56% 的答案。**

已在 README 里标注,并单开 issue 跟踪。本 PR 不修 —— 那是个会改写线上正文的破坏性改动,需要自己的生产回放当验收门。

## 测试

TDD:`test_report_renders_verbatim_quote_rate` / `test_report_shows_na_when_no_answer_quoted` 先失败再实现。

```
tests/test_faithfulness.py tests/test_eval_regression_wrapper.py tests/test_quote_verifier.py
tests/test_chat_trust.py tests/test_retrieval_metrics.py
89 passed
```

`ruff check eval/` 干净。
