### PR TITLE
fix(deploy): no-op 部署也同步 .deploy-version.json,根治漂移看门狗误报

### DIFF
--- a/backend/tests/test_deploy_noop_version_sync.py
+++ b/backend/tests/test_deploy_noop_version_sync.py
@@ -1,0 +1,134 @@
+"""deploy.sh 必须在 no-op 部署时同步 backend/.deploy-version.json。
+
+scheduled smoke 的漂移看门狗拿 /api/version 的 commit 对比 master HEAD。
+deploy.sh 对不影响服务进程的提交(eval/tests/docs-only)故意跳过重启——
+但部署身份文件仍须推进到新 HEAD(/api/version 每请求重读该文件,bind-mount
+下即时生效),否则每次这类合并都会触发"CD stalled"误报(2026-07-10 事故)。
+
+这些测试在临时 git 沙箱里真实运行 deploy.sh:no-op 路径只依赖
+git/flock/python3,不会调用 docker/gh/curl,可在 CI 直接执行。
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_SH = ROOT / "deploy.sh"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            *args,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture()
+def sandbox(tmp_path):
+    """origin(裸仓库) + seed(推送提交用) + work(模拟 VPS 工作树)。"""
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", "-q", "-b", "master", str(origin)], check=True
+    )
+
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "clone", "-q", str(origin), str(seed)], check=True)
+    _git(seed, "checkout", "-q", "-B", "master")
+    (seed / "backend" / "eval").mkdir(parents=True)
+    (seed / "backend" / "eval" / "report.md").write_text("v1\n", encoding="utf-8")
+    (seed / "README.md").write_text("v1\n", encoding="utf-8")
+    _git(seed, "add", "-A")
+    _git(seed, "commit", "-q", "-m", "c1")
+    _git(seed, "push", "-q", "origin", "master")
+    base = _git(seed, "rev-parse", "HEAD")
+
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", "-q", str(origin), str(work)], check=True)
+    shutil.copy(DEPLOY_SH, work / "deploy.sh")
+    state = work / ".deploy-state"
+    state.mkdir()
+    (state / "last-frontend-build").write_text(base + "\n", encoding="utf-8")
+    (state / "last-backend-restart").write_text(base + "\n", encoding="utf-8")
+    (work / "backend" / ".deploy-version.json").write_text(
+        json.dumps(
+            {
+                "app": "fojin",
+                "version": "3.0.0",
+                "commit": base,
+                "commit_short": base[:7],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return {"seed": seed, "work": work, "base": base}
+
+
+def _push_commit(sandbox: dict, relpath: str, content: str, msg: str) -> str:
+    seed = sandbox["seed"]
+    target = seed / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    _git(seed, "add", "-A")
+    _git(seed, "commit", "-q", "-m", msg)
+    _git(seed, "push", "-q", "origin", "master")
+    return _git(seed, "rev-parse", "HEAD")
+
+
+def _run_deploy(work: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(work / "deploy.sh"), "master"],
+        cwd=work,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _deployed_commit(work: Path) -> str:
+    data = json.loads(
+        (work / "backend" / ".deploy-version.json").read_text(encoding="utf-8")
+    )
+    return data["commit"]
+
+
+def test_eval_only_merge_advances_deploy_identity_without_restart(sandbox):
+    new = _push_commit(sandbox, "backend/eval/report.md", "v2\n", "eval only")
+
+    result = _run_deploy(sandbox["work"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "跳过 restart" in result.stdout  # 仍走跳过重启的路径
+    assert _deployed_commit(sandbox["work"]) == new  # 但部署身份必须推进
+
+
+def test_docs_only_merge_advances_deploy_identity(sandbox):
+    new = _push_commit(sandbox, "README.md", "v2\n", "docs only")
+
+    result = _run_deploy(sandbox["work"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _deployed_commit(sandbox["work"]) == new
+
+
+def test_noop_rerun_with_no_new_commits_stays_clean(sandbox):
+    """HEAD 未动的例行 no-op(webhook ping/重跑)也保持身份一致且成功退出。"""
+    result = _run_deploy(sandbox["work"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _deployed_commit(sandbox["work"]) == sandbox["base"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,9 @@
 #     这样即便别的进程 (webhook CD / 手动 git pull) 已经把代码拉下来,
 #     我们也能正确判断未部署的差量。
 #   - 部署后做真实健康检查, 不是 `sleep 10` 了事。
+#   - 部署身份与看门狗一致: /api/version 每请求重读 backend/.deploy-version.json。
+#     判定"无需部署"时也要把身份推进到 HEAD, 否则 eval/tests/docs-only 合并
+#     会让 scheduled smoke 的漂移看门狗误报 CD 停摆 (2026-07-10 事故)。
 #
 set -euo pipefail
 
@@ -257,7 +260,13 @@ $FORCE_BACKEND   && { log "--force-backend 已指定。";   backend_changed=true
 $REBUILD_BACKEND && { log "--rebuild-backend 已指定。"; backend_changed=true; backend_image_changed=true; }
 
 if ! $frontend_changed && ! $backend_changed; then
-  log "无任何变更信号 (marker/.env/flag) — 无需部署。"
+  # 走到这里意味着工作树已 ff 到 NEW_REV 且服务行为与之等价 (eval/tests/docs-only
+  # 等非服务路径改动)。部署身份仍须推进: /api/version 每请求重读该文件 (bind-mount
+  # 即时可见), 不推进的话 scheduled smoke 的漂移看门狗会把"故意不重启"误报成
+  # "CD stalled" (2026-07-10)。此路径后续无 compose 步骤, 写在判定之后不会重演
+  # 2026-07-05 "身份先于部署成功落盘" 的虚报事故。
+  write_deploy_version_file "$NEW_REV"
+  log "无任何变更信号 (marker/.env/flag) — 无需部署 (部署身份已同步到当前 HEAD)。"
   exit 0
 fi
 


### PR DESCRIPTION
## 问题

2026-07-09 16:09 与 07-10 05:06 两次 scheduled Production smoke 红灯,报 "Production is 1 commit(s) behind … CD looks stalled"。排查(VPS deploy.log)证实 **CD 完全健康**:#954 (`34479d0`) 是 eval-only 改动,deploy.sh 按设计跳过重启;但「无任何变更信号」分支直接 `exit 0`,从不更新 `backend/.deploy-version.json`,于是 `/api/version` 停在上次重启的 `51898cd`,漂移看门狗(#872 引入)把「故意不重启」误读成「CD 停摆」。

任何 eval/tests/docs-only 合并后只要 master 静默 >120min,看门狗都会再次误报。

## 修法

no-op 分支退出前调用 `write_deploy_version_file "$NEW_REV"`:

- 语义正确:此时工作树已 ff 到 NEW_REV,且判定证明服务行为与之等价——「已部署的代码树」就是 NEW_REV;
- 即时生效:`/api/version` 每请求重读该文件(`app/core/version.py`),bind-mount 下无需重启;
- 不踩 07-05 的坑:写入在全部判定之后,且该路径无后续 compose 步骤,不存在「身份先于部署成功落盘」。

单一事实来源保留在 deploy.sh(不给看门狗复制一份路径过滤逻辑,避免两处漂移)。

## 测试(TDD)

`backend/tests/test_deploy_noop_version_sync.py`:临时 git 沙箱(bare origin + 模拟 VPS 工作树)里**真实运行 deploy.sh**——no-op 路径只依赖 git/flock/python3,不触碰 docker/gh/curl,CI 可直接跑。三个用例:eval-only 合并、docs-only 合并(修复前均 RED)、HEAD 未动的例行 no-op(基线)。本地 backend 全套 987 passed。

## 部署说明

合并触发的 webhook 部署仍执行**旧版** deploy.sh(先 ff-merge 后按旧逻辑 no-op),所以本 PR 自身的 commit 仍会短暂让 `/api/version` 落后;合并后需在 VPS 手动跑一次 `deploy.sh`(新版逻辑会在 no-op 中把身份同步到 HEAD),此后看门狗即恢复常绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)