### PR TITLE
fix(reader): 移除阅读器工具栏「行首」按钮

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -19,7 +19,6 @@ import {
   DiffOutlined,
   VerticalAlignTopOutlined,
   DownloadOutlined,
-  NumberOutlined,
 } from "@ant-design/icons";
 import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, getJuanLineAnchors, type ApparatusEntryItem } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
@@ -436,7 +435,6 @@ export default function TextReaderPage() {
   const [citationOpen, setCitationOpen] = useState(false);
   const [annotationOpen, setAnnotationOpen] = useState(false);
   const [apparatusOn, setApparatusOn] = useState(false);
-  const [showLineRef, setShowLineRef] = useState(false);
   const [parallelPanelOpen, setParallelPanelOpen] = useState(false);
 
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
@@ -1042,16 +1040,6 @@ export default function TextReaderPage() {
               {t("reader.apparatus.toggle")}
             </Button>
           </Tooltip>
-          <Tooltip title={t("reader.lineref.tooltip")}>
-            <Button
-              size="small"
-              type={showLineRef ? "primary" : "default"}
-              icon={<NumberOutlined />}
-              onClick={() => setShowLineRef((v) => !v)}
-            >
-              {t("reader.lineref.toggle")}
-            </Button>
-          </Tooltip>
           <Tooltip title={t("reader.parallel.tooltip")}>
             <Button
               size="small"
@@ -1134,7 +1122,7 @@ export default function TextReaderPage() {
                   {langData?.default_lang ? getLangLabel(langData.default_lang) : t("reader.compare.original")}
                 </div>
                 <div
-                  className={`reader-body${showLineRef ? " show-lineref" : ""}`}
+                  className="reader-body"
                   style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
                 >
                   {reflowedContent.map((seg, i) => renderSegment(seg, i, readerCtx))}
@@ -1161,7 +1149,7 @@ export default function TextReaderPage() {
           </Row>
         ) : (
           <div
-            className={`reader-body${showLineRef ? " show-lineref" : ""}`}
+            className="reader-body"
             style={{ "--reader-font-size": `${fontSize}px` } as React.CSSProperties}
           >
             {reflowedContent.map((seg, i) => renderSegment(seg, i, readerCtx))}

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -797,21 +797,6 @@
   height: 0;
   overflow: hidden;
 }
-/* 「显示行首」开：把零宽行锚渲染成 CBETA 页·栏·行号浅色上标。 */
-.reader-body.show-lineref .cbeta-line {
-  width: auto;
-  height: auto;
-  overflow: visible;
-  vertical-align: super;
-  margin: 0 0.25em;
-  font-size: 0.6em;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: #b8860b;
-  user-select: none;
-}
-.reader-body.show-lineref .cbeta-line::before {
-  content: attr(data-ref);
-}
 .cbeta-line-flash {
   animation: cbeta-line-flash-kf 2.2s ease-out;
 }


### PR DESCRIPTION
## 变更
移除阅读器(TextReaderPage)工具栏上的「行首」toggle 按钮。

- 删除 `行首` 按钮的 `<Tooltip>`/`<Button>` 块
- 删除已无用的 `showLineRef` state
- 两处 `reader-body${showLineRef ? " show-lineref" : ""}` → 纯 `"reader-body"`
- 删除仅此处使用的 `NumberOutlined` 图标导入
- 删除已失效的 `.reader-body.show-lineref .cbeta-line` CSS 规则

## 保留(独立功能,未动)
- 点击行锚弹出的「行号定位」浮层(复制引用 / 复制链接),`reader.lineref.citation/copied/copy_*` 等 key 仍在使用
- 底层零宽 `.cbeta-line` 行锚

## 验证
- 基于 master 的干净提交(不含当前 feat 分支的 7 个 chat 提交)
- i18n ratchet 通过(保留了跨藏对照的 `t("reader.parallel.tooltip")` i18n key,未引入硬编码中文)
- 未使用的 `reader.lineref.tooltip` / `reader.lineref.toggle` 两个翻译 key 暂留(不触发 ratchet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)