### PR TITLE
chore(deploy): 把 ENABLE_SENTENCE_PARALLELS 接入 backend compose env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,8 @@ services:
       ALIYUN_SMS_ACCESS_KEY_SECRET: ${ALIYUN_SMS_ACCESS_KEY_SECRET:-}
       ALIYUN_SMS_SIGN_NAME: ${ALIYUN_SMS_SIGN_NAME:-佛津}
       ALIYUN_SMS_TEMPLATE_CODE: ${ALIYUN_SMS_TEMPLATE_CODE:-}
+      # 逐句对读 (sentence-level parallel) — ship-dark flag, reads from .env; default false.
+      ENABLE_SENTENCE_PARALLELS: ${ENABLE_SENTENCE_PARALLELS:-false}
     ports:
       - "127.0.0.1:${BACKEND_PORT:-8000}:8000"
     volumes:
@@ -215,6 +217,8 @@ services:
       ALIYUN_SMS_ACCESS_KEY_SECRET: ${ALIYUN_SMS_ACCESS_KEY_SECRET:-}
       ALIYUN_SMS_SIGN_NAME: ${ALIYUN_SMS_SIGN_NAME:-佛津}
       ALIYUN_SMS_TEMPLATE_CODE: ${ALIYUN_SMS_TEMPLATE_CODE:-}
+      # 逐句对读 (sentence-level parallel) — ship-dark flag, reads from .env; default false.
+      ENABLE_SENTENCE_PARALLELS: ${ENABLE_SENTENCE_PARALLELS:-false}
     ports:
       - "127.0.0.1:8001:8000"
     volumes:


### PR DESCRIPTION
逐句对读的 flag `enable_sentence_parallels` 此前没接进 `docker-compose.yml` 的 backend `environment:` 块,导致容器只能用 config 默认 `false`——即便 prod `.env` 设了也进不去容器。

本 PR 给 `backend` 与 `backend2` 双副本都加上:
```yaml
ENABLE_SENTENCE_PARALLELS: ${ENABLE_SENTENCE_PARALLELS:-false}
```
- default `false` → ship-dark 不变;prod `.env` 设 `ENABLE_SENTENCE_PARALLELS=true` 即上线
- 纯部署配置,无代码/迁移改动

合并后需在 prod 滚动重建 backend/backend2 使新 env 生效(`.env` 已置 true)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)