### PR TITLE
fix(alignment): 句级对齐提质 — 阈值 0.65 + 碎片过滤

### DIFF
--- a/backend/app/services/sentence_align.py
+++ b/backend/app/services/sentence_align.py
@@ -31,7 +31,8 @@ path trusts them; see the batch job docstring):
 * ``MIN_SENTENCE_SIMILARITY`` — pairs whose averaged cosine is below this are
   dropped AFTER the DP (bertalign's post-filter): the DP finds the best
   monotonic path, then genuinely unrelated pairs on that path are discarded.
-  0.4 is a conservative cut for BGE-M3 cross-lingual sentence cosines.
+  0.65 keeps confident 汉↔外文 pairs; prod data showed the 0.4–0.6 band was
+  overwhelmingly spurious while hand-verified good parallels score ≥0.75.
 * ``MAX_SENTENCES_PER_CHUNK`` — guard on the O(m·n) DP / embedding batch. Chunk
   pairs are paragraph-sized (rarely >~40 sentences a side); a side past this cap
   is refused rather than risk a pathological run.
@@ -46,8 +47,16 @@ from app.services.embedding import generate_embeddings_batch
 
 # ── tunables (module constants, not config.py) ──────────────────────────────
 GAP_PENALTY = 0.5
-MIN_SENTENCE_SIMILARITY = 0.4
+# Raised 0.4 → 0.65 after prod data (2026-07-12): 97% of 汉↔外文 cross-lingual
+# pairs scored 0.4–0.6 and were mostly spurious; hand-verified good parallels
+# score ≥0.75 ("佛說如是。"↔"That is what the Buddha said" = 0.81). 0.65 keeps
+# confident pairs and drops the low-signal flood.
+MIN_SENTENCE_SIMILARITY = 0.65
 MAX_SENTENCES_PER_CHUNK = 200
+# Drop degenerate "sentences" — bare punctuation ("。") or a 1-char stub ("身。")
+# that the splitter emits from punctuation-dense verse and which produced garbage
+# alignments. Counts alnum chars only (letters / CJK ideographs / digits).
+MIN_MEANINGFUL_SENTENCE_CHARS = 2
 
 # Chinese sentence terminators and the closing quotes that terminate / attach to
 # the preceding sentence. Opening 「『 are deliberately NOT boundaries, so nested
@@ -104,6 +113,10 @@ def _emit(out: list[Sentence], text: str, start: int, end: int, base_offset: int
     while e > s and text[e - 1].isspace():
         e -= 1
     if e <= s:
+        return
+    # Skip degenerate fragments (bare punctuation / single stray char) — they are
+    # noise for cross-lingual alignment. Count content chars (alnum), not punct.
+    if sum(1 for c in text[s:e] if c.isalnum()) < MIN_MEANINGFUL_SENTENCE_CHARS:
         return
     out.append(Sentence(char_start=base_offset + s, char_end=base_offset + e, text=text[s:e]))
 

--- a/backend/tests/test_sentence_align.py
+++ b/backend/tests/test_sentence_align.py
@@ -114,9 +114,28 @@ class TestSplitOther:
         assert [s.text for s in sents] == ["Really?!", "Yes."]
 
     def test_blank_lines_collapse(self):
-        text = "A.\n\n\nB."
+        text = "Aa.\n\n\nBb."
         sents = split_sentences(text, "en")
-        assert [s.text for s in sents] == ["A.", "B."]
+        assert [s.text for s in sents] == ["Aa.", "Bb."]
+
+    def test_degenerate_fragments_dropped(self):
+        # Bare punctuation and single-char stubs (the prod garbage: "。", "身。")
+        # must be filtered — they produced spurious cross-lingual alignments.
+        assert split_sentences("。", "lzh") == []
+        assert split_sentences("身。", "lzh") == []
+        # A real short verse line survives (≥2 content chars).
+        assert [s.text for s in split_sentences("諸行無常。", "lzh")] == ["諸行無常。"]
+        # Mixed: only the meaningful sentence is kept, the "。" stub is dropped.
+        got = [s.text for s in split_sentences("身。諸行無常。", "lzh")]
+        assert got == ["諸行無常。"]
+
+    def test_degenerate_fragment_offsets_stay_exact(self):
+        # Dropping a leading stub must not corrupt the surviving sentence's offsets.
+        text = "身。諸行無常。"
+        sents = split_sentences(text, "lzh", base_offset=100)
+        assert len(sents) == 1
+        s = sents[0]
+        assert text[s.char_start - 100 : s.char_end - 100] == s.text
 
 
 # ── cosine_matrix ───────────────────────────────────────────────────────────


### PR DESCRIPTION
逐句对读在 fojin.app 上线后**实地浏览器验证**发现:功能渲染正常,但数据质量差——出现「。」↔「o subtle,」这类卡片(汉文侧只有句号、跨语弱匹配)。已先关闭 flag 止损(prod `.env` 置 false + 滚动重启),本 PR 修根因。

## 数据诊断(prod 27,625 句对)
- similarity 分布:**97% < 0.6**(69% 在 0.4-0.5),仅 759 对 ≥0.6
- 极短碎片(side_a 去标点 ≤1 字)占 **10%**(2739 对)
- **但 ≥0.75 的抽查全是正确平行**:「佛說如是。」↔"That is what the Buddha said"(0.81)、「何等為四？」↔"What four?"(0.79)——功能可行,问题纯在阈值太松

## 两处修复(`sentence_align.py`)
1. `MIN_SENTENCE_SIMILARITY` **0.4 → 0.65**:丢掉 0.4-0.6 的低信号洪流
2. 新增 `MIN_MEANINGFUL_SENTENCE_CHARS=2`:`_emit` 里按 alnum 字符数过滤退化碎片(「。」「身。」)

## 测试
- `test_sentence_align.py`:更新空行折叠用例、新增碎片过滤 + 偏移正确性用例
- 全套 `pytest tests/ -q` → **1247 passed**;`ruff==0.9.7 check app/ eval/` 通过

## 合并后 prod 操作(我来做)
`TRUNCATE sentence_alignments` → 用新逻辑重跑 `refine_sentence_alignments.py` → 抽查质量 → 重新翻开 flag 上线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)