### PR TITLE
perf(kg): 地图 /geo 与 /lineage-arcs 加 HTTP 缓存 + Redis 存 gzip

### DIFF
--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -1,3 +1,5 @@
+import base64
+import gzip
 import hashlib
 import json
 
@@ -13,6 +15,12 @@ KG_GEO_CACHE_TTL = 1800  # 30 min
 KG_LINEAGE_CACHE_TTL = 1800
 KG_STATS_CACHE_TTL = 3600  # 1 hour — recomputed on import, fine to be ~1h stale
 KG_TIMELINE_CACHE_TTL = 3600
+# HTTP caching for the heavy map payloads (/geo, /lineage-arcs). The data is
+# already served up to ~30 min stale from Redis, so letting the browser/CDN
+# reuse it for a few minutes is safe and makes a page refresh near-instant
+# (browser cache / 304) instead of re-downloading ~2.6MB every time.
+KG_MAP_HTTP_MAX_AGE = 600  # 10 min fresh in browser/CDN
+KG_MAP_HTTP_SWR = 1800  # then serve-stale-while-revalidate up to 30 min
 from app.schemas.knowledge_graph import (
     KGEntityDetailResponse,
     KGEntityResponse,
@@ -40,6 +48,38 @@ from app.services.knowledge_graph import (
 )
 
 router = APIRouter(prefix="/kg", tags=["knowledge-graph"])
+
+
+def _gzip_b64(payload_json: str) -> str:
+    """gzip a JSON string and base64-encode it for Redis (client is
+    decode_responses=True, so raw gzip bytes can't be stored/read as str).
+
+    mtime=0 makes compression deterministic, so identical data always yields the
+    same bytes → the same ETag survives cache expiry/recompute → clients keep
+    getting 304 instead of re-downloading when the data hasn't actually changed."""
+    gz = gzip.compress(payload_json.encode("utf-8"), compresslevel=6, mtime=0)
+    return base64.b64encode(gz).decode("ascii")
+
+
+def _map_response_from_gz(gz: bytes, request: Request, max_age: int, swr: int) -> Response:
+    """Serve a pre-gzipped JSON blob with browser/CDN caching headers.
+
+    Honors If-None-Match (304) and Accept-Encoding. Returning the bytes with
+    Content-Encoding: gzip means nginx/CDN pass them through instead of
+    re-compressing ~16MB on every request."""
+    etag = 'W/"' + hashlib.sha1(gz).hexdigest() + '"'  # nosec B324 - cache validator, not security
+    headers = {
+        "ETag": etag,
+        "Cache-Control": f"public, max-age={max_age}, stale-while-revalidate={swr}",
+        "Vary": "Accept-Encoding",
+    }
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+    if "gzip" in request.headers.get("accept-encoding", ""):
+        headers["Content-Encoding"] = "gzip"
+        return Response(content=gz, media_type="application/json", headers=headers)
+    # Rare client that doesn't accept gzip (e.g. bare curl): decompress on the fly.
+    return Response(content=gzip.decompress(gz), media_type="application/json", headers=headers)
 
 
 @router.get("/entities", response_model=KGSearchResponse)
@@ -218,10 +258,14 @@ async def get_kg_geo_entities(
             sort_keys=True,
             separators=(",", ":"),
         )
-        cache_key = f"kg:geo:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
+        # `gz:` version prefix: values are now gzip+base64, not raw JSON — a new
+        # prefix avoids misreading stale raw-JSON entries from before this change.
+        cache_key = f"kg:geo:gz:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
         cached = await redis_client.get(cache_key)
         if cached:
-            return Response(content=cached, media_type="application/json")
+            return _map_response_from_gz(
+                base64.b64decode(cached), request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
+            )
 
     entities, total = await get_geo_entities(
         db, entity_types, year_start, year_end, bounds, limit
@@ -230,10 +274,12 @@ async def get_kg_geo_entities(
         entities=[KGGeoEntity(**e) for e in entities],
         total=total,
     )
-    payload = response.model_dump_json()
+    b64 = _gzip_b64(response.model_dump_json())
     if redis_client and cache_key:
-        await redis_client.setex(cache_key, jittered_ttl(KG_GEO_CACHE_TTL), payload)
-    return Response(content=payload, media_type="application/json")
+        await redis_client.setex(cache_key, jittered_ttl(KG_GEO_CACHE_TTL), b64)
+    return _map_response_from_gz(
+        base64.b64decode(b64), request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
+    )
 
 
 @router.get("/lineage-arcs", response_model=KGLineageArcsResponse)
@@ -256,17 +302,21 @@ async def get_kg_lineage_arcs(
             sort_keys=True,
             separators=(",", ":"),
         )
-        cache_key = f"kg:lineage:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
+        cache_key = f"kg:lineage:gz:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
         cached = await redis_client.get(cache_key)
         if cached:
-            return Response(content=cached, media_type="application/json")
+            return _map_response_from_gz(
+                base64.b64decode(cached), request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
+            )
 
     arcs, total = await get_lineage_arcs(db, school, year_start, year_end, limit)
     response = KGLineageArcsResponse(arcs=arcs, total=total)
-    payload = response.model_dump_json()
+    b64 = _gzip_b64(response.model_dump_json())
     if redis_client and cache_key:
-        await redis_client.setex(cache_key, jittered_ttl(KG_LINEAGE_CACHE_TTL), payload)
-    return Response(content=payload, media_type="application/json")
+        await redis_client.setex(cache_key, jittered_ttl(KG_LINEAGE_CACHE_TTL), b64)
+    return _map_response_from_gz(
+        base64.b64decode(b64), request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
+    )
 
 
 @router.get("/texts/{text_id}/entities", response_model=list[KGEntityResponse])

--- a/backend/tests/test_kg.py
+++ b/backend/tests/test_kg.py
@@ -302,3 +302,83 @@ async def test_search_results_expose_relation_count(kg_client):
         assert results[1]["relation_count"] == 0
 
 
+# ---------------------------------------------------------------------------
+# Test 8: /geo map payload — gzip + HTTP caching helper (pure-function level)
+# ---------------------------------------------------------------------------
+def test_map_response_gzip_roundtrip_headers_and_304():
+    import base64
+    import gzip
+    from types import SimpleNamespace
+
+    from app.api.knowledge_graph import _gzip_b64, _map_response_from_gz
+
+    payload = '{"entities":[{"id":1,"name_zh":"玄奘"}],"total":1}'
+    b64 = _gzip_b64(payload)
+    gz = base64.b64decode(b64)
+
+    # Deterministic compression → identical data yields identical bytes (stable ETag).
+    assert _gzip_b64(payload) == b64
+
+    # gzip-capable client → Content-Encoding: gzip; body decompresses to the original.
+    req = SimpleNamespace(headers={"accept-encoding": "gzip, deflate"})
+    resp = _map_response_from_gz(gz, req, 600, 1800)
+    assert resp.status_code == 200
+    assert resp.headers["content-encoding"] == "gzip"
+    assert "public" in resp.headers["cache-control"]
+    assert "max-age=600" in resp.headers["cache-control"]
+    etag = resp.headers["etag"]
+    assert etag.startswith('W/"')
+    assert gzip.decompress(resp.body).decode() == payload
+
+    # Matching If-None-Match → 304 with no body, ETag echoed back.
+    req304 = SimpleNamespace(headers={"accept-encoding": "gzip", "if-none-match": etag})
+    resp304 = _map_response_from_gz(gz, req304, 600, 1800)
+    assert resp304.status_code == 304
+    assert resp304.headers["etag"] == etag
+    assert not resp304.body
+
+    # Client that doesn't accept gzip → plain JSON, no Content-Encoding.
+    reqid = SimpleNamespace(headers={"accept-encoding": "identity"})
+    respid = _map_response_from_gz(gz, reqid, 600, 1800)
+    assert "content-encoding" not in respid.headers
+    assert respid.body.decode() == payload
+
+
+# ---------------------------------------------------------------------------
+# Test 9: /geo endpoint exposes cache headers and honors conditional requests
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_geo_cache_headers_and_conditional_304(kg_client):
+    geo = [
+        {
+            "id": 1, "entity_type": "person", "name_zh": "玄奘", "name_en": None,
+            "description": None, "latitude": 34.34, "longitude": 108.94,
+            "year_start": 602, "year_end": 664, "province": None, "city": None,
+            "district": None,
+        }
+    ]
+    with patch(f"{_KG_API}.get_geo_entities") as m:
+        m.return_value = (geo, 1)
+        # Accept-Encoding: identity keeps the body uncompressed so httpx doesn't
+        # transparently decode it — lets us assert the JSON and headers directly.
+        r = await kg_client.get(
+            "/api/kg/geo", params={"limit": 100},
+            headers={"Accept-Encoding": "identity"},
+        )
+        assert r.status_code == 200
+        assert "public" in r.headers["cache-control"]
+        assert "max-age=" in r.headers["cache-control"]
+        etag = r.headers["etag"]
+        assert etag
+        data = r.json()
+        assert data["total"] == 1
+        assert data["entities"][0]["name_zh"] == "玄奘"
+
+        # Re-request with the ETag → 304 Not Modified (no re-download).
+        r2 = await kg_client.get(
+            "/api/kg/geo", params={"limit": 100},
+            headers={"Accept-Encoding": "identity", "If-None-Match": etag},
+        )
+        assert r2.status_code == 304
+
+


### PR DESCRIPTION
## 问题
「佛教地理」地图页(`/map`)刷新慢。实测:`/api/kg/geo?limit=80000` 一次拉全部 ~6.5 万地理实体 = **~16MB 原始 JSON / 2.6MB gzip**,**响应无任何 HTTP 缓存头** → 浏览器/CDN 每次刷新都重下 2.6MB;即便命中 Redis(存 16MB 原始 JSON),nginx 仍每次重新 gzip 16MB。稳态刷新 ~3.3s,其中 ~2.5s 是那 2.6MB 传输。

## 改动(仅缓存层 · 无前端改动 · 无 DB 迁移)
`backend/app/api/knowledge_graph.py` 的 `/geo` 与 `/lineage-arcs`:
- **HTTP 缓存头**:`Cache-Control: public, max-age=600, stale-while-revalidate=1800` + 弱 `ETag` + `Vary: Accept-Encoding`,支持 `If-None-Match → 304`。刷新走浏览器缓存/304,几乎瞬时。
- **Redis 存 gzip+base64**(客户端 `decode_responses=True`,不能存裸二进制):命中时以 `Content-Encoding: gzip` 直接返回预压缩字节,nginx/CDN 透传、不再重复 gzip 16MB;Redis 占用 ~16MB → ~3.5MB。
- **确定性压缩**(`mtime=0`):相同数据 → 相同 ETag,缓存过期重算后仍返回 304,不重新下载。
- 缓存 key 加 `gz:` 版本前缀,避免读到旧的原始 JSON 值。

## 测试
`test_kg.py` 新增:
- `test_map_response_gzip_roundtrip_headers_and_304` — 纯函数:gzip 往返、确定性、Content-Encoding、Cache-Control、ETag、304、非 gzip 客户端回退。
- `test_geo_cache_headers_and_conditional_304` — 端点:缓存头 + 条件请求 304。

本地 `pytest tests/test_kg.py` 全 13 项通过;`ruff check` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)