### PR TITLE
perf(kg): 地图预热 + 廉价 304 + /geo payload 瘦身

### DIFF
--- a/backend/app/api/knowledge_graph.py
+++ b/backend/app/api/knowledge_graph.py
@@ -1,7 +1,9 @@
+import asyncio
 import base64
 import gzip
 import hashlib
 import json
+import logging
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import Response
@@ -21,6 +23,11 @@ KG_TIMELINE_CACHE_TTL = 3600
 # (browser cache / 304) instead of re-downloading ~2.6MB every time.
 KG_MAP_HTTP_MAX_AGE = 600  # 10 min fresh in browser/CDN
 KG_MAP_HTTP_SWR = 1800  # then serve-stale-while-revalidate up to 30 min
+# Background warming for /geo. A cold recompute measured ~7s (two sequential
+# scans of kg_entities + serializing ~65k rows), so without this the first
+# visitor after every TTL lapse eats it. Warm well inside the 30 min TTL.
+KG_GEO_WARM_INTERVAL = 1200  # 20 min
+KG_GEO_WARM_LIMIT = 80000  # the exact shape the map page requests
 from app.schemas.knowledge_graph import (
     KGEntityDetailResponse,
     KGEntityResponse,
@@ -49,16 +56,53 @@ from app.services.knowledge_graph import (
 
 router = APIRouter(prefix="/kg", tags=["knowledge-graph"])
 
+logger = logging.getLogger(__name__)
 
-def _gzip_b64(payload_json: str) -> str:
-    """gzip a JSON string and base64-encode it for Redis (client is
-    decode_responses=True, so raw gzip bytes can't be stored/read as str).
 
-    mtime=0 makes compression deterministic, so identical data always yields the
-    same bytes → the same ETag survives cache expiry/recompute → clients keep
-    getting 304 instead of re-downloading when the data hasn't actually changed."""
-    gz = gzip.compress(payload_json.encode("utf-8"), compresslevel=6, mtime=0)
-    return base64.b64encode(gz).decode("ascii")
+def _gzip_bytes(payload_json: str) -> bytes:
+    """Deterministic gzip (mtime=0): identical data → identical bytes → a stable
+    ETag that survives cache expiry/recompute, so clients keep getting 304
+    instead of re-downloading when the data hasn't actually changed."""
+    return gzip.compress(payload_json.encode("utf-8"), compresslevel=6, mtime=0)
+
+
+def _etag_of(gz: bytes) -> str:
+    return 'W/"' + hashlib.sha1(gz).hexdigest() + '"'  # nosec B324 - cache validator, not security
+
+
+def _etag_key(cache_key: str) -> str:
+    """Tiny sibling key holding just the ETag, so a revalidating client can be
+    answered with 304 without pulling and base64-decoding the ~2.3MB blob."""
+    return cache_key + ":etag"
+
+
+def _map_cache_headers(etag: str, max_age: int, swr: int) -> dict[str, str]:
+    return {
+        "ETag": etag,
+        "Cache-Control": f"public, max-age={max_age}, stale-while-revalidate={swr}",
+        "Vary": "Accept-Encoding",
+    }
+
+
+async def _try_304(
+    redis_client, cache_key: str, request: Request, max_age: int, swr: int
+) -> Response | None:
+    """Answer a conditional request from the tiny ETag key alone (cheap path)."""
+    inm = request.headers.get("if-none-match")
+    if not inm:
+        return None
+    cached_etag = await redis_client.get(_etag_key(cache_key))
+    if cached_etag and cached_etag == inm:
+        return Response(status_code=304, headers=_map_cache_headers(cached_etag, max_age, swr))
+    return None
+
+
+async def _store_gz(redis_client, cache_key: str, gz: bytes, ttl: int) -> None:
+    """Cache gzip bytes as base64 (the redis client is decode_responses=True, so
+    raw binary can't round-trip) plus the small sibling ETag key."""
+    jttl = jittered_ttl(ttl)
+    await redis_client.setex(cache_key, jttl, base64.b64encode(gz).decode("ascii"))
+    await redis_client.setex(_etag_key(cache_key), jttl, _etag_of(gz))
 
 
 def _map_response_from_gz(gz: bytes, request: Request, max_age: int, swr: int) -> Response:
@@ -67,12 +111,8 @@ def _map_response_from_gz(gz: bytes, request: Request, max_age: int, swr: int) -
     Honors If-None-Match (304) and Accept-Encoding. Returning the bytes with
     Content-Encoding: gzip means nginx/CDN pass them through instead of
     re-compressing ~16MB on every request."""
-    etag = 'W/"' + hashlib.sha1(gz).hexdigest() + '"'  # nosec B324 - cache validator, not security
-    headers = {
-        "ETag": etag,
-        "Cache-Control": f"public, max-age={max_age}, stale-while-revalidate={swr}",
-        "Vary": "Accept-Encoding",
-    }
+    etag = _etag_of(gz)
+    headers = _map_cache_headers(etag, max_age, swr)
     if request.headers.get("if-none-match") == etag:
         return Response(status_code=304, headers=headers)
     if "gzip" in request.headers.get("accept-encoding", ""):
@@ -80,6 +120,72 @@ def _map_response_from_gz(gz: bytes, request: Request, max_age: int, swr: int) -
         return Response(content=gz, media_type="application/json", headers=headers)
     # Rare client that doesn't accept gzip (e.g. bare curl): decompress on the fly.
     return Response(content=gzip.decompress(gz), media_type="application/json", headers=headers)
+
+
+def _geo_cache_key(entity_types, year_start, year_end, bounds, limit) -> str:
+    key_payload = json.dumps(
+        {"t": entity_types, "ys": year_start, "ye": year_end, "b": bounds, "l": limit},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    # `gz:` version prefix: values are gzip+base64, not the raw JSON stored by
+    # earlier builds — a new prefix avoids misreading stale entries.
+    return f"kg:geo:gz:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
+
+
+async def _build_geo_payload(db, entity_types, year_start, year_end, bounds, limit) -> str:
+    """Build the /geo JSON, trimmed.
+
+    Only 50 of ~65k geo entities have a year_start and 13 have a year_end, so
+    emitting those (and the other mostly-null fields) as explicit nulls burned
+    ~5.5MB of a ~16MB payload for nothing — exclude_none drops them. Rounding
+    lat/lng to 5 decimals (~1m, far finer than a map dot needs) trims more.
+    Raw JSON ~16MB → ~10.4MB; gzip barely shrinks (it already ate the repeated
+    nulls), so the real win is browser JSON-parse time and memory."""
+    entities, total = await get_geo_entities(
+        db, entity_types, year_start, year_end, bounds, limit
+    )
+    for e in entities:
+        if e.get("latitude") is not None:
+            e["latitude"] = round(e["latitude"], 5)
+        if e.get("longitude") is not None:
+            e["longitude"] = round(e["longitude"], 5)
+    response = KGGeoResponse(
+        entities=[KGGeoEntity(**e) for e in entities],
+        total=total,
+    )
+    return response.model_dump_json(exclude_none=True)
+
+
+async def warm_kg_geo(redis) -> None:
+    """Recompute the map's default /geo payload and refresh its cache, off the
+    request path.
+
+    Opens its own DB session (called from the lifespan loop, not a request).
+    Best-effort: any failure is logged and swallowed so it never affects the app."""
+    from app.database import async_session
+
+    try:
+        cache_key = _geo_cache_key(None, None, None, None, KG_GEO_WARM_LIMIT)
+        async with async_session() as session:
+            payload = await _build_geo_payload(
+                session, None, None, None, None, KG_GEO_WARM_LIMIT
+            )
+        gz = _gzip_bytes(payload)
+        await _store_gz(redis, cache_key, gz, KG_GEO_CACHE_TTL)
+        logger.info("kg geo cache warmed: %d KB gzip", len(gz) // 1024)
+    except Exception:
+        logger.exception("kg geo warm failed")
+
+
+async def kg_geo_warm_loop(redis) -> None:
+    """Background task: warm /geo at startup, then every KG_GEO_WARM_INTERVAL.
+
+    Keeps the cache populated so no real user pays the ~7s cold recompute.
+    Cancelled on shutdown by the lifespan handler."""
+    while True:
+        await warm_kg_geo(redis)
+        await asyncio.sleep(KG_GEO_WARM_INTERVAL)
 
 
 @router.get("/entities", response_model=KGSearchResponse)
@@ -253,33 +359,25 @@ async def get_kg_geo_entities(
     redis_client = getattr(request.app.state, "redis", None)
     cache_key = None
     if redis_client:
-        key_payload = json.dumps(
-            {"t": entity_types, "ys": year_start, "ye": year_end, "b": bounds, "l": limit},
-            sort_keys=True,
-            separators=(",", ":"),
+        cache_key = _geo_cache_key(entity_types, year_start, year_end, bounds, limit)
+        not_modified = await _try_304(
+            redis_client, cache_key, request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
         )
-        # `gz:` version prefix: values are now gzip+base64, not raw JSON — a new
-        # prefix avoids misreading stale raw-JSON entries from before this change.
-        cache_key = f"kg:geo:gz:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
+        if not_modified is not None:
+            return not_modified
         cached = await redis_client.get(cache_key)
         if cached:
             return _map_response_from_gz(
                 base64.b64decode(cached), request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
             )
 
-    entities, total = await get_geo_entities(
+    payload = await _build_geo_payload(
         db, entity_types, year_start, year_end, bounds, limit
     )
-    response = KGGeoResponse(
-        entities=[KGGeoEntity(**e) for e in entities],
-        total=total,
-    )
-    b64 = _gzip_b64(response.model_dump_json())
+    gz = _gzip_bytes(payload)
     if redis_client and cache_key:
-        await redis_client.setex(cache_key, jittered_ttl(KG_GEO_CACHE_TTL), b64)
-    return _map_response_from_gz(
-        base64.b64decode(b64), request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
-    )
+        await _store_gz(redis_client, cache_key, gz, KG_GEO_CACHE_TTL)
+    return _map_response_from_gz(gz, request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR)
 
 
 @router.get("/lineage-arcs", response_model=KGLineageArcsResponse)
@@ -303,6 +401,11 @@ async def get_kg_lineage_arcs(
             separators=(",", ":"),
         )
         cache_key = f"kg:lineage:gz:{hashlib.sha1(key_payload.encode()).hexdigest()}"  # nosec B324
+        not_modified = await _try_304(
+            redis_client, cache_key, request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
+        )
+        if not_modified is not None:
+            return not_modified
         cached = await redis_client.get(cache_key)
         if cached:
             return _map_response_from_gz(
@@ -311,12 +414,13 @@ async def get_kg_lineage_arcs(
 
     arcs, total = await get_lineage_arcs(db, school, year_start, year_end, limit)
     response = KGLineageArcsResponse(arcs=arcs, total=total)
-    b64 = _gzip_b64(response.model_dump_json())
+    # Deliberately NOT exclude_none here (unlike /geo): the map's arc filter and
+    # tooltip test `arc.year === null`, so arcs must keep explicit nulls. The
+    # arcs payload is small anyway (~8k rows, only fetched when 师承 is ticked).
+    gz = _gzip_bytes(response.model_dump_json())
     if redis_client and cache_key:
-        await redis_client.setex(cache_key, jittered_ttl(KG_LINEAGE_CACHE_TTL), b64)
-    return _map_response_from_gz(
-        base64.b64decode(b64), request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR
-    )
+        await _store_gz(redis_client, cache_key, gz, KG_LINEAGE_CACHE_TTL)
+    return _map_response_from_gz(gz, request, KG_MAP_HTTP_MAX_AGE, KG_MAP_HTTP_SWR)
 
 
 @router.get("/texts/{text_id}/entities", response_model=list[KGEntityResponse])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -129,15 +129,24 @@ async def lifespan(app: FastAPI):
 
     app.state.catalog_warm_task = asyncio.create_task(catalog_warm_loop(app.state.redis))
 
+    # Same idea for the map's /kg/geo payload: a cold recompute is ~7s (two seq
+    # scans of kg_entities + serializing ~65k rows). With HTTP caching now in
+    # front of it, organic traffic no longer keeps the Redis key warm, so the
+    # first visitor after each TTL lapse would eat it. Warm it off the request path.
+    from app.api.knowledge_graph import kg_geo_warm_loop
+
+    app.state.kg_geo_warm_task = asyncio.create_task(kg_geo_warm_loop(app.state.redis))
+
     yield
     # Shutdown
-    warm_task = getattr(app.state, "catalog_warm_task", None)
-    if warm_task is not None:
-        warm_task.cancel()
-        # Await the cancellation so it actually completes before the loop closes
-        # (otherwise asyncio emits "Task exception was never retrieved" on teardown).
-        with suppress(asyncio.CancelledError):
-            await warm_task
+    for _task_attr in ("catalog_warm_task", "kg_geo_warm_task"):
+        warm_task = getattr(app.state, _task_attr, None)
+        if warm_task is not None:
+            warm_task.cancel()
+            # Await the cancellation so it actually completes before the loop closes
+            # (otherwise asyncio emits "Task exception was never retrieved" on teardown).
+            with suppress(asyncio.CancelledError):
+                await warm_task
     if _HAS_DIANJIN:
         await get_dianjin_client().close()
     await app.state.redis.close()

--- a/backend/tests/test_kg.py
+++ b/backend/tests/test_kg.py
@@ -306,18 +306,16 @@ async def test_search_results_expose_relation_count(kg_client):
 # Test 8: /geo map payload — gzip + HTTP caching helper (pure-function level)
 # ---------------------------------------------------------------------------
 def test_map_response_gzip_roundtrip_headers_and_304():
-    import base64
     import gzip
     from types import SimpleNamespace
 
-    from app.api.knowledge_graph import _gzip_b64, _map_response_from_gz
+    from app.api.knowledge_graph import _gzip_bytes, _map_response_from_gz
 
     payload = '{"entities":[{"id":1,"name_zh":"玄奘"}],"total":1}'
-    b64 = _gzip_b64(payload)
-    gz = base64.b64decode(b64)
+    gz = _gzip_bytes(payload)
 
     # Deterministic compression → identical data yields identical bytes (stable ETag).
-    assert _gzip_b64(payload) == b64
+    assert _gzip_bytes(payload) == gz
 
     # gzip-capable client → Content-Encoding: gzip; body decompresses to the original.
     req = SimpleNamespace(headers={"accept-encoding": "gzip, deflate"})
@@ -380,5 +378,86 @@ async def test_geo_cache_headers_and_conditional_304(kg_client):
             headers={"Accept-Encoding": "identity", "If-None-Match": etag},
         )
         assert r2.status_code == 304
+
+
+# ---------------------------------------------------------------------------
+# Test 10: /geo payload is slimmed — null fields omitted, coords rounded
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_geo_payload_omits_nulls_and_rounds_coords(kg_client):
+    geo = [
+        {
+            "id": 1, "entity_type": "temple", "name_zh": "白馬寺", "name_en": None,
+            "description": None, "latitude": 34.7231234567, "longitude": 112.4567891234,
+            "year_start": None, "year_end": None, "province": None, "city": None,
+            "district": None,
+        }
+    ]
+    with patch(f"{_KG_API}.get_geo_entities") as m:
+        m.return_value = (geo, 1)
+        r = await kg_client.get(
+            "/api/kg/geo", params={"limit": 100},
+            headers={"Accept-Encoding": "identity"},
+        )
+        assert r.status_code == 200
+        body = r.text
+        # None-valued fields must not be serialized at all (they were ~5.5MB of
+        # the ~16MB payload: only 50/65k rows have year_start, 13 have year_end).
+        for absent in ("year_start", "year_end", "description", "name_en",
+                       "province", "city", "district"):
+            assert f'"{absent}"' not in body, f"{absent} should be omitted when null"
+        e = r.json()["entities"][0]
+        assert e["latitude"] == 34.72312  # rounded to 5 dp (~1 m)
+        assert e["longitude"] == 112.45679
+        assert e["name_zh"] == "白馬寺"
+
+
+# ---------------------------------------------------------------------------
+# Test 11: conditional requests are answered from the tiny ETag key alone
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_try_304_reads_only_the_small_etag_key():
+    from types import SimpleNamespace
+
+    from app.api.knowledge_graph import _etag_key, _try_304
+
+    etag = 'W/"deadbeef"'
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=etag)
+
+    req = SimpleNamespace(headers={"if-none-match": etag})
+    resp = await _try_304(redis, "kg:geo:gz:k", req, 600, 1800)
+    assert resp is not None
+    assert resp.status_code == 304
+    assert resp.headers["etag"] == etag
+    # Crucially: it only touched the tiny sibling key, never the ~2.3MB blob.
+    redis.get.assert_awaited_once_with(_etag_key("kg:geo:gz:k"))
+
+    # A stale/absent validator must NOT short-circuit.
+    redis.get = AsyncMock(return_value='W/"other"')
+    assert await _try_304(redis, "kg:geo:gz:k", req, 600, 1800) is None
+    # No If-None-Match at all → no shortcut, no Redis call.
+    redis.get = AsyncMock(return_value=etag)
+    assert await _try_304(redis, "kg:geo:gz:k", SimpleNamespace(headers={}), 600, 1800) is None
+    redis.get.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Test 12: caching writes both the blob and its sibling ETag key
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_store_gz_writes_blob_and_etag_keys():
+    from app.api.knowledge_graph import _etag_of, _gzip_bytes, _store_gz
+
+    redis = AsyncMock()
+    gz = _gzip_bytes('{"total":0,"entities":[]}')
+    await _store_gz(redis, "kg:geo:gz:k", gz, 1800)
+
+    written = {c.args[0]: c.args[2] for c in redis.setex.await_args_list}
+    assert set(written) == {"kg:geo:gz:k", "kg:geo:gz:k:etag"}
+    assert written["kg:geo:gz:k:etag"] == _etag_of(gz)
+    # Blob is stored base64-encoded (redis client is decode_responses=True).
+    import base64
+    assert base64.b64decode(written["kg:geo:gz:k"]) == gz
 
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -780,19 +780,22 @@ export async function getKGStats(): Promise<KGStats> {
   return data;
 }
 
+// /kg/geo is serialized with exclude_none (the payload is ~65k entities; emitting
+// the mostly-null fields as explicit nulls cost ~5.5MB of raw JSON), so every
+// nullable field may be ABSENT rather than null. Compare with `!= null`, never `!== null`.
 export interface KGGeoEntity {
   id: number;
   entity_type: string;
   name_zh: string;
-  name_en: string | null;
-  description: string | null;
+  name_en?: string | null;
+  description?: string | null;
   latitude: number;
   longitude: number;
-  year_start: number | null;
-  year_end: number | null;
-  province: string | null;
-  city: string | null;
-  district: string | null;
+  year_start?: number | null;
+  year_end?: number | null;
+  province?: string | null;
+  city?: string | null;
+  district?: string | null;
 }
 
 export interface KGGeoResponse {

--- a/frontend/src/components/kg-map/DeckGLMap.tsx
+++ b/frontend/src/components/kg-map/DeckGLMap.tsx
@@ -164,7 +164,9 @@ export default function DeckGLMap({
       if (currentYear !== null) {
         // Entities without year data are always shown (timeless features).
         // Only filter entities that explicitly fall outside the current year.
-        if (e.year_start !== null || e.year_end !== null) {
+        // `!= null` (not `!== null`): /kg/geo omits null fields, so a missing
+        // year arrives as undefined.
+        if (e.year_start != null || e.year_end != null) {
           const start = e.year_start ?? e.year_end ?? -Infinity;
           const end = e.year_end ?? e.year_start ?? Infinity;
           if (currentYear < start || currentYear > end) return false;
@@ -358,7 +360,7 @@ export default function DeckGLMap({
                 {t("geo.local_name_country", { name: countryLabel })}
               </div>
             )}
-            {(e.year_start !== null || e.year_end !== null) && (
+            {(e.year_start != null || e.year_end != null) && (
               <div className="tooltip-meta">
                 📜 {formatYearRange(t, e.year_start, e.year_end)}
               </div>
@@ -408,10 +410,15 @@ function formatYear(t: TFunction, year: number): string {
   return t("geo.year_ce", { n: year });
 }
 
-function formatYearRange(t: TFunction, start: number | null, end: number | null): string {
-  if (start !== null && end !== null) return `${formatYear(t, start)} — ${formatYear(t, end)}`;
-  if (start !== null) return `${formatYear(t, start)} —`;
-  if (end !== null) return `— ${formatYear(t, end)}`;
+// start/end may be undefined: /kg/geo omits null fields from its payload.
+function formatYearRange(
+  t: TFunction,
+  start?: number | null,
+  end?: number | null,
+): string {
+  if (start != null && end != null) return `${formatYear(t, start)} — ${formatYear(t, end)}`;
+  if (start != null) return `${formatYear(t, start)} —`;
+  if (end != null) return `— ${formatYear(t, end)}`;
   return "";
 }
 
@@ -474,9 +481,10 @@ const COUNTRY_KEY_OVERRIDES: Record<string, string> = {
   "巴西": "geo.country_br",
 };
 
+// desc/nameEn may be undefined: /kg/geo omits null fields from its payload.
 function detectCountryFlag(
-  desc: string | null,
-  nameEn: string | null,
+  desc: string | null | undefined,
+  nameEn: string | null | undefined,
   nameZh: string,
 ): string {
   const haystack = `${desc ?? ""} ${nameEn ?? ""} ${nameZh}`;
@@ -487,8 +495,8 @@ function detectCountryFlag(
 }
 
 function detectCountryName(
-  desc: string | null,
-  nameEn: string | null,
+  desc: string | null | undefined,
+  nameEn: string | null | undefined,
   nameZh: string,
 ): string | null {
   const haystack = `${desc ?? ""} ${nameEn ?? ""} ${nameZh}`;
@@ -505,7 +513,7 @@ function detectScript(s: string): 'cjk' | 'hangul' | 'latin' | 'other' {
   return 'other';
 }
 
-function detectSource(desc: string | null): string | null {
+function detectSource(desc: string | null | undefined): string | null {
   if (!desc) return null;
   const sources = ["OSM", "OpenStreetMap", "Wikidata", "DILA", "BDRC", "GeoNames"];
   for (const s of sources) {

--- a/frontend/src/components/kg-map/MapEntityPopup.tsx
+++ b/frontend/src/components/kg-map/MapEntityPopup.tsx
@@ -24,10 +24,15 @@ function formatYear(t: TFunction, year: number): string {
   return t("geo.year_ce", { n: year });
 }
 
-function formatYearRange(t: TFunction, start: number | null, end: number | null): string {
-  if (start !== null && end !== null) return `${formatYear(t, start)} — ${formatYear(t, end)}`;
-  if (start !== null) return `${formatYear(t, start)} —`;
-  if (end !== null) return `— ${formatYear(t, end)}`;
+// start/end may be undefined: /kg/geo omits null fields from its payload.
+function formatYearRange(
+  t: TFunction,
+  start?: number | null,
+  end?: number | null,
+): string {
+  if (start != null && end != null) return `${formatYear(t, start)} — ${formatYear(t, end)}`;
+  if (start != null) return `${formatYear(t, start)} —`;
+  if (end != null) return `— ${formatYear(t, end)}`;
   return "";
 }
 


### PR DESCRIPTION
接 #974 的 HTTP 缓存优化,补掉实测暴露的三个短板。

## 1) 冷启动预热 — 消除 ~7s 惩罚
**实测**:冷路径 TTFB **8.77s** vs 热路径 1.81s。每 30min TTL 过期后,第一个访客要付两次 `kg_entities` 全表顺序扫描 + 16MB 序列化。

**而 #974 的 HTTP 缓存反而加剧了它**:浏览器缓存让打到服务端的请求变稀 → Redis key 更少被自然流量"顺带焐热" → 任一到达服务端的请求撞上过期缓存的概率反而更高。

照搬现有 `catalog_warm_loop` 范式新增 `kg_geo_warm_loop`(每 20min,稳在 30min TTL 内),lifespan 启动/关闭,预热前端实际请求的默认 key(无过滤 · limit=80000)。

## 2) 廉价 304
原实现为了算 ETag,**每次条件请求都要把 2.3MB blob 从 Redis 取出 + base64 解码 + sha1,只为回一个 304**。改为额外存一个 `<key>:etag` 小键;带 `If-None-Match` 时先比对它,命中直接 304,完全不碰大 blob。

## 3) /geo payload 瘦身
6.5 万实体里 `year_start` **仅 50 个非空**、`year_end` **仅 13 个**——却以显式 `null` 形式白占 ~2.4MB(连同其它 mostly-null 字段共 ~5.5MB)。`exclude_none` 去掉 + 经纬度取 5 位小数(~1m,远超地图打点所需)。

| | 原始 JSON | gzip(实际传输) |
|---|---|---|
| 前 | 15.96 MB | 2.26 MB |
| 后 | **10.42 MB** | 2.02 MB |

诚实说明:**gzip 本就吃掉了重复的 null**,所以传输只降 ~11%;**真正收益是浏览器 JSON 解析耗时与内存**(6.5 万点主线程卡顿的来源)。

`lineage-arcs` **刻意不做** `exclude_none` — 前端弧线筛选/tooltip 判 `arc.year === null`,必须保留显式 null。

## 前端配套(必须,否则是 bug)
`exclude_none` 后字段是"缺失"而非 null,`undefined !== null` 为 **true**:
- `KGGeoEntity` 可空字段改为可选;
- `DeckGLMap` 年代筛选 + tooltip 年代行改用 `!= null` — **原写法会给 6.5 万个无年代的点渲染出乱码年代行**(真 bug,tsc 也帮忙抓出了 `detect*` 的类型不匹配);
- `formatYearRange` / `detect*` 放宽入参类型。

## 测试
新增 4 项:`exclude_none` 无 null 键 + 经纬度取整、廉价 304 只读小键、双键写入、gzip 确定性。
后端 **16 项全过**;前端 tsc 干净 + ESLint 干净 + i18n ratchet 通过 + vitest **186 项全过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)