### PR TITLE
feat(chat): 祖师长廊 —— 印章卡片呈现 15 位祖师,每句法语都带出处

### DIFF
--- a/backend/app/services/master_profiles.py
+++ b/backend/app/services/master_profiles.py
@@ -12,6 +12,28 @@ from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True, slots=True)
+class Epigraph:
+    """A representative line for the master, quoted VERBATIM from a text we host.
+
+    The master gallery is an extension of FoJin's citation discipline, not an
+    exception to it: a line only appears on a master's card if it was checked
+    character-for-character against that master's OWN work in our corpus, and it
+    carries its source so the reader can open the passage.
+
+    Verified 2026-07-12 against production (whitespace/punctuation normalized —
+    CBETA content hard-wraps mid-word, so a naive substring check false-negatives).
+    Masters whose own works we do not host get no epigraph: we would rather show
+    nothing than attribute a line we cannot back up.
+    """
+
+    quote: str
+    text_id: int  # buddhist_texts.id — links straight into the reader
+    cbeta_id: str
+    title_zh: str
+    juan: int
+
+
+@dataclass(frozen=True, slots=True)
 class MasterProfile:
     id: str
     name_zh: str
@@ -24,6 +46,9 @@ class MasterProfile:
     system_prompt: str = ""
     # Short description for the frontend selector
     description: str = ""
+    # Verified representative line shown on the master's gallery card. None when
+    # our corpus holds none of the master's own writing (see Epigraph docstring).
+    epigraph: Epigraph | None = None
 
 
 def _master_prompt(name: str, tradition: str, dates: str, rules: str, style: str) -> str:
@@ -68,6 +93,13 @@ _register(MasterProfile(
     description="大乘中观奠基者、八宗共祖，八不中道、缘起性空、二谛中道",
     # 大智度论(39), 中论(40), 十二门论(41), 回诤论(7806), 十住毗婆沙论(7708)
     fojin_text_ids=[39, 40, 41, 7806, 7708],
+    epigraph=Epigraph(
+        quote="眾因緣生法，我說即是空",
+        text_id=40,
+        cbeta_id="T1564",
+        title_zh="中論",
+        juan=4,
+    ),
     system_prompt=(
         '你是龙树菩萨（大乘中观学派奠基者，汉传素尊为"八宗共祖"，印度大乘佛教最重要的论师），印度·中观，约150-250。\n'
         "本内容依据历史佛教文献生成，仅供学习参考。如需正式修行指导，请亲近善知识。\n\n"
@@ -148,6 +180,13 @@ _register(MasterProfile(
     dates="538-597",
     description="天台宗创始人，一念三千、三谛圆融、止观双修",
     fojin_text_ids=[53, 52, 8085, 6513],  # 摩诃止观, 法华玄义, 小止观, 法华经
+    epigraph=Epigraph(
+        quote="止觀明靜，前代未聞",
+        text_id=53,
+        cbeta_id="T1911",
+        title_zh="摩訶止觀",
+        juan=1,
+    ),
     system_prompt=(
         '你是智顗大师（天台宗创始人，被尊为"东土小释迦"），天台宗，538-597。\n'
         "本内容依据历史佛教文献生成，仅供学习参考。如需正式修行指导，请亲近善知识。\n\n"
@@ -256,7 +295,18 @@ _register(MasterProfile(
     tradition="禅宗",
     dates="638-713",
     description="禅宗六祖，直指人心、见性成佛",
+    # NOTE: these IDs are wrong — 8169 is T2013 禪宗永嘉集 (玄覺撰), not 坛经, and
+    # 6513 is T0262 法華經, not 金刚经. 六祖壇經 is T2008 = text_id 58. Left as-is here
+    # because correcting them changes this persona's RAG scope, which is a behaviour
+    # change beyond this UI PR — tracked separately.
     fojin_text_ids=[8169, 6513],  # 坛经, 金刚经 (approximate FoJin IDs)
+    epigraph=Epigraph(
+        quote="菩提本無樹，明鏡亦非臺",
+        text_id=58,
+        cbeta_id="T2008",
+        title_zh="六祖大師法寶壇經",
+        juan=1,
+    ),
     system_prompt=(
         "你是慧能大师（禅宗六祖，南宗禅创立者），禅宗，638-713。\n"
         "本内容依据历史佛教文献生成，仅供学习参考。如需正式修行指导，请亲近善知识。\n\n"
@@ -478,7 +528,14 @@ _register(MasterProfile(
     tradition="华严宗",
     dates="643-712",
     description="华严宗三祖，法界缘起、事事无碍",
-    fojin_text_ids=[8038],  # 金师子章 (approximate)
+    fojin_text_ids=[8038],  # 实为 T1866 華嚴一乘教義分齊章（非金师子章）
+    epigraph=Epigraph(
+        quote="一即一切，一切即一",
+        text_id=8038,
+        cbeta_id="T1866",
+        title_zh="華嚴一乘教義分齊章",
+        juan=4,
+    ),
     system_prompt=(
         "你是法藏大师（华严宗三祖，华严教义体系的真正创立者，武则天国师），华严宗，643-712。\n"
         "本内容依据历史佛教文献生成，仅供学习参考。如需正式修行指导，请亲近善知识。\n\n"
@@ -595,7 +652,14 @@ _register(MasterProfile(
     tradition="三论宗/中观",
     dates="344-413",
     description="中国四大译经家之一，般若空性、中道",
-    fojin_text_ids=[6513],  # 法华经 (approximate)
+    fojin_text_ids=[6513],  # T0262 妙法蓮華經（罗什译）
+    epigraph=Epigraph(
+        quote="諸佛世尊，唯以一大事因緣故出現於世",
+        text_id=6513,
+        cbeta_id="T0262",
+        title_zh="妙法蓮華經",
+        juan=1,
+    ),
     system_prompt=(
         '你是鸠摩罗什（中国四大译经家之一，以文学影响论为首，三论宗实际创始人），三论宗/中观，344-413。\n'
         "本内容依据历史佛教文献生成，仅供学习参考。如需正式修行指导，请亲近善知识。\n\n"
@@ -1457,7 +1521,7 @@ def get_master(master_id: str) -> MasterProfile | None:
 
 
 def list_masters() -> list[dict]:
-    """Return all masters as a list of dicts for the frontend selector."""
+    """Return all masters as a list of dicts for the frontend gallery/selector."""
     return [
         {
             "id": m.id,
@@ -1466,6 +1530,19 @@ def list_masters() -> list[dict]:
             "tradition": m.tradition,
             "dates": m.dates,
             "description": m.description,
+            # None for the masters whose own writing we don't host — the card then
+            # says so rather than showing an unbacked line. See Epigraph docstring.
+            "epigraph": (
+                {
+                    "quote": m.epigraph.quote,
+                    "text_id": m.epigraph.text_id,
+                    "cbeta_id": m.epigraph.cbeta_id,
+                    "title_zh": m.epigraph.title_zh,
+                    "juan": m.epigraph.juan,
+                }
+                if m.epigraph
+                else None
+            ),
         }
         for m in MASTERS.values()
     ]

--- a/backend/tests/test_master_epigraphs.py
+++ b/backend/tests/test_master_epigraphs.py
@@ -1,0 +1,82 @@
+"""祖师长廊 — the epigraph shown on each master's gallery card.
+
+The gallery is an extension of FoJin's citation discipline, not an exception to
+it. These tests guard the one invariant that makes that true: a master's card
+either carries a line WITH a checkable source, or it carries no line at all.
+
+The quotes themselves were verified character-for-character against production
+on 2026-07-12 (whitespace/punctuation normalized — CBETA content hard-wraps
+mid-word, so a naive substring check false-negatives). What the suite can still
+guard, cheaply and forever, is that nobody later adds a quote without a source.
+"""
+
+import pytest
+
+from app.services.master_profiles import MASTERS, list_masters
+
+# Verified 2026-07-12 against fojin.app: each line occurs verbatim in the cited
+# text, and the cited text is that master's own work (or, for 鸠摩罗什, his
+# translation — the text FoJin already scopes his RAG to).
+EXPECTED_VERIFIED = {
+    "nagarjuna": ("T1564", 40),
+    "zhiyi": ("T1911", 53),
+    "huineng": ("T2008", 58),
+    "fazang": ("T1866", 8038),
+    "kumarajiva": ("T0262", 6513),
+}
+
+
+def test_every_epigraph_carries_a_checkable_source():
+    """No line may appear on a card without somewhere to go and check it."""
+    for mid, m in MASTERS.items():
+        ep = m.epigraph
+        if ep is None:
+            continue
+        assert ep.quote.strip(), f"{mid}: epigraph with an empty quote"
+        assert ep.cbeta_id.strip(), f"{mid}: quote without a CBETA id"
+        assert ep.title_zh.strip(), f"{mid}: quote without a text title"
+        assert ep.text_id > 0, f"{mid}: quote without a reader-resolvable text_id"
+        assert ep.juan > 0, f"{mid}: quote without a fascicle number"
+
+
+def test_only_the_verified_masters_have_an_epigraph():
+    """Masters whose own writing we don't host must show nothing.
+
+    Ten of the fifteen are in that position (玄奘/印光/蕅益/虚云/米拉日巴/阿姜查/
+    宗喀巴/阿底峡/觉音/马哈希). Showing them a plausible-sounding line we cannot
+    open would be exactly the failure this product exists to prevent — so if a
+    future edit adds one, this test should make someone justify it.
+    """
+    with_epigraph = {mid for mid, m in MASTERS.items() if m.epigraph is not None}
+    assert with_epigraph == set(EXPECTED_VERIFIED), (
+        "The set of masters carrying a quote changed. A new quote must first be "
+        "verified verbatim against that master's own work in our corpus."
+    )
+
+
+@pytest.mark.parametrize(("master_id", "expected"), sorted(EXPECTED_VERIFIED.items()))
+def test_epigraph_points_at_the_verified_source(master_id, expected):
+    cbeta_id, text_id = expected
+    ep = MASTERS[master_id].epigraph
+    assert ep is not None
+    assert ep.cbeta_id == cbeta_id
+    assert ep.text_id == text_id
+
+
+def test_list_masters_exposes_epigraph_to_the_frontend():
+    masters = list_masters()
+    assert len(masters) == len(MASTERS)
+
+    by_id = {m["id"]: m for m in masters}
+    for mid in MASTERS:
+        assert "epigraph" in by_id[mid], f"{mid}: gallery card has no epigraph field"
+
+    huineng = by_id["huineng"]["epigraph"]
+    assert huineng is not None
+    assert huineng["quote"] == "菩提本無樹，明鏡亦非臺"
+    assert huineng["cbeta_id"] == "T2008"
+    assert huineng["text_id"] == 58  # deep-links straight into the reader
+    assert huineng["juan"] == 1
+
+    # A master we hold no writing for says so by omission, not by invention.
+    assert by_id["yinguang"]["epigraph"] is None

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1481,5 +1481,14 @@
   "admin_align_review.review_error": "Action failed, please retry",
   "admin_align_review.empty": "No pending alignment candidates",
   "admin_align_review.load_error": "Failed to load, please retry",
-  "admin_align_review.back_to_coverage": "Back to coverage"
+  "admin_align_review.back_to_coverage": "Back to coverage",
+  "chat.gallery_title": "Master Gallery",
+  "chat.gallery_hint": "Pick an interpretive lineage — read the canon through this master's tradition, not a chat with the person",
+  "chat.tradition_all": "All",
+  "chat.epigraph_verified": "Verified",
+  "chat.epigraph_none": "We host none of this master's own writing, so no line is shown",
+  "chat.epigraph_unset": "Not set",
+  "chat.master_lens": "Reading through this lineage",
+  "chat.change_master": "Change lineage",
+  "chat.master_disclaimer": "What follows is an AI interpretation generated from the canon — not the master's own teaching. Every citation carries its text and fascicle number; open it to check the original."
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1481,5 +1481,14 @@
   "admin_align_review.review_error": "操作失敗，請重試",
   "admin_align_review.empty": "暫無待複核的候選對齊",
   "admin_align_review.load_error": "載入失敗，請重試",
-  "admin_align_review.back_to_coverage": "返回覆蓋率"
+  "admin_align_review.back_to_coverage": "返回覆蓋率",
+  "chat.gallery_title": "祖師長廊",
+  "chat.gallery_hint": "選擇一條詮釋進路——以該祖師的宗風解經，而非與其本人對話",
+  "chat.tradition_all": "全部",
+  "chat.epigraph_verified": "已核驗",
+  "chat.epigraph_none": "本站未收其本人著作，故不列代表法語",
+  "chat.epigraph_unset": "未設",
+  "chat.master_lens": "依此宗風解經",
+  "chat.change_master": "更換宗風",
+  "chat.master_disclaimer": "以下為 AI 依據典籍生成的詮釋，非祖師本人開示。每處引證均標註經號與卷次，可點開核對原文。"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1481,5 +1481,14 @@
   "admin_align_review.review_error": "操作失败，请重试",
   "admin_align_review.empty": "暂无待复核的候选对齐",
   "admin_align_review.load_error": "加载失败，请重试",
-  "admin_align_review.back_to_coverage": "返回覆盖率"
+  "admin_align_review.back_to_coverage": "返回覆盖率",
+  "chat.gallery_title": "祖师长廊",
+  "chat.gallery_hint": "选择一条诠释进路——以该祖师的宗风解经，而非与其本人对话",
+  "chat.tradition_all": "全部",
+  "chat.epigraph_verified": "已核验",
+  "chat.epigraph_none": "本站未收其本人著作，故不列代表法语",
+  "chat.epigraph_unset": "未设",
+  "chat.master_lens": "依此宗风解经",
+  "chat.change_master": "更换宗风",
+  "chat.master_disclaimer": "以下为 AI 依据典籍生成的诠释，非祖师本人开示。每处引证均标注经号与卷次，可点开核对原文。"
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2324,3 +2324,31 @@ export async function reviewAlignmentCandidate(
   );
   return data;
 }
+
+// ── Buddhist master personas (祖师长廊) ───────────────────────────────────────
+
+/** A representative line, quoted verbatim from a text FoJin hosts and checked
+ *  against the master's OWN work. Null on the profile when our corpus holds none
+ *  of the master's writing — we show that plainly rather than an unbacked line. */
+export interface MasterEpigraph {
+  quote: string;
+  text_id: number;
+  cbeta_id: string;
+  title_zh: string;
+  juan: number;
+}
+
+export interface MasterProfile {
+  id: string;
+  name_zh: string;
+  name_en: string;
+  tradition: string;
+  dates: string;
+  description: string;
+  epigraph: MasterEpigraph | null;
+}
+
+export async function getMasters(): Promise<MasterProfile[]> {
+  const { data } = await api.get<{ masters: MasterProfile[] }>("/chat/masters");
+  return data.masters;
+}

--- a/frontend/src/components/MasterGallery.tsx
+++ b/frontend/src/components/MasterGallery.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { Spin } from "antd";
+import { getMasters, type MasterProfile } from "../api/client";
+import "../styles/master-gallery.css";
+
+/**
+ * 祖师长廊 — the master picker.
+ *
+ * Deliberately has NO portraits. Fabricating faces for real historical teachers
+ * would contradict the one thing this product sells (every claim carries a
+ * source), so each master is stamped with a cinnabar seal of their name instead
+ * — which also happens to be exactly what `--fj-accent: #8b2500` already is.
+ *
+ * The card's last line is the point: a master's representative line is shown
+ * only when it was verified verbatim against that master's own work in our
+ * corpus, and it links to the passage. Masters whose writing we don't host say
+ * so. The gallery is an extension of the citation discipline, not an exception.
+ */
+
+/** Traditions, derived from the `tradition` string the API already returns. */
+type Lineage = "india" | "han" | "tibetan" | "theravada";
+
+const LINEAGE_KEYS: Record<Lineage, string> = {
+  india: "chat.tradition_india",
+  han: "chat.tradition_han",
+  tibetan: "chat.tradition_tibetan",
+  theravada: "chat.tradition_theravada",
+};
+
+function lineageOf(m: MasterProfile): Lineage {
+  // Matching against the API's `tradition` data values ("藏传·噶举派", "南传·上座部论师",
+  // "印度·中观", …), not UI copy — the displayed chip labels go through t() below.
+  const t = m.tradition;
+  if (t.startsWith("藏传")) return "tibetan"; // i18n-exempt
+  if (t.startsWith("南传")) return "theravada"; // i18n-exempt
+  if (t.startsWith("印度")) return "india"; // i18n-exempt
+  return "han";
+}
+
+/** Seal text: the first two characters of the name — 慧能大师 → 慧能. */
+function sealOf(m: MasterProfile): string {
+  return Array.from(m.name_zh).slice(0, 2).join("");
+}
+
+export function MasterSeal({ text, size = 46 }: { text: string; size?: number }) {
+  return (
+    <span
+      className="mg-seal"
+      style={{ width: size, height: size, fontSize: Math.round(size * 0.32) }}
+      aria-hidden="true"
+    >
+      <span className="mg-seal-text">{text}</span>
+    </span>
+  );
+}
+
+interface Props {
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+  /** Reader deep-link for an epigraph's source passage. */
+  onOpenSource?: (textId: number, juan: number) => void;
+}
+
+export default function MasterGallery({ selectedId, onSelect, onOpenSource }: Props) {
+  const { t, i18n } = useTranslation();
+  const [lineage, setLineage] = useState<Lineage | "all">("all");
+
+  const { data: masters, isLoading } = useQuery({
+    queryKey: ["chat-masters"],
+    queryFn: getMasters,
+    staleTime: 60 * 60 * 1000, // curated data; effectively static
+  });
+
+  const isEn = i18n.language?.startsWith("en");
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: masters?.length ?? 0 };
+    for (const m of masters ?? []) {
+      const l = lineageOf(m);
+      c[l] = (c[l] ?? 0) + 1;
+    }
+    return c;
+  }, [masters]);
+
+  const shown = useMemo(
+    () => (masters ?? []).filter((m) => lineage === "all" || lineageOf(m) === lineage),
+    [masters, lineage],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="mg-loading">
+        <Spin />
+      </div>
+    );
+  }
+
+  const filters: Array<Lineage | "all"> = ["all", "india", "han", "tibetan", "theravada"];
+
+  return (
+    <div className="mg">
+      <div className="mg-chips" role="group" aria-label={t("chat.gallery_title")}>
+        {filters.map((f) => (
+          <button
+            key={f}
+            type="button"
+            className="mg-chip"
+            aria-pressed={lineage === f}
+            onClick={() => setLineage(f)}
+          >
+            {f === "all" ? t("chat.tradition_all") : t(LINEAGE_KEYS[f])}
+            <span className="mg-chip-n">{counts[f] ?? 0}</span>
+          </button>
+        ))}
+        <button
+          type="button"
+          className="mg-chip mg-chip-plain"
+          aria-pressed={selectedId === null}
+          onClick={() => onSelect(null)}
+        >
+          {t("chat.general_assistant")}
+        </button>
+      </div>
+
+      <div className="mg-grid">
+        {shown.map((m) => {
+          const ep = m.epigraph;
+          const selected = selectedId === m.id;
+          return (
+            <button
+              key={m.id}
+              type="button"
+              className={`mg-card${selected ? " is-selected" : ""}`}
+              aria-pressed={selected}
+              onClick={() => onSelect(m.id)}
+            >
+              <span className="mg-card-top">
+                <MasterSeal text={sealOf(m)} />
+                <span className="mg-id">
+                  <span className="mg-name">{isEn ? m.name_en : m.name_zh}</span>
+                  <span className="mg-meta">
+                    <span className="mg-school">{m.tradition}</span> · {m.dates}
+                  </span>
+                </span>
+              </span>
+
+              <span className="mg-rule" />
+
+              {ep ? (
+                <>
+                  <span className="mg-quote">「{ep.quote}」</span>
+                  <span className="mg-src">
+                    <span className="mg-ref">
+                      {ep.cbeta_id}《{ep.title_zh}》
+                    </span>
+                    <span className="mg-badge">✓ {t("chat.epigraph_verified")}</span>
+                    {onOpenSource && (
+                      <span
+                        className="mg-open"
+                        role="link"
+                        tabIndex={0}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onOpenSource(ep.text_id, ep.juan);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onOpenSource(ep.text_id, ep.juan);
+                          }
+                        }}
+                      >
+                        ↗
+                      </span>
+                    )}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="mg-quote mg-quote-none">{t("chat.epigraph_none")}</span>
+                  <span className="mg-src">
+                    <span className="mg-badge mg-badge-none">— {t("chat.epigraph_unset")}</span>
+                  </span>
+                </>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback, useMemo, useEffect, lazy, Suspense, memo
 import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
-import { Input, Button, message, Alert, Tooltip, Modal, Select, Tag, Spin } from "antd";
+import { Input, Button, message, Alert, Tooltip, Modal, Tag, Spin } from "antd";
 import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
@@ -34,6 +34,8 @@ import {
 const ShareCard = lazy(() => import("../components/ShareCard"));
 const CitationDrawer = lazy(() => import("../components/CitationDrawer"));
 import ChatModelSelector from "../components/ChatModelSelector";
+import MasterGallery, { MasterSeal } from "../components/MasterGallery";
+import { getMasters } from "../api/client";
 import type { CitationTarget } from "../components/CitationDrawer";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -544,6 +546,18 @@ export default function ChatPage() {
   const { user } = useAuthStore();
   const [input, setInput] = useState("");
   const [masterId, setMasterId] = useState<string | null>(null);
+  // 祖师长廊: opened from the composer to swap lineage mid-thread. The gallery
+  // itself lives in the empty state; this is the way back to it.
+  const [galleryOpen, setGalleryOpen] = useState(false);
+  const { data: mastersData } = useQuery({
+    queryKey: ["chat-masters"],
+    queryFn: getMasters,
+    staleTime: 60 * 60 * 1000, // curated data; effectively static
+  });
+  const selectedMaster = useMemo(
+    () => mastersData?.find((m) => m.id === masterId) ?? null,
+    [mastersData, masterId],
+  );
   const [modelId, setModelId] = useState<string>(() => {
     if (typeof window === "undefined") return "deepseek:v4-pro";
     return window.localStorage.getItem("fojin.chat.modelId") || "deepseek:v4-pro";
@@ -1446,6 +1460,32 @@ export default function ChatPage() {
                     </Button>
                   </div>
                 )}
+
+                {/* 祖师长廊 — the second act of the empty state. The 15 master
+                    personas are this product's sharpest differentiator and used
+                    to hide inside a grey dropdown; here they are the front door. */}
+                <div style={{ marginTop: 34, textAlign: "left" }}>
+                  <div style={{ textAlign: "center", marginBottom: 14 }}>
+                    <div style={{
+                      fontSize: 16,
+                      fontFamily: '"Noto Serif SC", serif',
+                      color: "var(--fj-ink)",
+                      marginBottom: 4,
+                    }}>
+                      {t("chat.gallery_title")}
+                    </div>
+                    <div style={{ fontSize: 12.5, lineHeight: 1.7 }}>
+                      {t("chat.gallery_hint")}
+                    </div>
+                  </div>
+                  <MasterGallery
+                    selectedId={masterId}
+                    onSelect={setMasterId}
+                    onOpenSource={(textId, juan) =>
+                      window.open(`/texts/${textId}/read?juan=${juan}`, "_blank", "noopener")
+                    }
+                  />
+                </div>
               </div>
             )}
             {messages.map((m) => (
@@ -1491,56 +1531,60 @@ export default function ChatPage() {
                 }
               />
             )}
-            <div style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 8 }}>
-              <span style={{ fontSize: 13, color: "#8b7355", whiteSpace: "nowrap" }}>{t("chat.master_mode")}</span>
-              <Select
-                allowClear
-                placeholder={t("chat.general_assistant")}
-                value={masterId}
-                onChange={(v) => setMasterId(v || null)}
-                style={{ width: 260, fontSize: 13 }}
+            {/* 宗风 selector. Was a grey <Select> reading "通用助手" — the 15 master
+                personas, this product's sharpest differentiator, hid inside it.
+                Now: the chosen lineage is stated plainly, and the gallery is one
+                click away. Wording is "依此宗风解经", never "和祖师聊天" — you are
+                choosing an interpretive lens, not a chat character. */}
+            <div className="mg-head" style={{ marginBottom: 8 }}>
+              {selectedMaster ? (
+                <>
+                  <MasterSeal text={Array.from(selectedMaster.name_zh).slice(0, 2).join("")} size={34} />
+                  <span className="mg-head-id">
+                    <span className="mg-head-name">{selectedMaster.name_zh}</span>
+                    <span className="mg-head-sub">
+                      {selectedMaster.tradition} · {selectedMaster.dates} · {t("chat.master_lens")}
+                    </span>
+                  </span>
+                </>
+              ) : (
+                <span className="mg-head-id">
+                  <span className="mg-head-name">{t("chat.general_assistant")}</span>
+                  <span className="mg-head-sub">{t("chat.gallery_hint")}</span>
+                </span>
+              )}
+              <Button
                 size="small"
-                options={[
-                  { value: "", label: `🟢 ${t("chat.general_assistant")}` },
-                  {
-                    label: t("chat.tradition_han"),
-                    options: [
-                      { value: "zhiyi", label: t("chat.master_zhiyi") },
-                      { value: "huineng", label: t("chat.master_huineng") },
-                      { value: "xuanzang", label: t("chat.master_xuanzang") },
-                      { value: "fazang", label: t("chat.master_fazang") },
-                      { value: "kumarajiva", label: t("chat.master_kumarajiva") },
-                      { value: "yinguang", label: t("chat.master_yinguang") },
-                      { value: "ouyi", label: t("chat.master_ouyi") },
-                      { value: "xuyun", label: t("chat.master_xuyun") },
-                    ],
-                  },
-                  {
-                    label: t("chat.tradition_india"),
-                    options: [
-                      { value: "nagarjuna", label: t("chat.master_nagarjuna") },
-                    ],
-                  },
-                  {
-                    label: t("chat.tradition_tibetan"),
-                    options: [
-                      { value: "atisha", label: t("chat.master_atisha") },
-                      { value: "tsongkhapa", label: t("chat.master_tsongkhapa") },
-                      { value: "milarepa", label: t("chat.master_milarepa") },
-                    ],
-                  },
-                  {
-                    label: t("chat.tradition_theravada"),
-                    options: [
-                      { value: "buddhaghosa", label: t("chat.master_buddhaghosa") },
-                      { value: "mahasi-sayadaw", label: t("chat.master_mahasi") },
-                      { value: "ajahn-chah", label: t("chat.master_ajahn_chah") },
-                    ],
-                  },
-                ]}
-              />
-              {masterId && <span style={{ fontSize: 11, color: "#a09070" }}>{t("chat.rag_scope_hint")}</span>}
+                className="mg-head-swap"
+                onClick={() => setGalleryOpen(true)}
+              >
+                {t("chat.change_master")}
+              </Button>
             </div>
+            {selectedMaster && (
+              <div className="mg-disclaimer" style={{ marginTop: 0, marginBottom: 8 }}>
+                {t("chat.master_disclaimer")}
+              </div>
+            )}
+            <Modal
+              open={galleryOpen}
+              onCancel={() => setGalleryOpen(false)}
+              footer={null}
+              width={880}
+              title={t("chat.gallery_title")}
+              destroyOnClose
+            >
+              <MasterGallery
+                selectedId={masterId}
+                onSelect={(id) => {
+                  setMasterId(id);
+                  setGalleryOpen(false);
+                }}
+                onOpenSource={(textId, juan) =>
+                  window.open(`/texts/${textId}/read?juan=${juan}`, "_blank", "noopener")
+                }
+              />
+            </Modal>
             {!user && !keyStatus?.has_api_key && quota && quota.remaining >= 0 && (
               <Alert
                 message={<span>{t("chat.quota_info", { limit: quota.limit, remaining: quota.remaining })}<a onClick={() => navigate("/login")}>{t("chat.login")}</a>{t("chat.login_quota_hint")}</span>}

--- a/frontend/src/styles/master-gallery.css
+++ b/frontend/src/styles/master-gallery.css
@@ -1,0 +1,279 @@
+/* 祖师长廊 — master picker.
+   No portraits by design: a cinnabar name-seal stands in for the avatar.
+   Every colour below comes from the existing FoJin token set; --fj-accent
+   (#8b2500) already *is* seal-ink red, so the seal needs no new colour. */
+
+.mg {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}
+
+.mg-loading {
+  display: flex;
+  justify-content: center;
+  padding: 40px 0;
+}
+
+/* ── Lineage filter chips ── */
+.mg-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mg-chip {
+  font: inherit;
+  font-size: 13px;
+  padding: 4px 13px;
+  border-radius: 999px;
+  border: 1px solid var(--fj-border, #d9d0c1);
+  background: transparent;
+  color: var(--fj-ink-light, #5c4f3d);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.mg-chip:hover {
+  border-color: var(--fj-accent, #8b2500);
+  color: var(--fj-accent, #8b2500);
+}
+
+.mg-chip:focus-visible {
+  outline: 2px solid var(--fj-accent, #8b2500);
+  outline-offset: 2px;
+}
+
+.mg-chip[aria-pressed="true"] {
+  background: var(--fj-accent, #8b2500);
+  border-color: var(--fj-accent, #8b2500);
+  color: #fff;
+}
+
+.mg-chip-n {
+  margin-left: 5px;
+  opacity: 0.6;
+  font-variant-numeric: tabular-nums;
+}
+
+/* 通用助手 sits apart from the lineage filters — it is a choice, not a filter. */
+.mg-chip-plain {
+  margin-left: auto;
+}
+
+/* ── Card grid ── */
+.mg-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(252px, 1fr));
+  gap: 12px;
+}
+
+.mg-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  background: #fffdfa;
+  border: 1px solid var(--fj-border, #d9d0c1);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: border-color 0.16s, box-shadow 0.16s, transform 0.16s;
+}
+
+.mg-card:hover {
+  border-color: var(--fj-accent, #8b2500);
+  box-shadow: 0 4px 14px -6px rgba(139, 37, 0, 0.28);
+  transform: translateY(-1px);
+}
+
+.mg-card:focus-visible {
+  outline: 2px solid var(--fj-accent, #8b2500);
+  outline-offset: 2px;
+}
+
+.mg-card.is-selected {
+  border-color: var(--fj-accent, #8b2500);
+  box-shadow: inset 0 0 0 1px var(--fj-accent, #8b2500);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mg-card,
+  .mg-chip {
+    transition: none;
+  }
+  .mg-card:hover {
+    transform: none;
+  }
+}
+
+.mg-card-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+}
+
+/* ── The seal (白文印: name reversed out of cinnabar) ── */
+.mg-seal {
+  flex-shrink: 0;
+  background: var(--fj-accent, #8b2500);
+  border-radius: 2px;
+  display: grid;
+  place-items: center;
+  padding: 3px;
+}
+
+.mg-seal-text {
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-weight: 700;
+  line-height: 1.05;
+  color: #fdf6ee;
+  letter-spacing: 0.02em;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  white-space: nowrap;
+}
+
+.mg-id {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.mg-name {
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--fj-ink, #2b2318);
+  letter-spacing: 0.02em;
+}
+
+.mg-meta {
+  font-size: 12px;
+  color: var(--fj-ink-muted, #9a8e7a);
+  font-variant-numeric: tabular-nums;
+}
+
+.mg-school {
+  color: var(--fj-ink-light, #5c4f3d);
+}
+
+.mg-rule {
+  height: 1px;
+  background: var(--fj-border, #d9d0c1);
+}
+
+/* ── The quote: the typographic hero of the card ── */
+.mg-quote {
+  display: block;
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-size: 15px;
+  line-height: 1.8;
+  color: var(--fj-ink, #2b2318);
+  min-height: 3.6em;
+}
+
+.mg-quote-none {
+  font-size: 13px;
+  color: var(--fj-ink-muted, #9a8e7a);
+  line-height: 1.7;
+}
+
+/* ── Source line: every quote carries its citation and its verified state,
+      in the same vocabulary the chat answers already use. ── */
+.mg-src {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 11.5px;
+  color: var(--fj-ink-muted, #9a8e7a);
+}
+
+.mg-ref {
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  color: var(--fj-ink-light, #5c4f3d);
+}
+
+.mg-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 10.5px;
+  font-weight: 600;
+  background: #e8f0e4;
+  color: #3f6b32;
+  white-space: nowrap;
+}
+
+.mg-badge-none {
+  background: #ecebe8;
+  color: #83796a;
+}
+
+.mg-open {
+  margin-left: auto;
+  color: var(--fj-accent, #8b2500);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0 2px;
+}
+
+.mg-open:focus-visible {
+  outline: 2px solid var(--fj-accent, #8b2500);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+
+/* ── Persona header, shown above the thread once a lineage is chosen ── */
+.mg-head {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 10px 14px;
+  background: #fffdfa;
+  border: 1px solid var(--fj-border, #d9d0c1);
+  border-radius: 3px;
+}
+
+.mg-head-id {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.mg-head-name {
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--fj-ink, #2b2318);
+}
+
+.mg-head-sub {
+  font-size: 11.5px;
+  color: var(--fj-ink-muted, #9a8e7a);
+}
+
+.mg-head-swap {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* The disclaimer is not fine print — it is the fuse on the whole persona idea. */
+.mg-disclaimer {
+  margin-top: 8px;
+  font-size: 11.5px;
+  line-height: 1.7;
+  color: var(--fj-ink-muted, #9a8e7a);
+  padding: 8px 12px;
+  background: var(--fj-bg-alt, #f0ebe2);
+  border-left: 2px solid var(--fj-border, #d9d0c1);
+  border-radius: 3px;
+}


### PR DESCRIPTION
法师模式是 FoJin 最独特的能力,却一直藏在一个写着「通用助手」的灰色下拉框里。本 PR 把它做成 `/chat` 空状态的门面。

## 不用画像 —— 这是刻意的
为真实历史祖师**凭空生成人脸**,会直接否定本产品的立身之本(凡有引文必有出处),对佛教受众也可能是冒犯。改用**朱砂白文印**(名号反白)。

恰好 `--fj-accent (#8b2500)` **本就是印泥色** —— 本 PR 未新增一个颜色。

## 卡片的最后一行才是灵魂
每句代表法语**必须逐字命中该祖师本人的典籍**,并带经号·卷次、可跳阅读器核对。15 位中只有 **5 位**有:

| 祖师 | 法语 | 出处 |
|---|---|---|
| 龙树 | 眾因緣生法，我說即是空 | T1564《中論》卷4 |
| 鸠摩罗什 | 諸佛世尊，唯以一大事因緣故出現於世 | T0262《妙法蓮華經》卷1 |
| 智顗 | 止觀明靜，前代未聞 | T1911《摩訶止觀》卷1 |
| 慧能 | 菩提本無樹，明鏡亦非臺 | T2008《六祖壇經》卷1 |
| 法藏 | 一即一切，一切即一 | T1866《教義分齊章》卷4 |

**其余 10 位库中无其本人著作,卡片诚实显示「未设」。宁可留白,不可杜撰。**

### 核验过程推翻了三处常见误引
1. 《中論》原文是「**眾**因緣生法」,而非流传甚广的「因緣所生法」(后者是天台的转述)
2. 印光「敦倫盡分」**全文库确无**(《文钞》非大正藏文本)
3. CBETA 原文有**词中硬换行**(`法\n\n性寂然名「止」`),朴素子串比对会产生**假阴性**,须归一化

## 措辞
「**依此宗风解经**」「更换宗风」,而非「和祖师聊天」—— 选的是**诠释进路**,不是聊天角色。并常驻声明:*此为 AI 依据典籍生成的诠释,非祖师本人开示*。

## 改动
- `MasterProfile` 新增 `Epigraph`,`list_masters()` 透出
- 新增 `MasterGallery` 组件 + `master-gallery.css`
- `ChatPage`:空状态嵌入长廊;下拉框 → 人格头部(印章+名号+宗风)+ 长廊 Modal
- i18n 9 键 × 3 语言(传承匹配为数据值,标 `i18n-exempt`)
- 测试:守住「**卡片上不得出现无出处引文**」这一不变式

**无迁移、无 DB 改动。**

## ⚠️ 已知遗留(未在本 PR 修改)
`慧能`/`虚云` 的 `fojin_text_ids` 指向错误:`8169` 实为 **T2013 永嘉集**(非坛经),坛经 T2008 = **id 58**。原注释即自标 `approximate`。
**这导致慧能人格检索不到《壇經》** —— 但修它会改变 RAG 行为,超出本 UI PR 范围,应单独修。

## 测试
后端 8 项新增全过 + ruff 干净;前端 tsc/ESLint/i18n ratchet 干净,vitest 186 项全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)