### PR TITLE
fix(chat): 修正祖师 RAG 作用域(慧能检索不到《壇經》)+ 可复跑的引文核验

### DIFF
--- a/backend/app/services/master_profiles.py
+++ b/backend/app/services/master_profiles.py
@@ -179,7 +179,10 @@ _register(MasterProfile(
     tradition="天台宗",
     dates="538-597",
     description="天台宗创始人，一念三千、三谛圆融、止观双修",
-    fojin_text_ids=[53, 52, 8085, 6513],  # 摩诃止观, 法华玄义, 小止观, 法华经
+    # 53 = T1911 摩訶止觀, 52 = T1718 妙法蓮華經文句 (the old comment said 法华玄义 —
+    # that is T1716, text_id 7889, and is NOT in this scope), 8085 = T1915 修習止觀坐禪
+    # 法要, 6513 = T0262 妙法蓮華經. Scope left as-is; only the comment was wrong.
+    fojin_text_ids=[53, 52, 8085, 6513],
     epigraph=Epigraph(
         quote="止觀明靜，前代未聞",
         text_id=53,
@@ -295,11 +298,11 @@ _register(MasterProfile(
     tradition="禅宗",
     dates="638-713",
     description="禅宗六祖，直指人心、见性成佛",
-    # NOTE: these IDs are wrong — 8169 is T2013 禪宗永嘉集 (玄覺撰), not 坛经, and
-    # 6513 is T0262 法華經, not 金刚经. 六祖壇經 is T2008 = text_id 58. Left as-is here
-    # because correcting them changes this persona's RAG scope, which is a behaviour
-    # change beyond this UI PR — tracked separately.
-    fojin_text_ids=[8169, 6513],  # 坛经, 金刚经 (approximate FoJin IDs)
+    # 坛经 T2008(58) + 金刚经 T0235b(63, 罗什译). Corrected 2026-07-12: these were
+    # [8169, 6513] — 8169 is T2013 禪宗永嘉集 (玄覺撰, NOT 慧能), 6513 is T0262 法華經
+    # (NOT 金刚经). The IDs were guessed (the old comment said "approximate"), so this
+    # persona was hard-scoped to a text he did not write and could never cite 壇經.
+    fojin_text_ids=[58, 63],
     epigraph=Epigraph(
         quote="菩提本無樹，明鏡亦非臺",
         text_id=58,
@@ -528,7 +531,9 @@ _register(MasterProfile(
     tradition="华严宗",
     dates="643-712",
     description="华严宗三祖，法界缘起、事事无碍",
-    fojin_text_ids=[8038],  # 实为 T1866 華嚴一乘教義分齊章（非金师子章）
+    # 8038 = T1866 華嚴一乘教義分齊章 (法藏述). The old comment called it 金师子章 —
+    # wrong text, right master; the ID itself was fine.
+    fojin_text_ids=[8038],
     epigraph=Epigraph(
         quote="一即一切，一切即一",
         text_id=8038,
@@ -898,7 +903,11 @@ _register(MasterProfile(
     tradition="禅宗·五宗兼嗣",
     dates="1840-1959",
     description="近代禅宗泰斗，参话头、老实修行",
-    fojin_text_ids=[8169],  # 坛经 (approximate)
+    # Empty on purpose. Was [8169] — T2013 禪宗永嘉集 (玄覺撰), which 虚云 (1840-1959)
+    # did not write; the ID was a guess. His 《虛雲和尚法彙》 is modern and not in CBETA,
+    # so like 印光/蕅益 he gets the documented no-indexed-corpus treatment: full-corpus
+    # vector RAG with precise retrieval disabled (see _master_text_scope in chat.py).
+    fojin_text_ids=[],
     system_prompt=(
         "你是虚云老和尚（近代禅宗泰斗，世寿一百二十岁，一身兼嗣禅门五宗法脉），禅宗·五宗兼嗣，1840-1959。\n"
         "本内容依据历史佛教文献生成，仅供学习参考。如需正式修行指导，请亲近善知识。\n\n"

--- a/backend/scripts/verify_master_epigraphs.py
+++ b/backend/scripts/verify_master_epigraphs.py
@@ -1,0 +1,102 @@
+"""Re-verify every 祖师长廊 epigraph against the corpus. Exits non-zero on any miss.
+
+    docker compose exec -T backend python -u scripts/verify_master_epigraphs.py
+
+Why this exists
+---------------
+The gallery's whole claim is that a master's card only carries a line we can back
+up. That was established by hand once (2026-07-12); this script makes it a check
+anyone can re-run — after a data reimport, a text_id change, or a new epigraph.
+
+It reuses ``quote_verifier._normalise`` on purpose. Verifying by naive substring
+match is a TRAP that already bit us twice:
+
+  1. CBETA content hard-wraps mid-word — 摩訶止觀 stores ``法\\n\\n性寂然名「止」`` —
+     so ``"法性寂然名止" in content`` is False even though the line is right there.
+  2. The corpus is 繁體 while our UI/quotes drift 简体, and CBETA punctuation differs
+     from anything a human types.
+
+``_normalise`` handles all of it (NFKC + 繁→简 fold + strip punctuation/whitespace),
+which is precisely why the production quote-verifier uses it. Any bespoke matcher
+here would re-introduce the false-negatives it exists to prevent.
+
+The other half of the trap is the search API: ``/api/search/content`` is token-fuzzy,
+so its top hit is NOT proof — it cheerfully "finds" 印光's 「敦倫盡分」 inside 《長阿含經》.
+This script never searches; it reads the exact cited juan and checks it contains the
+line. That is the only claim the card makes.
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import text as sql
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+from app.services.master_profiles import MASTERS
+from app.services.quote_verifier import _normalise
+
+
+async def main() -> int:
+    engine = create_async_engine(settings.database_url)
+    failures: list[str] = []
+    checked = 0
+
+    async with async_sessionmaker(engine, class_=AsyncSession)() as s:
+        for mid, m in MASTERS.items():
+            ep = m.epigraph
+            if ep is None:
+                print(f"  —  {m.name_zh:<12} 未设 (no work of his in the corpus)")
+                continue
+
+            checked += 1
+            # lang='lzh' matters: text_contents is unique on (text_id, juan_num, lang),
+            # so a juan can also hold an English/Pali rendering. Comparing a 漢文 quote
+            # against a translation would fail for the wrong reason.
+            row = (
+                await s.execute(
+                    sql(
+                        "SELECT content FROM text_contents "
+                        "WHERE text_id = :tid AND juan_num = :juan AND lang = 'lzh' LIMIT 1"
+                    ),
+                    {"tid": ep.text_id, "juan": ep.juan},
+                )
+            ).first()
+
+            if row is None or not row[0]:
+                failures.append(f"{mid}: no content for text_id={ep.text_id} juan={ep.juan}")
+                print(f"  ✗  {m.name_zh:<12} 卷内容取不到 (text_id={ep.text_id} juan={ep.juan})")
+                continue
+
+            if _normalise(ep.quote) in _normalise(row[0]):
+                print(
+                    f"  ✅ {m.name_zh:<12} 「{ep.quote}」 "
+                    f"— {ep.cbeta_id}《{ep.title_zh}》卷{ep.juan}"
+                )
+            else:
+                failures.append(
+                    f"{mid}: 「{ep.quote}」 NOT found in {ep.cbeta_id} 卷{ep.juan}"
+                )
+                print(f"  ❌ {m.name_zh:<12} 「{ep.quote}」 不在 {ep.cbeta_id} 卷{ep.juan}")
+
+            # The card links the quote into the reader under this master's own
+            # scope; if the cited text isn't in his scope, the card and the RAG
+            # disagree (exactly the 慧能 bug).
+            if m.fojin_text_ids and ep.text_id not in m.fojin_text_ids:
+                failures.append(
+                    f"{mid}: epigraph text_id={ep.text_id} outside RAG scope {m.fojin_text_ids}"
+                )
+
+    await engine.dispose()
+
+    print(f"\n{checked} epigraph(s) checked, {len(failures)} problem(s).")
+    for f in failures:
+        print(f"  !! {f}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_master_epigraphs.py
+++ b/backend/tests/test_master_epigraphs.py
@@ -63,6 +63,49 @@ def test_epigraph_points_at_the_verified_source(master_id, expected):
     assert ep.text_id == text_id
 
 
+def test_epigraph_text_lies_inside_the_masters_own_rag_scope():
+    """The line on a master's card must come from a text that master is scoped to.
+
+    This is the invariant that would have caught the 慧能 bug: his fojin_text_ids
+    were guessed ([8169, 6513] — 永嘉集 by 玄覺, and 法華經), so the persona was
+    hard-scoped to a text he did not write and could never cite 壇經 — while his
+    card quotes 壇經. Card and RAG scope disagreeing is the smell; assert they can't.
+
+    Masters with an EMPTY scope are exempt: `[]` means "no indexed corpus" (see
+    _master_text_scope in chat.py) and those masters carry no epigraph anyway.
+    """
+    for mid, m in MASTERS.items():
+        if m.epigraph is None or not m.fojin_text_ids:
+            continue
+        assert m.epigraph.text_id in m.fojin_text_ids, (
+            f"{mid}: card quotes text_id={m.epigraph.text_id} "
+            f"({m.epigraph.cbeta_id}) but the persona is scoped to "
+            f"{m.fojin_text_ids} — the master cannot actually cite his own epigraph."
+        )
+
+
+# The RAG scope is a HARD filter, and getting it wrong is not cosmetic: a 2026-05-07
+# production trace had 楞严经 leaking into Ajahn Chah's context. These IDs were
+# resolved against the live corpus on 2026-07-12 — pin them so a future guess can't
+# silently replace a verified id.
+EXPECTED_SCOPE = {
+    "nagarjuna": [39, 40, 41, 7806, 7708],  # 大智度論/中論/十二門論/迴諍論/十住毘婆沙論
+    "zhiyi": [53, 52, 8085, 6513],  # 摩訶止觀/法華文句/小止觀/法華經
+    "huineng": [58, 63],  # 六祖壇經 T2008 / 金剛經 T0235b
+    "fazang": [8038],  # 華嚴一乘教義分齊章 T1866
+    "kumarajiva": [6513],  # 妙法蓮華經 T0262（其译）
+    "xuyun": [],  # 《法彙》不在 CBETA — no indexed corpus
+}
+
+
+@pytest.mark.parametrize(("master_id", "expected"), sorted(EXPECTED_SCOPE.items()))
+def test_master_rag_scope_pinned_to_verified_text_ids(master_id, expected):
+    assert MASTERS[master_id].fojin_text_ids == expected, (
+        f"{master_id}: RAG scope changed. text_ids are a hard filter — verify any new "
+        f"id actually is that master's own work before changing this."
+    )
+
+
 def test_list_masters_exposes_epigraph_to_the_frontend():
     masters = list_masters()
     assert len(masters) == len(MASTERS)


### PR DESCRIPTION
## 真 bug:`fojin_text_ids` 是**硬作用域**,而它们是猜的

`chat.py` 的 `_master_text_scope` 文档写明这是**硬过滤**,并记录过一次生产事故(2026-05-07 msg 4437:`or None` 把空列表塌陷,《楞严经》泄漏进阿姜查南传上下文)。而这些 ID 的原注释**自己就写着 `approximate`** —— 确实是猜的,且猜错了。

| 祖师 | 原值 | 实际是什么 | 修正为 |
|---|---|---|---|
| **慧能** | `[8169, 6513]` | 8169 = T2013**《禪宗永嘉集》(玄覺撰)**、6513 = T0262**《法華經》** | `[58, 63]` |
| **虚云** | `[8169]` | 同样是《永嘉集》—— 他没写过 | `[]` |

**后果:慧能人格被硬锁在一部他没写过的书上,永远检索不到《六祖壇經》。** 修正为 T2008《壇經》(58) + T0235b《金剛經》(63,罗什译)—— 正是原注释的本意。

虚云的《法彙》是近代著作、不在 CBETA,故按**文档既定设计**置空:全库向量检索 + 关闭精确检索(与印光/蕅益一致)。

法藏/智顗:**ID 本身正确**,只是注释指错了书,一并更正。

**玄奘刻意不动**:他现在是空(= 全库向量检索);若贸然补上《成唯識論》(44),反而会把他**硬锁死在一本书里**,失去心經/大般若/瑜伽師地論 —— 比现状更糟。

## 加上本该早就存在的不变式
`test_epigraph_text_lies_inside_the_masters_own_rag_scope`:**祖师卡片引用的经,必须落在他自己的 RAG 作用域内。**

这条测试会**直接抓住慧能这个 bug** —— 卡片引《壇經》而作用域里没有《壇經》,本身就是矛盾。另 pin 住已核验的 text_ids,防止再被猜测替换。

## `scripts/verify_master_epigraphs.py` —— 把一次性手工核验变成可复跑
复用**生产的** `quote_verifier._normalise`(NFKC + 繁→简折叠 + 剥离标点空白),因为朴素子串比对是个**已经咬过我们两次**的陷阱:

1. **CBETA 原文词中硬换行** ——《摩訶止觀》存的是 `法\n\n性寂然名「止」`,导致 `"法性寂然名止" in content` 为 **False**,尽管原句就在那里;
2. 藏经是**繁体**而引文常为简体,标点也不一致。

脚本**从不搜索**(`/api/search/content` 是分词模糊匹配,首条**不构成证据** —— 它曾"找到"印光的「敦倫盡分」出自**《長阿含經》**),而是直读被引的那一卷,检查其确实包含该句。

## 测试
后端全量 **1267 项通过**;ruff 干净。**无迁移。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)