### PR TITLE
fix(pwa): 长时间开着的标签页也能发现新版本

### DIFF
--- a/frontend/public/sw-update.js
+++ b/frontend/public/sw-update.js
@@ -6,11 +6,29 @@
 (function () {
   if (!("serviceWorker" in navigator)) return;
 
-  // Restore the #185 behavior: proactively check for a newer sw.js.
-  navigator.serviceWorker.getRegistrations().then(function (regs) {
-    regs.forEach(function (reg) {
-      reg.update().catch(function () {});
+  // How often a long-lived tab re-checks for a new sw.js.
+  var CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 min
+
+  function checkForUpdate() {
+    navigator.serviceWorker.getRegistrations().then(function (regs) {
+      regs.forEach(function (reg) {
+        reg.update().catch(function () {});
+      });
     });
+  }
+
+  // Restore the #185 behavior: proactively check for a newer sw.js.
+  checkForUpdate();
+
+  // ...but a load-time check alone only helps people who navigate. FoJin is an
+  // SPA people leave open for a long reading session, and route changes don't
+  // reload — so a tab opened before a deploy would never discover the new SW
+  // and would keep running the old bundle indefinitely. Re-check periodically,
+  // and again whenever the tab is brought back to the foreground (the cheap
+  // proxy for "the user came back after a while").
+  setInterval(checkForUpdate, CHECK_INTERVAL_MS);
+  document.addEventListener("visibilitychange", function () {
+    if (document.visibilityState === "visible") checkForUpdate();
   });
 
   // With skipWaiting + clientsClaim, a new SW can take over mid-session.


### PR DESCRIPTION
`sw-update.js` 原本只在**页面加载时** `reg.update()` 一次。这对会导航的访客够用,但 FoJin 是 SPA —— 读经的人可能开着标签页**数小时不导航**。期间发布新版,该标签页**永远发现不了新的 sw.js**,会一直跑旧包。

补两处触发:
- **每 30 分钟**周期性检查
- **标签页重新可见时**再查一次(「用户回来了」的廉价代理)

新 SW 一旦接管,**既有的** `controllerchange` 处理器会重载一次页面,使页面与 precache 重新同步 —— 这条链路本来就在,只是缺了**发现新版本的时机**。

> 附带说明:排查中确认 `sw.js` 的缓存头(`no-cache, no-store` + CF `BYPASS`)与 `skipWaiting`/`clientsClaim` 配置**本来就是对的**。之前疑似「部署后拿到旧资源」主要是验证时**没等够** precache 安装(103 条 / 8.6MB),并非配置有误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)