### PR TITLE
fix(chat): 长廊卡片对玄奘/蕅益说了假话 —— 库里明明有他们的著作

### DIFF
--- a/backend/app/services/master_profiles.py
+++ b/backend/app/services/master_profiles.py
@@ -415,7 +415,17 @@ _register(MasterProfile(
     tradition="法相唯识宗",
     dates="602-664",
     description="法相唯识宗创立者，西行取经译经大师",
-    fojin_text_ids=[],  # Will use keyword matching
+    # Left empty on purpose: [] = full-corpus vector RAG (precise retrieval off).
+    # Do NOT "helpfully" set this to [44] — fojin_text_ids is a HARD scope, so that
+    # would lock him to 成唯識論 alone and lose 心經/大般若/俱舍論, which is worse.
+    fojin_text_ids=[],
+    epigraph=Epigraph(
+        quote="彼依識所變，此能變唯三",
+        text_id=44,
+        cbeta_id="T1585",
+        title_zh="成唯識論",
+        juan=1,
+    ),
     system_prompt=(
         "你是玄奘法师（法相唯识宗创立者，中国佛教最伟大的译经家），法相唯识宗，602-664。\n"
         "本内容依据历史佛教文献生成，仅供学习参考。如需正式修行指导，请亲近善知识。\n\n"
@@ -822,7 +832,17 @@ _register(MasterProfile(
     tradition="天台/净土·跨宗派",
     dates="1599-1655",
     description="教宗天台、行归净土，融通禅教律净",
+    # [] = full-corpus vector RAG. 《靈峰宗論》/《彌陀要解》 are not in the corpus;
+    # 《教觀綱宗》 (T1939) is, and the card cites it — but scoping him to that alone
+    # would be worse than the full corpus, so the hard scope stays empty.
     fojin_text_ids=[],
+    epigraph=Epigraph(
+        quote="佛祖之要，教觀而已矣",
+        text_id=8109,
+        cbeta_id="T1939",
+        title_zh="教觀綱宗",
+        juan=1,
+    ),
     system_prompt=(
         '你是蕅益大师（明末四大高僧之一，净土宗第九祖，号八不道人，"教宗天台，行归净土"），天台/净土·跨宗派，1599-1655。\n'
         "本内容依据历史佛教文献生成，仅供学习参考。如需正式修行指导，请亲近善知识。\n\n"

--- a/backend/scripts/verify_master_epigraphs.py
+++ b/backend/scripts/verify_master_epigraphs.py
@@ -39,6 +39,49 @@ from app.config import settings
 from app.services.master_profiles import MASTERS
 from app.services.quote_verifier import _normalise
 
+# Names a master's own works are filed under in buddhist_texts.translator. Needed
+# because the DB spells some of them differently from name_zh — 蕅益's works are
+# attributed to his dharma name 智旭, and Tibetan/Pali names have 繁/简 variants.
+#
+# This drives the NEGATIVE half of the check, and it exists because the positive
+# half alone was not enough: the first cut of the gallery verified the 5 masters
+# that HAD a line and never checked the 10 that didn't — so 玄奘's card claimed
+# 「本站未收其本人著作」 while 《成唯識論》(T1585) sat right there in the corpus, and
+# 蕅益's did the same over 《教觀綱宗》(T1939). A card that states something we can't
+# back is the exact failure this product exists to prevent, so assert it can't.
+CORPUS_ALIASES: dict[str, list[str]] = {
+    "nagarjuna": ["龍樹", "龙树"],
+    "zhiyi": ["智顗"],
+    "huineng": ["慧能", "宗寶"],
+    "xuanzang": ["玄奘"],
+    "fazang": ["法藏"],
+    "kumarajiva": ["鳩摩羅什", "鸠摩罗什"],
+    "yinguang": ["印光"],
+    "ouyi": ["智旭", "蕅益"],
+    "xuyun": ["虛雲", "虚云"],
+    "milarepa": ["米拉日巴", "密勒日巴"],
+    "ajahn-chah": ["阿姜查"],
+    "tsongkhapa": ["宗喀巴"],
+    "atisha": ["阿底峽", "阿底峡"],
+    "buddhaghosa": ["覺音", "觉音"],
+    "mahasi-sayadaw": ["馬哈希", "马哈希"],
+}
+
+
+async def _works_we_host(s: AsyncSession, master_id: str) -> list[tuple]:
+    """Texts in our corpus attributed to this master (author or translator)."""
+    aliases = CORPUS_ALIASES.get(master_id, [])
+    if not aliases:
+        return []
+    rows = await s.execute(
+        sql(
+            "SELECT cbeta_id, title_zh FROM buddhist_texts "
+            "WHERE translator ILIKE ANY(:pats) ORDER BY id LIMIT 5"
+        ),
+        {"pats": [f"%{a}%" for a in aliases]},
+    )
+    return list(rows.fetchall())
+
 
 async def main() -> int:
     engine = create_async_engine(settings.database_url)
@@ -49,7 +92,18 @@ async def main() -> int:
         for mid, m in MASTERS.items():
             ep = m.epigraph
             if ep is None:
-                print(f"  —  {m.name_zh:<12} 未设 (no work of his in the corpus)")
+                # The card shows 未设. Prove we are entitled to say that: if the
+                # corpus DOES hold this master's own work, a line should have been
+                # curated from it and the card is quietly misleading.
+                works = await _works_we_host(s, mid)
+                if works:
+                    listed = "; ".join(f"{c}《{t}》" for c, t in works[:3])
+                    failures.append(
+                        f"{mid}: card shows 未设, but we host his work — {listed}. Curate a line."
+                    )
+                    print(f"  ⚠️  {m.name_zh:<12} 未设,但库中有其著作:{listed}")
+                else:
+                    print(f"  —  {m.name_zh:<12} 未设 (corpus holds none of his work — confirmed)")
                 continue
 
             checked += 1

--- a/backend/tests/test_master_epigraphs.py
+++ b/backend/tests/test_master_epigraphs.py
@@ -21,8 +21,10 @@ EXPECTED_VERIFIED = {
     "nagarjuna": ("T1564", 40),
     "zhiyi": ("T1911", 53),
     "huineng": ("T2008", 58),
+    "xuanzang": ("T1585", 44),
     "fazang": ("T1866", 8038),
     "kumarajiva": ("T0262", 6513),
+    "ouyi": ("T1939", 8109),
 }
 
 
@@ -42,10 +44,14 @@ def test_every_epigraph_carries_a_checkable_source():
 def test_only_the_verified_masters_have_an_epigraph():
     """Masters whose own writing we don't host must show nothing.
 
-    Ten of the fifteen are in that position (玄奘/印光/蕅益/虚云/米拉日巴/阿姜查/
-    宗喀巴/阿底峡/觉音/马哈希). Showing them a plausible-sounding line we cannot
-    open would be exactly the failure this product exists to prevent — so if a
-    future edit adds one, this test should make someone justify it.
+    Eight of the fifteen are in that position (印光/虚云/米拉日巴/阿姜查/宗喀巴/
+    阿底峡/觉音/马哈希) — each confirmed against the corpus, not assumed.
+
+    The reverse error is just as bad and we already made it: the first cut left
+    玄奘 and 蕅益 at 未设 while 《成唯識論》(T1585) and 《教觀綱宗》(T1939) sat in the
+    corpus, so their cards claimed we hold none of their writing. That claim is
+    now gone from the UI, and scripts/verify_master_epigraphs.py checks the
+    negative case against the DB so it cannot silently come back.
     """
     with_epigraph = {mid for mid, m in MASTERS.items() if m.epigraph is not None}
     assert with_epigraph == set(EXPECTED_VERIFIED), (

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1486,7 +1486,7 @@
   "chat.gallery_hint": "Pick an interpretive lineage — read the canon through this master's tradition, not a chat with the person",
   "chat.tradition_all": "All",
   "chat.epigraph_verified": "Verified",
-  "chat.epigraph_none": "We host none of this master's own writing, so no line is shown",
+  "chat.epigraph_none": "No verified representative line selected yet",
   "chat.epigraph_unset": "Not set",
   "chat.master_lens": "Reading through this lineage",
   "chat.change_master": "Change lineage",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1486,7 +1486,7 @@
   "chat.gallery_hint": "選擇一條詮釋進路——以該祖師的宗風解經，而非與其本人對話",
   "chat.tradition_all": "全部",
   "chat.epigraph_verified": "已核驗",
-  "chat.epigraph_none": "本站未收其本人著作，故不列代表法語",
+  "chat.epigraph_none": "暫未選定經核驗的代表法語",
   "chat.epigraph_unset": "未設",
   "chat.master_lens": "依此宗風解經",
   "chat.change_master": "更換宗風",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1486,7 +1486,7 @@
   "chat.gallery_hint": "选择一条诠释进路——以该祖师的宗风解经，而非与其本人对话",
   "chat.tradition_all": "全部",
   "chat.epigraph_verified": "已核验",
-  "chat.epigraph_none": "本站未收其本人著作，故不列代表法语",
+  "chat.epigraph_none": "暂未选定经核验的代表法语",
   "chat.epigraph_unset": "未设",
   "chat.master_lens": "依此宗风解经",
   "chat.change_master": "更换宗风",


### PR DESCRIPTION
## 我的漏洞

做长廊时,我只核验了 **5 位「有代表法语」的正例**,**10 位「未设」的反例一个都没验**,就让卡片印上「本站未收其本人著作」。

**这是一句我从未核实过的断言 —— 而这个功能的全部论点,恰恰是「不能说没有出处的话」。**

逐一核查后,其中 **2 位是假的**:

| 祖师 | 卡片声称 | 实际 |
|---|---|---|
| **玄奘** | 本站未收其本人著作 | ❌ T1585**《成唯識論》**(id 44)、T1579**《瑜伽師地論》**(id 43) 都在库里 |
| **蕅益** | 本站未收其本人著作 | ❌ T1939**《教觀綱宗》**(id 8109,**智旭述**) |

其余 8 位(印光/虚云/米拉日巴/阿姜查/宗喀巴/阿底峡/觉音/马哈希)**确实**不在库中 —— 这次是逐个搜过的,不是想当然。

## 修复

**① 补上两句已逐字核验的代表法语**

| 祖师 | 法语 | 出处 |
|---|---|---|
| 玄奘 | 彼依識所變，此能變唯三 | T1585《成唯識論》卷1 |
| 蕅益 | 佛祖之要，教觀而已矣 | T1939《教觀綱宗》卷1 |

> 蕅益那句**朴素子串比对为 `False`** —— 原文存的是 `教非觀\n不傳`,**又一次撞上 CBETA 硬换行**。归一化后 `True`。

两人的 `fojin_text_ids` **刻意仍留空**:它是**硬作用域**,贸然设成 `[44]` 会把玄奘锁死在《成唯識論》一本书里、失去心經/大般若,反而更糟。

**② 卡片文案改为卡片自己能担保的说法**

「本站未收其本人著作」→「**暂未选定经核验的代表法语**」

前者是一个**全库断言,卡片无法担保** —— 一旦入藏新典籍,它又会悄悄变成谎话。

**③ `verify_master_epigraphs.py` 补上反例检查(防复发的关键)**

对每位「未设」的祖师,去 `buddhist_texts.translator` 搜其本人著作;**一旦搜到,即报错**「库中有他的书,却显示未设 —— 该补一句法语」。

**我手工核验时漏掉的正是这一环。**

## 测试
后端 **1269 项通过**;ruff 干净;i18n ratchet 通过。**无迁移。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)