### PR TITLE
fix(chat): 长廊不再有 8 张空卡 —— 无可引法语时显示宗风简介

### DIFF
--- a/frontend/src/components/MasterGallery.tsx
+++ b/frontend/src/components/MasterGallery.tsx
@@ -179,12 +179,15 @@ export default function MasterGallery({ selectedId, onSelect, onOpenSource }: Pr
                   </span>
                 </>
               ) : (
-                <>
-                  <span className="mg-quote mg-quote-none">{t("chat.epigraph_none")}</span>
-                  <span className="mg-src">
-                    <span className="mg-badge mg-badge-none">— {t("chat.epigraph_unset")}</span>
-                  </span>
-                </>
+                /* No verified line for this master — our corpus holds none of his
+                   own writing. That is a reason to show no QUOTE; it was never a
+                   reason to show an empty card. The editorial description says what
+                   this lineage is about, which is what someone picking one actually
+                   needs. Deliberately no quote marks, no citation and no badge: the
+                   card makes no claim to be quoting him, so it cannot be wrong about
+                   one. Half a gallery of "not set" placeholders reads as unfinished,
+                   not as principled. */
+                <span className="mg-desc">{m.description}</span>
               )}
             </button>
           );

--- a/frontend/src/styles/master-gallery.css
+++ b/frontend/src/styles/master-gallery.css
@@ -177,10 +177,17 @@
   min-height: 3.6em;
 }
 
-.mg-quote-none {
-  font-size: 13px;
-  color: var(--fj-ink-muted, #9a8e7a);
-  line-height: 1.7;
+/* The fallback when we hold none of a master's own writing: his editorial
+   description. Set apart from a quote on purpose — no 「」, no citation, no
+   badge, and a lighter weight — so it can never be mistaken for something we
+   are claiming he said. */
+.mg-desc {
+  display: block;
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-size: 13.5px;
+  line-height: 1.8;
+  color: var(--fj-ink-light, #5c4f3d);
+  min-height: 3.6em;
 }
 
 /* ── Source line: every quote carries its citation and its verified state,
@@ -224,11 +231,6 @@
   background: #e8f0e4;
   color: #3f6b32;
   white-space: nowrap;
-}
-
-.mg-badge-none {
-  background: #ecebe8;
-  color: #83796a;
 }
 
 .mg-open {


### PR DESCRIPTION
## 我的设计错误

「宁可留白,不可杜撰」这条原则是对的,但我把它**错误地执行**成了「没有可引的法语 = 卡上没东西可说」。

结果:15 张卡里 **8 张**写着「暂未选定经核验的代表法语 / — 未设」。**门面上一半是死的。**

半个长廊贴满「未设」,读起来不像克制,像**没做完**。

## 修法

每位祖师的 `description` **一直躺在数据里**(API 也早就返回),而且写得正是卡片该说的话:

| 祖师 | 简介 |
|---|---|
| 印光 | 净土宗十三祖,老实念佛、敦伦尽分 |
| 米拉日巴 | 藏传噶举派祖师,雪山闭关瑜伽士,以道歌说法 |
| 觉音 | 《清净道论》作者,上座部禅修与教理百科全书 |

卡片的职责是帮人**选一条诠释进路** —— 简介完全胜任,而且它是**编辑性描述、不是伪造的引文**,不违反任何原则。

- **有已核验法语** → 「…」+ 经号 + ✓已核验 + ↗(强证据,平台的差异化)
- **没有** → 显示简介:**无引号、无出处、无徽章**

去掉「未设」徽章:**没有徽章 = 没有主张**。卡片不声称在引用他,自然也就不可能引错。这比在门面上到处贴「未设」既诚实又有用。

## 测试
纯前端。tsc / ESLint / i18n ratchet 干净;vitest **186 项通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)