### PR TITLE
fix(chat): 长廊收进弹窗,空状态只留一条印章带

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1490,5 +1490,7 @@
   "chat.epigraph_unset": "Not set",
   "chat.master_lens": "Reading through this lineage",
   "chat.change_master": "Change lineage",
-  "chat.master_disclaimer": "What follows is an AI interpretation generated from the canon — not the master's own teaching. Every citation carries its text and fascicle number; open it to check the original."
+  "chat.master_disclaimer": "What follows is an AI interpretation generated from the canon — not the master's own teaching. Every citation carries its text and fascicle number; open it to check the original.",
+  "chat.gallery_strip": "Read through a lineage · {{n}} masters",
+  "chat.gallery_view_all": "View all"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1490,5 +1490,7 @@
   "chat.epigraph_unset": "未設",
   "chat.master_lens": "依此宗風解經",
   "chat.change_master": "更換宗風",
-  "chat.master_disclaimer": "以下為 AI 依據典籍生成的詮釋，非祖師本人開示。每處引證均標註經號與卷次，可點開核對原文。"
+  "chat.master_disclaimer": "以下為 AI 依據典籍生成的詮釋，非祖師本人開示。每處引證均標註經號與卷次，可點開核對原文。",
+  "chat.gallery_strip": "以宗風解經 · {{n}} 位祖師",
+  "chat.gallery_view_all": "全部"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1490,5 +1490,7 @@
   "chat.epigraph_unset": "未设",
   "chat.master_lens": "依此宗风解经",
   "chat.change_master": "更换宗风",
-  "chat.master_disclaimer": "以下为 AI 依据典籍生成的诠释，非祖师本人开示。每处引证均标注经号与卷次，可点开核对原文。"
+  "chat.master_disclaimer": "以下为 AI 依据典籍生成的诠释，非祖师本人开示。每处引证均标注经号与卷次，可点开核对原文。",
+  "chat.gallery_strip": "以宗风解经 · {{n}} 位祖师",
+  "chat.gallery_view_all": "全部"
 }

--- a/frontend/src/components/MasterGallery.tsx
+++ b/frontend/src/components/MasterGallery.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
-import { Spin } from "antd";
+import { Spin, Tooltip } from "antd";
 import { getMasters, type MasterProfile } from "../api/client";
 import "../styles/master-gallery.css";
 
@@ -53,6 +53,67 @@ export function MasterSeal({ text, size = 46 }: { text: string; size?: number })
     >
       <span className="mg-seal-text">{text}</span>
     </span>
+  );
+}
+
+/**
+ * The strip that stands in for the gallery on the chat's empty state.
+ *
+ * The full gallery is ~960px tall — taller than the viewport — so putting it
+ * inline turned /chat's front page into a wall of cards you had to scroll past
+ * before you could do the one thing the page is for: ask a question. But hiding
+ * it entirely behind a button is how the 15 personas got lost in the first place.
+ *
+ * So: the seals stay on the page (they are the thing that makes someone curious —
+ * fifteen cinnabar stamps are hard to ignore), and the depth — quotes, 经号,
+ * verification badges — lives one click away in the modal.
+ */
+export function MasterSealStrip({
+  selectedId,
+  onSelect,
+  onOpenAll,
+}: {
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+  onOpenAll: () => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const { data: masters } = useQuery({
+    queryKey: ["chat-masters"],
+    queryFn: getMasters,
+    staleTime: 60 * 60 * 1000,
+  });
+  const isEn = i18n.language?.startsWith("en");
+
+  if (!masters?.length) return null;
+
+  return (
+    <div className="mg-strip">
+      <span className="mg-strip-label">
+        {t("chat.gallery_strip", { n: masters.length })}
+      </span>
+      <span className="mg-strip-seals">
+        {masters.map((m) => (
+          <Tooltip
+            key={m.id}
+            title={`${isEn ? m.name_en : m.name_zh} · ${m.tradition}`}
+          >
+            <button
+              type="button"
+              className={`mg-strip-seal${selectedId === m.id ? " is-selected" : ""}`}
+              aria-pressed={selectedId === m.id}
+              aria-label={isEn ? m.name_en : m.name_zh}
+              onClick={() => onSelect(m.id)}
+            >
+              <MasterSeal text={sealOf(m)} size={30} />
+            </button>
+          </Tooltip>
+        ))}
+      </span>
+      <button type="button" className="mg-strip-all" onClick={onOpenAll}>
+        {t("chat.gallery_view_all")} →
+      </button>
+    </div>
   );
 }
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -34,7 +34,7 @@ import {
 const ShareCard = lazy(() => import("../components/ShareCard"));
 const CitationDrawer = lazy(() => import("../components/CitationDrawer"));
 import ChatModelSelector from "../components/ChatModelSelector";
-import MasterGallery, { MasterSeal } from "../components/MasterGallery";
+import MasterGallery, { MasterSeal, MasterSealStrip } from "../components/MasterGallery";
 import { getMasters } from "../api/client";
 import type { CitationTarget } from "../components/CitationDrawer";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -1461,31 +1461,16 @@ export default function ChatPage() {
                   </div>
                 )}
 
-                {/* 祖师长廊 — the second act of the empty state. The 15 master
-                    personas are this product's sharpest differentiator and used
-                    to hide inside a grey dropdown; here they are the front door. */}
-                <div style={{ marginTop: 34, textAlign: "left" }}>
-                  <div style={{ textAlign: "center", marginBottom: 14 }}>
-                    <div style={{
-                      fontSize: 16,
-                      fontFamily: '"Noto Serif SC", serif',
-                      color: "var(--fj-ink)",
-                      marginBottom: 4,
-                    }}>
-                      {t("chat.gallery_title")}
-                    </div>
-                    <div style={{ fontSize: 12.5, lineHeight: 1.7 }}>
-                      {t("chat.gallery_hint")}
-                    </div>
-                  </div>
-                  <MasterGallery
-                    selectedId={masterId}
-                    onSelect={setMasterId}
-                    onOpenSource={(textId, juan) =>
-                      window.open(`/texts/${textId}/read?juan=${juan}`, "_blank", "noopener")
-                    }
-                  />
-                </div>
+                {/* 祖师长廊, as a strip. The full gallery is ~960px — taller than
+                    the viewport — so inlining it buried the one thing this page is
+                    for (asking a question) under a wall of cards, complete with a
+                    scroll-inside-a-scroll. The seals stay visible because they are
+                    what makes anyone curious; the depth is one click away. */}
+                <MasterSealStrip
+                  selectedId={masterId}
+                  onSelect={setMasterId}
+                  onOpenAll={() => setGalleryOpen(true)}
+                />
               </div>
             )}
             {messages.map((m) => (

--- a/frontend/src/styles/master-gallery.css
+++ b/frontend/src/styles/master-gallery.css
@@ -247,6 +247,99 @@
   border-radius: 2px;
 }
 
+/* ── Seal strip: the gallery's footprint on the chat empty state ──
+   ~60px instead of the gallery's ~960px. The seals are what make someone
+   curious; the depth lives in the modal. */
+.mg-strip {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  margin-top: 22px;
+  background: #fffdfa;
+  border: 1px solid var(--fj-border, #d9d0c1);
+  border-radius: 3px;
+  text-align: left;
+}
+
+.mg-strip-label {
+  flex-shrink: 0;
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-size: 13px;
+  color: var(--fj-ink-light, #5c4f3d);
+  white-space: nowrap;
+}
+
+/* Scrolls rather than wraps: the strip must stay one row tall, or it starts
+   growing back toward the wall of cards it replaced. */
+.mg-strip-seals {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  overflow-x: auto;
+  padding: 2px 0;
+  scrollbar-width: thin;
+}
+
+.mg-strip-seal {
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  line-height: 0;
+  cursor: pointer;
+  border-radius: 3px;
+  opacity: 0.82;
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.mg-strip-seal:hover {
+  opacity: 1;
+  transform: translateY(-1px);
+}
+
+.mg-strip-seal:focus-visible {
+  outline: 2px solid var(--fj-accent, #8b2500);
+  outline-offset: 2px;
+}
+
+.mg-strip-seal.is-selected {
+  opacity: 1;
+  box-shadow: 0 0 0 2px var(--fj-bg, #f8f5ef), 0 0 0 3px var(--fj-accent, #8b2500);
+}
+
+.mg-strip-all {
+  flex-shrink: 0;
+  margin-left: auto;
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--fj-accent, #8b2500);
+  background: transparent;
+  border: 1px solid var(--fj-border, #d9d0c1);
+  border-radius: 3px;
+  padding: 4px 11px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.mg-strip-all:hover {
+  border-color: var(--fj-accent, #8b2500);
+}
+
+.mg-strip-all:focus-visible {
+  outline: 2px solid var(--fj-accent, #8b2500);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mg-strip-seal {
+    transition: none;
+  }
+  .mg-strip-seal:hover {
+    transform: none;
+  }
+}
+
 /* ── Persona header, shown above the thread once a lineage is chosen ── */
 .mg-head {
   display: flex;


### PR DESCRIPTION
## 我过度矫正了

从「藏在灰色下拉框里」(太少)一路冲到「铺满整个空状态」(太多)。**实测数据:**

| | |
|---|---|
| 长廊高度 | **963px** |
| 聊天可视区 | **437px** |
| 占视口 | **124%** —— 它一个人比整屏还高 |
| 滚动套滚动 | ✅ 存在(437px 窗口里塞 1533px) |
| 「选择一条诠释进路」 | **重复 2 次**(长廊副标题 + 底部人格条) |
| 「更换宗风」+ 弹窗 | **本来就已存在** —— 内联长廊是个**重复入口** |

`/chat` 的本职是让人**问问题**。把 15 张卡糊在它脸上,是把主次颠倒了。

## 但也不能纯退回弹窗
那会把 15 位祖师**又藏回按钮后面** —— 正是我们出发时要解决的问题。

## 中间路线:发现留在页面,深度留在弹窗

空状态改为一条 **~60px** 的印章带:

```
以宗风解经 · 15 位祖师   [印][印][印]…×15        [全部 →]
```

- **15 枚朱砂印看得见** —— 这是长廊唯一不可替代的价值(印章的视觉冲击力才让人产生「这是什么」的好奇)
- **点任一印**直接选定宗风;**点「全部」**开完整弹窗(法语、经号、✓已核验 都在里面)
- 高度 **963px → ~60px**,聊天页恢复本职
- 顺手消掉重复文案与滚动套滚动

## 测试
纯前端。tsc / ESLint / i18n ratchet 干净;vitest **186 项通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)