### PR TITLE
fix(chat): 优化人格条文案;「更换宗风」→「更换宗派」

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1483,12 +1483,12 @@
   "admin_align_review.load_error": "Failed to load, please retry",
   "admin_align_review.back_to_coverage": "Back to coverage",
   "chat.gallery_title": "Master Gallery",
-  "chat.gallery_hint": "Pick an interpretive lineage — read the canon through this master's tradition, not a chat with the person",
+  "chat.gallery_hint": "Switch school — read the canon through a master's approach",
   "chat.tradition_all": "All",
   "chat.epigraph_verified": "Verified",
   "chat.epigraph_none": "No verified representative line selected yet",
   "chat.epigraph_unset": "Not set",
   "chat.master_lens": "Reading through this lineage",
-  "chat.change_master": "Change lineage",
+  "chat.change_master": "Change school",
   "chat.master_disclaimer": "What follows is an AI interpretation generated from the canon — not the master's own teaching. Every citation carries its text and fascicle number; open it to check the original."
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1483,12 +1483,12 @@
   "admin_align_review.load_error": "載入失敗，請重試",
   "admin_align_review.back_to_coverage": "返回覆蓋率",
   "chat.gallery_title": "祖師長廊",
-  "chat.gallery_hint": "選擇一條詮釋進路——以該祖師的宗風解經，而非與其本人對話",
+  "chat.gallery_hint": "切換宗派，依祖師宗風解經",
   "chat.tradition_all": "全部",
   "chat.epigraph_verified": "已核驗",
   "chat.epigraph_none": "暫未選定經核驗的代表法語",
   "chat.epigraph_unset": "未設",
   "chat.master_lens": "依此宗風解經",
-  "chat.change_master": "更換宗風",
+  "chat.change_master": "更換宗派",
   "chat.master_disclaimer": "以下為 AI 依據典籍生成的詮釋，非祖師本人開示。每處引證均標註經號與卷次，可點開核對原文。"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1483,12 +1483,12 @@
   "admin_align_review.load_error": "加载失败，请重试",
   "admin_align_review.back_to_coverage": "返回覆盖率",
   "chat.gallery_title": "祖师长廊",
-  "chat.gallery_hint": "选择一条诠释进路——以该祖师的宗风解经，而非与其本人对话",
+  "chat.gallery_hint": "切换宗派，依祖师宗风解经",
   "chat.tradition_all": "全部",
   "chat.epigraph_verified": "已核验",
   "chat.epigraph_none": "暂未选定经核验的代表法语",
   "chat.epigraph_unset": "未设",
   "chat.master_lens": "依此宗风解经",
-  "chat.change_master": "更换宗风",
+  "chat.change_master": "更换宗派",
   "chat.master_disclaimer": "以下为 AI 依据典籍生成的诠释，非祖师本人开示。每处引证均标注经号与卷次，可点开核对原文。"
 }


### PR DESCRIPTION
旧副标题「选择一条诠释进路——以该祖师的宗风解经，而非与其本人对话」有**两个结构性毛病**,不只是啰嗦:

1. 它**只在「通用助手」态下显示**,却说「以**该祖师**的宗风解经」—— 此时并无「该祖师」,**指代落空**。
2. 「而非与其本人对话」与 `master_disclaimer` **重复**,而后者恰在**选中祖师时**才出现 —— 那才是需要这句话的位置。在通用助手态下先防一件**还没发生的事**,既冗余又消极。

这句的职责其实只是:**说清旁边那个按钮能干什么。**

| | 旧 | 新 |
|---|---|---|
| 副标题 | 选择一条诠释进路——以该祖师的宗风解经，而非与其本人对话(25字) | **切换宗派，依祖师宗风解经**(11字) |
| 按钮 | 更换宗风 | **更换宗派** |

免责声明仍留在它该在的位置(选中祖师后),内容不变。

三语言同步,键数保持 **1478** 一致。i18n ratchet / tsc 干净;vitest **186 项通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)