### PR TITLE
feat(chat): 卡片统一以简介为主干,已核验法语作为附加证据

### DIFF
--- a/frontend/src/components/MasterGallery.tsx
+++ b/frontend/src/components/MasterGallery.tsx
@@ -148,7 +148,23 @@ export default function MasterGallery({ selectedId, onSelect, onOpenSource }: Pr
 
               <span className="mg-rule" />
 
-              {ep ? (
+              {/* The description is the spine — every card has one, because it is
+                  what answers the question someone browsing here actually has:
+                  "which of these should I pick?". 「眾因緣生法，我說即是空」 is a
+                  beautiful line, but to anyone who doesn't already know 中观 it
+                  answers nothing.
+
+                  The verified quote below is a different job, and only the seven
+                  masters whose own writing we host can do it: the description is
+                  OUR editorial prose (you can only take our word for it), while
+                  the quote is from the canon, checked character-by-character, and
+                  linked to the passage (you can go check us). Every card says what
+                  it is; seven also say "don't take my word — here's the source."
+                  That is the whole product, in one line, and it is why the quote
+                  is an addition here and never a replacement. */}
+              <span className="mg-desc">{m.description}</span>
+
+              {ep && (
                 <>
                   <span className="mg-quote">「{ep.quote}」</span>
                   <span className="mg-src">
@@ -178,16 +194,6 @@ export default function MasterGallery({ selectedId, onSelect, onOpenSource }: Pr
                     )}
                   </span>
                 </>
-              ) : (
-                /* No verified line for this master — our corpus holds none of his
-                   own writing. That is a reason to show no QUOTE; it was never a
-                   reason to show an empty card. The editorial description says what
-                   this lineage is about, which is what someone picking one actually
-                   needs. Deliberately no quote marks, no citation and no badge: the
-                   card makes no claim to be quoting him, so it cannot be wrong about
-                   one. Half a gallery of "not set" placeholders reads as unfinished,
-                   not as principled. */
-                <span className="mg-desc">{m.description}</span>
               )}
             </button>
           );

--- a/frontend/src/styles/master-gallery.css
+++ b/frontend/src/styles/master-gallery.css
@@ -167,27 +167,32 @@
   background: var(--fj-border, #d9d0c1);
 }
 
-/* ── The quote: the typographic hero of the card ── */
-.mg-quote {
-  display: block;
-  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
-  font-size: 15px;
-  line-height: 1.8;
-  color: var(--fj-ink, #2b2318);
-  min-height: 3.6em;
-}
-
-/* The fallback when we hold none of a master's own writing: his editorial
-   description. Set apart from a quote on purpose — no 「」, no citation, no
-   badge, and a lighter weight — so it can never be mistaken for something we
-   are claiming he said. */
+/* ── The description: the spine. Every card has one, because it answers the
+      question someone browsing actually has — "which of these do I pick?".
+      It is OUR editorial prose, so it is set plainly: no 「」, no citation, no
+      badge. It must never be mistakable for something we claim he said. ── */
 .mg-desc {
   display: block;
   font-family: "Noto Serif SC", "Source Han Serif SC", serif;
   font-size: 13.5px;
   line-height: 1.8;
   color: var(--fj-ink-light, #5c4f3d);
-  min-height: 3.6em;
+  min-height: 2.8em; /* ~2 lines, so a short description doesn't collapse the card */
+}
+
+/* ── The quote: the evidence, and a different job from the description above.
+      Only the seven masters whose own writing we host can carry one. Set darker
+      and larger than the description it follows — this is the quotation, and the
+      one thing on the card the reader can go and verify. ── */
+.mg-quote {
+  display: block;
+  margin-top: 2px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--fj-border, #d9d0c1);
+  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
+  font-size: 14.5px;
+  line-height: 1.8;
+  color: var(--fj-ink, #2b2318);
 }
 
 /* ── Source line: every quote carries its citation and its verified state,


### PR DESCRIPTION
卡片原本是**二选一**:7 张显示法语,8 张显示简介 —— 两种不同解剖结构混排。

但「统一」的正确方向**不是把法语删掉**,而是**把缺的那一半补上**。

## 两者的性质根本不同

| | 简介 | 已核验法语 |
|---|---|---|
| 来源 | **FoJin 自己写的**编辑性文字 | **出自藏经**,逐字核验过 |
| 读者能做什么 | 只能**相信我们** | 可以**去查我们**(点 ↗ 跳原文) |

只留简介,15 张卡**全都在说「相信我们」**;保留法语,7 张卡在说「**别信我,去核对原文**」。

后者是引文核验体系(`quote_verifier` / 信任徽章)**在门面上唯一能被看见的地方**,也是这个长廊区别于任何 AI 角色扮演产品的**全部依据**。为了网格整齐而删掉它,是拿产品最贵的资产换视觉舒适。

## 病根不是「该删哪个」,是「少了哪个」

新用户读「眾因緣生法，我說即是空」**根本无法据此选择** —— 它美,但不回答「我该选谁」。回答这个问题的恰恰是**简介**,而有法语的那 7 位**偏偏没有简介**。

## 改法
- **简介**成为 15 张卡的**统一主干**(回答「我该选谁」)
- **法语 + 经号 + ✓已核验** 作为其中 7 张的**附加行**(回答「凭什么信你」),以虚线分隔,字号更大、墨色更深 —— 它是引文,值得这个重量

纯前端。tsc / ESLint / i18n ratchet 干净;vitest **186 项通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)