### PR TITLE
chore(deps): 移除后端未使用的 pgvector 依赖

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,6 @@ cryptography==49.0.0
 bcrypt==4.1.1
 defusedxml==0.7.1
 lxml==6.1.1
-pgvector==0.5.0
 openai==2.44.0
 tiktoken==0.13.0
 opencc-python-reimplemented==0.1.7


### PR DESCRIPTION
## 背景

`backend/requirements.txt` 里钉着 `pgvector`，但**全后端零个 Python import**（`app/` `scripts/` `tests/` `eval/` `alembic/` 全搜过，只有 `search_unified.py:118` 的一句注释提到它）。

所有向量操作都走**裸 SQL**：

- `app/services/embedding.py:134` — 手工把向量序列化成 `"[" + ",".join(...) + "]"`
- `app/services/embedding.py:147` — asyncpg 以 `$1::vector` 转型，`te.embedding <=> $1::vector` 算余弦距离
- 建表 / 建索引 — alembic 里的 `op.execute("ALTER TABLE … ADD COLUMN embedding vector(1536)")` / `USING hnsw (embedding vector_cosine_ops)`

Python 客户端库在这条链路上没有位置。

## 为什么值得删

留着它没收益，却制造**伪风险面**。刚合的 #958 把它从 0.4.2 升到 0.5.0——那是个破坏性发布（移除 `utils` 包与 re-export、改变 `vector` 的返回类型、去掉 NumPy 依赖、砍掉 SQLAlchemy < 2）。当时要专门去验证一遍"其实打不到我们"才敢合。删掉之后，以后不必再为一个没人用的包做这种论证。

## 边界

删的是 **Python 客户端库**，和 Postgres 的 `vector` **扩展无关**：`CREATE EXTENSION vector`、`vector(1536)` 列、HNSW 索引（`0011` / `0098` / `0108` 等迁移）全部不受影响。

CI 的 `Backend smoke tests` / `ES Integration` / `Alembic dry-run` 都会按 requirements.txt 装依赖并 import 整个 app —— 若真有隐藏引用会立刻 ImportError。

🤖 Generated with [Claude Code](https://claude.com/claude-code)