### PR TITLE
fix(admin): 按生产实测校准 weak_evidence 阈值 + 角标显示真实积压量

### DIFF
--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -200,8 +200,9 @@ class ScoreDistribution(BaseModel):
 class AnswerQueueResponse(BaseModel):
     total_unreviewed: int
     score_distribution: ScoreDistribution
-    # 标签 -> 命中条数。用来事后校准 WEAK_EVIDENCE_THRESHOLD(现为 0.37,而生产
-    # 实测分布已是 p10=0.31 —— 阈值偏高在误报,但本次不拍脑袋改数值)。
+    # 标签 -> 命中条数。用来事后校准 WEAK_EVIDENCE_THRESHOLD(2026-07-14 已按
+    # 生产实测 p10=0.261 从 0.37 重新校准到 0.26 —— 旧值已高于 p25=0.316,在
+    # 误报;继续用这份分布追踪是否需要再次校准)。
     tag_distribution: dict[str, int] = Field(default_factory=dict)
     items: list[AnswerQueueItem]
 

--- a/backend/app/services/answer_quality.py
+++ b/backend/app/services/answer_quality.py
@@ -13,9 +13,15 @@ from app.models.chat import ChatAnswerDiagnostic, ChatMessage
 # Calibrated 2026-06-30 to ~p10 of the live max(source.score) distribution
 # (p10≈0.366), so weak_evidence flags only the bottom decile of retrieval
 # strength rather than ~the bottom quartile. ChatSource.score is the blended
-# vector+rerank score. Re-read score_distribution from the queue endpoint and
-# adjust if the corpus/reranker changes.
-WEAK_EVIDENCE_THRESHOLD = 0.37
+# vector+rerank score.
+#
+# Re-calibrated 2026-07-14: 30-day production distribution has shifted down
+# (p10=0.261, p25=0.316). The old 0.37 sat above p25 — it was flagging over a
+# quarter of answers, well past the "bottom decile" design intent — so it was
+# false-positiving on a growing share of the queue. Reset to the current p10
+# (0.26). Re-read score_distribution from the queue endpoint and recalibrate
+# again if the corpus/reranker changes.
+WEAK_EVIDENCE_THRESHOLD = 0.26
 ABNORMAL_MIN_CHARS = 20
 
 # Prefixes of LLM-failure replies (see chat._FAILED_ANSWER_PREFIXES). Failed /
@@ -113,7 +119,7 @@ def classify_answer(
     if mss is not None and mss < WEAK_EVIDENCE_THRESHOLD:
         tags.append("weak_evidence")
         # graded: deeper below threshold => more suspect.
-        # 注:gap 最大只有 WEAK_EVIDENCE_THRESHOLD(0.37),所以 0.5 这个封顶永远够
+        # 注:gap 最大只有 WEAK_EVIDENCE_THRESHOLD(0.26),所以 0.5 这个封顶永远够
         # 不着 —— 生产旧代码自带的死枝,此处保持原样不动:改评分语义会让 SQL 侧的
         # 排序表达式与这里算出的显示分数对不上。
         score += WEIGHTS["weak_evidence"] + min(WEAK_EVIDENCE_THRESHOLD - mss, 0.5) * 2.0
@@ -333,7 +339,8 @@ async def build_bad_answer_queue(
         )
     await _attach_questions(db, items)
 
-    # 标签分布:事后据此校准 WEAK_EVIDENCE_THRESHOLD(本次不动 0.37 这个数值)。
+    # 标签分布:事后据此校准 WEAK_EVIDENCE_THRESHOLD(2026-07-14 已按 p10 从 0.37
+    # 重新校准到 0.26,见文件顶部注释;后续再变化仍照此读数校准)。
     dist_row = (
         await db.execute(
             select(

--- a/backend/tests/test_answer_quality.py
+++ b/backend/tests/test_answer_quality.py
@@ -106,7 +106,7 @@ def test_weak_evidence_is_flagged_and_graded():
     far, score_far = classify_answer(_OK_ANSWER, None, _diag(max_source_score=0.01))
     assert near == ["weak_evidence"] and far == ["weak_evidence"]
     assert score_near == 1.02   # 1.0 + 0.01 * 2
-    assert score_far == 1.72    # 1.0 + 0.36 * 2
+    assert score_far == 1.5     # 1.0 + 0.25 * 2
 
 
 def test_multiple_detectors_stack():
@@ -507,9 +507,9 @@ async def test_fabricated_citation_enters_queue_with_tag(aq_session):
 @pytest.mark.anyio
 async def test_queue_orders_by_suspicion_desc(aq_session):
     weak = await _seed_turn(
-        aq_session, question="q1", answer=_OK_ANSWER, sources=_sources(0.30),
-        diag=_diag_row(source_count=1, max_source_score=0.30),
-    )  # weak_evidence ≈ 1.14
+        aq_session, question="q1", answer=_OK_ANSWER, sources=_sources(0.20),
+        diag=_diag_row(source_count=1, max_source_score=0.20),
+    )  # weak_evidence ≈ 1.12
     downvoted = await _seed_turn(
         aq_session, question="q2", answer=_OK_ANSWER, sources=_sources(0.9),
         feedback="down", diag=_diag_row(),

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -97,7 +97,7 @@ export default function Layout() {
     ...(isAdmin
       ? [
           {
-            icon: <Badge count={adminBadgeTotal} size="small" offset={[4, -2]}><DashboardOutlined /></Badge>,
+            icon: <Badge count={adminBadgeTotal} size="small" offset={[4, -2]} overflowCount={9999}><DashboardOutlined /></Badge>,
             label: t("nav.admin"),
             path: "/admin",
             // 常驻 4 项。判据是「需不需要你主动定期查看」:
@@ -198,6 +198,12 @@ export default function Layout() {
               item.children ? (
                 <Dropdown
                   key={item.path}
+                  // Menu items carry count badges and can be wider than the
+                  // trigger button; by default antd/rc-dropdown stretches the
+                  // popup's min-width to match the (narrower) trigger, which
+                  // pushed wide items into a horizontal scrollbar. Force a
+                  // generous min-width instead.
+                  overlayStyle={{ minWidth: 200 }}
                   menu={{
                     items: item.children.map((child) => ({
                       key: child.path,
@@ -206,6 +212,7 @@ export default function Layout() {
                           count={child.count}
                           size="small"
                           offset={[10, 0]}
+                          overflowCount={9999}
                           style={{ marginLeft: 8 }}
                         >
                           <span>{child.label}</span>
@@ -391,7 +398,13 @@ export default function Layout() {
                   >
                     {child.label}
                     {child.count ? (
-                      <Badge count={child.count} size="small" offset={[10, 0]} style={{ marginLeft: 8 }} />
+                      <Badge
+                        count={child.count}
+                        size="small"
+                        offset={[10, 0]}
+                        overflowCount={9999}
+                        style={{ marginLeft: 8 }}
+                      />
                     ) : null}
                   </Button>
                 ))}

--- a/frontend/src/pages/AdminAnswerQualityPage.tsx
+++ b/frontend/src/pages/AdminAnswerQualityPage.tsx
@@ -47,7 +47,7 @@ const REASON_COLORS: Record<string, string> = {
 
 // Mirrors backend WEAK_EVIDENCE_THRESHOLD (answer_quality.py) — keep in sync if
 // the backend threshold is recalibrated. Display-only (reds weak sources).
-const WEAK_SCORE = 0.37;
+const WEAK_SCORE = 0.26;
 
 const CATEGORY_OPTION_KEYS = [
   { value: "recall", labelKey: "admin_aq.category.recall" },


### PR DESCRIPTION
## 背景:PR #998 上线后的第一次测量

新判据(「引用是否可核对」)上线后立刻拿到了生产真实分布:

```
待办:差答案 566(30 天窗口)· 对齐候选 758 · 源建议/反馈/标注 均为 0
标签:quote_relaxed 350 · weak_evidence 265 · citation_corrected 75
      fabricated_citation 0 · downvoted 0 · abnormal 0
来源分:p10=0.261  p25=0.316  p50=0.609  p90=0.885
```

**换判据是成功的**:队列主体是 `quote_relaxed`(350 条「转述当原文引」)—— 正是核心的引用完整性失败,与已知的逐字引用保真度 38.1% 对得上。`weak_evidence` 只占 38%,没有沦为新噪音。`fabricated_citation = 0`(模型不会在无来源时凭空编造引用)。

据此做两项校准。

## 1. `WEAK_EVIDENCE_THRESHOLD`:0.37 → 0.26

这个阈值的**设计意图是只标记检索强度最差的那一成(p10)**。它在 2026-06-30 按当时的 p10≈0.366 校准为 0.37。

但生产分布已经下移:**p10=0.261、p25=0.316** —— **0.37 已经高于 p25**,意味着它在标记超过 25% 的答案,远超设计意图,正在误报(265 条)。按当前 p10 重新校准为 0.26。

前端有个镜像常量 `WEAK_SCORE`(`AdminAnswerQualityPage.tsx`),已同步。

## 2. 角标:`99+` 藏住了真实规模

antd `Badge` 默认 `overflowCount=99`,于是 566 和 758 都显示成 `99+` —— **看不出是 566 还是 5660**,而让管理员感知积压规模正是角标存在的意义。改为 `overflowCount={9999}`(桌面端 + 移动端两处渲染)。

顺带修掉加了角标后下拉菜单出现的横向滚动条。

### 一个被角标推翻的数字

上线前我们以为对齐候选只有 **50** 条 —— 那其实是复核页 `limit=50` 的**分页大小**。角标走的是真 `COUNT(*)`,暴露出真实积压是 **758 条**,差了一个数量级。

## 测试

后端 1286 passed;前端 39 files / 189 tests passed;`tsc --noEmit` 干净。

阈值变更带出一个**隐性依赖**(grep 抓不到,靠理解触发条件才发现):`test_queue_orders_by_suspicion_desc` 里 `max_source_score=0.30` 在新阈值下不再触发 `weak_evidence`(0.30 > 0.26),已改为 0.20 并同步注释。已过一遍全部 `max_source_score=` 取值,其余无影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)