### PR TITLE
fix(admin): 菜单角标改为排在文字之后,不再压住标签

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -207,16 +207,25 @@ export default function Layout() {
                   menu={{
                     items: item.children.map((child) => ({
                       key: child.path,
+                      // 角标必须是独立元素排在文字之后。用 <Badge> 包裹 label 会把
+                      // 计数绝对定位到子元素右上角 —— 数字一长(447/758)就压在文字上。
                       label: child.count ? (
-                        <Badge
-                          count={child.count}
-                          size="small"
-                          offset={[10, 0]}
-                          overflowCount={9999}
-                          style={{ marginLeft: 8 }}
+                        <span
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 8,
+                            width: "100%",
+                          }}
                         >
                           <span>{child.label}</span>
-                        </Badge>
+                          <Badge
+                            count={child.count}
+                            size="small"
+                            overflowCount={9999}
+                            style={{ marginLeft: "auto" }}
+                          />
+                        </span>
                       ) : (
                         child.label
                       ),
@@ -401,7 +410,6 @@ export default function Layout() {
                       <Badge
                         count={child.count}
                         size="small"
-                        offset={[10, 0]}
                         overflowCount={9999}
                         style={{ marginLeft: 8 }}
                       />


### PR DESCRIPTION
## 问题

PR #999 上线后到生产上用眼睛看,发现角标**压在菜单文字上**:

- `[447]` 盖住「差答案队列」的「列」
- `[758]` 盖住「跨藏对齐覆盖率」的「率」

## 根因

桌面端用的是 antd Badge 的**包裹式**写法:

```tsx
<Badge count={447}><span>差答案队列</span></Badge>
```

这种用法 antd 会把计数**绝对定位到子元素的右上角**。计数是个位数时勉强能看,数字一长(447 / 758)就直接盖在文字上。

## 修法

改为 inline-flex 行布局,角标作为**独立元素**右对齐排在文字之后:

```tsx
<span style={{ display: "inline-flex", alignItems: "center", gap: 8, width: "100%" }}>
  <span>{child.label}</span>
  <Badge count={child.count} size="small" overflowCount={9999} style={{ marginLeft: "auto" }} />
</span>
```

移动端本来就用的是独立 Badge(不会重叠),顺带去掉了对它无意义的 `offset`。

## 验证

**在真实浏览器里看过了**(本地 dev server 代理到生产 API,拿真实的 447 / 758 渲染):文字完整可读,角标右对齐,无横向滚动条。

`tsc --noEmit` 干净;前端 39 files / 189 tests passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)