### PR TITLE
fix(admin): 顶层角标改红点,修复它挡住悬停打不开菜单

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -97,7 +97,18 @@ export default function Layout() {
     ...(isAdmin
       ? [
           {
-            icon: <Badge count={adminBadgeTotal} size="small" offset={[4, -2]} overflowCount={9999}><DashboardOutlined /></Badge>,
+            // 顶层只用一个红点表示「有活儿」,不显示精确总数:四位数的角标会盖住
+            // 「管理」二字,而且它的 sup 会挡住触发区、导致悬停打不开菜单。精确计数
+            // 由下拉里的每一项各自给出。pointerEvents:none 是双保险。
+            icon: (
+              <Badge
+                dot={adminBadgeTotal > 0}
+                offset={[2, -2]}
+                style={{ pointerEvents: "none" }}
+              >
+                <DashboardOutlined />
+              </Badge>
+            ),
             label: t("nav.admin"),
             path: "/admin",
             // 常驻 4 项。判据是「需不需要你主动定期查看」:


### PR DESCRIPTION
## 回归

PR #1000 上线后到生产上验,发现顶层「管理」的**四位数计数角标(1205)**引入了一个功能性回归:

- 它**盖住了「管理」二字**
- 它的 `sup` 元素**挡住了触发区的鼠标事件** —— **悬停打不开下拉菜单了,必须点击**

这是上一版角标改动引入的(此前悬停一直能打开)。

## 修法

顶层其实不需要精确总数 —— 下拉里每一项(差答案队列 `447`、跨藏对齐 `758`)已经各自给出准确计数。顶层只需要告诉你「有活儿」。

改为 `dot`(有待办就亮红点),并加 `pointerEvents: "none"` 作为双保险。

移动端复用同一个 `item.icon`,一处改动两端生效。

## 验证

**在真实浏览器里确认悬停恢复正常**:鼠标移上「管理」即可展开菜单,4 项齐全。

`tsc --noEmit` 干净;前端 39 files / 189 tests passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)