### PR TITLE
perf(home): antd 按路由拆分,首屏 eager JS −320KB(−18%)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -99,9 +99,10 @@ function manualChunks(id: string): string | undefined {
   ) {
     return "vendor-react";
   }
-  if (id.includes("/node_modules/antd/")) {
-    return "vendor-antd";
-  }
+  // antd 不再强制并入单一 vendor chunk：那样会把 admin 才用的 Table/Form 等
+  // 和首页只需的 AutoComplete 焊在一起(~1.15MB),而首页(唯一静态导入的路由)
+  // 一 import antd 就把整块拉进首屏。交回 rolldown 按已有的路由懒加载边界拆分,
+  // 首屏只承担自己那一小片 antd,admin 的重组件留在各自 route chunk。
   if (id.includes("/node_modules/@tanstack/react-query/")) {
     return "vendor-query";
   }


### PR DESCRIPTION
## 问题
`vite.config.ts` 的 `manualChunks` 把**全站 `node_modules/antd/` 强制并入单一 `vendor-antd` chunk(1.15MB)**。而 `HomePage` 是 `App.tsx` 里**唯一静态导入的路由**(其余全 `lazy()`),它 `import` 的 antd `AutoComplete` 就把整块 `vendor-antd`(含 admin 才用的 Table / Form / DatePicker 等)拽进首屏 `modulepreload`——非管理员访客在首页白下载了 admin 的 antd。

## 改动(仅 `vite.config.ts` 一处)
移除 antd 的强制分组,交回 rolldown 按**已有的路由懒加载边界**自然拆分。首屏只承担 `AutoComplete/Select/图标` 那一小片 antd;admin 重组件留在各自 route chunk,按需加载。零组件代码改动。

## 实测(rolldown build,前后对比)
| | 首屏 eager JS | 总 dist JS |
|---|---|---|
| 改前(单块 vendor-antd) | 1.81 MB | 6.82 MB |
| 改后(按路由拆) | **1.49 MB** | 6.85 MB |
| 差 | **−320KB / −18%** | +30KB / +0.4% |

总体积几乎不变(+0.4%)= antd 核心仍被 rolldown 共享,**无重复膨胀**;单块 `vendor-antd`(1178KB)消失,拆成按需的 `select` / `genStyleUtils` / `ContextIsolator` / 图标等小块。

## 权衡
入口 `index.js` 478→869KB(antd 被并入)——首访更快,代价是 app 代码变更时返回访客跨部署缓存失效面变大。fojin 流量以新落地访客为主(微信分享),**首访收益 > 跨部署缓存**,故净正向。若想进一步优化可另议(如把 HomePage 也改 lazy,但会给落地页引入 Suspense 闪烁)。

## 验证
- `tsc -b && vite build` 通过
- 本地 `vite preview` 冒烟:首页(antd `AutoComplete` 渲染正常)+ 懒加载路由 `/login`(antd 表单渲染正常)均**无控制台错误**,eager 与 lazy 两侧 antd 都正常

与纯 UI 的 #1002 独立,可分别 review / 回滚。

🤖 Generated with [Claude Code](https://claude.com/claude-code)