### PR TITLE
feat(alignment): MITRA 质量门一致扩展到引用抽屉 + 覆盖 catalog

### DIFF
--- a/backend/app/api/alignment.py
+++ b/backend/app/api/alignment.py
@@ -27,6 +27,7 @@ from app.services.alignment_read_model import (
     get_chunk_parallels,
     get_sentence_parallels,
 )
+from app.services.mitra_gate import mitra_score_predicate
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/alignment", tags=["alignment"])
@@ -835,17 +836,24 @@ async def compute_alignment_catalog(
 
     # 2. mitra side (mitra_alignments) — bulk; cheap count + min(juan), NO join/
     #    distinct/array_agg (those pushed the unified query to ~77s on 896K rows).
-    #    Once mitra_e_score is backfilled, add: WHERE mitra_e_score >= 0.30
+    #    Quality-gated by the SAME NULL-permissive predicate as RAG/drawer so the
+    #    catalog counts trustworthy coverage, not raw imports (no-op until the
+    #    mitra_e_score backfill lands). This is the gate the old TODO here asked
+    #    for; it now lives in one place (services.mitra_gate).
+    mitra_pred, mitra_params = mitra_score_predicate()
+    mitra_where = f"WHERE {mitra_pred}" if mitra_pred else ""
     mitra_rows = (
         await db.execute(
             sql_text(
-                """
+                f"""
                 SELECT text_id, foreign_lang, count(*) AS pair_count,
                        min(juan_num) AS sample_juan
                 FROM mitra_alignments
+                {mitra_where}
                 GROUP BY text_id, foreign_lang
                 """
-            )
+            ),
+            mitra_params,
         )
     ).fetchall()
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -68,12 +68,14 @@ class Settings(BaseSettings):
     # back to alignment_pairs-only parallels without a redeploy.
     enable_mitra_rag_parallels: bool = True
 
-    # Quality gate for the MITRA parallels above: keep only rows whose proxy
-    # quality score (mitra_e_score) clears mitra_min_score. NULL-permissive —
-    # unscored rows (the whole table until a prod backfill runs) still flow, so
-    # enabling this before the backfill is a no-op. Set enable_mitra_score_gate
-    # false to drop the score predicate entirely and fall back to the pre-gate
-    # confidence ordering, without a redeploy.
+    # Quality gate for the MITRA parallels: keep only rows whose proxy quality
+    # score (mitra_e_score) clears mitra_min_score. NULL-permissive — unscored
+    # rows (the whole table until a prod backfill runs) still flow, so enabling
+    # this before the backfill is a no-op. Governs ALL MITRA read paths via
+    # services.mitra_gate: the RAG context (_attach_mitra_parallels), the
+    # citation drawer (get_chunk_parallels) and the coverage catalog
+    # (compute_alignment_catalog). Set false to drop the predicate everywhere
+    # and fall back to ungated (pre-gate) behavior, without a redeploy.
     mitra_min_score: float = 0.30
     enable_mitra_score_gate: bool = True
 

--- a/backend/app/services/alignment_read_model.py
+++ b/backend/app/services/alignment_read_model.py
@@ -32,6 +32,8 @@ from sqlalchemy import bindparam
 from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.services.mitra_gate import mitra_score_predicate
+
 logger = logging.getLogger(__name__)
 
 Granularity = Literal["sutta", "chunk"]
@@ -268,14 +270,21 @@ async def get_chunk_parallels(
         ))
 
     # MITRA cross-lingual parallels (inline Sanskrit/Tibetan, CC BY-SA 4.0).
+    # Apply the SAME NULL-permissive quality gate the RAG path uses, so the
+    # drawer never shows a low-scored parallel the answer path already filtered
+    # out. NULL-permissive → a no-op until mitra_e_score is backfilled.
+    mitra_pred, mitra_params = mitra_score_predicate()
+    mitra_gate_sql = f" AND {mitra_pred}" if mitra_pred else ""
     mitra_rows = (await session.execute(
         sql_text(
             "SELECT foreign_text, foreign_lang, confidence "
             "FROM mitra_alignments "
-            "WHERE text_id = :tid AND juan_num = :juan AND chunk_index = :cidx "
+            "WHERE text_id = :tid AND juan_num = :juan AND chunk_index = :cidx"
+            f"{mitra_gate_sql} "
             "ORDER BY foreign_lang, id LIMIT :limit"
         ),
-        {"tid": text_id, "juan": juan_num, "cidx": chunk_index, "limit": MITRA_CHUNK_LIMIT},
+        {"tid": text_id, "juan": juan_num, "cidx": chunk_index,
+         "limit": MITRA_CHUNK_LIMIT, **mitra_params},
     )).fetchall()
     for foreign_text, foreign_lang, conf in mitra_rows:
         records.append(ParallelRecord(

--- a/backend/app/services/mitra_gate.py
+++ b/backend/app/services/mitra_gate.py
@@ -1,0 +1,42 @@
+"""One definition of the MITRA quality gate, shared across read paths.
+
+``mitra_alignments`` rows carry a proxy quality score (``mitra_e_score``, a
+BGE-M3 cosine; the real MITRA-E semantic gate is a later phase). Rows below
+``settings.mitra_min_score`` are low-quality alignments that should not be
+served. The predicate is **NULL-PERMISSIVE**: rows whose score has not been
+backfilled yet still pass, so enabling the gate before the backfill completes is
+a no-op and it self-activates as scores land.
+
+The RAG context path (``rag_retrieval._attach_mitra_parallels``) already applies
+this gate inline (with its own score-ordered window over the
+``ix_mitra_align_chunk_escore`` partial index). This module mirrors that exact
+predicate so the two paths that historically **bypassed** the gate — the
+citation drawer (``alignment_read_model.get_chunk_parallels``) and the coverage
+catalog (``api.alignment.compute_alignment_catalog``) — can adopt it without
+drifting on what "gated" means. Same flag/threshold, same ``:min_score`` bind.
+"""
+
+from app.config import settings
+
+
+def build_mitra_score_predicate(
+    enabled: bool, threshold: float, column: str = "mitra_e_score"
+) -> tuple[str, dict]:
+    """Pure core: the gate predicate + bind params, or ``("", {})`` when off.
+
+    ``column`` lets callers qualify the name for aliased queries
+    (e.g. ``"ma.mitra_e_score"``). The predicate is NULL-permissive.
+    """
+    if not enabled:
+        return "", {}
+    return (
+        f"({column} IS NULL OR {column} >= :min_score)",
+        {"min_score": threshold},
+    )
+
+
+def mitra_score_predicate(column: str = "mitra_e_score") -> tuple[str, dict]:
+    """Config-driven wrapper: reads the live gate flag + threshold from settings."""
+    return build_mitra_score_predicate(
+        settings.enable_mitra_score_gate, settings.mitra_min_score, column
+    )

--- a/backend/tests/test_mitra_gate.py
+++ b/backend/tests/test_mitra_gate.py
@@ -1,0 +1,23 @@
+"""The shared MITRA quality-gate predicate (mirrors the RAG gate, reused by the
+drawer + catalog paths that historically bypassed it)."""
+
+from app.services.mitra_gate import build_mitra_score_predicate
+
+
+def test_disabled_gate_emits_no_predicate_and_no_binds():
+    assert build_mitra_score_predicate(False, 0.30) == ("", {})
+
+
+def test_enabled_gate_is_null_permissive_and_binds_min_score():
+    pred, params = build_mitra_score_predicate(True, 0.30)
+    # NULL-permissive: unscored (pre-backfill) rows must still pass, so enabling
+    # the gate before the backfill runs is a no-op.
+    assert "mitra_e_score IS NULL OR" in pred
+    assert "mitra_e_score >= :min_score" in pred
+    assert params == {"min_score": 0.30}
+
+
+def test_column_can_be_qualified_for_aliased_queries():
+    # RAG's CTE aliases the table as ``ma``; the drawer/catalog use the bare name.
+    pred, _ = build_mitra_score_predicate(True, 0.5, column="ma.mitra_e_score")
+    assert pred == "(ma.mitra_e_score IS NULL OR ma.mitra_e_score >= :min_score)"


### PR DESCRIPTION
## 背景 / 洞
RAG 答案路径(`_attach_mitra_parallels`)**早就**按 `mitra_e_score` 质量门过滤 MITRA 平行(`enable_mitra_score_gate=True`,NULL-permissive,`≥ mitra_min_score`)。但另外两条读 `mitra_alignments` 的路**绕过了这道门**:

- **引用抽屉** `alignment_read_model.get_chunk_parallels` — 用户点开引用看到的跨藏平行;
- **覆盖 catalog** `api.alignment.compute_alignment_catalog` — `/api/alignment/catalog` 的计数。

后果:用户在抽屉里读到、且 catalog 计数里算进的,是**答案路径已经滤掉**的未过质量分的对齐(生产实测 catalog 现为 912,719 对 / 1,016 部,全部未过门)。`alignment.py` 里那句 `# Once mitra_e_score is backfilled, add: WHERE mitra_e_score >= 0.30` 的 TODO 就是这个洞。

## 改动
- 新增 `services/mitra_gate.py`,把门谓词收敛成**单一定义**(与 RAG 现有门**字节一致**、同用 `:min_score` 绑定),供抽屉 + catalog 复用 —— 防止三条路再次在"什么算 gated"上分叉(这正是上一个显示 bug 的成因:各写各的)。`build_mitra_score_predicate` 走 TDD。
- 抽屉 + catalog 接上同一 **NULL-permissive** 谓词。
- **RAG 原样不动**:它已是参照实现,且其测试锁了模块常量的 mock 方式,重构它得不偿失。
- **复用现有 config**(`enable_mitra_score_gate` / `mitra_min_score`)——无新配置项、**无 DB 迁移**。

## 行为与影响
- 合并即生效(flag 本就默认 `True`,与 RAG 一致)。
- **NULL-permissive** ⇒ 影响随 `mitra_e_score` 回填进度而定:
  - 回填 ≈ 0:对抽屉/catalog 是 **no-op**(未评分行照过);
  - 回填后:抽屉少显低分平行、**catalog 计数下降到"可信覆盖"**(912,719 这个数会随之变小 —— 这是预期,不是 bug)。
- **回滚**:`enable_mitra_score_gate=False`,三条路一起退回未过滤,无需 redeploy。

## ⚠️ 上线 runbook(建议按序)
1. **先量分布**(生产只读):`SELECT count(*) FILTER (WHERE mitra_e_score IS NOT NULL) AS scored, count(*) FILTER (WHERE mitra_e_score >= 0.30) AS pass, count(*) AS total FROM mitra_alignments;` —— 看回填到哪了、`0.30` 会滤掉多少。
2. **合并后核 catalog delta**:再拉一次 `/api/alignment/catalog`,对比 `total_pairs`(912,719 → ?),确认下降幅度与 step 1 预期一致。
3. 若 `0.30` 阈值把好对齐也误杀(代理分未标定),调 `mitra_min_score` 或先 `enable_mitra_score_gate=False` 等真 MITRA-E 门就位。

## 测试
- 新增 `test_mitra_gate.py`(TDD:disabled→无谓词 / enabled→NULL-permissive+绑定 / 列名可限定)。
- 回归:`test_rag_mitra_score_gate`、`test_alignment_read_model`、`test_search_parallel_sentences`(那条"句级搜索无门"断言不受影响)等 **51 项相关测试全绿**;ruff 干净。
- CI 的 real-Postgres 后端 smoke 会验证抽屉/catalog 改后 SQL 语法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MECzeP2iz6RMW3rrgN9x4J