### PR TITLE
fix(collections): 跨藏对照表按 UI 语言渲染经名,不再直出 CBETA 繁体

### DIFF
--- a/frontend/src/pages/CollectionsPage.test.tsx
+++ b/frontend/src/pages/CollectionsPage.test.tsx
@@ -5,6 +5,7 @@ import { HelmetProvider } from "react-helmet-async";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import i18n from "../i18n";
 import enTranslation from "../../public/locales/en/translation.json";
+import zhHantTranslation from "../../public/locales/zh-Hant/translation.json";
 import CollectionsPage from "./CollectionsPage";
 import { api, getAlignmentCatalog } from "../api/client";
 
@@ -44,7 +45,11 @@ function renderPage() {
 
 describe("CollectionsPage", () => {
   beforeAll(() => {
+    // Only `zh` is inlined into the i18n instance; the others load over
+    // HttpBackend, which never resolves under jsdom. Preload the bundles the
+    // tests switch to, or changeLanguage() hangs until the test times out.
     i18n.addResourceBundle("en", "translation", enTranslation, true, true);
+    i18n.addResourceBundle("zh-Hant", "translation", zhHantTranslation, true, true);
   });
 
   beforeEach(async () => {
@@ -136,5 +141,45 @@ describe("CollectionsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Avatamsaka Sutra Series/ }));
     expect(screen.getAllByRole("heading", { level: 3 }).length).toBeGreaterThan(0);
     expect(screen.queryAllByRole("heading", { level: 4 })).toHaveLength(0);
+  });
+
+  describe("cross-canon catalog script", () => {
+    // The catalog passes CBETA's traditional title_zh straight through.
+    const traditionalEntry = {
+      text_id: 43,
+      cbeta_id: "T1579",
+      title_zh: "瑜伽師地論",
+      other_lang: "bo",
+      pair_count: 39046,
+      partner_count: 0,
+      avg_confidence: null,
+      sources: ["mitra"],
+      sample_juan: 1,
+      sample_partner_id: null,
+      sample_partner_title: "",
+    };
+
+    beforeEach(() => {
+      vi.mocked(getAlignmentCatalog).mockResolvedValue({
+        entries: [traditionalEntry],
+        total_pairs: 39046,
+      });
+    });
+
+    it("folds catalog titles to simplified for 中文简体 readers", async () => {
+      await i18n.changeLanguage("zh");
+      renderPage();
+
+      expect(await screen.findByText("瑜伽师地论")).toBeInTheDocument();
+      expect(screen.queryByText("瑜伽師地論")).not.toBeInTheDocument();
+    });
+
+    it("keeps catalog titles traditional for 繁體 readers", async () => {
+      await i18n.changeLanguage("zh-Hant");
+      renderPage();
+
+      expect(await screen.findByText("瑜伽師地論")).toBeInTheDocument();
+      expect(screen.queryByText("瑜伽师地论")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -27,6 +27,7 @@ import {
   type ResourceCategory,
 } from "../data/collections";
 import { getAlignmentCatalog } from "../api/client";
+import { localizeHan } from "../utils/hanScript";
 import "../styles/sources.css";
 import "../styles/collections.css";
 
@@ -237,7 +238,7 @@ const LANG_TINT: Record<string, string> = { bo: "#7c5cbf", sa: "#bd7b3a", pi: "#
 /** 跨藏对照专区：哪些经有逐段对照语料（可发现性入口）。
     API 失败/空数据时整块隐身，可与 backend 端点解耦部署。 */
 function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useNavigate> }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { data } = useQuery({
     queryKey: ["alignmentCatalog"],
     queryFn: getAlignmentCatalog,
@@ -258,7 +259,17 @@ function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useN
     for (const e of data.entries) {
       let g = m.get(e.text_id);
       if (!g) {
-        g = { text_id: e.text_id, title: e.title_zh || e.cbeta_id, cbeta_id: e.cbeta_id, sample_juan: e.sample_juan, total: 0, langs: [] };
+        // title_zh is CBETA's own string, i.e. always traditional. Render it in
+        // the reader's script instead of leaking the corpus's — otherwise a
+        // 中文简体 visitor gets 大方廣佛華嚴經 sitting under 华严经系列.
+        g = {
+          text_id: e.text_id,
+          title: localizeHan(e.title_zh || e.cbeta_id, i18n.language),
+          cbeta_id: e.cbeta_id,
+          sample_juan: e.sample_juan,
+          total: 0,
+          langs: [],
+        };
         m.set(e.text_id, g);
       }
       g.langs.push({ lang: e.other_lang, count: e.pair_count });
@@ -267,7 +278,7 @@ function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useN
     const arr = [...m.values()];
     arr.forEach((g) => g.langs.sort((a, b) => b.count - a.count));
     return arr.sort((a, b) => b.total - a.total);
-  }, [data]);
+  }, [data, i18n.language]);
 
   if (!data || groups.length === 0) return null;
 

--- a/frontend/src/pages/CrossCanonPage.test.tsx
+++ b/frontend/src/pages/CrossCanonPage.test.tsx
@@ -1,0 +1,70 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import i18n from "../i18n";
+import zhHantTranslation from "../../public/locales/zh-Hant/translation.json";
+import CrossCanonPage from "./CrossCanonPage";
+import { getAlignmentCatalog } from "../api/client";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return { ...actual, getAlignmentCatalog: vi.fn() };
+});
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/cross-canon"]}>
+        <CrossCanonPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CrossCanonPage", () => {
+  beforeAll(() => {
+    // Only `zh` is inlined; other bundles load over HttpBackend, which never
+    // resolves under jsdom.
+    i18n.addResourceBundle("zh-Hant", "translation", zhHantTranslation, true, true);
+  });
+
+  beforeEach(() => {
+    // CBETA's own title string — always traditional.
+    vi.mocked(getAlignmentCatalog).mockResolvedValue({
+      entries: [
+        {
+          text_id: 43,
+          cbeta_id: "T1579",
+          title_zh: "瑜伽師地論",
+          other_lang: "bo",
+          pair_count: 39046,
+          partner_count: 0,
+          avg_confidence: null,
+          sources: ["mitra"],
+          sample_juan: 1,
+          sample_partner_id: null,
+          sample_partner_title: "",
+        },
+      ],
+      total_pairs: 39046,
+    });
+  });
+
+  it("folds catalog titles to simplified for 中文简体 readers", async () => {
+    await i18n.changeLanguage("zh");
+    renderPage();
+
+    expect(await screen.findByText("瑜伽师地论")).toBeInTheDocument();
+    expect(screen.queryByText("瑜伽師地論")).not.toBeInTheDocument();
+  });
+
+  it("keeps catalog titles traditional for 繁體 readers", async () => {
+    await i18n.changeLanguage("zh-Hant");
+    renderPage();
+
+    expect(await screen.findByText("瑜伽師地論")).toBeInTheDocument();
+    expect(screen.queryByText("瑜伽师地论")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CrossCanonPage.tsx
+++ b/frontend/src/pages/CrossCanonPage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Tag, Input, Empty, Spin } from "antd";
 import { TranslationOutlined, SearchOutlined } from "@ant-design/icons";
 import { getAlignmentCatalog } from "../api/client";
+import { localizeHan } from "../utils/hanScript";
 import { taishoSection, SECTION_ORDER } from "../data/taishoSections";
 
 const LANG_LABELS: Record<string, { labelKey: string; color: string }> = {
@@ -28,7 +29,7 @@ type Work = {
     完整 ~1000 部跨语对齐经典，按 Taishō 部类分组 + 语种/部类筛选 + 搜索。
     纯前端：复用 cached catalog，部类从 cbeta_id（T-number）推导。 */
 export default function CrossCanonPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const [langFilter, setLangFilter] = useState<"all" | "both" | "bo" | "sa">("all");
   const [section, setSection] = useState<string>("");
@@ -50,7 +51,9 @@ export default function CrossCanonPage() {
       if (!w) {
         w = {
           text_id: e.text_id,
-          title: e.title_zh || e.cbeta_id,
+          // CBETA's title_zh is always traditional; render it in the reader's
+          // script. Also makes the search box below match what's on screen.
+          title: localizeHan(e.title_zh || e.cbeta_id, i18n.language),
           section: taishoSection(e.cbeta_id),
           sample_juan: e.sample_juan,
           total: 0,
@@ -68,7 +71,7 @@ export default function CrossCanonPage() {
     const arr = [...m.values()];
     arr.forEach((w) => w.langs.sort((a, b) => b.count - a.count));
     return arr.sort((a, b) => b.total - a.total);
-  }, [data]);
+  }, [data, i18n.language]);
 
   const sectionCounts = useMemo(() => {
     const c = new Map<string, number>();

--- a/frontend/src/utils/hanScript.test.ts
+++ b/frontend/src/utils/hanScript.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { localizeHan, scriptForLanguage } from "./hanScript";
+
+/**
+ * Backend-supplied text titles (`title_zh`) come straight out of CBETA, which
+ * stores traditional Chinese. The UI happily renders them next to hand-curated
+ * simplified copy, so a 中文简体 reader sees 大方廣佛華嚴經 sitting directly
+ * under 华严经系列. The script a title is rendered in should follow the UI
+ * language, not the upstream corpus.
+ */
+
+describe("scriptForLanguage", () => {
+  it("maps the simplified locales", () => {
+    expect(scriptForLanguage("zh")).toBe("simplified");
+    expect(scriptForLanguage("zh-CN")).toBe("simplified");
+  });
+
+  it("maps the traditional locales", () => {
+    expect(scriptForLanguage("zh-Hant")).toBe("traditional");
+    expect(scriptForLanguage("zh-TW")).toBe("traditional");
+    expect(scriptForLanguage("zh-HK")).toBe("traditional");
+  });
+
+  it("renders Chinese titles simplified for non-Chinese UI languages", () => {
+    // The curated en.json keeps canonical titles in simplified Chinese, so
+    // English readers should see the same script rather than a third variant.
+    expect(scriptForLanguage("en")).toBe("simplified");
+  });
+});
+
+describe("localizeHan", () => {
+  it("folds CBETA traditional titles to simplified for zh readers", () => {
+    expect(localizeHan("大方廣佛華嚴經", "zh")).toBe("大方广佛华严经");
+    expect(localizeHan("瑜伽師地論", "zh")).toBe("瑜伽师地论");
+    expect(localizeHan("阿毘達磨俱舍釋論", "zh")).toBe("阿毘达磨俱舍释论");
+  });
+
+  it("keeps traditional titles traditional for zh-Hant readers", () => {
+    expect(localizeHan("大方廣佛華嚴經", "zh-Hant")).toBe("大方廣佛華嚴經");
+  });
+
+  it("converts simplified input to traditional for zh-Hant readers", () => {
+    expect(localizeHan("大方广佛华严经", "zh-TW")).toBe("大方廣佛華嚴經");
+  });
+
+  it("leaves text with no Han characters untouched", () => {
+    expect(localizeHan("T0279", "zh")).toBe("T0279");
+    expect(localizeHan("", "zh")).toBe("");
+  });
+
+  it("is a no-op when the text is already in the target script", () => {
+    expect(localizeHan("瑜伽师地论", "zh")).toBe("瑜伽师地论");
+  });
+});

--- a/frontend/src/utils/hanScript.ts
+++ b/frontend/src/utils/hanScript.ts
@@ -1,0 +1,47 @@
+/**
+ * Render Han text in the script the UI language asks for.
+ *
+ * Backend text titles (`title_zh`) are passed through from CBETA, which stores
+ * traditional Chinese, while the hand-curated page copy is written per locale.
+ * Rendering the upstream string verbatim put 大方廣佛華嚴經 directly under
+ * 华严经系列 for 中文简体 readers — the corpus's script leaking into the UI.
+ * The script a title renders in should follow the reader's language.
+ *
+ * Conversion is OpenCC's 1 char → 1 char mapping (same lib the citation matcher
+ * already folds with), so offsets are preserved and non-Han text is untouched.
+ */
+import * as OpenCC from "opencc-js";
+
+export type HanScript = "simplified" | "traditional";
+
+const toSimplified = OpenCC.Converter({ from: "tw", to: "cn" });
+const toTraditional = OpenCC.Converter({ from: "cn", to: "tw" });
+
+/**
+ * The traditional-script locales, mirroring `normalizeCollectionLocale` in
+ * data/collections.ts. Everything else — including `en`, whose curated titles
+ * are simplified Chinese — renders simplified.
+ */
+export function scriptForLanguage(language: string): HanScript {
+  if (
+    language.startsWith("zh-Hant") ||
+    language.startsWith("zh-TW") ||
+    language.startsWith("zh-HK")
+  ) {
+    return "traditional";
+  }
+  return "simplified";
+}
+
+/** Convert `text` into the Han script matching `language`. */
+export function localizeHan(text: string, language: string): string {
+  if (!text) return text;
+  try {
+    return scriptForLanguage(language) === "traditional"
+      ? toTraditional(text)
+      : toSimplified(text);
+  } catch {
+    // Never let a converter hiccup blank out a title.
+    return text;
+  }
+}


### PR DESCRIPTION
## 问题

`/collections` 首屏第一个数据组件「跨藏对照」把 catalog 的 `title_zh` 原样渲染。CBETA 存的是**繁体**,于是在一个 `html lang="zh-CN"`、语言切换器写着「中文简体」、13 个卡片标题全是简体的页面上,表格却是:

> 瑜伽師地論 · 大寶積經 · 大方廣佛華嚴經 · 阿毘達磨俱舍釋論 · 正法念處經

其中「大方**廣**佛**華嚴經**」正好压在「华严经系列」正上方。**语料的字体泄漏进了 UI。**

## 改动

新增 `utils/hanScript.ts`:

```ts
localizeHan(text, language)   // zh/en → 简体；zh-Hant/zh-TW/zh-HK → 繁体
```

语言映射与 `data/collections.ts` 的 `normalizeCollectionLocale` 保持一致(`en` 归简体,因为 `en.json` 的策展经名本就是简体)。

复用 **`opencc-js`** —— 它已经是前端依赖,`utils/citationMatch.ts` 早就用它折简繁做引文匹配,那里的注释直接写着「CBETA stores traditional Chinese while LLM answers are usually simplified」。**代码库一直知道这件事,只是这个页面没接上。**

同时修 **`/cross-canon`**:它复用同一份 cached catalog,而且正是本表「查看全部」的落点 —— 不一起修的话,用户点一下就撞见繁体。顺带让它的搜索框能匹配屏幕上实际显示的字。该页此前**无测试文件**,本 PR 补上。

## 验证

单测(先 RED 后 GREEN):`hanScript` 8 条 + `CollectionsPage` 2 条 + `CrossCanonPage` 2 条;全量 **209 passed**;tsc / eslint 干净。

> 测试环境注意:i18n 只内联了 `zh`,其余走 `HttpBackend`,在 jsdom 下 `changeLanguage("zh-Hant")` 会挂死到超时。已按现有 `en` 的模式在 `beforeAll` 预载 `zh-Hant` bundle。

dev server 挂生产 API 真机验证:

| 语言 | 表格实际渲染 | 结果 |
|---|---|---|
| 中文简体 | 瑜伽师地论 · 大宝积经 · 大方广佛华严经 | 繁体残留 **0** ✅ |
| 繁體 (`?lang=zh-Hant`) | 瑜伽師地論 · 大寶積經 · 大方廣佛華嚴經 | 简体残留 **0** ✅(未被误转) |

## 已知残留(判断为可接受)

`阿毘達磨` 的 **毘** 不会被转成 **毗** —— 实测 OpenCC 的 `t` / `tw` / `twp` / `hk` 四种配置**均保留该异体字**(这是异体字问题,不是繁简问题)。故表格作「阿毘达磨俱舍论」而策展卡片作「阿毗达磨系列」。

判断:**不修**。经名保留 CBETA 原形是学术惯例,而「阿毗达磨系列」是佛津自己的编目用字 —— 两者用途不同,不必强行统一。

## 未处理(建议另议)

`title_zh` 在全站多处直出繁体,均不在本 PR 范围:

- `TextDetailPage` —— 放进了 `<title>`、`og:title`、JSON-LD `schema.org` 和页面 `h1`,**改动有 SEO 后果**,值得单独决策
- `ChatPage`、`AdminAnswerQualityPage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwGfQRF21tp5TMDvNMSFnj