### PR TITLE
feat(collections): 专题深链路由 /collections/:id(可分享 / 可收藏 / 可收录)

### DIFF
--- a/backend/app/api/sitemap.py
+++ b/backend/app/api/sitemap.py
@@ -40,6 +40,25 @@ STATIC_PAGES = [
     ("/sutras/medicine-buddha-sutra", "monthly", "0.9"),
     ("/sutras/platform-sutra", "monthly", "0.9"),
     ("/sutras/vimalakirti-sutra", "monthly", "0.9"),
+    # Full cross-canon browse (~1000 aligned texts) — a larger index than
+    # /collections, and previously not listed at all.
+    ("/cross-canon", "weekly", "0.7"),
+    # Curated series deep links. These mirror the ids in
+    # frontend/src/content/collectionLocales/*.json; tests/test_sitemap_collections.py
+    # fails if the two lists drift apart.
+    ("/collections/huayan", "monthly", "0.7"),
+    ("/collections/prajna", "monthly", "0.7"),
+    ("/collections/lotus", "monthly", "0.7"),
+    ("/collections/shurangama", "monthly", "0.7"),
+    ("/collections/pureland", "monthly", "0.7"),
+    ("/collections/yogacara", "monthly", "0.7"),
+    ("/collections/chan", "monthly", "0.7"),
+    ("/collections/vinaya", "monthly", "0.7"),
+    ("/collections/agama", "monthly", "0.7"),
+    ("/collections/esoteric", "monthly", "0.7"),
+    ("/collections/nirvana", "monthly", "0.7"),
+    ("/collections/abhidharma", "monthly", "0.7"),
+    ("/collections/pali-canon", "monthly", "0.7"),
 ]
 
 

--- a/backend/tests/test_sitemap_collections.py
+++ b/backend/tests/test_sitemap_collections.py
@@ -1,0 +1,42 @@
+"""The 13 curated collection series each have their own URL now
+(/collections/<id>); the sitemap has to name them or the deep links stay
+invisible to crawlers — which was most of the point of adding them.
+"""
+
+import json
+from pathlib import Path
+
+from app.api.sitemap import STATIC_PAGES
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_COLLECTIONS_JSON = _FRONTEND / "src" / "content" / "collectionLocales" / "zh.json"
+
+
+def _curated_collection_ids() -> list[str]:
+    data = json.loads(_COLLECTIONS_JSON.read_text(encoding="utf-8"))
+    return [c["id"] for c in data["collections"]]
+
+
+def test_every_curated_collection_is_in_the_sitemap():
+    paths = {p for p, _, _ in STATIC_PAGES}
+    missing = [
+        f"/collections/{cid}"
+        for cid in _curated_collection_ids()
+        if f"/collections/{cid}" not in paths
+    ]
+    assert not missing, f"collection deep links missing from sitemap: {missing}"
+
+
+def test_sitemap_has_no_stale_collection_links():
+    curated = set(_curated_collection_ids())
+    listed = {
+        p.removeprefix("/collections/")
+        for p, _, _ in STATIC_PAGES
+        if p.startswith("/collections/")
+    }
+    assert listed <= curated, f"sitemap lists collections that no longer exist: {listed - curated}"
+
+
+def test_cross_canon_browse_page_is_listed():
+    # ~1000 aligned texts, a bigger index than /collections, previously absent.
+    assert "/cross-canon" in {p for p, _, _ in STATIC_PAGES}

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1097,6 +1097,7 @@
   "geo.country_tw": "Taiwan",
   "geo.country_br": "Brazil",
   "collections.page_title": "Text Collections | FoJin",
+  "collections.detail_page_title": "{{name}} — Text Collections | FoJin",
   "collections.page_desc": "Browse Buddhist classics by series, including main texts, commentaries, and related resources.",
   "collections.title": "Text Collections",
   "collections.subtitle": "{{series}} series · {{texts}} texts · {{resources}} external resources",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1097,6 +1097,7 @@
   "geo.country_tw": "臺灣",
   "geo.country_br": "巴西",
   "collections.page_title": "經典專題 | 佛津",
+  "collections.detail_page_title": "{{name}} — 經典專題 | 佛津",
   "collections.page_desc": "按經論系列分類瀏覽佛教經典，包含主要經典、註疏論釋及相關資源。",
   "collections.title": "經典專題",
   "collections.subtitle": "{{series}} 個經論系列 · {{texts}} 部典籍 · {{resources}} 個外部資源",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1097,6 +1097,7 @@
   "geo.country_tw": "台湾",
   "geo.country_br": "巴西",
   "collections.page_title": "经典专题 | 佛津",
+  "collections.detail_page_title": "{{name}} — 经典专题 | 佛津",
   "collections.page_desc": "按经论系列分类浏览佛教经典，包含主要经典、注疏论释及相关资源。",
   "collections.title": "经典专题",
   "collections.subtitle": "{{series}} 个经论系列 · {{texts}} 部典籍 · {{resources}} 个外部资源",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,6 +78,7 @@ function App() {
             <Route path="/texts/:id/read" element={<TextReaderPage />} />
             <Route path="/sources" element={<SourcesPage />} />
             <Route path="/collections" element={<CollectionsPage />} />
+            <Route path="/collections/:collectionId" element={<CollectionsPage />} />
             <Route path="/cross-canon" element={<CrossCanonPage />} />
             <Route path="/topics" element={<TopicsPage />} />
             <Route path="/sutras/:slug" element={<SutraLandingPage />} />

--- a/frontend/src/pages/CollectionsPage.test.tsx
+++ b/frontend/src/pages/CollectionsPage.test.tsx
@@ -2,7 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import i18n from "../i18n";
 import enTranslation from "../../public/locales/en/translation.json";
 import zhHantTranslation from "../../public/locales/zh-Hant/translation.json";
@@ -26,7 +26,7 @@ function LocationProbe() {
   return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
 }
 
-function renderPage() {
+function renderPage(entry = "/collections") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -34,8 +34,11 @@ function renderPage() {
   return render(
     <HelmetProvider>
       <QueryClientProvider client={client}>
-        <MemoryRouter initialEntries={["/collections"]}>
-          <CollectionsPage />
+        <MemoryRouter initialEntries={[entry]}>
+          <Routes>
+            <Route path="/collections" element={<CollectionsPage />} />
+            <Route path="/collections/:collectionId" element={<CollectionsPage />} />
+          </Routes>
           <LocationProbe />
         </MemoryRouter>
       </QueryClientProvider>
@@ -180,6 +183,59 @@ describe("CollectionsPage", () => {
 
       expect(await screen.findByText("瑜伽師地論")).toBeInTheDocument();
       expect(screen.queryByText("瑜伽师地论")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("deep linking", () => {
+    // A collection used to be reachable only by expanding a local useState, so
+    // all 13 shared one URL: unshareable, unbookmarkable, and indistinguishable
+    // to crawlers.
+    it("opens the collection named in the URL", () => {
+      renderPage("/collections/huayan");
+
+      expect(screen.getByText("Online Reading")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Avatamsaka Sutra Series/ }),
+      ).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("leaves every collection closed on the bare index", () => {
+      renderPage("/collections");
+
+      expect(screen.queryByText("Online Reading")).not.toBeInTheDocument();
+    });
+
+    it("falls back to the index for an unknown collection id", () => {
+      renderPage("/collections/does-not-exist");
+
+      expect(screen.getByRole("heading", { level: 1, name: "Text Collections" })).toBeInTheDocument();
+      expect(screen.queryByText("Online Reading")).not.toBeInTheDocument();
+    });
+
+    it("puts the opened collection in the URL", () => {
+      renderPage("/collections");
+
+      fireEvent.click(screen.getByRole("button", { name: /Avatamsaka Sutra Series/ }));
+      expect(screen.getByTestId("location")).toHaveTextContent("/collections/huayan");
+    });
+
+    it("returns to the index URL when the collection is closed again", () => {
+      renderPage("/collections/huayan");
+
+      fireEvent.click(screen.getByRole("button", { name: /Avatamsaka Sutra Series/ }));
+      expect(screen.getByTestId("location")).toHaveTextContent("/collections");
+      expect(screen.queryByText("Online Reading")).not.toBeInTheDocument();
+    });
+
+    it("opens only one collection at a time", () => {
+      renderPage("/collections/huayan");
+
+      fireEvent.click(screen.getByRole("button", { name: /Pure Land Sutras/ }));
+
+      expect(screen.getByTestId("location")).toHaveTextContent("/collections/pureland");
+      expect(
+        screen.getByRole("button", { name: /Avatamsaka Sutra Series/ }),
+      ).toHaveAttribute("aria-expanded", "false");
     });
   });
 });

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { Input, Tag, Empty } from "antd";
@@ -130,10 +130,21 @@ function ResourceTabs({ resources, resourceCategories }: { resources: Collection
   );
 }
 
-function CollectionCard({ coll, cbetaMap, resourceCategories }: { coll: Collection; cbetaMap: Record<string, number>; resourceCategories: ResourceCategoryLabels }) {
+function CollectionCard({
+  coll,
+  cbetaMap,
+  resourceCategories,
+  expanded,
+  onToggle,
+}: {
+  coll: Collection;
+  cbetaMap: Record<string, number>;
+  resourceCategories: ResourceCategoryLabels;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [expanded, setExpanded] = useState(false);
 
   const totalResources = RESOURCE_CATEGORY_KEYS.reduce(
     (sum, k) => sum + (coll.resources[k]?.length || 0),
@@ -155,7 +166,7 @@ function CollectionCard({ coll, cbetaMap, resourceCategories }: { coll: Collecti
           className="coll-card-header"
           aria-expanded={expanded}
           aria-controls={panelId}
-          onClick={() => setExpanded(!expanded)}
+          onClick={onToggle}
         >
           <span className="coll-card-title-row">
             <BookOutlined className="coll-card-icon" aria-hidden="true" />
@@ -374,11 +385,25 @@ function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useN
 export default function CollectionsPage() {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
+  const { collectionId } = useParams<{ collectionId?: string }>();
   const [search, setSearch] = useState("");
   const [showTop, setShowTop] = useState(false);
   const [cbetaMap, setCbetaMap] = useState<Record<string, number>>({});
   const collections = useMemo(() => getLocalizedCollections(i18n.language), [i18n.language]);
   const resourceCategories = useMemo(() => getLocalizedResourceCategories(i18n.language), [i18n.language]);
+
+  // Which collection is open lives in the URL, not in each card's useState, so a
+  // series can be linked, bookmarked and crawled instead of all 13 sharing
+  // /collections. An unknown id degrades to the plain index rather than 404ing —
+  // a stale bookmark should still land somewhere useful.
+  const openCollection = useMemo(
+    () => collections.find((c) => c.id === collectionId),
+    [collections, collectionId],
+  );
+  // One open at a time: the URL names a single collection, so the accordion
+  // state stays a clean bijection with it.
+  const toggleCollection = (id: string) =>
+    navigate(openCollection?.id === id ? "/collections" : `/collections/${id}`);
 
   useEffect(() => {
     const onScroll = () => setShowTop(window.scrollY > 400);
@@ -430,9 +455,27 @@ export default function CollectionsPage() {
 
   return (
     <div className="sources-page">
+      {/* Each /collections/:id must describe itself, or the 13 URLs read as
+          duplicates of the index to a crawler and the deep links cost more
+          than they earn. Canonical points at the open series' own URL. */}
       <Helmet>
-        <title>{t("collections.page_title")}</title>
-        <meta name="description" content={t("collections.page_desc")} />
+        <title>
+          {openCollection
+            ? t("collections.detail_page_title", { name: openCollection.name })
+            : t("collections.page_title")}
+        </title>
+        <meta
+          name="description"
+          content={openCollection ? openCollection.description : t("collections.page_desc")}
+        />
+        <link
+          rel="canonical"
+          href={
+            openCollection
+              ? `https://fojin.app/collections/${openCollection.id}`
+              : "https://fojin.app/collections"
+          }
+        />
       </Helmet>
 
       <div className="sources-header">
@@ -464,7 +507,14 @@ export default function CollectionsPage() {
       ) : (
         <div className="coll-list">
           {filtered.map((c) => (
-            <CollectionCard key={c.id} coll={c} cbetaMap={cbetaMap} resourceCategories={resourceCategories} />
+            <CollectionCard
+              key={c.id}
+              coll={c}
+              cbetaMap={cbetaMap}
+              resourceCategories={resourceCategories}
+              expanded={openCollection?.id === c.id}
+              onToggle={() => toggleCollection(c.id)}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
> 替代 #1010 —— #1008 合并时删除了它的 base 分支,GitHub 自动关闭了 #1010。内容一致,base 已改为 master,净 diff 只含深链改动(#1008 的改动已在 master)。

## 问题

13 专题共用一个 `/collections` URL,展开只是卡片内部 `useState`——单个专题不能分享、不能收藏、返回丢状态、对爬虫是同一页。这些人工策展内容拿不到独立 SEO 权重。

## 改动

- 新增路由 `/collections/:collectionId`,复用同一个 CollectionsPage,展开态由 URL 驱动
- **一次只开一个**(以前可同时展开多个)——URL 只指向一个专题,状态与 URL 成干净的双射,索引页也不再是一堆同时铺开的长卡片
- 未知 id **退化为索引页,不 404**
- 每个 `/collections/:id` 独立 Helmet title/description/canonical(机制与既有 Sutra/Search/Person 页一致)
- sitemap 补 13 条深链 + 此前**漏登的 `/cross-canon`**;新增 `test_sitemap_collections.py` 以 zh.json 的 id 为真相防漂移

## 验证

前端全量 **218 passed**(新增 6 条深链行为,先 RED 后 GREEN)+ 后端 sitemap **3 passed**;tsc / eslint 干净。dev server 挂生产 API 真机验证:`/collections/chan` 直开禅宗系列、URL 与 title 同步、切专题只开一个、未知 id 退化索引。

## 已知(全站既有,非本 PR 引入)

react-helmet-async 不认领 index.html 静态 canonical,client 端双 canonical 并存——`/sutras/heart-sutra` 等既有 SEO 页一样,由 seoPages 预渲染兜底。深链要完整预渲染可后续把 13 id 加进 seoPages。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwGfQRF21tp5TMDvNMSFnj