### PR TITLE
test(admin): 修「重试成功清除错误态」的 flaky 断言(缺 waitFor)

### DIFF
--- a/frontend/src/pages/AdminAnswerQualityPage.test.tsx
+++ b/frontend/src/pages/AdminAnswerQualityPage.test.tsx
@@ -140,8 +140,12 @@ describe("AdminAnswerQualityPage", () => {
       { timeout: 3000 },
     );
 
-    // 4. 断言错误横幅消失
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    // 4. 断言错误横幅消失。必须 waitFor：第 3 步的 waitFor 只确认 mock 被第二
+    //    次「调用」，但那一刻请求可能尚未 resolve、React 尚未重渲染清除 alert。
+    //    同步断言在慢 CI 上会偶发失败（该测试此前的 flaky 根因）。
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
 
     // 5. 断言"未复核 1 条"出现
     await waitFor(() => {


### PR DESCRIPTION
## 问题

`AdminAnswerQualityPage` 的 **「点击重试按钮后,请求成功并清除错误态」** 测试在慢 CI 环境下**偶发失败**,近日多次误挡与它无关的 PR 的 `Frontend build`(#1009 连挂两次、#1008/#1011 也偶发)。本地稳过,CI 慢环境才触发——典型时序 flaky。

## 根因

```js
// 3. 断言 getAnswerQualityQueue 被调用了第二次
await waitFor(() => {
  expect(vi.mocked(getAnswerQualityQueue)).toHaveBeenCalledTimes(2);
}, { timeout: 3000 });

// 4. 断言错误横幅消失  ← ❌ 同步断言
expect(screen.queryByRole("alert")).not.toBeInTheDocument();
```

第 3 步的 `waitFor` 只等到 mock 被**调用**第二次(调用计数 +1),但那一刻第二次请求的 promise 可能尚未 resolve、React 尚未重渲染清除 alert。第 4 步紧接着用**同步**断言 alert 消失——**调用计数 ≠ 数据返回 + UI 更新**,慢环境下这段时间差就让同步断言扑空。

## 修复

把第 4 步包进 `waitFor`,等重渲染真正清除 alert 后再断言:

```js
// 4. 断言错误横幅消失
await waitFor(() => {
  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
});
```

标准的 testing-library 反竞态模式,消除「等 mock 调用」与「等 UI 更新」之间的时间差。

## 验证

本地连跑 6 次稳过;全量 **212 passed**;tsc / eslint 干净。仅改一处断言的等待方式,不动被测组件、不改其他测试。

> 背景:这个 flaky 是发现于 /collections 三个 P R(#1008 已合 / #1009 / #1011)的合并过程中——它反复误挡 CI。先合本 PR,#1009/#1011 rebase 后即不再被它挡。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwGfQRF21tp5TMDvNMSFnj