### PR TITLE
chore: ignore local research notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ CLAUDE.md
 data/
 !backend/app/data/
 .coverage
+
+# Local research notes — internal strategy snapshots, not for publication
+docs/research/


### PR DESCRIPTION
`docs/research/` holds internal strategy snapshots — peer-project surveys, licensing open questions, and unexecuted outreach plans. They're useful to keep on disk locally, but this is a public repository and they aren't meant for publication.

Ignoring the directory keeps the notes available locally while stopping them from cluttering `git status` or being committed by accident.

3 lines, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRR4gxhpnSM139bB2isk3Q