### PR TITLE
fix(seo_dict): skip 2-char reverse-index lookups that can never use the trgm index

### DIFF
--- a/backend/app/api/seo_dict.py
+++ b/backend/app/api/seo_dict.py
@@ -52,7 +52,13 @@ router = APIRouter(tags=["seo"])
 _DEFINITION_PREVIEW_CHARS = 220
 _REVERSE_INDEX_LIMIT = 8
 _MAX_HEADWORD_LEN = 200
-_MIN_HEADWORD_LEN = 2  # single-char terms match ~everything + defeat the trgm index
+# pg_trgm can only use ix_text_contents_content_trgm for an unanchored
+# ``ILIKE '%term%'`` when the pattern holds at least one *complete* trigram —
+# i.e. 3+ characters. At 2 characters the planner extracts nothing and falls
+# back to a Seq Scan over 276MB of TOASTed content, so the lookup can never
+# finish inside _REVERSE_INDEX_TIMEOUT_MS. This was 2 (single-char only), which
+# let every 2-char headword through to a guaranteed-timeout seq scan.
+_MIN_HEADWORD_LEN = 3
 # Cap how long the best-effort reverse-index lookup may hold a pool connection.
 # Terms the trgm index can't serve seq-scan the 406MB content table; bounding
 # this (vs the global ~60s) is what stops crawler load from exhausting the pool.
@@ -120,10 +126,11 @@ async def _fetch_reverse_index(
 
     text_contents.content has a GIN trigram index (ix_text_contents_content_trgm,
     migration 0157) that serves most ILIKE substring matches sub-second. But
-    short/uncommon CJK terms the index can't serve seq-scan the 406MB table for
-    tens of seconds; under crawler load those pile up and exhaust the connection
-    pool (prod outage 2026-06-23). This block is a best-effort SEO nicety, so:
-      - skip single-char headwords (match ~everything, worst case for trgm), and
+    terms the index can't serve seq-scan the content table for tens of seconds;
+    under crawler load those pile up and exhaust the connection pool (prod outage
+    2026-06-23). This block is a best-effort SEO nicety, so:
+      - skip headwords under _MIN_HEADWORD_LEN chars — pg_trgm cannot extract a
+        trigram from them, so they are guaranteed seq scans (see the constant),
       - cap the per-query statement_timeout so a slow lookup fails fast and
         releases its pool connection instead of holding it ~60s; on timeout we
         drop the "appears in N sutras" block rather than starve the pool.

--- a/backend/tests/test_seo_dict_reverse_index.py
+++ b/backend/tests/test_seo_dict_reverse_index.py
@@ -27,13 +27,41 @@ async def test_skips_single_char_and_overlong_headwords():
 
 
 @pytest.mark.anyio
+async def test_skips_two_char_headwords_the_trgm_index_cannot_serve():
+    """A 2-char headword can NEVER be served by the trgm index, so running it
+    is pure waste — it always burns the full timeout budget and returns nothing.
+
+    pg_trgm can only use the index for a ``LIKE '%x%'`` pattern when the pattern
+    contains at least one *complete* trigram, i.e. 3+ characters. An unanchored
+    2-char pattern yields zero extractable trigrams, so the planner falls back to
+    a Seq Scan over ``text_contents`` — 276MB of TOASTed content that must be
+    detoasted and ILIKE-rechecked row by row.
+
+    Measured on prod (2026-07-21), 8 random 2-char headwords: 11.8s / 13.5s /
+    14.0s / 14.8s and 4 more that did not finish within 20s — against a 3s
+    budget. Success rate is therefore 0%: every such lookup times out, rolls
+    back, and renders the page without the block. It also touches ~795MB of
+    shared buffers (shared_buffers is 640MB), flushing the cache that the
+    *fast* 3+-char lookups depend on — which is why they time out too.
+
+    So this is not a tradeoff: skipping 2-char lookups loses no functionality
+    that exists today, and stops the collateral damage.
+    """
+    db = AsyncMock()
+    assert await _fetch_reverse_index(db, "般若") == []
+    assert await _fetch_reverse_index(db, "菩提") == []
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_caps_statement_timeout_before_the_ilike():
     db = AsyncMock()
     res = MagicMock()
     res.all.return_value = []
     db.execute.return_value = res
 
-    await _fetch_reverse_index(db, "般若")
+    # 3+ chars: the trgm index can serve this, so it is allowed through to the DB.
+    await _fetch_reverse_index(db, "波羅蜜")
 
     first_sql = str(db.execute.await_args_list[0].args[0]).lower()
     assert "statement_timeout" in first_sql, (
@@ -56,7 +84,7 @@ async def test_best_effort_empty_and_rollback_on_db_error():
 
     db.execute.side_effect = _exec
 
-    out = await _fetch_reverse_index(db, "般若")
+    out = await _fetch_reverse_index(db, "波羅蜜")
     assert out == []
     db.rollback.assert_awaited()  # aborted txn cleaned so the session is reusable
 


### PR DESCRIPTION
## 问题

生产 `/dict/*` 页面的「此词出现在 N 部经中」反查，**每 30 分钟产生 1,508 次 `statement timeout`**（≈50/min），而同窗口生产其它所有后端错误合计只有 1 条。

排查发现根因**不是缺索引** —— `ix_text_contents_content_trgm` 存在且对 3+ 字词工作正常。真正的 bug 是 `_MIN_HEADWORD_LEN` 的阈值**少设了一个字**。

## 根因

pg_trgm 只有在无锚定的 `ILIKE '%词%'` 模式能抽出**至少一个完整 trigram**（即 3 字以上）时才能用索引。2 字模式抽不出任何 trigram，planner 只能退化成对 `text_contents` 的 Seq Scan —— 而该列是 **276MB 的 TOAST 正文**（19,490 行，平均 14,869 字符，最长 14.6M），必须逐行 detoast 再做 ILIKE 复核。

生产实测（预算 3 秒）：

| 词 | 计划 | 实际耗时 |
|---|---|---|
| `齋主`（2字） | **Seq Scan** | **29,739 ms**（`shared hit=101,673` ≈ 795MB） |
| `鼓山寺`（3字） | Bitmap Index Scan | **3.9 ms** |

8 个随机 2 字词条：11.8s / 13.5s / 14.0s / 14.8s，另 4 个 20 秒未跑完。

## 为什么这个改动零风险

**2 字反查今天的成功率是 0%** —— 它们无一例外撞满 3 秒熔断、回滚、然后照常渲染页面（不带该区块）。跳过它们**不会移除任何现存行为**，只是不再为一个必然为空的结果白烧 3 秒 CPU。

## 连带收益

2 字词只占超时量的 24%（1,508 次中 364 次），但它们是**发动机**：每次运行触及 ~795MB 缓冲区，而 `shared_buffers` 只有 640MB —— 每跑一次就冲刷掉快查询赖以生存的缓存。这解释了为什么剩下 76% 的 ≥3 字词在隔离测试中只要 3–20ms，在生产里却也超时（`pg_stat_activity` 显示 4 核机上常驻 3–5 个后端各烧满 3 秒，`wait_event` 为空 = 纯 CPU）。

预期这 24% 确定消除；剩余 76% 应因缓存压力缓解而改善，但**幅度未经证实**，上线后需实测。

## 排查中被证伪的假设（留档）

- ~~通用计划（generic plan）导致 Seq Scan~~ —— `force_generic_plan` 确实是 45,781ms vs custom 5.957ms，但 `plan_cache_mode=auto` 实测连续 60 次执行从未翻转，耗时在 3ms↔8s 间反复横跳。生产没走通用计划。
- ~~缓存冷热造成的测量偏差~~ —— 对照实验：从未被查询过的冷词在 psql 中仍只需 5–11ms。

## 测试

- 新增 `test_skips_two_char_headwords_the_trgm_index_cannot_serve`（先写后修，确认 red → green）
- 既有两个用 `般若`（2字）的测试改用 `波羅蜜`（3字），因为 2 字现在会被跳过
- 全量：**1296 passed**

## 后续（不在本 PR）

真正的长期解法是反查不该是对 TOAST 正文的子串扫描 —— 应改为预计算倒排表（term → text_ids）。本 PR 只做零风险的止血。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPrZmdAxMvk7EA21EncNvL
