### PR TITLE
fix(search): 搜索结果接回站内阅读器，修 /read/:id/:juan 这条不存在的路由

### DIFF
--- a/frontend/src/components/search/ContentCard.test.tsx
+++ b/frontend/src/components/search/ContentCard.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import ContentCard from "./ContentCard";
+import type { ContentSearchHit } from "../../api/client";
+import type { TextId } from "../../types/branded";
+
+function makeHit(overrides: Partial<ContentSearchHit> = {}): ContentSearchHit {
+  return {
+    text_id: 12326 as TextId,
+    cbeta_id: "X0348",
+    title_zh: "維摩經無我疏",
+    translator: "傳燈著",
+    dynasty: "明",
+    juan_num: 10,
+    lang: "lzh",
+    source_code: "cbeta",
+    highlight: ["...釋入<em>不二法門</em>品二..."],
+    score: 1.0,
+    matched_juan_count: 1,
+    matched_juans: [{ juan_num: 10, highlight: ["...釋入<em>不二法門</em>品二..."], score: 1.0 }],
+    ...overrides,
+  };
+}
+
+function renderCard(hit: ContentSearchHit, rank = 1) {
+  return render(
+    <MemoryRouter>
+      <ContentCard hit={hit} rank={rank} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ContentCard 组件", () => {
+  // 全文命中是搜索页的主力结果。此前这张卡唯一的出口是站外 CBETA 链接，
+  // 等于把用户从自家全文索引直接送走，而站内阅读器才带标注/校勘/跨藏对照。
+  it("命中卷链接到站内阅读器 /texts/{text_id}/read?juan={juan_num}", () => {
+    renderCard(makeHit({ text_id: 99 as TextId, juan_num: 7 }));
+
+    const readLink = screen.getByText("阅读").closest("a");
+    expect(readLink).toHaveAttribute("href", "/texts/99/read?juan=7");
+  });
+
+  it("展开的其他匹配卷各自链接到对应卷", () => {
+    renderCard(
+      makeHit({
+        text_id: 99 as TextId,
+        juan_num: 7,
+        matched_juan_count: 2,
+        matched_juans: [
+          { juan_num: 7, highlight: ["a"], score: 1.0 },
+          { juan_num: 12, highlight: ["b"], score: 0.9 },
+        ],
+      }),
+    );
+
+    fireEvent.click(screen.getByText(/展开/));
+
+    const links = screen.getAllByText("阅读").map((el) => el.closest("a"));
+    expect(links.map((a) => a?.getAttribute("href"))).toContain("/texts/99/read?juan=12");
+  });
+
+  it("站外 CBETA 链接保留，作为次要出口", () => {
+    renderCard(makeHit({ cbeta_id: "T0251" }));
+
+    const cbetaLink = screen.getByText(/CBETA/).closest("a");
+    expect(cbetaLink).toHaveAttribute("href", "https://cbetaonline.dila.edu.tw/zh/T0251");
+    expect(cbetaLink).toHaveAttribute("target", "_blank");
+  });
+});

--- a/frontend/src/components/search/ContentCard.tsx
+++ b/frontend/src/components/search/ContentCard.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Tag, Button } from "antd";
-import { LinkOutlined } from "@ant-design/icons";
+import { LinkOutlined, ReadOutlined } from "@ant-design/icons";
+import { Link } from "react-router-dom";
 import { sanitizeHighlight } from "../../utils/sanitize";
-import { buildCbetaReadUrl } from "../../utils/sourceUrls";
+import { buildCbetaReadUrl, buildReaderUrl } from "../../utils/sourceUrls";
 import type { ContentSearchHit } from "../../api/client";
 
 const LANG_KEYS: Record<string, string> = {
@@ -41,13 +42,21 @@ export default function ContentCard({ hit, rank }: { hit: ContentSearchHit; rank
             <div key={j} className="s-card-meta" style={{ lineHeight: 1.7 }}
               dangerouslySetInnerHTML={{ __html: `...${sanitizeHighlight(h)}...` }} />
           ))}
-          {cbetaUrl && (
-            <Button type="primary" size="small" icon={<LinkOutlined />}
-              style={{ background: "#8b2500", borderColor: "#8b2500", marginTop: 6 }}
-              href={cbetaUrl} target="_blank" rel="noopener noreferrer">
-              {t("search.cbeta_read")}
-            </Button>
-          )}
+          {/* 站内阅读器排在前面：它带标注、校勘、跨藏对照，CBETA 外链只作次要出口 */}
+          <div style={{ display: "flex", gap: 8, marginTop: 6 }}>
+            <Link to={buildReaderUrl(hit.text_id, hit.juan_num)}>
+              <Button type="primary" size="small" icon={<ReadOutlined />}
+                style={{ background: "#8b2500", borderColor: "#8b2500" }}>
+                {t("search.read")}
+              </Button>
+            </Link>
+            {cbetaUrl && (
+              <Button size="small" icon={<LinkOutlined />}
+                href={cbetaUrl} target="_blank" rel="noopener noreferrer">
+                {t("search.cbeta_read")}
+              </Button>
+            )}
+          </div>
         </div>
         {/* 展开其他匹配卷 */}
         {hasMore && expanded && hit.matched_juans
@@ -59,6 +68,11 @@ export default function ContentCard({ hit, rank }: { hit: ContentSearchHit; rank
                 <div key={k} className="s-card-meta" style={{ lineHeight: 1.7 }}
                   dangerouslySetInnerHTML={{ __html: `...${sanitizeHighlight(h)}...` }} />
               ))}
+              <Link to={buildReaderUrl(hit.text_id, j.juan_num)}>
+                <Button size="small" icon={<ReadOutlined />} style={{ marginTop: 6 }}>
+                  {t("search.read")}
+                </Button>
+              </Link>
             </div>
           ))}
         {hasMore && (

--- a/frontend/src/components/search/ParallelSentenceCard.test.tsx
+++ b/frontend/src/components/search/ParallelSentenceCard.test.tsx
@@ -74,10 +74,11 @@ describe("ParallelSentenceCard 组件", () => {
     expect(screen.queryByText(/对齐质量/)).not.toBeInTheDocument();
   });
 
-  it("text_id 有效时阅读按钮链接到 /read/{text_id}/{juan_num}", () => {
+  // /read/:id/:juan 从来就不是一条路由（App.tsx 只有 /texts/:id/read），点进去必然 404。
+  it("text_id 有效时阅读按钮链接到站内阅读器 /texts/{text_id}/read?juan={juan_num}", () => {
     renderCard(makeHit({ text_id: 99 as TextId, juan_num: 2 }));
     const readLink = screen.getByText("阅读").closest("a");
-    expect(readLink).toHaveAttribute("href", "/read/99/2");
+    expect(readLink).toHaveAttribute("href", "/texts/99/read?juan=2");
   });
 
   it("text_id 为 0 时不渲染阅读按钮", () => {

--- a/frontend/src/components/search/ParallelSentenceCard.tsx
+++ b/frontend/src/components/search/ParallelSentenceCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Tag, Button } from "antd";
 import { ReadOutlined } from "@ant-design/icons";
 import { Link } from "react-router-dom";
+import { buildReaderUrl } from "../../utils/sourceUrls";
 import type { ParallelSentenceHit } from "../../api/client";
 
 // Mirror CrossLangCard's language tag palette so lang badges stay consistent
@@ -97,7 +98,7 @@ export default function ParallelSentenceCard({
 
         <div style={{ marginTop: 8, display: "flex", gap: 8, alignItems: "center" }}>
           {canRead && (
-            <Link to={`/read/${hit.text_id}/${hit.juan_num}`}>
+            <Link to={buildReaderUrl(hit.text_id, hit.juan_num)}>
               <Button size="small" icon={<ReadOutlined />}>
                 {t("search.read")}
               </Button>

--- a/frontend/src/components/search/SemanticCard.test.tsx
+++ b/frontend/src/components/search/SemanticCard.test.tsx
@@ -77,11 +77,12 @@ describe("SemanticCard 组件", () => {
     expect(screen.getByText(snippet)).toBeInTheDocument();
   });
 
-  it("阅读按钮链接到 /read/{text_id}/{juan_num}", () => {
+  // /read/:id/:juan 从来就不是一条路由（App.tsx 只有 /texts/:id/read），点进去必然 404。
+  it("阅读按钮链接到站内阅读器 /texts/{text_id}/read?juan={juan_num}", () => {
     renderCard(makeHit({ text_id: 99 as TextId, juan_num: 3, has_content: true }));
 
     const readLink = screen.getByText("阅读").closest("a");
-    expect(readLink).toHaveAttribute("href", "/read/99/3");
+    expect(readLink).toHaveAttribute("href", "/texts/99/read?juan=3");
   });
 
   it("has_content 为 false 时不渲染阅读按钮", () => {

--- a/frontend/src/components/search/SemanticCard.tsx
+++ b/frontend/src/components/search/SemanticCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Tag, Button, Progress } from "antd";
 import { LinkOutlined, ReadOutlined } from "@ant-design/icons";
 import { Link } from "react-router-dom";
-import { buildCbetaReadUrl } from "../../utils/sourceUrls";
+import { buildCbetaReadUrl, buildReaderUrl } from "../../utils/sourceUrls";
 import type { SemanticSearchHit } from "../../api/client";
 
 /** 语义搜索结果卡片：展示向量匹配的经文片段和相似度分数 */
@@ -67,7 +67,7 @@ export default function SemanticCard({ hit, rank }: { hit: SemanticSearchHit; ra
 
         <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
           {hit.has_content && (
-            <Link to={`/read/${hit.text_id}/${hit.juan_num}`}>
+            <Link to={buildReaderUrl(hit.text_id, hit.juan_num)}>
               <Button size="small" icon={<ReadOutlined />}>
                 {t("search.read")}
               </Button>

--- a/frontend/src/utils/sourceUrls.test.ts
+++ b/frontend/src/utils/sourceUrls.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import i18n from "../i18n";
 import enTranslation from "../../public/locales/en/translation.json";
-import { getSourceLabel } from "./sourceUrls";
+import { buildReaderUrl, getSourceLabel } from "./sourceUrls";
 
 i18n.addResourceBundle("en", "translation", enTranslation, true, true);
 
@@ -13,5 +13,24 @@ describe("source URL labels", () => {
 
   it("falls back to the source code for unknown labels", () => {
     expect(getSourceLabel("unknown-source", i18n.getFixedT("en"))).toBe("UNKNOWN-SOURCE");
+  });
+});
+
+describe("buildReaderUrl", () => {
+  // 站内阅读器的真实路由是 /texts/:id/read，卷号走 ?juan= 查询参数
+  // （TextReaderPage 读 searchParams.get("juan")）。搜索卡片一律经此构建，
+  // 避免再出现拼错的 /read/:id/:juan 这类不存在的路径。
+  it("builds the in-app reader URL with the juan query param", () => {
+    expect(buildReaderUrl(12326, 10)).toBe("/texts/12326/read?juan=10");
+  });
+
+  it("omits the juan param when no juan is given", () => {
+    expect(buildReaderUrl(12326)).toBe("/texts/12326/read");
+  });
+
+  // ParallelSentenceHit.juan_num 可以是 null；旧的模板字符串会把它拼成
+  // 字面量 "null"（/read/12326/null），必须退化成不带卷号的阅读器 URL。
+  it("treats a null juan as no juan rather than stringifying it", () => {
+    expect(buildReaderUrl(12326, null)).toBe("/texts/12326/read");
   });
 });

--- a/frontend/src/utils/sourceUrls.ts
+++ b/frontend/src/utils/sourceUrls.ts
@@ -40,6 +40,18 @@ export function buildCbetaReadUrl(cbetaId: string): string | null {
   return null;
 }
 
+/**
+ * 站内阅读器的 URL。路由是 /texts/:id/read，卷号走 ?juan= 查询参数
+ * （TextReaderPage 读 searchParams.get("juan")）。
+ *
+ * 所有指向站内阅读器的链接都应经过这里：曾经有卡片手写 `/read/:id/:juan`，
+ * 那条路由从不存在，点进去一律 404。
+ */
+export function buildReaderUrl(textId: number, juanNum?: number | null): string {
+  const base = `/texts/${textId}/read`;
+  return juanNum == null ? base : `${base}?juan=${juanNum}`;
+}
+
 const SOURCE_LABEL_KEYS: Record<string, string> = {
   cbeta: "sourceLabel.cbeta",
   "cbeta-org": "sourceLabel.cbeta",


### PR DESCRIPTION
## 问题

三张搜索结果卡片，没有一张能把用户送进站内阅读器。

| 卡片 | 现状 |
|---|---|
| `ContentCard`（全文命中，搜「不二法门」有 2,115 条，主力结果） | 唯一出口是站外 CBETA 链接，标题也不可点 |
| `SemanticCard` | 「阅读」按钮链到 `/read/:textId/:juanNum` → **404** |
| `ParallelSentenceCard` | 同上 → **404** |

`/read/:id/:juan` 这条路由**从来没在 `App.tsx` 里注册过**，站内阅读器的真实路由是 `/texts/:id/read`。生产实测 https://fojin.app/read/12326/10 是 404 页。

结果就是：自家全文索引搜出来的命中，要么被送去 CBETA，要么点进 404。而站内阅读器带标注、校勘、跨藏对照、AI 解读侧栏、导出——是全站功能最全的页面。

**为什么一直没被发现**：`SemanticCard.test.tsx` 和 `ParallelSentenceCard.test.tsx` 里原本写的是 `expect(readLink).toHaveAttribute("href", "/read/99/2")`，测试把错误 URL 断言死了。

## 改动

新增 `buildReaderUrl(textId, juanNum)`（`utils/sourceUrls.ts`），三处统一走它，卷号走 `?juan=`（`TextReaderPage` 读 `searchParams.get("juan")`）。

- `ContentCard`：「阅读」升为主按钮，CBETA 外链降为次按钮保留；展开的其他匹配卷各自给直达该卷的入口
- `SemanticCard` / `ParallelSentenceCard`：改用 helper，路径修正
- 顺带修掉 `ParallelSentenceHit.juan_num` 为 `null` 时旧模板字符串拼出字面量 `/read/42/null` 的问题（`tsc` 抓出来的，测试没覆盖）——helper 里 null 退化成不带卷号

无新增 i18n 文案键（复用已有的 `search.read`）。

## 验证

- 先改红两条锁死错误 URL 的断言，确认 6 个测试按预期失败，再实现
- `vitest run` 全量：**46 文件 / 236 测试通过**
- `tsc --noEmit` 干净，`eslint` 干净
- 端到端真跑（dev server 代理指生产）：
  - 搜「不二法门」→ 点「阅读」→ `/texts/12326/read?juan=10`，落在命中的「釋入不二法門品」段落
  - 跨语对照 tab → 点「阅读」→ `/texts/8890/read?juan=4`，維摩經義記卷第四
  - 生产站直接验证 `?juan=` 契约：`fojin.app/texts/12326/read?juan=10` → 第 10 卷

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDD5HMUNML8sPjMPQPHSCr