### PR TITLE
feat(nav): 跨藏对照与开放数据进导航，两个已上线功能不再只能靠猜 URL 到达

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -8,6 +8,8 @@
   "nav.search": "Search",
   "nav.sources": "Sources",
   "nav.collections": "Collections",
+  "nav.cross_canon": "Cross-Canon",
+  "nav.exports": "Open Data",
   "nav.dictionary": "Buddhist Dictionary",
   "nav.kg": "Knowledge Graph",
   "nav.geo": "Buddhist Geography",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -8,6 +8,8 @@
   "nav.search": "搜尋",
   "nav.sources": "資料來源",
   "nav.collections": "經典專題",
+  "nav.cross_canon": "跨藏對照",
+  "nav.exports": "開放資料",
   "nav.dictionary": "佛學辭典",
   "nav.kg": "知識圖譜",
   "nav.geo": "佛教地理",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -8,6 +8,8 @@
   "nav.search": "搜索",
   "nav.sources": "数据源",
   "nav.collections": "经典专题",
+  "nav.cross_canon": "跨藏对照",
+  "nav.exports": "开放数据",
   "nav.dictionary": "佛学辞典",
   "nav.kg": "知识图谱",
   "nav.geo": "佛教地理",

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
+import Layout from "./Layout";
+
+/** 把当前路径渲染出来，供断言导航是否真的发生 */
+function LocationProbe() {
+  return <div data-testid="pathname">{useLocation().pathname}</div>;
+}
+
+function renderLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="*" element={<LocationProbe />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Layout 顶部导航", () => {
+  // 跨藏对照（1,016 部经 · 91 万组逐段对照）与开放数据下载此前只能靠猜 URL 到达：
+  // 页面早就建好并跑在生产上，但导航里没有任何入口。
+  it("跨藏对照有导航入口，点击进入 /cross-canon", () => {
+    renderLayout();
+
+    fireEvent.click(screen.getByText("跨藏对照"));
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/cross-canon");
+  });
+
+  it("开放数据有导航入口，点击进入 /exports", () => {
+    renderLayout();
+
+    fireEvent.click(screen.getByText("开放数据"));
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/exports");
+  });
+
+  it("既有导航项不受影响", () => {
+    renderLayout();
+
+    for (const label of ["数据源", "AI 问答", "佛学辞典", "知识图谱", "佛教地理", "经典专题"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,6 +15,8 @@ import {
   RobotOutlined,
   GithubOutlined,
   GlobalOutlined,
+  TranslationOutlined,
+  DownloadOutlined,
   // ExperimentOutlined,  // research nav hidden (研究助手 待重构后再上线)
   // BarChartOutlined,   // dashboard nav hidden (数据总览 暂不对外公开)
   // FieldTimeOutlined,  // timeline nav deferred (pending polish)
@@ -79,6 +81,10 @@ export default function Layout() {
   }> = [
     { icon: <DatabaseOutlined />, label: t("nav.sources"), path: "/sources" },
     { icon: <RobotOutlined />, label: t("nav.chat"), path: "/chat" },
+    // 跨藏对照(/cross-canon)：1,016 部经 · 91 万组逐段跨语对照，是相对 CBETA /
+    // SuttaCentral 最硬的差异化。此前页面早就跑在生产上，导航里却没有入口，
+    // 只能靠 /collections 里的对照表或手敲 URL 到达。
+    { icon: <TranslationOutlined />, label: t("nav.cross_canon"), path: "/cross-canon" },
     // 研究助手(/research)暂从导航撤下：当前输出偏"更长的问答"，未凸显跨藏对比这一
     // 差异化，等重构(跨藏对比表 + 内联可点证据 + 流式)后再上线。后端 API 与
     // fojin-mcp 保留，/research 路由仍可直达。
@@ -87,6 +93,9 @@ export default function Layout() {
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
     { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
+    // 开放数据(/exports)：CSV / JSON / JSON-LD 批量导出，对应 README 里
+    // 「corpus other tools can call」的定位。同样是建好了但导航没入口。
+    { icon: <DownloadOutlined />, label: t("nav.exports"), path: "/exports" },
     // 数据总览(/dashboard)暂不对外公开：从导航撤下，路由仍可直达 /dashboard。
     // { icon: <BarChartOutlined />, label: t("nav.dashboard"), path: "/dashboard" },
     // 历史时间线(/timeline)暂不放导航：待打磨后再上线（路由仍可直达 /timeline）。

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,3 +4,19 @@ import "@testing-library/jest-dom/vitest";
 // (en-US) can't flip tests to a backend-loaded locale.
 import i18n from "../i18n";
 i18n.changeLanguage("zh");
+
+// jsdom ships no matchMedia. Any component tree containing CursorGlow (i.e.
+// anything rendering Layout) throws on mount without this.
+if (!window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}


### PR DESCRIPTION
## 问题

两个页面早就建好、跑在生产上、功能完整，但 `Layout.tsx` 的导航里没有任何入口：

| 页面 | 内容 | 此前如何到达 |
|---|---|---|
| `/cross-canon` 跨藏对照 | **1,016 部经 · 912,344 组逐段跨语对照**（藏 / 梵 / 巴），按语种 + 部类分面 | 只能从 `/collections` 的对照表间接进入，或手敲 URL |
| `/exports` 开放数据下载 | CSV / JSON / JSON-LD 批量导出（10,531 典籍元数据、113,582 图谱实体、27,970 关系） | 完全没有入口，只能手敲 URL |

跨藏对照是相对 CBETA / SuttaCentral 最硬的差异化；开放数据对应 README 里 "corpus other tools can call" 的定位。两个都是「资产已建成，但用户走不到」。

## 改动

- `Layout.tsx` navItems 加两项：跨藏对照排在 AI 问答之后（内容型、差异化优先），开放数据排在末位（工具型）
- 图标沿用两个页面自己用的 `TranslationOutlined` / `DownloadOutlined`，保持一致
- 新增 `nav.cross_canon` / `nav.exports` 三语文案（zh / zh-Hant / en）

公开导航项 6 → 8。中英文都实测排得下：英文最长，末项 Open Data 结束于 x≈1050/1568，无溢出、不换行。

## 顺带

补上 `Layout` 的第一个测试。跑起来发现测试环境缺 `window.matchMedia` —— 任何渲染 `Layout` 的测试树都会在 `CursorGlow` 挂载时抛 `TypeError`，所以之前一直没人给 Layout 写测试。在 `test/setup.ts` 里补了 stub。

## 验证

- 先写测试断言两个导航项存在且点击后落到对应路由，确认按预期红（`Unable to find an element with the text: 跨藏对照 / 开放数据`），再改代码
- `vitest run` 全量：**46 文件 / 233 测试通过**
- `tsc --noEmit` 干净，`eslint` 干净，`npm run i18n:check` 通过（0 hardcoded，baseline 保持）
- 端到端真跑（dev server 代理指生产）：
  - 中文导航：数据源 · AI 问答 · **跨藏对照** · 佛学辞典 · 知识图谱 · 佛教地理 · 经典专题 · **开放数据**
  - 点「跨藏对照」→ `/cross-canon`，页面渲染「1016 texts · 912,344 aligned passages」
  - 点「开放数据」→ `/exports`，三个导出卡片正常
  - 英文 locale 同样验证

## 已知的相邻问题（本 PR 不动）

导航项是 `<Button onClick={navigate}>` 而非 `<a href>`，不能中键新开、爬虫也跟不进去。若要让这两个页面吃到 SEO，需要单独一个 PR 把导航改成真链接。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDD5HMUNML8sPjMPQPHSCr