### PR TITLE
fix(dict): decode numeric character references left in dictionary entries

### DIFF
--- a/backend/scripts/archive/imports/import_buddhaspace.py
+++ b/backend/scripts/archive/imports/import_buddhaspace.py
@@ -30,7 +30,13 @@ import json
 import os
 import re
 import sys
+
+# Imported as a bare name, not as the ``html`` module: _strip_html()'s parameter
+# is itself called ``html`` and would shadow it.
+from html import unescape
 from urllib.parse import unquote, urljoin
+
+from scripts.fix_dict_html_entities import decode_numeric_entities
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -114,9 +120,20 @@ def _strip_html(html: str) -> str:
     text_out = re.sub(r"</?p[^>]*>", "\n", text_out, flags=re.IGNORECASE)
     # Remove all other HTML tags
     text_out = re.sub(r"<[^>]+>", "", text_out)
-    # Decode HTML entities
-    text_out = text_out.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
-    text_out = text_out.replace("&nbsp;", " ").replace("&quot;", '"')
+    # Decode HTML entities.
+    #
+    # This used to be a hand-rolled chain of five .replace() calls with no
+    # handling for numeric character references, which is how 2,463 headwords and
+    # 7,663 definitions ended up in prod reading '&#X4E98;以' instead of '亘以'
+    # (see scripts/fix_dict_html_entities.py). The '&amp;' -> '&' replacement ran
+    # first, so a source '&amp;#X4E98;' was turned INTO the literal '&#X4E98;'
+    # and then never decoded.
+    #
+    # html.unescape() handles named + numeric references correctly in one pass.
+    # buddhaspace.org double-escapes its rare characters, so after unescape we
+    # still hold a literal '&#X4E98;' — decode_numeric_entities() finishes the job.
+    text_out = unescape(text_out)
+    text_out = decode_numeric_entities(text_out)
     # Normalize whitespace per line, collapse blank lines
     lines = [line.strip() for line in text_out.split("\n")]
     text_out = "\n".join(line for line in lines if line)

--- a/backend/scripts/fix_dict_html_entities.py
+++ b/backend/scripts/fix_dict_html_entities.py
@@ -1,0 +1,180 @@
+"""Decode numeric character references left as literal text in dictionary_entries.
+
+Prod 2026-07-21: 2,463 headwords and 7,663 definitions read like ``&#X4E98;以``
+instead of ``亘以``. Affected sources are 一切經音義（慧琳音義） (2,255 headwords /
+6,986 definitions) and 續一切經音義（希麟） (208 / 676) — two phonological
+dictionaries dense in rare characters, which buddhaspace.org serves as numeric
+character references.
+
+Cause: ``scripts/archive/imports/import_buddhaspace.py::_strip_html`` decoded five
+named entities by hand and no numeric ones. Because its ``&amp;`` → ``&`` pass runs
+first, a source ``&amp;#X4E98;`` is turned INTO the literal ``&#X4E98;`` and then
+left there. That importer is fixed in the same change; this script repairs the rows
+already in the database.
+
+Why it matters beyond cosmetics: each junk headword is a /dict/ page crawlers index,
+and every crawl costs a reverse-index lookup against a 276MB TOASTed column.
+
+Usage:
+    python -m scripts.fix_dict_html_entities              # dry run (default)
+    python -m scripts.fix_dict_html_entities --write      # apply
+    python -m scripts.fix_dict_html_entities --limit 20   # sample a few rows
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+
+# app.database is imported inside main() on purpose: importing it builds the
+# async engine, and decode_numeric_entities() is a pure function that its tests
+# must be able to import without standing up a database.
+
+# Matches ``&#1234;`` and ``&#x4E98;`` / ``&#X4E98;``. Named entities are
+# deliberately NOT matched — see decode_numeric_entities().
+_NUMERIC_REF = re.compile(r"&#(?:[xX]([0-9A-Fa-f]+)|([0-9]+));")
+
+
+def _is_safe_codepoint(cp: int) -> bool:
+    """Reject anything Postgres text cannot hold or that is not a scalar value.
+
+    Surrogates (U+D800–DFFF) are not valid on their own, U+0000 cannot be stored
+    in a Postgres text column at all, and C0 controls would be invisible damage.
+    """
+    if cp > 0x10FFFF:
+        return False
+    if 0xD800 <= cp <= 0xDFFF:
+        return False
+    if cp < 0x20:
+        return False
+    return True
+
+
+def decode_numeric_entities(s: str) -> str:
+    """Replace numeric character references with the characters they denote.
+
+    Only numeric references are touched. Named entities (``&amp;``, ``&nbsp;``…)
+    are left verbatim so this can never rewrite a legitimate ``&`` sitting in a
+    definition body — this is a repair migration, not a general text cleaner.
+
+    Unsafe or unrepresentable code points are left as-is rather than replaced
+    with a placeholder, so anything skipped stays findable by the same
+    ``LIKE '%&#%'`` query that found it.
+    """
+    if not s:
+        return s
+
+    def _repl(m: re.Match[str]) -> str:
+        hex_digits, dec_digits = m.group(1), m.group(2)
+        try:
+            cp = int(hex_digits, 16) if hex_digits is not None else int(dec_digits, 10)
+        except ValueError:  # pragma: no cover - regex already constrains the digits
+            return m.group(0)
+        if not _is_safe_codepoint(cp):
+            return m.group(0)
+        return chr(cp)
+
+    return _NUMERIC_REF.sub(_repl, s)
+
+
+SELECT_SQL = """
+    SELECT id, headword, definition
+    FROM dictionary_entries
+    WHERE headword LIKE '%&#%' OR definition LIKE '%&#%'
+    ORDER BY id
+"""
+
+UPDATE_SQL = """
+    UPDATE dictionary_entries
+    SET headword = :headword, definition = :definition
+    WHERE id = :id
+"""
+
+
+async def main() -> int:
+    from sqlalchemy import text
+
+    from app.database import async_session
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--write",
+        action="store_true",
+        help="apply the changes; without it the script only reports (default: dry run)",
+    )
+    ap.add_argument("--limit", type=int, default=0, help="only consider the first N rows")
+    ap.add_argument("--samples", type=int, default=15, help="how many before/after pairs to print")
+    args = ap.parse_args()
+
+    async with async_session() as session:
+        rows = (await session.execute(text(SELECT_SQL))).all()
+        if args.limit:
+            rows = rows[: args.limit]
+
+        planned = []
+        skipped = []
+        for row_id, headword, definition in rows:
+            new_head = decode_numeric_entities(headword or "")
+            new_def = decode_numeric_entities(definition or "")
+            if new_head == (headword or "") and new_def == (definition or ""):
+                # Nothing decodable — a leftover unsafe reference, or a stray '&#'
+                # that is not a character reference at all.
+                skipped.append((row_id, headword))
+                continue
+            planned.append(
+                {
+                    "id": row_id,
+                    "headword": new_head,
+                    "definition": new_def,
+                    "_old_head": headword,
+                }
+            )
+
+        head_changes = sum(1 for p in planned if p["headword"] != p["_old_head"])
+
+        print(f"匹配行数        : {len(rows)}")
+        print(f"可修复          : {len(planned)}  (其中 headword 变化 {head_changes})")
+        print(f"跳过(无可解码)  : {len(skipped)}")
+
+        if planned:
+            print("\n--- headword 修改样本 (修前 -> 修后) ---")
+            shown = 0
+            for p in planned:
+                if p["headword"] == p["_old_head"]:
+                    continue
+                print(f"  {p['_old_head']!r}  ->  {p['headword']!r}")
+                shown += 1
+                if shown >= args.samples:
+                    break
+
+        if skipped:
+            print("\n--- 跳过样本 ---")
+            for row_id, hw in skipped[:5]:
+                print(f"  id={row_id} headword={hw!r}")
+
+        if not args.write:
+            print("\n[dry-run] 未写入任何数据。确认无误后加 --write 执行。")
+            return 0
+
+        for p in planned:
+            p.pop("_old_head")
+        await session.execute(text(UPDATE_SQL), planned)
+        await session.commit()
+        print(f"\n[write] 已更新 {len(planned)} 行。")
+
+        left = (
+            await session.execute(
+                text(
+                    "SELECT count(*) FROM dictionary_entries "
+                    "WHERE headword LIKE '%&#%' OR definition LIKE '%&#%'"
+                )
+            )
+        ).scalar()
+        print(f"[verify] 仍含 '&#' 的行: {left}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/backend/tests/test_fix_dict_html_entities.py
+++ b/backend/tests/test_fix_dict_html_entities.py
@@ -1,0 +1,98 @@
+"""Numeric character references leaked into dictionary_entries as literal text.
+
+Prod 2026-07-21: 2,463 headwords + 7,663 definitions across 一切經音義（慧琳音義）
+and 續一切經音義（希麟）read like ``&#X4E98;以`` instead of ``亘以``.
+
+Cause: ``import_buddhaspace.py::_strip_html`` hand-rolled entity decoding for five
+named entities only. Its ``&amp;`` → ``&`` pass runs first, so a source ``&amp;#X4E98;``
+is turned INTO the literal ``&#X4E98;`` and then never decoded — the importer
+manufactures the bad string itself.
+
+These junk headwords each generate a /dict/ page that crawlers index, and every
+one costs a reverse-index lookup (see test_seo_dict_reverse_index.py).
+
+We decode ONLY numeric references. Named entities (``&amp;`` etc.) are left alone
+so the backfill can never rewrite a legitimate ``&`` in a definition body.
+"""
+
+import pytest
+
+from scripts.fix_dict_html_entities import decode_numeric_entities
+
+
+def test_decodes_uppercase_hex_reference():
+    # The exact shape found in prod.
+    assert decode_numeric_entities("&#X4E98;以") == "亘以"
+    assert decode_numeric_entities("&#X4EBE;喪") == "亾喪"
+
+
+def test_decodes_lowercase_hex_and_decimal():
+    assert decode_numeric_entities("&#x4E98;以") == "亘以"
+    assert decode_numeric_entities("&#20120;") == "亘"  # 0x4E98 == 20120
+
+
+def test_decodes_multiple_references_in_one_string():
+    # 63 prod headwords carry two references, one carries three.
+    assert decode_numeric_entities("&#X4E98;和&#X4EBE;") == "亘和亾"
+
+
+def test_leaves_named_entities_alone():
+    """Conservative on purpose: a definition body may legitimately contain '&'.
+
+    Decoding named entities would let the backfill rewrite text that was never
+    broken, which is not what this migration is for.
+    """
+    assert decode_numeric_entities("A &amp; B") == "A &amp; B"
+    assert decode_numeric_entities("&nbsp;&lt;tag&gt;") == "&nbsp;&lt;tag&gt;"
+
+
+def test_leaves_clean_text_untouched():
+    assert decode_numeric_entities("亘以") == "亘以"
+    assert decode_numeric_entities("") == ""
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "&#XD800;x",  # surrogate — not a valid scalar value
+        "&#X110000;x",  # beyond U+10FFFF
+        "&#X0;x",  # NUL: Postgres text cannot store it
+        "&#X1F;x",  # C0 control
+    ],
+)
+def test_refuses_unsafe_codepoints(bad):
+    """Leave the row untouched rather than write something unstorable.
+
+    A backfill that half-decodes a row is worse than one that skips it: the
+    skipped rows stay findable by the same LIKE '%&#%' query.
+    """
+    assert decode_numeric_entities(bad) == bad
+
+
+def test_partial_decode_is_all_or_nothing_per_reference():
+    """One unsafe reference must not block the safe ones in the same string."""
+    out = decode_numeric_entities("&#X4E98;&#XD800;")
+    assert out == "亘&#XD800;"
+
+
+def test_is_idempotent():
+    once = decode_numeric_entities("&#X4E98;以")
+    assert decode_numeric_entities(once) == once
+
+
+def test_importer_strip_html_no_longer_manufactures_the_bad_string():
+    """Regression guard on the importer that created the mess.
+
+    buddhaspace.org double-escapes rare characters, so the source carries
+    ``&amp;#X4E98;``. The old hand-rolled decoder replaced ``&amp;`` with ``&``
+    first and had no numeric-reference pass, so it produced the literal
+    ``&#X4E98;`` and stored that. Re-running the importer must now yield the
+    character itself.
+    """
+    from scripts.archive.imports.import_buddhaspace import _strip_html
+
+    assert _strip_html("<p>&amp;#X4E98;以</p>") == "亘以"
+    # Single-escaped input must work too.
+    assert _strip_html("<p>&#X4E98;以</p>") == "亘以"
+    # Ordinary named entities still decode.
+    assert _strip_html("<p>A &amp; B</p>") == "A & B"


### PR DESCRIPTION
## 问题

生产 `dictionary_entries` 里有 **2,463 个 headword + 7,663 个 definition** 长这样：

```
&#X4E98;以     应为  亘以
毘&#X9262;舍那  应为  毘鉢舍那   (vipaśyanā)
鷲&#X5CEF;     应为  鷲峯
```

受影响的是 **一切經音義（慧琳音義）**（2,255 / 6,986）和 **續一切經音義（希麟）**（208 / 676）——两部专收生僻字的音義书，buddhaspace.org 用数字字符引用提供这些字。

除了不可读，每个垃圾 headword 都会生成一个被爬虫索引的 `/dict/` 页面，每次抓取都要付一次对 276MB TOAST 列的反查（即 #1014 修的那条查询）。

## 根因在导入器，不在源数据

`import_buddhaspace.py::_strip_html` 手写了实体解码，只覆盖 5 个具名实体、没有任何数字引用处理。而且它的 `&amp;` → `&` 这一步**先执行**：

```python
text_out = text_out.replace("&amp;", "&")   # &amp;#X4E98;  ->  &#X4E98;
# ……然后再没有任何数字引用解码
```

源站是双重转义的 `&amp;#X4E98;`，这行代码**亲手把它变成了**字面量 `&#X4E98;`，然后原样入库。是导入器自己制造了这个坏字符串。

## 改动

- `_strip_html()` 改用 `html.unescape()` + 一道数字引用解码。源站双重转义，所以两道都需要。
  - ⚠️ 附带修了一个隐患：该函数的参数名就叫 `html`，会遮蔽 `html` 模块，所以按 `from html import unescape` 引入。
- 新增 `scripts/fix_dict_html_entities.py` 修复已入库的行。**默认 dry-run，`--write` 才写**。

## 两个刻意的保守设计

1. **只解码数字引用，不碰具名实体**（`&amp;` 等原样保留）。这是一次修复迁移，不是通用文本清洗——绝不能让它改写 definition 正文里合法的 `&`。
2. **不安全码点整个保留不动**（代理区 / >U+10FFFF / NUL / C0 控制符），而不是替换成占位符。半解码的行比跳过的行更糟：跳过的行仍能被同一条 `LIKE '%&#%'` 查出来。

## 生产 dry-run（只读，已执行）

```
匹配行数        : 8598
可修复          : 8598  (其中 headword 变化 2463)
跳过(无可解码)  : 0
```

零跳过 = 全部码点合法（实测范围 U+4E2A–U+9F69，全在 CJK 基本区）。抽样：

```
&#X98E1;風      -> 飡風
&#X7240;榻      -> 牀榻
&#X7A45;[禾*會] -> 穅[禾*會]      ← CBETA 组字符标记正确地未被碰
```

## 测试

12 项新测试（先写后修，确认 red → green），含导入器回归守卫；全量 **1307 passed**。

## 注意

本 PR 只含代码。**生产数据回填需要单独执行 `--write`**，尚未执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPrZmdAxMvk7EA21EncNvL
