### PR TITLE
fix(source-health): 给巡检判定加可信度分档，并独立复核证书

### DIFF
--- a/backend/alembic/versions/0172_add_source_health_confidence.py
+++ b/backend/alembic/versions/0172_add_source_health_confidence.py
@@ -1,0 +1,62 @@
+"""Add data_sources.health_confidence.
+
+``health_status`` alone cannot be shown to a reader, because the daily probe
+runs from a single VPS and not every verdict survives a change of vantage. A
+2026-07-21 audit of the 42 non-``ok`` sources in production found:
+
+  - 16 ``timeout`` and 8 DNS failures — the classic signature of a datacenter
+    IP being blocked, or of the prober's own resolver, not of a dead site;
+  - 2 cert verdicts contradicted by the certificate itself: ``www.cnki.net``
+    was recorded "Hostname mismatch" though its leaf carries ``*.cnki.net``
+    (which covers it) and runs to 2027, and a Sinica host was recorded
+    "certificate has expired" with a leaf valid for another month;
+  - against which the genuinely actionable ones — HTTP 4xx/5xx from the server
+    itself, and certs independently re-confirmed as expired (台大, 不丹) or
+    issued for an unrelated name (PTS, DILA-cbc, 驹泽) — held up.
+
+``health_confidence`` records which of those two groups a verdict is in, so a
+future reader-facing badge can show the ~12 defensible ones without also
+labelling live institutions as broken. Values: ``high`` | ``low``.
+
+Defaults to ``high`` for existing rows: the column only ever *narrows* what may
+be displayed, and nothing reads it yet, so backfilling optimistically keeps the
+admin view unchanged until the next cron pass writes real values.
+
+Revision ID: 0172
+Revises: 0171
+Create Date: 2026-07-21
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0172"
+down_revision = "0171"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            "ALTER TABLE data_sources "
+            "ADD COLUMN IF NOT EXISTS health_confidence VARCHAR(10) "
+            "NOT NULL DEFAULT 'high'"
+        )
+    )
+    op.execute(
+        text(
+            "COMMENT ON COLUMN data_sources.health_confidence IS "
+            "'Whether the latest health verdict holds beyond the prober''s own "
+            "vantage: high = server-issued HTTP status, independently "
+            "re-confirmed cert fault, or a host resolving into non-public "
+            "space; low = timeout / DNS failure / a cert rejection the leaf "
+            "re-read did not corroborate. Only high verdicts are safe to show "
+            "a reader as a fault of the source. "
+            "Set by scripts/health_check_sources.py.'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(text("ALTER TABLE data_sources DROP COLUMN IF EXISTS health_confidence"))

--- a/backend/app/models/source.py
+++ b/backend/app/models/source.py
@@ -35,6 +35,11 @@ class DataSource(Base):
     # Actionable context for the latest probe: redirect target for moved,
     # failure reason otherwise, NULL when ok.
     health_detail: Mapped[str | None] = mapped_column(String(500))
+    # Whether health_status holds beyond the prober's own vantage: high|low.
+    # The cron runs from one VPS, where a timeout or a DNS miss often says more
+    # about the probe environment than about the site — only "high" verdicts may
+    # be presented to a reader as a fault of the source.
+    health_confidence: Mapped[str] = mapped_column(String(10), server_default="high")
     # When the source first entered its current continuous unreachable streak;
     # NULL when not unreachable. now() - unreachable_since is the streak length.
     unreachable_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/schemas/source.py
+++ b/backend/app/schemas/source.py
@@ -48,6 +48,7 @@ class DataSourceResponse(BaseModel):
     health_status: str = "ok"
     health_checked_at: datetime | None = None
     health_detail: str | None = None
+    health_confidence: str = "high"
     license_spdx: str | None = None
     license_url: str | None = None
     license_notes: str | None = None

--- a/backend/app/services/source_health.py
+++ b/backend/app/services/source_health.py
@@ -12,7 +12,7 @@ Valid statuses: ok | degraded | cert_invalid | unreachable | moved
 
 import ipaddress
 import socket
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from urllib.parse import urlsplit
 
@@ -70,6 +70,42 @@ def _ip_is_blocked(ip: str) -> bool:
     )
 
 
+HOST_PUBLIC = "public"
+HOST_DNS_UNRESOLVED = "dns_unresolved"
+HOST_NON_PUBLIC = "non_public"
+
+
+def classify_host(host: str | None) -> str:
+    """Why (or whether) ``host`` may be probed: public / dns_unresolved / non_public.
+
+    These two failure modes were previously collapsed into one verdict
+    ("unresolvable or non-public host"), which is wrong in both directions:
+
+    - **dns_unresolved** usually says more about the *prober* than the site. The
+      cron runs from a single VPS; several curated academic domains that resolve
+      fine elsewhere fail ``getaddrinfo`` there. Reporting those as a fault of
+      the source puts a wrong badge on a live institution.
+    - **non_public** is a fact the prober can establish on its own — the name
+      resolves to RFC1918 / loopback / metadata space — and is exactly the SSRF
+      target the guard exists to refuse.
+
+    Only the latter deserves editorial confidence; see :func:`probe_confidence`.
+    A host with no name to look up is ``non_public`` (fail closed), keeping the
+    SSRF guard's original semantics.
+    """
+    if not host:
+        return HOST_NON_PUBLIC
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except (socket.gaierror, UnicodeError, OSError):
+        return HOST_DNS_UNRESOLVED
+    if not infos:
+        return HOST_DNS_UNRESOLVED
+    if any(_ip_is_blocked(info[4][0]) for info in infos):
+        return HOST_NON_PUBLIC
+    return HOST_PUBLIC
+
+
 def host_is_public(host: str | None) -> bool:
     """True only when *every* address ``host`` resolves to is publicly routable.
 
@@ -78,14 +114,97 @@ def host_is_public(host: str | None) -> bool:
     redirect the probe at ``169.254.169.254`` (cloud metadata) or an RFC1918
     host — an SSRF. A residual DNS-rebinding window remains between this check
     and httpx's own connect-time resolution; acceptable for a cron over curated
-    academic sites, but noted deliberately."""
-    if not host:
+    academic sites, but noted deliberately.
+
+    Stays a strict allow-list over :func:`classify_host`: anything that is not
+    provably public — including a name that would not resolve — is refused."""
+    return classify_host(host) == HOST_PUBLIC
+
+
+CERT_EXPIRED = "expired"
+CERT_HOSTNAME_MISMATCH = "hostname_mismatch"
+CERT_LOOKS_VALID = "looks_valid"
+CERT_UNKNOWN = "unknown"
+
+
+def _san_matches(host: str, pattern: str) -> bool:
+    """RFC 6125 hostname matching for a single dNSName entry.
+
+    A wildcard is only valid in the left-most label and only spans one label:
+    ``*.cnki.net`` matches ``www.cnki.net`` but neither ``cnki.net`` itself nor
+    ``a.b.cnki.net``."""
+    host = host.lower().rstrip(".")
+    pattern = pattern.lower().rstrip(".")
+    if not pattern:
         return False
-    try:
-        infos = socket.getaddrinfo(host, None)
-    except (socket.gaierror, UnicodeError, OSError):
+    if not pattern.startswith("*."):
+        return host == pattern
+    suffix = pattern[1:]  # ".cnki.net"
+    if not host.endswith(suffix):
         return False
-    return bool(infos) and all(not _ip_is_blocked(info[4][0]) for info in infos)
+    leftmost = host[: -len(suffix)]
+    return bool(leftmost) and "." not in leftmost
+
+
+def classify_cert(
+    *,
+    host: str,
+    not_after: datetime | None,
+    san_dns: Sequence[str],
+    now: datetime,
+) -> str:
+    """Re-derive a cert verdict from the leaf itself, independent of the handshake.
+
+    A TLS handshake failure is not by itself evidence that the *site* is broken.
+    Two production examples: ``www.cnki.net`` was recorded as "Hostname
+    mismatch" though its leaf carries ``*.cnki.net`` (which covers it) and runs
+    to 2027; a Sinica site was recorded as "has expired" with a leaf valid for
+    another month. In both, what the prober saw differs from what the rest of
+    the world sees — interception, a stale trust store, a geo-routed edge — and
+    the source is fine.
+
+    Expiry is checked before hostname because it is the harder, wholly
+    vantage-independent fact. ``CERT_UNKNOWN`` means the leaf could not be read
+    at all (e.g. the server aborts the handshake before sending one), so nothing
+    was re-verified and nothing may be claimed.
+    """
+    if not_after is None:
+        return CERT_UNKNOWN
+    if not_after <= now:
+        return CERT_EXPIRED
+    if not san_dns:
+        return CERT_UNKNOWN
+    if any(_san_matches(host, pattern) for pattern in san_dns):
+        return CERT_LOOKS_VALID
+    return CERT_HOSTNAME_MISMATCH
+
+
+CONFIDENCE_HIGH = "high"
+CONFIDENCE_LOW = "low"
+
+
+def probe_confidence(*, status: str, error: str | None, cert: str | None) -> str:
+    """How much a verdict may be trusted outside the prober's own vantage.
+
+    Only ``high`` verdicts are safe to show a reader as a fault of the *source*;
+    ``low`` ones are recorded for operators but say as much about the probe
+    environment as about the site.
+
+    high — the server answered with an HTTP status (same everywhere), the leaf
+    cert was independently re-checked and is genuinely expired or genuinely
+    issued for another name, or the host resolves into non-public space.
+
+    low — timeouts, dropped connections and DNS failures (all routinely caused
+    by a datacenter IP being blocked or by the VPS's resolver), plus any cert
+    rejection the re-check could not corroborate.
+    """
+    if error is None:
+        return CONFIDENCE_HIGH
+    if error == SSL_ERROR:
+        return CONFIDENCE_HIGH if cert in (CERT_EXPIRED, CERT_HOSTNAME_MISMATCH) else CONFIDENCE_LOW
+    if error == HOST_NON_PUBLIC:
+        return CONFIDENCE_HIGH
+    return CONFIDENCE_LOW
 
 
 def _registrable_host(url: str | None) -> str:

--- a/backend/scripts/health_check_sources.py
+++ b/backend/scripts/health_check_sources.py
@@ -39,12 +39,16 @@ from sqlalchemy.orm import sessionmaker
 from app.api.sources import SOURCES_LIST_CACHE_KEY
 from app.config import settings
 from app.services.source_health import (
+    CONFIDENCE_HIGH,
+    HOST_PUBLIC,
     SSL_CHAIN_INCOMPLETE,
     SSL_ERROR,
     VALID_STATUSES,
+    classify_cert,
     classify_health,
-    host_is_public,
+    classify_host,
     is_incomplete_chain_error,
+    probe_confidence,
     resolve_unreachable_since,
 )
 
@@ -80,15 +84,85 @@ def _error_kind(exc: Exception) -> str:
 HEALTH_DETAIL_MAXLEN = 500
 
 
-def _verdict(code: str, status: str | None, detail: str | None) -> dict:
+def _verdict(
+    code: str,
+    status: str | None,
+    detail: str | None,
+    confidence: str = CONFIDENCE_HIGH,
+) -> dict:
     """A probe result. ``detail`` is the storage-ready health_detail value:
     the redirect target for ``moved``, the failure reason otherwise, ``None``
     for ``ok`` (and for skipped probes, where ``status`` is also ``None``).
 
+    ``confidence`` says whether the verdict holds beyond this prober's vantage
+    — see :func:`app.services.source_health.probe_confidence`. Only ``high``
+    verdicts are safe to present as a fault of the source itself. It defaults to
+    ``high`` because the paths that do not pass it (skipped probes, malformed
+    URLs, redirect-budget exhaustion) are all conclusions the prober reaches
+    from the stored config alone, with no network ambiguity.
+
     ``detail`` is hard-capped to the column width — see HEALTH_DETAIL_MAXLEN."""
     if detail is not None and len(detail) > HEALTH_DETAIL_MAXLEN:
         detail = detail[: HEALTH_DETAIL_MAXLEN - 1] + "…"
-    return {"code": code, "status": status, "detail": detail}
+    return {"code": code, "status": status, "detail": detail, "confidence": confidence}
+
+
+def leaf_facts_from_der(der: bytes) -> tuple[datetime | None, list[str]]:
+    """Parse a DER leaf into its ``notAfter`` and dNSName SANs.
+
+    Split out from the socket work above so the parsing — the part that depends
+    on the ``cryptography`` API surface — is unit-testable against a real
+    certificate without a network. Returns ``(None, [])`` for anything
+    unparseable, i.e. "could not re-check"."""
+    if not der:
+        return None, []
+    try:
+        cert = x509.load_der_x509_certificate(der)
+    except Exception:
+        return None, []
+    try:
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(
+            x509.DNSName
+        )
+    except x509.ExtensionNotFound:
+        san = []
+    return cert.not_valid_after_utc, list(san)
+
+
+def _read_leaf_facts(host: str, port: int) -> tuple[datetime | None, list[str]]:
+    """The leaf certificate's ``notAfter`` and dNSName SANs, or ``(None, [])``.
+
+    Read with verification disabled so the cert is legible even when the chain
+    does not validate — it is inspected, never trusted. This is what lets
+    :func:`classify_cert` re-derive a verdict from the certificate itself rather
+    than from whatever OpenSSL made of the handshake on this particular host,
+    which is how a healthy source (leaf valid, hostname covered) stops being
+    badged over a vantage-specific TLS failure.
+
+    Any failure returns ``(None, [])`` — "could not re-check", which downgrades
+    confidence rather than inventing a verdict. Blocking socket/TLS work; call
+    via ``asyncio.to_thread``."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        with (
+            socket.create_connection((host, port), timeout=TIMEOUT) as sock,
+            ctx.wrap_socket(sock, server_hostname=host) as ssock,
+        ):
+            der = ssock.getpeercert(binary_form=True)
+    except Exception:
+        return None, []
+    return leaf_facts_from_der(der)
+
+
+async def _cert_recheck(url: str) -> str:
+    """Re-derive the cert verdict for ``url``'s host from the leaf itself."""
+    parts = urlsplit(url)
+    if not parts.hostname:
+        return classify_cert(host="", not_after=None, san_dns=[], now=datetime.now(UTC))
+    not_after, san = await asyncio.to_thread(_read_leaf_facts, parts.hostname, parts.port or 443)
+    return classify_cert(host=parts.hostname, not_after=not_after, san_dns=san, now=datetime.now(UTC))
 
 
 async def _serves_content(client: httpx.AsyncClient, url: str) -> bool:
@@ -179,12 +253,24 @@ async def _probe_once(
     try:
         for _ in range(MAX_REDIRECTS + 1):
             host = urlsplit(current).hostname
-            if not host_is_public(host):
-                # Host does not resolve, or resolves to a non-public address —
-                # refuse to probe it. From an editor's view the source is
-                # effectively unreachable.
+            reachability = classify_host(host)
+            if reachability != HOST_PUBLIC:
+                # Refuse to probe. Both buckets end as "unreachable" from an
+                # editor's view, but they are not equally trustworthy: a name
+                # that resolves into non-public space is a fact this prober
+                # established (and the SSRF target the guard exists for), while
+                # a DNS failure on a single VPS routinely says nothing about the
+                # site. Keep them distinct in the detail and in the confidence.
+                status = classify_health(
+                    error=reachability, status_code=None, requested_url=url, final_url=None
+                )
                 return (
-                    _verdict(code, "unreachable", f"unresolvable or non-public host: {host}"),
+                    _verdict(
+                        code,
+                        status,
+                        f"{reachability}: {host}",
+                        probe_confidence(status=status, error=reachability, cert=None),
+                    ),
                     False,
                 )
             resp = await client.get(current, follow_redirects=False, timeout=TIMEOUT)
@@ -219,7 +305,15 @@ async def _probe_once(
         status = classify_health(
             error="redirect_loop", status_code=None, requested_url=url, final_url=None
         )
-        return _verdict(code, status, f"exceeded {MAX_REDIRECTS} redirect hops"), False
+        return (
+            _verdict(
+                code,
+                status,
+                f"exceeded {MAX_REDIRECTS} redirect hops",
+                probe_confidence(status=status, error="redirect_loop", cert=None),
+            ),
+            False,
+        )
     except Exception as exc:  # every probe failure maps to a health verdict
         kind = _error_kind(exc)
         if (
@@ -234,7 +328,18 @@ async def _probe_once(
             )
             return _verdict(code, status, None), False
         status = classify_health(error=kind, status_code=None, requested_url=url, final_url=None)
-        return _verdict(code, status, f"{kind}: {str(exc)[:160]}"), kind in ("timeout", "connect")
+        # A rejected handshake is not by itself evidence the *site* is broken:
+        # re-read the leaf and see whether the certificate is actually expired
+        # or actually issued for another name. When it checks out, the fault is
+        # local to this vantage and the verdict drops to low confidence.
+        cert = await _cert_recheck(current) if kind == SSL_ERROR else None
+        detail = f"{kind}: {str(exc)[:160]}"
+        if cert is not None:
+            detail = f"{detail} [leaf: {cert}]"
+        return (
+            _verdict(code, status, detail, probe_confidence(status=status, error=kind, cert=cert)),
+            kind in ("timeout", "connect"),
+        )
 
 
 async def probe(
@@ -321,13 +426,15 @@ async def main(dry_run: bool) -> None:
                     text(
                         "UPDATE data_sources "
                         "SET health_status = :s, health_checked_at = :t, "
-                        "    health_detail = :d, unreachable_since = :u "
+                        "    health_detail = :d, health_confidence = :f, "
+                        "    unreachable_since = :u "
                         "WHERE code = :c AND is_active = true"
                     ),
                     {
                         "s": r["status"],
                         "t": checked_at,
                         "d": r["detail"],
+                        "f": r["confidence"],
                         "u": unreachable_since,
                         "c": r["code"],
                     },

--- a/backend/tests/test_health_check_probe.py
+++ b/backend/tests/test_health_check_probe.py
@@ -7,9 +7,13 @@ the right inputs and retries the right failures."""
 
 import importlib.util
 import pathlib
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
+from cryptography import x509
+
+from app.services.source_health import HOST_DNS_UNRESOLVED, HOST_NON_PUBLIC, HOST_PUBLIC
 
 # health_check_sources.py is a cron script, not an importable package module —
 # load it by path so we can exercise its probe orchestration directly.
@@ -19,6 +23,10 @@ hc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(hc)
 
 URL = "https://src.example.org/"
+
+# 证书复核用的固定时间点，避免测试依赖真实时钟。
+PAST = datetime.now(UTC) - timedelta(days=30)
+FUTURE = datetime.now(UTC) + timedelta(days=200)
 
 
 class FakeResp:
@@ -59,7 +67,7 @@ def _patch(monkeypatch):
     # We test probe orchestration, not the SSRF/DNS guard (covered elsewhere) or
     # the real TLS/AIA handshake: treat every host as public, the leaf as
     # AIA-advertising by default, and drop the retry backoff so tests are fast.
-    monkeypatch.setattr(hc, "host_is_public", lambda host: True)
+    monkeypatch.setattr(hc, "classify_host", lambda host: HOST_PUBLIC)
     monkeypatch.setattr(hc, "_leaf_declares_aia_issuer", lambda host, port: True)
     monkeypatch.setattr(hc, "RETRY_BACKOFF", 0)
 
@@ -152,3 +160,139 @@ async def test_cross_domain_redirect_is_moved():
 async def test_missing_url_is_skipped():
     v = await hc.probe(FakeClient(), FakeClient(), "src", None)
     assert v["status"] is None  # no verdict invented for an absent base_url
+
+
+# --- 判定要带 confidence，且证书失败必须独立复核 ---------------------------
+# 生产实测：42 条非 ok 里 24 条是 timeout/DNS（换个观测点结论可能就变），
+# 另有 2 条证书判定与实际证书对不上（www.cnki.net 的叶证书是 *.cnki.net、
+# 2027 年才到期，却被记成 Hostname mismatch）。判定必须自带可信度，
+# 前台才能只展示站得住的那部分。
+
+
+async def test_http_status_verdict_is_high_confidence():
+    client = FakeClient(FakeResp(404))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "degraded"
+    assert v["confidence"] == "high"
+
+
+async def test_timeout_verdict_is_low_confidence(monkeypatch):
+    client = FakeClient(httpx.ConnectTimeout("timed out"), httpx.ConnectTimeout("timed out"))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "unreachable"
+    assert v["confidence"] == "low"
+
+
+async def test_dns_failure_is_reported_separately_and_low_confidence(monkeypatch):
+    # 探测机解析不了 ≠ 站点没了。
+    monkeypatch.setattr(hc, "classify_host", lambda host: HOST_DNS_UNRESOLVED)
+    v = await hc.probe(FakeClient(), FakeClient(), "src", URL)
+    assert v["status"] == "unreachable"
+    assert v["confidence"] == "low"
+    assert "dns_unresolved" in v["detail"]
+
+
+async def test_non_public_host_is_high_confidence(monkeypatch):
+    # 解析到内网地址是探测机自己就能确定的事实，也正是 SSRF 要拦的。
+    monkeypatch.setattr(hc, "classify_host", lambda host: HOST_NON_PUBLIC)
+    v = await hc.probe(FakeClient(), FakeClient(), "src", URL)
+    assert v["status"] == "unreachable"
+    assert v["confidence"] == "high"
+    assert "non_public" in v["detail"]
+
+
+async def test_cert_failure_with_healthy_leaf_is_low_confidence(monkeypatch):
+    # CNKI 的情形：握手被拒，但叶证书未过期且覆盖该主机名 → 是观测点的问题。
+    monkeypatch.setattr(hc, "_read_leaf_facts", lambda host, port: (FUTURE, ["*.cnki.net", "cnki.net"]))
+    client = FakeClient(httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] Hostname mismatch"))
+    v = await hc.probe(client, FakeClient(), "src", "https://www.cnki.net/")
+    assert v["status"] == "cert_invalid"
+    assert v["confidence"] == "low"
+    assert "looks_valid" in v["detail"]
+
+
+async def test_cert_failure_with_expired_leaf_is_high_confidence(monkeypatch):
+    # 台大的情形：叶证书确实已过期，全网一致，可以放心报出去。
+    monkeypatch.setattr(hc, "_read_leaf_facts", lambda host, port: (PAST, ["www.example.org"]))
+    client = FakeClient(httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate has expired"))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "cert_invalid"
+    assert v["confidence"] == "high"
+    assert "expired" in v["detail"]
+
+
+async def test_cert_failure_with_unreadable_leaf_is_low_confidence(monkeypatch):
+    # 服务器在发证书前就掐断握手（TLSV1_ALERT_INTERNAL_ERROR）：无从复核。
+    monkeypatch.setattr(hc, "_read_leaf_facts", lambda host, port: (None, []))
+    client = FakeClient(httpx.ConnectError("[SSL: TLSV1_ALERT_INTERNAL_ERROR] internal error"))
+    v = await hc.probe(client, FakeClient(), "src", URL)
+    assert v["status"] == "cert_invalid"
+    assert v["confidence"] == "low"
+
+
+async def test_ok_verdict_is_high_confidence():
+    v = await hc.probe(FakeClient(FakeResp(200)), FakeClient(), "src", URL)
+    assert v["status"] == "ok"
+    assert v["confidence"] == "high"
+
+
+# --- 叶证书解析：拿真证书验，别只验 mock ---------------------------------
+# 判定逻辑此前只在 _read_leaf_facts 被 mock 的情况下测过，等于没验证过
+# cryptography 的 API 用法（not_valid_after_utc 是 42+ 才有的属性）。
+
+
+def _self_signed(not_after, san_names):
+    """一张自签证书，只用来喂解析函数 —— 不联网、不信任。"""
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "leaf.example")])
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_after - timedelta(days=365))
+        .not_valid_after(not_after)
+    )
+    if san_names:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(n) for n in san_names]), critical=False
+        )
+    cert = builder.sign(key, hashes.SHA256())
+    return cert.public_bytes(serialization.Encoding.DER)
+
+
+def test_leaf_facts_reads_not_after_and_sans():
+    der = _self_signed(FUTURE.replace(microsecond=0), ["*.cnki.net", "cnki.net"])
+    not_after, san = hc.leaf_facts_from_der(der)
+    assert not_after is not None
+    assert not_after.tzinfo is not None, "classify_cert 拿它和 aware 的 now 比较，必须带时区"
+    assert abs((not_after - FUTURE).total_seconds()) < 2
+    assert san == ["*.cnki.net", "cnki.net"]
+
+
+def test_leaf_facts_without_san_extension():
+    der = _self_signed(FUTURE.replace(microsecond=0), [])
+    not_after, san = hc.leaf_facts_from_der(der)
+    assert not_after is not None
+    assert san == []
+
+
+def test_leaf_facts_on_garbage_is_unknown():
+    assert hc.leaf_facts_from_der(b"not a certificate") == (None, [])
+    assert hc.leaf_facts_from_der(b"") == (None, [])
+
+
+def test_leaf_facts_feed_classify_cert_end_to_end():
+    # 解析出来的东西必须能直接喂给 classify_cert —— 这是两者之间唯一的接口。
+    from app.services.source_health import CERT_LOOKS_VALID, classify_cert
+
+    der = _self_signed(FUTURE.replace(microsecond=0), ["*.cnki.net"])
+    not_after, san = hc.leaf_facts_from_der(der)
+    assert (
+        classify_cert(host="www.cnki.net", not_after=not_after, san_dns=san, now=datetime.now(UTC)) == CERT_LOOKS_VALID
+    )

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -3,16 +3,30 @@
 数据源健康状态分类的单元测试。Pure logic, no DB / network."""
 
 import importlib.util
+import socket
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
 from app.services.source_health import (
+    CERT_EXPIRED,
+    CERT_HOSTNAME_MISMATCH,
+    CERT_LOOKS_VALID,
+    CERT_UNKNOWN,
+    CONFIDENCE_HIGH,
+    CONFIDENCE_LOW,
+    HOST_DNS_UNRESOLVED,
+    HOST_NON_PUBLIC,
+    HOST_PUBLIC,
+    SSL_ERROR,
     _ip_is_blocked,
+    classify_cert,
     classify_health,
+    classify_host,
     host_is_public,
     is_incomplete_chain_error,
+    probe_confidence,
     resolve_unreachable_since,
 )
 
@@ -304,3 +318,167 @@ def test_0166_migration_keeps_source_health_update_narrow():
     assert "not a hard dependency for scripts/archive/imports/import_gretil.py" in (
         migration.GRETIL_DISTRIBUTION_UPDATE["license_note"]
     )
+
+
+# --- classify_host: DNS 查不到 ≠ 非公网地址 --------------------------------
+# 生产上 42 条非 ok 里有 8 条是「unresolvable or non-public host」，把「探测机
+# 解析不了」和「解析到内网地址」混成了一类。前者往往是探测点的网络问题
+# （VPS 的 DNS 到不了某些院校域名），后者才是真要拦的 SSRF 目标。
+
+
+def test_classify_host_non_public_address():
+    assert classify_host("127.0.0.1") == HOST_NON_PUBLIC
+    assert classify_host("169.254.169.254") == HOST_NON_PUBLIC
+
+
+def test_classify_host_public_address():
+    assert classify_host("8.8.8.8") == HOST_PUBLIC
+
+
+def test_classify_host_unresolvable_is_its_own_bucket(monkeypatch):
+    # 解析失败 ≠ 解析到内网地址。这里必须打桩 getaddrinfo：开发机上的
+    # DNS 代理（fake-IP）会把连不存在的域名都答成 198.18.x.x，真去查会
+    # 让这条测试在不同机器上给出不同结果。
+    def boom(*_args, **_kwargs):
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", boom)
+    assert classify_host("anything.example") == HOST_DNS_UNRESOLVED
+
+
+def test_classify_host_empty_is_non_public_fail_closed():
+    # 空主机名没有可探测的目标，按 SSRF 防线的「fail closed」归到非公网。
+    assert classify_host(None) == HOST_NON_PUBLIC
+    assert classify_host("") == HOST_NON_PUBLIC
+
+
+def test_host_is_public_still_fails_closed_for_both_buckets(monkeypatch):
+    # SSRF 防线的语义不能松：只有 public 放行，dns_unresolved 也照样拦。
+    assert host_is_public("8.8.8.8") is True
+    assert host_is_public("127.0.0.1") is False
+
+    def boom(*_args, **_kwargs):
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", boom)
+    assert host_is_public("anything.example") is False
+
+
+# --- classify_cert: 独立复核证书，别把环境问题当成站点问题 ------------------
+# 生产实测：www.cnki.net 的证书是 *.cnki.net、2027 年才到期，探测器却记成
+# "Hostname mismatch"；遊方站证书 2026-08 到期，探测器记成 "has expired"。
+# 两条都是探测点看到的东西和全网不一致，不该当作站点的毛病报出去。
+
+NOW = datetime(2026, 7, 21, tzinfo=UTC)
+
+
+def test_classify_cert_expired():
+    assert (
+        classify_cert(
+            host="buddhism.lib.ntu.edu.tw",
+            not_after=datetime(2026, 7, 15, tzinfo=UTC),
+            san_dns=["buddhism.lib.ntu.edu.tw"],
+            now=NOW,
+        )
+        == CERT_EXPIRED
+    )
+
+
+def test_classify_cert_hostname_mismatch():
+    # PTS 巴英辞典实测：证书是 *.stackcp.com，压根不含 palitext.com。
+    assert (
+        classify_cert(
+            host="www.palitext.com",
+            not_after=datetime(2027, 1, 4, tzinfo=UTC),
+            san_dns=["*.stackcp.com", "stackcp.com"],
+            now=NOW,
+        )
+        == CERT_HOSTNAME_MISMATCH
+    )
+
+
+def test_classify_cert_wildcard_covers_one_label():
+    # CNKI 的真实情况：*.cnki.net 覆盖 www.cnki.net，不是 mismatch。
+    assert (
+        classify_cert(
+            host="www.cnki.net",
+            not_after=datetime(2027, 3, 9, tzinfo=UTC),
+            san_dns=["*.cnki.net", "caj.d.cnki.net"],
+            now=NOW,
+        )
+        == CERT_LOOKS_VALID
+    )
+
+
+def test_classify_cert_wildcard_does_not_span_dots_or_bare_domain():
+    # *.cnki.net 既不覆盖 cnki.net 本身，也不覆盖 a.b.cnki.net。
+    assert (
+        classify_cert(host="cnki.net", not_after=datetime(2027, 3, 9, tzinfo=UTC), san_dns=["*.cnki.net"], now=NOW)
+        == CERT_HOSTNAME_MISMATCH
+    )
+    assert (
+        classify_cert(host="a.b.cnki.net", not_after=datetime(2027, 3, 9, tzinfo=UTC), san_dns=["*.cnki.net"], now=NOW)
+        == CERT_HOSTNAME_MISMATCH
+    )
+
+
+def test_classify_cert_expiry_wins_over_hostname():
+    # 两个毛病都占时，报更硬的那个：过期是全网一致的事实。
+    assert (
+        classify_cert(host="x.example", not_after=datetime(2020, 1, 1, tzinfo=UTC), san_dns=["other.example"], now=NOW)
+        == CERT_EXPIRED
+    )
+
+
+def test_classify_cert_unknown_when_leaf_unavailable():
+    # 连证书都取不到（TLSV1_ALERT_INTERNAL_ERROR 那两条），无从复核。
+    assert classify_cert(host="x.example", not_after=None, san_dns=[], now=NOW) == CERT_UNKNOWN
+
+
+# --- probe_confidence: 哪些判定敢放到用户面前 -------------------------------
+
+
+def test_confidence_high_for_http_status_verdicts():
+    # 服务器真的答了一个码，全网一致。
+    assert probe_confidence(status="degraded", error=None, cert=None) == CONFIDENCE_HIGH
+    assert probe_confidence(status="unreachable", error=None, cert=None) == CONFIDENCE_HIGH
+
+
+def test_confidence_high_for_independently_confirmed_cert_faults():
+    assert probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=CERT_EXPIRED) == CONFIDENCE_HIGH
+    assert probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=CERT_HOSTNAME_MISMATCH) == CONFIDENCE_HIGH
+
+
+def test_confidence_low_when_cert_looks_fine_but_handshake_failed():
+    # CNKI / 遊方：OpenSSL 拒了，但独立复核证书是好的 → 是探测点的问题。
+    assert probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=CERT_LOOKS_VALID) == CONFIDENCE_LOW
+
+
+def test_confidence_low_for_cert_we_could_not_recheck():
+    assert probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=CERT_UNKNOWN) == CONFIDENCE_LOW
+
+
+def test_confidence_low_for_timeout_and_dns():
+    assert probe_confidence(status="unreachable", error="timeout", cert=None) == CONFIDENCE_LOW
+    assert probe_confidence(status="unreachable", error="connect", cert=None) == CONFIDENCE_LOW
+    assert probe_confidence(status="unreachable", error=HOST_DNS_UNRESOLVED, cert=None) == CONFIDENCE_LOW
+
+
+def test_confidence_high_for_non_public_host():
+    # 解析到内网地址是探测机能确定的事实，也是真该拦的。
+    assert probe_confidence(status="unreachable", error=HOST_NON_PUBLIC, cert=None) == CONFIDENCE_HIGH
+
+
+def test_confidence_high_for_ok():
+    assert probe_confidence(status="ok", error=None, cert=None) == CONFIDENCE_HIGH
+
+
+def test_0172_migration_adds_health_confidence():
+    migration_path = (
+        Path(__file__).resolve().parents[1] / "alembic" / "versions" / "0172_add_source_health_confidence.py"
+    )
+    assert migration_path.exists()
+    migration = _load_migration(migration_path)
+
+    assert migration.revision == "0172"
+    assert migration.down_revision == "0171"


### PR DESCRIPTION
## 起因

想给 `/sources` 加「此源已失效」角标，先核了一遍数据 —— **发现不能直接用**。

生产 617 个源里 42 个非 `ok`。2026-07-21 逐条核对（证书是全网一致的，可脱离观测点独立验证）：

| 类别 | 条数 | 核对结果 |
|---|---|---|
| `timeout` | 16 | 巡检 cron 只从一台 VPS 发起，机房 IP 被挡就长这样 —— **真假不明** |
| DNS `unresolvable` | 8 | 同上，且代码把「解析不到」和「解析到内网地址」混成了一类 —— **真假不明** |
| HTTP 502/503/404/522 | 5 | 服务器自己回的码，全网一致 —— **可信** |
| 证书类 | 12 | 抽查 9 条可核：**7 真 2 假** |

证书类逐条：

| 站点 | 判定 | 实际叶证书 | |
|---|---|---|---|
| 台大佛学数位图书馆 ×2 | expired | 到期 2026-07-15（6 天前） | ✅ |
| 花园大学禅学研究所 | expired | 到期 2023-05，SAN=`iriz01` | ✅ |
| 不丹国家图书馆 | expired | 到期 2026-07-10（11 天前） | ✅ |
| PTS 巴英辞典 | mismatch | SAN=`*.stackcp.com`，不含 palitext.com | ✅ |
| 汉文佛典著者数据库 | mismatch | SAN=`dazangthings.nz`，不含 cbc.dila.edu.tw | ✅ |
| 驹泽大学 | mismatch | SAN=`wwwopac.*`，不含 repo.* | ✅ |
| **中国知网** | mismatch | SAN 含 `*.cnki.net`，**覆盖 www.cnki.net**，到 2027 | ❌ 误报 |
| **遊方·历代僧传** | expired | 到期 2026-08-13，**没过期** | ❌ 误报 |

照现状加角标，会把知网标成「证书异常」，还会把 24 条真假不明的一并标出去。所以先修探测器，**前台一行没动**。

## 改动

**1. `host_is_public()` 拆成 `classify_host()`** —— `dns_unresolved`（解析不到，多半是探测环境）与 `non_public`（解析到 RFC1918/loopback/metadata，是 SSRF 防线要拦的事实）分开。`host_is_public` 保留为其上的严格白名单（只有 `public` 放行），**SSRF 行为零变化**，原有测试全部保留。

**2. SSL 失败时重读叶证书**，用 `classify_cert()` 从证书本身重新判定，含 RFC 6125 通配符匹配：`*.cnki.net` 覆盖 `www.cnki.net`，但不覆盖 `cnki.net` 本身或 `a.b.cnki.net`。握手被拒但证书查下来是好的 → 判为本观测点的问题。过期先于主机名判定，因为过期是更硬、更不依赖观测点的事实。

**3. 新增 `health_confidence` 列**（迁移 0172，接 0171，确认单 head 无重复 `down_revision`）：

- `high` = 服务器回的 HTTP 码 / 已独立复核的证书故障 / 解析到内网地址
- `low` = timeout / DNS / 复核不了的证书拒绝

存量行默认 `high`：这一列只会**收窄**可展示范围，且目前没有读者，下次 cron 跑完自然写入真值。

## 关于测试

证书解析拆出 `leaf_facts_from_der()` 以便脱网测试。**此前这段只在 `_read_leaf_facts` 被 mock 的前提下测过，等于没验证过 `cryptography` 的 API 用法** —— `not_valid_after_utc` 是 42+ 才有的属性。现在用自签证书直接喂解析函数，覆盖 notAfter 时区、SAN 提取、无 SAN 扩展、垃圾输入。

## 验证

- 三组失败测试先行（`classify_host` / `classify_cert` / `probe_confidence`），确认各自因正确原因红，再实现
- DNS 相关测试改成 monkeypatch `getaddrinfo`：开发机的 fake-IP DNS 代理会把不存在的域名也答成 `198.18.x.x`，真去查会让结论随机器变
- 全量后端 **1339 测试通过**，跑在按 `requirements.txt` 建的干净 venv 里（cryptography 49.0.0，与生产同版本）
- CI 口径 `ruff 0.9.7 check app/ eval/` 通过

## 下一步（不在本 PR）

跑一次 cron 让 `health_confidence` 落到真值，看 high 档实际剩多少条，再决定前台角标怎么展示。届时 timeout/DNS 那 24 条应当默认不进读者视野。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDD5HMUNML8sPjMPQPHSCr