### PR TITLE
chore(deploy): 把宿主机 nginx 配置纳入版本管理

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -261,6 +261,16 @@ app/services/*.py     业务层：核心逻辑都在这（RAG、检索、对齐�
 
 **部署走 `./deploy.sh`**（不要手动 `docker rm` + force-recreate，会竞态停服）。内部服务（PG/Redis/ES/backend/umami）只绑 `127.0.0.1`；nginx 负责 gzip、安全响应头、SSE 不压缩。前端容器对 docker host 网络可达，多用户环境需加认证反代。
 
+**请求链路——注意 compose 之上还有一层宿主机 nginx**：
+
+```
+client → Cloudflare → 宿主 nginx(:80) ─┬─ /api/、/docs、/openapi.json → backend 双副本(127.0.0.1:8000/:8001)
+                                       └─ 其余                        → fojin-frontend 容器(127.0.0.1:3000)
+                                                                          └─ /share/qa/…、sitemap、SEO SSR → backend
+```
+
+`/api/` **不经过前端容器**，由宿主 nginx 直连后端；`frontend/nginx.conf` 里的 `location /api/` 对 fojin.app 流量而言是死代码。宿主层配置（含 Cloudflare 真实 IP 还原）现已纳入版本管理：`deploy/host-nginx/`——但**它不由 `deploy.sh` 部署**，改动需手工同步。该目录的 README 记录了它与 `frontend/security-headers.conf` 之间已知的响应头冲突。
+
 **指标**：backend 在根路径暴露 `/metrics`（Prometheus 格式，nginx 不代理 → 仅内网；实现在 `app/core/metrics.py`）。HTTP 按路由模板计数/延迟 + RAG 检索耗时 + 引用护栏改写计数。抓取栈是可选 overlay（`docker-compose.observability.yml`），详见 `docs/OBSERVABILITY.md`。
 
 **本地开发**（详见 README "Development"）：

--- a/deploy/host-nginx/README.md
+++ b/deploy/host-nginx/README.md
@@ -1,0 +1,99 @@
+# Host nginx (the layer above docker-compose)
+
+These files live on the prod VPS at `/etc/nginx/`, **outside** any container.
+Until 2026-07-22 they existed only on that machine, which meant the layer that
+actually terminates every public request was invisible to code review — and it
+silently overrides decisions made in `frontend/security-headers.conf`.
+
+| Repo copy | Server path |
+|---|---|
+| `fojin.conf` | `/etc/nginx/conf.d/fojin.conf` |
+| `cloudflare-real-ip.conf` | `/etc/nginx/cloudflare-real-ip.conf` |
+
+## These files are NOT deployed by anything
+
+`deploy.sh` only touches the compose stack. Committing here makes the config
+**reviewable and diffable**; it does not ship it. Applying a change is manual:
+
+```bash
+scp deploy/host-nginx/fojin.conf sg-vps:/tmp/fojin.conf
+ssh sg-vps 'sudo cp /tmp/fojin.conf /etc/nginx/conf.d/fojin.conf && sudo nginx -t && sudo systemctl reload nginx'
+```
+
+Check for drift before trusting the repo copy:
+
+```bash
+ssh sg-vps 'sudo cat /etc/nginx/conf.d/fojin.conf' | diff -u deploy/host-nginx/fojin.conf - && echo "in sync"
+```
+
+The server also carries hand-made backups (`fojin.conf.bak-pre-cors`,
+`.bak-realip-*`, `.bak-zerodt-*`) from before this was versioned. They are the
+history this file now replaces; delete them once you trust git.
+
+## Request chain
+
+```
+client → Cloudflare → host nginx (:80) ─┬─ /api/, /docs, /openapi.json → fojin_backend (127.0.0.1:8000 / :8001)
+                                        └─ everything else            → fojin-frontend container (127.0.0.1:3000)
+                                                                          └─ /api/, /share/qa/…, sitemap, SEO SSR → backend
+```
+
+**`/api/` does not pass through the frontend container.** Host nginx proxies it
+straight to the two backend replicas. `frontend/nginx.conf`'s own `location
+/api/` block is therefore dead for fojin.app traffic — it only matters if
+something reaches the container directly.
+
+`stream.fojin.ai` is a separate server block on :443 with its own certificate,
+DNS-only (not proxied by Cloudflare), carrying `/api/chat/stream` with
+buffering off.
+
+## Client IP: verified working (2026-07-22)
+
+`cloudflare-real-ip.conf` gives nginx 22 `set_real_ip_from` ranges plus
+`real_ip_header CF-Connecting-IP`, so `$remote_addr` here is the true client.
+`$proxy_add_x_forwarded_for` then appends it, and `app/core/client_ip.py` reads
+the **last** XFF entry — which lines up.
+
+Confirmed empirically, not just by reading the config: a request from a known
+public IP produced `ratelimit:<that IP>:<window>` in Redis, and live
+`chat:anon:*` keys hold varied real IPv4/IPv6 client addresses rather than one
+shared bucket. The anonymous chat quota and the per-IP rate limits are genuinely
+per-client.
+
+**Known nit:** routes served *through* the frontend container (SEO/SSR — the
+sitemap, `/share/qa/{id}`, `/texts/{id}`) get one more hop, so the last XFF
+entry becomes the container-visible source (`10.255.1.1`) and they all share a
+single rate-limit bucket. None of them are in `STRICT_PATHS` and all are cheap
+public reads, so this is an availability nit (a crawler burst could 429 them for
+everyone), not an auth issue. Fixing it means adding `set_real_ip_from` +
+`real_ip_header X-Forwarded-For` inside `frontend/nginx.conf` too.
+
+**Maintenance:** the Cloudflare ranges are a snapshot taken 2026-07-06. If
+Cloudflare adds an edge range, requests through it stop being rewritten and fall
+back to the edge IP. Re-fetch periodically from <https://www.cloudflare.com/ips/>.
+
+## Known conflicts with the containerised config
+
+1. **`X-Frame-Options`.** This file sets `SAMEORIGIN` (lines 42, 69);
+   `frontend/security-headers.conf` sets `DENY`. Responses that pass through
+   both carry two conflicting values, which is invalid — Chrome drops the header
+   entirely, leaving no clickjacking protection. The durable fix lives in the
+   repo: `frame-ancestors 'none'` in the CSP, which cannot be voided by a
+   duplicate header from another layer. Ideally this file stops setting XFO at
+   all.
+
+2. **CORS on `/api/` (lines 65-66).** `Access-Control-Allow-Origin: *` is added
+   unconditionally, on top of FastAPI's own env-driven origin allowlist. Two
+   `Access-Control-Allow-Methods` headers on a preflight is the visible symptom.
+   It is currently fail-safe (browsers reject `*` together with credentials) but
+   it means the app's CORS policy is not the one actually served.
+
+3. **`stream.fojin.ai` preflight (lines 118-125)** reflects `$http_origin` with
+   `Access-Control-Allow-Credentials: true`, i.e. it approves preflight for *any*
+   origin. Harmless today because auth is a `Authorization: Bearer` header from
+   localStorage, which browsers never attach cross-origin on their own — but it
+   becomes a real CSRF hole the moment auth moves to cookies.
+
+4. `X-XSS-Protection: 1; mode=block` (lines 44, 71) is deprecated; modern
+   guidance is `0`, since the legacy auditor it enables has itself been a source
+   of vulnerabilities.

--- a/deploy/host-nginx/cloudflare-real-ip.conf
+++ b/deploy/host-nginx/cloudflare-real-ip.conf
@@ -1,0 +1,26 @@
+# Cloudflare edge → restore real client IP. Trust CF-Connecting-IP only
+# from Cloudflare source ranges (fetched 2026-07-06 from cloudflare.com/ips).
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 104.16.0.0/13;
+set_real_ip_from 104.24.0.0/14;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 131.0.72.0/22;
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2a06:98c0::/29;
+set_real_ip_from 2c0f:f248::/32;
+real_ip_header CF-Connecting-IP;
+real_ip_recursive on;

--- a/deploy/host-nginx/fojin.conf
+++ b/deploy/host-nginx/fojin.conf
@@ -1,0 +1,150 @@
+# Backend replicas for zero-downtime rolling deploys. nginx round-robins over
+# both; nginx's default proxy_next_upstream (error timeout) auto-retries the
+# other replica when one refuses connections (i.e. while it's being recreated),
+# so a rolling deploy never surfaces a 502. max_fails marks a down replica out
+# of rotation for fail_timeout so subsequent requests skip it entirely.
+upstream fojin_backend {
+    server 127.0.0.1:8000 max_fails=1 fail_timeout=10s;
+    server 127.0.0.1:8001 max_fails=1 fail_timeout=10s;
+}
+
+# fojin.ai → 301 redirect to fojin.app
+server {
+    listen 80;
+    server_name fojin.ai www.fojin.ai;
+    return 301 https://fojin.app$request_uri;
+}
+
+# Umami Analytics — analytics.fojin.app
+server {
+    listen 80;
+    server_name analytics.fojin.app;
+    include /etc/nginx/cloudflare-real-ip.conf;
+
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    add_header Pragma "no-cache" always;
+
+    location / {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# fojin.app (behind Cloudflare proxy, HTTP only)
+server {
+    listen 80;
+    server_name fojin.app www.fojin.app;
+    include /etc/nginx/cloudflare-real-ip.conf;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # GitHub webhook for auto-deploy
+    location /webhook/deploy {
+        proxy_pass http://127.0.0.1:9876/deploy;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Hub-Signature-256 $http_x_hub_signature_256;
+    }
+
+    location /api/ {
+        proxy_pass http://fojin_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+        # CORS for LOD / academic clients (Wikidata bots, Zotero, third-party
+        # scrapers). Safe-by-default: only GET/HEAD/OPTIONS. POST endpoints
+        # that need write CORS use the stream.fojin.ai block.
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+        # Repeat server-level security headers — add_header in a child block
+        # silently disables inheritance (nginx documented quirk).
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
+    location /docs {
+        proxy_pass http://fojin_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /openapi.json {
+        proxy_pass http://fojin_backend;
+        proxy_set_header Host $host;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+    gzip_min_length 1000;
+}
+
+# stream.fojin.ai — SSE streaming (DNS only, no Cloudflare proxy)
+server {
+    listen 172.19.63.22:443 ssl;
+    server_name stream.fojin.ai;
+
+    ssl_certificate /etc/letsencrypt/live/stream.fojin.ai/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/stream.fojin.ai/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    location /webhook/deploy {
+        proxy_pass http://127.0.0.1:9876/deploy;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Hub-Signature-256 $http_x_hub_signature_256;
+    }
+
+    location /api/chat/stream {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $http_origin;
+            add_header Access-Control-Allow-Methods "POST, OPTIONS";
+            add_header Access-Control-Allow-Headers "Authorization, Content-Type";
+            add_header Access-Control-Allow-Credentials "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+
+        proxy_pass http://fojin_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 120s;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        chunked_transfer_encoding off;
+        gzip off;
+    }
+
+    location / {
+        return 404;
+    }
+}
+
+server {
+    listen 80;
+    server_name stream.fojin.ai;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
## 背景

每个公网请求实际终结在 **VPS 宿主机上的 nginx**（在 docker-compose 之上），而这份配置此前只存在于那台机器上——真正决定站点安全响应头、CORS 和真实客户端 IP 还原的那一层，代码审查完全看不到，它的"历史"是live 文件旁边几个手改的 `.bak`。

## 改动

新增 `deploy/host-nginx/`，内含与服务器**逐字节一致**的两份副本，外加一份 README 记录链路、同步步骤、漂移检查命令，以及这层与 `frontend/security-headers.conf` 的四处冲突。

⚠️ **此目录不由任何流程自动部署** —— `deploy.sh` 只管 compose 栈。入库是为了「可审查、可回溯」，改动仍需手工同步。

## 这次因此暴露出来的两件事

**1. `/api/` 根本不经过前端容器。** 宿主 nginx 直连后端双副本，所以 `frontend/nginx.conf` 里的 `location /api/` 对 fojin.app 流量而言是死代码。

**2. 真实客户端 IP 的处理是正确的**——与仅凭仓库推断出的怀疑相反。`cloudflare-real-ip.conf` 提供 22 条 `set_real_ip_from` + `real_ip_header CF-Connecting-IP`，所以 `client_ip.py` 取的 XFF 尾项确实是客户端。

这条不是读配置读出来的，是在线上实测的：从一个已知公网 IP 发请求，Redis 里随即出现 `ratelimit:<该 IP>:<窗口>`；线上 `chat:anon:*` 键持有各不相同的真实 IPv4/IPv6 地址，而非一个共享桶。**匿名聊天配额和按 IP 限流都是真正按客户端生效的。**

已记录的唯一真实瑕疵：走前端容器的 SEO/SSR 路由（sitemap、`/share/qa/{id}`、`/texts/{id}`）多一跳，确实塌缩成单一桶（`10.255.1.1`）。都是廉价公开读、都不在 `STRICT_PATHS`，属可用性瑕疵。

`ARCHITECTURE.md §8` 补了链路图——原先的 compose 表格容易让人以为容器里的 nginx 就是公网入口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvgT37UH7QMswKfhqgutCF