### PR TITLE
fix(csp): 补 frame-ancestors 与 base-uri —— 这两条不会从 default-src 继承

### DIFF
--- a/frontend/security-headers.conf
+++ b/frontend/security-headers.conf
@@ -6,9 +6,18 @@
 # SecurityHeadersMiddleware was removed in P2-3 cleanup to keep nginx the only
 # source and avoid duplicate headers on proxied responses.
 add_header X-Content-Type-Options "nosniff" always;
+# Kept for pre-CSP2 clients, but do NOT rely on it: production sits behind a
+# reverse-proxy hop that is not in this repo and appends its own
+# `X-Frame-Options: SAMEORIGIN`. A response carrying two conflicting XFO values
+# is invalid, and Chrome drops the header entirely — which is why the real
+# clickjacking defense is `frame-ancestors` in the CSP below. That directive
+# does NOT inherit from `default-src`, so it has to be spelled out, and unlike
+# XFO it cannot be neutralised by a duplicate header from another layer.
 add_header X-Frame-Options "DENY" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.fojin.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://analytics.fojin.app https://*.cartocdn.com https://api.maptiler.com; font-src 'self' data:; worker-src 'self' blob:;" always;
+# `base-uri` also has no `default-src` fallback. Without it, any HTML injection
+# into <head> can repoint every relative URL on the page via <base href>.
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.fojin.app; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://analytics.fojin.app https://*.cartocdn.com https://api.maptiler.com; font-src 'self' data:; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self';" always;
 add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 add_header X-Permitted-Cross-Domain-Policies "none" always;


### PR DESCRIPTION
## 问题

线上同时返回两个**冲突**的 `X-Frame-Options`：`DENY`（本仓库的 `security-headers.conf`）和 `SAMEORIGIN`（来自仓库外的一层宿主 nginx，见 #1019）。

带有冲突 XFO 值的响应是无效的，**Chrome 会直接忽略整个头**。而 CSP 里没有 `frame-ancestors`——它**不会**从 `default-src` 继承。

净效果：站点实际上没有点击劫持防护。

## 修复

`frame-ancestors 'none'` 恢复了 `X-Frame-Options: DENY` 的本意，且与 XFO 不同，它**无法被另一层追加的重复头抵消**。已确认线上只返回**一个** CSP 头，所以这条指令是权威的，不会被交集掉。

`base-uri 'self'` 是同一类缺口：同样没有 `default-src` 回退，缺了它的话，任何注入进 `<head>` 的 HTML 都能用 `<base href>` 重定向页面上所有相对 URL（正好是 #1021 那个注入漏洞可以做到的事）。

## 验证

- `nginx -t` 通过
- `index.html` 中无 `<base>` 标签，加 `base-uri` 不会破坏现有行为
- 9 条 CSP 指令全部解析合法

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvgT37UH7QMswKfhqgutCF