### PR TITLE
fix(seo): 修复经由 re.sub 替换模板的 HTML 注入（未授权可利用）

### DIFF
--- a/backend/app/api/seo.py
+++ b/backend/app/api/seo.py
@@ -69,8 +69,38 @@ _SEO_JUAN_LIST_LIMIT = 50
 
 
 def _escape_meta_value(value: str) -> str:
-    """Escape characters that would break out of an HTML attribute value."""
-    return value.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
+    """Escape characters that would break out of an HTML attribute value.
+
+    The backslash is escaped for a second, non-obvious reason: these values are
+    spliced into the shell via ``re.sub``, whose *replacement template* itself
+    interprets escape sequences. Without this, ``\\074`` would survive this
+    function untouched and re-materialise as ``<`` after substitution. The
+    call sites now use callable replacements (which disable template parsing
+    entirely), so this is defence in depth against that being undone.
+
+    ``&`` must stay first so the entities emitted below aren't double-escaped.
+    """
+    return (
+        value.replace("&", "&amp;")
+        .replace("\\", "&#92;")
+        .replace('"', "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("'", "&#39;")
+    )
+
+
+def _sub_literal(pattern: re.Pattern[str], replacement: str, html: str, *, count: int = 1) -> str:
+    """``pattern.sub`` that treats ``replacement`` as a literal string.
+
+    Passing a plain string to ``re.sub`` makes it a *replacement template*:
+    ``\\1`` is a group reference (and raises ``re.error`` when the pattern has
+    no such group), and ``\\074`` is an octal character escape that runs
+    *after* our HTML escaping. Since every replacement here embeds
+    user-controlled text, a callable — which ``re`` never parses — is the
+    only safe form.
+    """
+    return pattern.sub(lambda _match: replacement, html, count=count)
 
 
 async def _fetch_index_html() -> str:
@@ -108,22 +138,22 @@ def _inject_meta(
     safe_canonical = _escape_meta_value(canonical_url)
     safe_robots = _escape_meta_value(robots)
 
-    new_html = _TITLE_RE.sub(f"<title>{safe_title}</title>", html, count=1)
-    new_html = _DESCRIPTION_RE.sub(
+    new_html = _sub_literal(_TITLE_RE, f"<title>{safe_title}</title>", html)
+    new_html = _sub_literal(
+        _DESCRIPTION_RE,
         f'<meta name="description" content="{safe_desc}" />',
         new_html,
-        count=1,
     )
-    new_html = _ROBOTS_RE.sub(
+    new_html = _sub_literal(
+        _ROBOTS_RE,
         f'<meta name="robots" content="{safe_robots}" />',
         new_html,
-        count=1,
     )
     canonical_tag = f'<link rel="canonical" href="{safe_canonical}" />'
     if _CANONICAL_RE.search(new_html):
-        new_html = _CANONICAL_RE.sub(canonical_tag, new_html, count=1)
+        new_html = _sub_literal(_CANONICAL_RE, canonical_tag, new_html)
     else:
-        new_html = _HEAD_CLOSE_RE.sub(f"  {canonical_tag}\n  </head>", new_html, count=1)
+        new_html = _sub_literal(_HEAD_CLOSE_RE, f"  {canonical_tag}\n  </head>", new_html)
     return new_html
 
 
@@ -222,7 +252,7 @@ async def _serve_text_seo_html(
             body = {"excerpt": "", "juans": [], "total_juans": 0}
         seo_block = _render_text_seo_body(text, body, base_url=base_url)
         if _ROOT_DIV_RE.search(patched):
-            patched = _ROOT_DIV_RE.sub(f'<div id="root"></div>\n{seo_block}', patched, count=1)
+            patched = _sub_literal(_ROOT_DIV_RE, f'<div id="root"></div>\n{seo_block}', patched)
         else:
             patched = patched.replace("</body>", f"{seo_block}\n</body>", 1)
     return HTMLResponse(content=patched)
@@ -333,11 +363,7 @@ async def _fetch_text_seo_body(db: AsyncSession, text_id: int) -> dict:
     if len(cleaned) > _SEO_BODY_CHAR_LIMIT:
         cleaned = cleaned[: _SEO_BODY_CHAR_LIMIT - 1].rstrip() + "…"
 
-    count_row = await db.execute(
-        select(TextContent.juan_num)
-        .where(TextContent.text_id == text_id)
-        .distinct()
-    )
+    count_row = await db.execute(select(TextContent.juan_num).where(TextContent.text_id == text_id).distinct())
     juans = sorted({r[0] for r in count_row.all() if r[0] is not None})
     return {"excerpt": cleaned, "juans": juans[:_SEO_JUAN_LIST_LIMIT], "total_juans": len(juans)}
 
@@ -375,9 +401,7 @@ def _render_text_seo_body(text, body: dict, *, base_url: str) -> str:
     if len(juans) > 1:
         parts.append("<h2>卷目录</h2><ul>")
         for j in juans:
-            parts.append(
-                f'<li><a href="{base_url}/texts/{text.id}/read?juan={int(j)}">第 {int(j)} 卷</a></li>'
-            )
+            parts.append(f'<li><a href="{base_url}/texts/{text.id}/read?juan={int(j)}">第 {int(j)} 卷</a></li>')
         if body.get("total_juans", 0) > _SEO_JUAN_LIST_LIMIT:
             parts.append(f"<li>…共 {body['total_juans']} 卷</li>")
         parts.append("</ul>")
@@ -399,7 +423,7 @@ def _inject_text_jsonld(html: str, payload: dict) -> str:
     """
     blob = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).replace("</", "<\\/")
     tag = f'<script type="application/ld+json">{blob}</script>'
-    return _HEAD_CLOSE_RE.sub(f"  {tag}\n  </head>", html, count=1)
+    return _sub_literal(_HEAD_CLOSE_RE, f"  {tag}\n  </head>", html)
 
 
 @router.get("/texts/{text_id}", response_class=HTMLResponse, include_in_schema=False)
@@ -523,7 +547,7 @@ def _inject_share_qa_meta(html: str, meta: dict[str, str]) -> str:
         f'  <meta property="og:url" content="{_escape_meta_value(meta["canonical"])}" />\n'
         f'  <meta name="twitter:card" content="summary_large_image" />\n  '
     )
-    return _HEAD_CLOSE_RE.sub(f"  {og_tags}</head>", new_html, count=1)
+    return _sub_literal(_HEAD_CLOSE_RE, f"  {og_tags}</head>", new_html)
 
 
 @router.get("/share/qa/{share_id}", response_class=HTMLResponse, include_in_schema=False)

--- a/backend/tests/test_seo_meta_injection.py
+++ b/backend/tests/test_seo_meta_injection.py
@@ -1,0 +1,117 @@
+"""Regression tests for HTML injection through the SEO meta-tag substitution.
+
+``_inject_meta`` / ``_inject_share_qa_meta`` splice user-controlled strings
+(shared-Q&A question/answer, text titles) into the SPA shell with
+``re.sub(pattern, repl, html)``. ``re.sub`` *interprets escape sequences in
+the replacement template*, so a payload can smuggle metacharacters past
+``_escape_meta_value`` — which only escapes ``& " < >`` — and have them
+materialise afterwards:
+
+    ``\\074`` -> ``<``      ``\\076`` -> ``>``      ``\\042`` -> ``"``
+
+``POST /api/share/qa`` is unauthenticated, so this was a stored HTML
+injection on the production origin reachable by anyone.
+
+A ``\\1`` in the same position raises ``re.error: invalid group reference``,
+which 500s the share page permanently.
+"""
+
+import re
+
+import pytest
+
+from app.api.seo import _escape_meta_value, _inject_meta, _inject_share_qa_meta
+
+SHELL = (
+    "<!doctype html><html><head>"
+    "<title>佛津</title>"
+    '<meta name="description" content="orig" />'
+    '<meta name="robots" content="index, follow" />'
+    "</head><body></body></html>"
+)
+
+# Octal escapes only — contains no literal < > " so _escape_meta_value is a no-op.
+OCTAL_PAYLOAD = r"\042\076\074meta http-equiv=\042refresh\042 content=\0420;url=https://evil.io\042\076"
+
+
+def _meta(**overrides) -> dict[str, str]:
+    base = {
+        "title": "什么是空？",
+        "description": "缘起性空",
+        "canonical": "https://fojin.app/share/qa/abc123",
+        "og_title": "什么是空？",
+        "og_description": "缘起性空",
+        "og_image": "https://fojin.app/api/og/share/qa/abc123",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestEscapeMetaValue:
+    def test_escapes_backslash_so_re_sub_cannot_reinterpret_it(self):
+        assert "\\" not in _escape_meta_value(r"a\074b")
+
+    def test_escapes_single_quote(self):
+        assert "'" not in _escape_meta_value("it's")
+
+    def test_still_escapes_the_original_four(self):
+        assert _escape_meta_value('<a href="x">&') == "&lt;a href=&quot;x&quot;&gt;&amp;"
+
+
+class TestInjectMetaOctalEscape:
+    @pytest.mark.parametrize("field", ["title", "description", "canonical_url"])
+    def test_octal_escapes_do_not_become_tags(self, field):
+        kwargs = {
+            "title": "safe",
+            "description": "safe",
+            "canonical_url": "https://fojin.app/x",
+            field: OCTAL_PAYLOAD,
+        }
+        out = _inject_meta(SHELL, **kwargs)
+        # The payload may appear as inert text, but must never form a tag.
+        assert "<meta http-equiv=" not in out
+        assert "refresh" not in out or "&#92;042refresh" in out
+
+    def test_title_payload_cannot_close_the_title_element(self):
+        out = _inject_meta(
+            SHELL,
+            title=r"\074/title\076\074meta http-equiv=\042refresh\042\076",
+            description="safe",
+            canonical_url="https://fojin.app/x",
+        )
+        # Exactly one closing </title> — the payload did not spawn another.
+        assert out.count("</title>") == 1
+        # "http-equiv" may survive as inert text inside <title>; what must not
+        # exist is a tag built out of it.
+        assert "<meta http-equiv" not in out
+
+
+class TestInjectMetaGroupReference:
+    """A backreference in the payload must not raise out of the injector."""
+
+    @pytest.mark.parametrize("payload", [r"hi\1there", r"a\g<1>b", "trailing backslash\\"])
+    def test_backreference_payload_does_not_raise(self, payload):
+        out = _inject_meta(
+            SHELL,
+            title=payload,
+            description=payload,
+            canonical_url="https://fojin.app/x",
+        )
+        assert "<title>" in out
+
+
+class TestInjectShareQaMeta:
+    def test_octal_escape_in_og_description_does_not_become_a_tag(self):
+        out = _inject_share_qa_meta(SHELL, _meta(og_description=OCTAL_PAYLOAD))
+        assert "<meta http-equiv=" not in out
+
+    def test_backreference_in_question_does_not_raise(self):
+        out = _inject_share_qa_meta(SHELL, _meta(title=r"什么是\1空？"))
+        assert 'property="og:title"' in out
+
+    def test_legitimate_content_is_still_rendered(self):
+        """The fix must not break normal Chinese/punctuation content."""
+        out = _inject_share_qa_meta(SHELL, _meta(title="什么是「空」？", og_description="缘起性空 & 中道"))
+        assert "什么是「空」？" in out
+        assert "&amp;" in out  # the & was escaped, not dropped
+        assert re.search(r'<meta property="og:title" content="[^"]*"', out)


### PR DESCRIPTION
## 漏洞

`_inject_meta` / `_inject_share_qa_meta` 用 `re.sub(pattern, repl, html)` 把用户可控字符串拼进 SPA 外壳。**字符串形式的 `repl` 是「替换模板」**——`re` 会解释其中的转义序列，所以八进制转义能绕过只过滤 `& " < >` 的 `_escape_meta_value`，并在过滤**之后**还原成元字符：

```
\074 → <     \076 → >     \042 → "
```

`POST /api/share/qa` 用的是 `get_optional_user`（**无需登录**），任何人都能存一段载荷，然后让 fojin.app 域名下的 `<head>` 渲染出任意标签——例如跳转到攻击者站点的 `<meta http-equiv="refresh">`。

实测复现（载荷通过过滤时不含任何 `<`、`>`、`"`）：

```
<meta name="description" content=""><meta http-equiv="refresh" content="0;url=https://evil.io">" />
```

CSP（无 `unsafe-inline`）挡住了脚本执行，但挡不住注入、跳转和篡改。

**附带的 DoS**：载荷中含 `\1` 会抛 `re.error: invalid group reference`，那个分享页从此永久 500。

## 修复

1. 新增 `_sub_literal()`，向 `.sub()` 传**可调用对象**——`re` 永不解析可调用形式的替换。七处嵌入用户数据的调用点全部改用它（title、description、robots、canonical ×2、SEO 正文块、JSON-LD、og 标签）。
2. `_escape_meta_value` 补上 `\` 与 `'` 的转义作为纵深防御，避免将来有人再引入模板式 `.sub()` 时重新踩雷。

> 注：`seo.py` 的 fallback 路径**一直是安全的**——它用普通 f-string 拼接，不解释转义。不要"顺手修"它。

## 测试

`tests/test_seo_meta_injection.py` 共 13 例：逐字段的八进制转义、title 元素逃逸、组引用 DoS，以及一条确保正常中文/标点内容仍能正确渲染的回归护栏。

修复后用**原始攻击载荷**复测：载荷成为属性内的惰性文本，不形成任何标签；三个 DoS 变体均不再抛异常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvgT37UH7QMswKfhqgutCF