### PR TITLE
perf(sitemap): 修掉让 /sitemap.xml 变成 20 秒请求的 count(DISTINCT)

### DIFF
--- a/backend/app/api/seo_dict.py
+++ b/backend/app/api/seo_dict.py
@@ -390,5 +390,16 @@ async def get_distinct_headwords(
 
 
 async def count_distinct_headwords(db: AsyncSession) -> int:
-    stmt = select(func.count(func.distinct(DictionaryEntry.headword)))
-    return (await db.execute(stmt)).scalar() or 0
+    """Number of distinct headwords — decides how many sitemap-dict batches exist.
+
+    Deliberately ``GROUP BY`` rather than the obvious
+    ``count(distinct headword)``. PostgreSQL cannot use an index for
+    ``count(DISTINCT ...)`` — it sorts or hash-aggregates every row — whereas
+    the grouped subquery reduces over ``ix_dictionary_entries_headword``.
+    Measured on production (747,539 rows / 553,678 distinct headwords):
+    13,691 ms before, 1,514 ms after, identical result. That single query was
+    essentially the whole ~20s ``/sitemap.xml`` response, which is the
+    crawler's entry point to the entire site.
+    """
+    subq = select(DictionaryEntry.headword).group_by(DictionaryEntry.headword).subquery()
+    return (await db.execute(select(func.count()).select_from(subq))).scalar() or 0

--- a/backend/tests/test_sitemap_dict_count.py
+++ b/backend/tests/test_sitemap_dict_count.py
@@ -1,0 +1,65 @@
+"""Characterisation tests for the dictionary headword count.
+
+`count_distinct_headwords` decides how many `/sitemap-dict-N.xml` batches the
+sitemap index advertises, so its value has to stay exact — an undercount
+silently drops dictionary pages out of the index.
+
+These pin the behaviour so the query underneath can be rewritten for speed.
+On production (747,539 rows / 553,678 distinct headwords) the original
+`count(DISTINCT headword)` took 13.7s, which was essentially the whole
+20s `/sitemap.xml` response; `GROUP BY` returns the identical number in 1.5s
+because PostgreSQL will not use an index for `count(DISTINCT ...)`.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.api.seo_dict import count_distinct_headwords
+from app.models.dictionary import DictionaryEntry
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(DictionaryEntry.__table__.create)
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db, pairs):
+    """pairs: (headword, source_id)"""
+    for i, (hw, src) in enumerate(pairs):
+        db.add(DictionaryEntry(headword=hw, source_id=src, lang="zh", external_id=f"e{i}"))
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_empty_table_is_zero(db):
+    assert await count_distinct_headwords(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_counts_each_headword_once(db):
+    await _seed(db, [("空", 1), ("般若", 1), ("涅槃", 1)])
+    assert await count_distinct_headwords(db) == 3
+
+
+@pytest.mark.asyncio
+async def test_same_headword_across_sources_counts_once(db):
+    """The real table has ~747k rows but only ~554k distinct headwords —
+    the same term defined by several dictionaries. Collapsing those is the
+    entire point of the DISTINCT."""
+    await _seed(db, [("空", 1), ("空", 2), ("空", 3), ("般若", 1), ("般若", 2)])
+    assert await count_distinct_headwords(db) == 2
+
+
+@pytest.mark.asyncio
+async def test_headwords_differing_only_by_case_or_space_are_distinct(db):
+    """No normalisation is applied — the count must match what
+    get_distinct_headwords() actually paginates over."""
+    await _seed(db, [("Buddha", 1), ("buddha", 1), ("Buddha ", 1)])
+    assert await count_distinct_headwords(db) == 3


### PR DESCRIPTION
## 问题

`/sitemap.xml` 稳定耗时 **~20.5 秒**，而其他 SEO 端点都在 1 秒内：

| 端点 | 耗时 |
|---|---|
| `/robots.txt` | 0.75s |
| `/feed.xml` | 0.97s |
| `/sitemap-static.xml` | 0.63s |
| **`/sitemap.xml`** | **20.5s** |

sitemap 索引是爬虫进入整站的入口。对一个价值高度依赖 SEO 的产品来说，这在持续拖累收录。

## 定位

在生产库上逐条给索引路由的三次查询计时：

```
count(*) buddhist_texts                 10,531 行      3.4 ms
count(*) kg_entities WHERE person       43,755 行     96.8 ms
count(DISTINCT headword)               553,678 行  13,691 ms   ← 就是它
```

绕过 CDN 和 nginx 直连后端也是 13-16 秒，所以这一条查询基本就是整个响应耗时。

## 原因与修复

**PostgreSQL 对 `count(DISTINCT ...)` 用不上索引**——它会对全部 747,539 行做排序或哈希聚合。改成分组子查询后，可以在既有的 `ix_dictionary_entries_headword` 上做归约。

用 SQLAlchemy 实际生成的 SQL 在生产上验证：

```
修复前: 13,691 ms
修复后:  1,398 ms   (Index Only Scan，快 9.8 倍)
两者结果均为 553,678 —— 完全一致
```

执行计划确认走了 `Index Only Scan using ix_dictionary_entries_headword`。

## 为什么需要精确值（不能用估算）

这个计数决定索引里声明多少个 `/sitemap-dict-N.xml` 分片，少算会**静默丢掉词典页**。所以不能换成 `reltuples` 之类的估算。

`tests/test_sitemap_dict_count.py` 锁定了行为（跨来源的同一词头只计一次、不做任何归一化），并且**先在旧实现上跑通**才替换实现——这是性能重构而非行为变更。

## 预期与后续

端点应从 ~20.5s 降到 ~2-3s。

另外单独提一句：该 URL 的 `cf-cache-status` 是 **DYNAMIC**，尽管响应带了 `Cache-Control: public, max-age=3600`——也就是说每一次爬虫访问都打到源站。加一条 Cloudflare Cache Rule 可以让它彻底不落源站，但那是控制台操作，不在这个 PR 范围内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvgT37UH7QMswKfhqgutCF