### PR TITLE
fix(ui): 修复 React 19 下 antd 静态 message/Modal 全面失效(注册、退出登录等 80+ 处)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@ant-design/charts": "^2.6.7",
+        "@ant-design/v5-patch-for-react-19": "^1.0.3",
         "@deck.gl/core": "^9.3.6",
         "@deck.gl/layers": "^9.3.6",
         "@deck.gl/react": "^9.3.6",
@@ -242,6 +243,20 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@ant-design/v5-patch-for-react-19": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/v5-patch-for-react-19/-/v5-patch-for-react-19-1.0.3.tgz",
+      "integrity": "sha512-iWfZuSUl5kuhqLUw7jJXUQFMMkM7XpW7apmKzQBQHU0cpifYW4A79xIBt9YVO5IBajKpPG5UKP87Ft7Yrw1p/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "antd": ">=5.22.6",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0"
       }
     },
     "node_modules/@antv/algorithm": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@ant-design/charts": "^2.6.7",
+    "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@deck.gl/core": "^9.3.6",
     "@deck.gl/layers": "^9.3.6",
     "@deck.gl/react": "^9.3.6",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,12 @@
+// MUST be imported before any antd usage. antd v5's static methods
+// (message.*, notification.*, Modal.confirm/info/...) internally rely on the
+// legacy ReactDOM.render, which React 19 removed — so on React 19 they
+// silently do nothing: no toast, no confirm dialog. This patch calls antd's
+// unstableSetRender to bridge them to React 19's createRoot. Without it,
+// registration feedback, logout confirmation, and ~80 other feedback call
+// sites across the app render nothing. See the react group bump (165f3f2,
+// 2026-07-03) that introduced React 19.
+import "@ant-design/v5-patch-for-react-19";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/frontend/src/test/antdStaticMethods.test.tsx
+++ b/frontend/src/test/antdStaticMethods.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { message, Modal } from "antd";
+
+// Regression guard for the React 19 + antd v5 static-method incompatibility.
+// antd's static message/Modal/notification rely on the legacy ReactDOM.render,
+// removed in React 19, so without @ant-design/v5-patch-for-react-19 they render
+// nothing — silently breaking registration feedback, logout confirmation, and
+// ~80 other call sites. The patch is imported in src/test/setup.ts to mirror
+// main.tsx; remove it and both assertions below fail (verified RED→GREEN).
+describe("antd static overlays render on React 19", () => {
+  beforeEach(() => message.destroy());
+  afterEach(() => {
+    message.destroy();
+    document.body.querySelectorAll(".ant-message, .ant-modal-root").forEach((n) => n.remove());
+  });
+
+  it("message.success renders a toast", async () => {
+    message.success("hello-toast-marker");
+    await waitFor(() => expect(document.body.textContent).toContain("hello-toast-marker"));
+  });
+
+  it("Modal.confirm renders a confirm dialog", async () => {
+    Modal.confirm({ title: "confirm-marker", content: "body" });
+    await waitFor(() => {
+      expect(document.querySelector(".ant-modal-confirm")).not.toBeNull();
+      expect(document.body.textContent).toContain("confirm-marker");
+    });
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,4 +1,8 @@
 import "@testing-library/jest-dom/vitest";
+// Mirror main.tsx: bridge antd v5's static message/Modal/notification methods
+// to React 19's render API. Without it these render nothing (see
+// src/test/antdStaticMethods.test.tsx and main.tsx).
+import "@ant-design/v5-patch-for-react-19";
 // Initialize i18n for component tests — zh resources are bundled inline, so
 // t() resolves synchronously. Pin the language so jsdom's navigator locale
 // (en-US) can't flip tests to a backend-loaded locale.


### PR DESCRIPTION
## 症状

用户反馈:**点「注册」没反应**、**点「退出登录」没反应、退不出去**。

## 根因

依赖组升级到 React 19(提交 `165f3f2`,**2026-07-03**)静默打断了全站的 antd v5 静态覆盖层。antd 的静态 `message.*`、`Modal.confirm/info/…`、`notification.*` 内部通过已被 React 19 移除的 `ReactDOM.render` 挂载——所以**过去三周它们什么都不渲染**:没有 toast、没有确认框、没有报错。

已复现的用户影响:
- **注册「没反应」**:请求其实成功、账号也建了,但 `message.success/error` 不渲染,用户看不到任何确认;遇到 409 重复时也看不到任何报错。生产日志显示近 12 小时真实注册 100% 是 409,而用户从未看到提示。
- **退出登录「没反应」**:`handleLogout` 用 `Modal.confirm` 弹确认框 → 确认框永不渲染 → `onOk` 里的 `logout()` 永不执行。
- 全站 **81 处**静态方法调用点、20+ 文件受影响(聊天错误提示、书签、反馈、管理操作、引用生成…)。

## 修复

引入官方补丁 `@ant-design/v5-patch-for-react-19`,在 `main.tsx` 首部、任何 antd 使用之前导入一次。它调用 antd 的 `unstableSetRender` 把静态方法桥接到 React 19 的 `createRoot`,**一次性修好全部 81 处**——这是 antd 官方给出的 v5 + React 19 方案。

## 回归护栏

`src/test/antdStaticMethods.test.tsx` 断言 `message.success` 和 `Modal.confirm` 真的挂载进 DOM。已验证 **RED→GREEN**:测试 setup 里没有补丁时两条都失败,有补丁时都通过。`setup.ts` 导入该补丁以镜像 `main.tsx`。

## 说明

我最初怀疑是「陈旧缓存/Service Worker」——**那个判断是错的**。此 bug 在干净浏览器的当前线上版本、以及 React 19 测试环境里都能复现,是全体用户都中招的真回归。

全套前端门禁通过:241 测试、tsc、eslint、i18n ratchet、build。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvgT37UH7QMswKfhqgutCF