### PR TITLE
test(smoke): 加一条真实用户流程测试,守住 antd 反馈层(防 React 19 那类回归)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -119,6 +119,12 @@ jobs:
       - name: Run smoke suite
         env:
           BASE_URL: ${{ github.event.inputs.base_url || 'https://fojin.app' }}
+          # Optional: a dedicated production test account enables the full
+          # logout-flow check in auth-feedback.spec.ts (which exercises
+          # Modal.confirm + real sign-out). Absent → that test skips, the rest
+          # still run. The always-on failed-login check needs no account.
+          SMOKE_USER: ${{ secrets.SMOKE_USER }}
+          SMOKE_PASSWORD: ${{ secrets.SMOKE_PASSWORD }}
         run: npx playwright test
 
       - name: Upload traces on failure

--- a/e2e/tests/auth-feedback.spec.ts
+++ b/e2e/tests/auth-feedback.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Guards the incident that shipped 2026-07-03 and stayed live for three weeks:
+ * a React 19 bump silently broke every antd v5 static overlay (message.*,
+ * Modal.confirm, notification.*), because they mount via the legacy
+ * ReactDOM.render that React 19 removed. Register and logout gave "no
+ * response" — the request ran, but no toast and no confirm dialog rendered —
+ * across ~80 call sites. Fixed by @ant-design/v5-patch-for-react-19 (#1028).
+ *
+ * A unit test (frontend/src/test/antdStaticMethods.test.tsx) already asserts
+ * message/Modal mount in jsdom. These are the *production* guards: only a real
+ * browser hitting real prod catches "the patch was dropped from the bundle".
+ *
+ * Selectors are locale-agnostic: a fresh browser resolves the UI to English,
+ * so placeholders read "Username"/"Password", not "用户名"/"密码".
+ */
+
+const USERNAME = /用户名|username/i;
+const PASSWORD = /密码|password/i;
+
+// Login with credentials that cannot authenticate. This is the safe probe:
+// no account is created, no state changes, a failed login is harmless — yet
+// the failure path calls antd's static message.error, which renders nothing
+// if the React 19 patch regresses. Covers the shared root cause behind the
+// register/logout/notification breakage (all go through the same static
+// render bridge the patch installs).
+test("a failed login surfaces an antd toast (React 19 static-method guard)", async ({ page }) => {
+  await page.goto("/login");
+
+  await page.getByPlaceholder(USERNAME).fill(`smoke_nouser_${Date.now()}`);
+  await page.getByPlaceholder(PASSWORD).fill("this-password-cannot-be-correct");
+  await page.locator('button[type="submit"]').click();
+
+  // If antd's static message is dead (React 19 without the patch), this notice
+  // never mounts and the test fails — exactly the signal that was missing for
+  // three weeks.
+  await expect(page.locator(".ant-message-notice")).toBeVisible({ timeout: 10_000 });
+});
+
+// Full logout flow, exercising Modal.confirm (the other overlay the incident
+// killed) and a real sign-out. Needs a dedicated production test account —
+// set SMOKE_USER / SMOKE_PASSWORD as repo secrets and pass them into the smoke
+// workflow's env to enable. Skipped (not failed) when absent, so the suite
+// stays green out of the box.
+test("logout shows the confirm dialog and signs out (needs SMOKE_USER)", async ({ page }) => {
+  const user = process.env.SMOKE_USER;
+  const pass = process.env.SMOKE_PASSWORD;
+  test.skip(!user || !pass, "set SMOKE_USER / SMOKE_PASSWORD to enable the logout-flow check");
+
+  await page.goto("/login");
+  await page.getByPlaceholder(USERNAME).fill(user!);
+  await page.getByPlaceholder(PASSWORD).fill(pass!);
+  await page.locator('button[type="submit"]').click();
+
+  // Logged in: the success toast rendered and the user menu button appears.
+  await expect(page.locator(".ant-message-notice")).toBeVisible({ timeout: 10_000 });
+  const userMenu = page.getByRole("button", { name: /用户菜单|user menu/i });
+  await expect(userMenu).toBeVisible({ timeout: 10_000 });
+
+  // Open the dropdown and click Log out. Playwright dispatches real browser
+  // events, so antd's menu onClick fires (unlike synthetic clicks).
+  await userMenu.hover();
+  await page.getByRole("menuitem", { name: /退出登录|log ?out/i }).click();
+
+  // THE guard: handleLogout opens Modal.confirm; its onOk calls logout(). If
+  // the dialog does not render, sign-out can never happen — the exact bug.
+  const confirm = page.locator(".ant-modal-confirm");
+  await expect(confirm).toBeVisible({ timeout: 10_000 });
+  await confirm.locator(".ant-modal-confirm-btns button").last().click();
+
+  // Signed out: the header shows the login entry again.
+  await expect(page.getByRole("button", { name: /^\s*登\s*录\s*$|^\s*log ?in\s*$/i })).toBeVisible({
+    timeout: 10_000,
+  });
+});


### PR DESCRIPTION
## 背景

React 19 升级(`165f3f2`)静默打断了 antd 静态 `message`/`Modal.confirm`,注册和退出登录「没反应」,**三周没被发现**——因为 CI 只验证「能构建、导入能解析」,**验证不了「点了有没有可见反馈」**。这正是生产 smoke 套件存在的意义(「单测和 curl 结构上抓不到的真实访客交互」)。

## 新增 `e2e/tests/auth-feedback.spec.ts`

**① 始终运行、零配置、零污染**:用错误凭证登录,断言出现 antd toast。失败路径调用静态 `message.error`——若 React 19 补丁回归,它什么都不渲染、toast 不出现,smoke 直接变红。**不建账号、不改状态、不需密钥。已针对生产验证通过(补丁在线时 PASS)。** 覆盖全部 ~80 处被打断调用点的共同根因。

**② 可选的完整登出流程**:设了 `SMOKE_USER` / `SMOKE_PASSWORD`(一个专用生产测试账号)后,它会登录→打开用户菜单→点退出→断言 `Modal.confirm` 弹出且成功登出——直接覆盖事故打断的另一个覆盖层。没有密钥时**跳过而非失败**;`smoke.yml` 已接好从仓库密钥传入。

## 为什么两层都要

- 前端单测 `antdStaticMethods.test.tsx` 在组件层守住同一回归(每个 PR 都跑)。
- 这条 smoke 守住「补丁是否真的编进了部署的 bundle」——只有真浏览器打真生产才抓得到。

选择器做了双语兼容(全新浏览器会把 UI 解析成英文,占位符是 Username/Password)。

## 如何启用完整登出检查(可选)

在仓库 Settings → Secrets 加 `SMOKE_USER` / `SMOKE_PASSWORD`(建一个专用测试账号),测试 ② 即自动激活。不加则保持跳过。

> 说明:smoke 打的是生产,所以**没有做「注册新账号」的测试**——那会每次往生产库灌测试账号且无法清理。用「失败登录出 toast」达到同样的回归检测效果,零副作用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvgT37UH7QMswKfhqgutCF