### PR TITLE
fix(theme,a11y): dark contrast near-miss + timeline baseline (review follow-up 3/3)

### DIFF
--- a/frontend/src/components/kg/KGTimeline.tsx
+++ b/frontend/src/components/kg/KGTimeline.tsx
@@ -359,7 +359,7 @@ export default function KGTimeline({
                 y1={baselineY}
                 x2={width - PADDING.right}
                 y2={baselineY}
-                stroke="var(--fj-border)"
+                stroke="var(--fj-bg-alt)"
                 strokeWidth={1}
               />
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -36,7 +36,7 @@
   --fj-bg-alt:    #3c342a;
   --fj-ink:       #efe8db;
   --fj-ink-light: #d2c7b1;
-  --fj-ink-muted: #bdb29b;
+  --fj-ink-muted: #c6bca6;
   --fj-accent:    #e5764a;
   --fj-gold:      #d6b579;
   --fj-border:    #60553f;
@@ -46,7 +46,7 @@
   --fj-timeline-band-a: #3c342a;
   --fj-timeline-band-b: #544a3a;
   --fj-sand-light:      #3d342a;
-  --fj-text-secondary:  #bdb29b;
+  --fj-text-secondary:  #c6bca6;
   --fj-accent-hover:    #ef8a5f;
   color-scheme: dark;
 }

--- a/frontend/src/theme/antdTheme.ts
+++ b/frontend/src/theme/antdTheme.ts
@@ -18,7 +18,7 @@ export function buildAntdTheme(isDark: boolean): ThemeConfig {
       colorBgElevated: "#544a3a",
       colorBorder: "#60553f",
       colorText: "#efe8db",
-      colorTextSecondary: "#bdb29b",
+      colorTextSecondary: "#c6bca6",
     },
     components: {
       // antd's Layout Header/Footer do NOT follow colorBgBase — they need their


### PR DESCRIPTION
Review follow-up item ③. Small, safe polish:
- **Contrast:** dark secondary text (`--fj-ink-muted`/`--fj-text-secondary`/antd `colorTextSecondary`) `#bdb29b`→`#c6bca6` — clears WCAG AA on the elevated `surface-alt` (4.14:1 → 4.61:1). The accent-on-card 3.35:1 near-miss is intentionally left: accent on cards is only the large icon (AA-large ✓), and brightening it would break white-on-accent buttons.
- **Light-preservation:** KGTimeline axis baseline back toward `--fj-bg-alt` (≈ the original light hairline) instead of the heavier `--fj-border`.
- The remaining review-flagged light deltas are truly sub-perceptual (≤5% alpha, ≤1–2 RGB snaps) or net improvements (e.g. an over-light muted label darkened); documented, not churned.

tsc/lint/tokens+theme tests green. Light mode byte-identical for these; dark secondary text slightly brighter (improvement).