### PR TITLE
chore(deps): react-router v6→v7.18.1 (fixes advisories, drops waiver)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,20 +141,10 @@ jobs:
         run: npm ci
 
       - name: Run npm audit
-        # --audit-level=high: block on high/critical; treat moderate/low as
-        # informational (still visible in the JSON report + full audit below).
-        # Waiver reason — react-router GHSA-wrjc-x8rr-h8h6 (open redirect via
-        #   backslash in <Link>/useNavigate) and GHSA-337j-9hxr-rhxg (constructor
-        #   injection in SSR-hydration deserializeErrors) are both *moderate* and
-        #   fixed only by react-router-dom 7.x, a breaking major upgrade. FoJin's
-        #   frontend is a client-side Vite SPA (no react-router SSR hydration), so
-        #   GHSA-337j does not apply; GHSA-wrjc is low-relevance (no user-controlled
-        #   URLs passed to Link/navigate). Tracked for a proper v7 migration; until
-        #   then don't fail CI on these moderates or block unrelated PRs.
-        run: |
-          npm audit --omit=dev --audit-level=high
-          echo "--- full prod advisories (informational, does not gate) ---"
-          npm audit --omit=dev || true
+        # Strict gate restored: the react-router moderates that #1038 waived
+        # (GHSA-wrjc-x8rr-h8h6 / GHSA-337j-9hxr-rhxg) are fixed by the v7 upgrade
+        # (react-router-dom 7.18.1), so `npm audit --omit=dev` is clean again.
+        run: npm audit --omit=dev
 
       - name: Run npm audit (JSON report)
         if: always()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "react-i18next": "^17.0.10",
         "react-map-gl": "^8.1.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.1",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "zustand": "^5.0.2"
@@ -3408,15 +3408,6 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
@@ -6110,7 +6101,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12104,36 +12094,48 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
+    },
+    "node_modules/react-router/node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "react-i18next": "^17.0.10",
     "react-map-gl": "^8.1.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.1",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "zustand": "^5.0.2"


### PR DESCRIPTION
## What
Migrates `react-router-dom` **6.30.4 → 7.18.1**, the real fix for the two moderate advisories (GHSA-wrjc-x8rr-h8h6, GHSA-337j-9hxr-rhxg) that #1038 temporarily waived. Restores the strict frontend `npm audit --omit=dev` gate (now 0 vulns).

## Why it's low-risk
FoJin is a client-side Vite SPA using only **library-mode** react-router APIs — `Routes`/`Route`/`Link`/`Navigate`/`Outlet` + `useNavigate`/`useParams`/`useSearchParams`/`useLocation`. **No** data-router loaders/actions/fetchers, no `defer`/`json`, no `future` flags. v7 library mode is a near-drop-in from v6 for exactly this surface.

## Verification
- `tsc` clean (no type breakage), ESLint clean, `vite build` OK.
- **All 250 vitest tests pass unchanged** (incl. the many MemoryRouter-rendered component tests).
- In-browser: home renders, SPA `navigate()` (/ → /sources) works client-side, no react-router console warnings/errors (only a pre-existing React-19 `element.ref` deprecation, unrelated).
- `npm audit --omit=dev` → **0 vulnerabilities**; strict CI gate restored (reverts the #1038 waiver).