### PR TITLE
chore(ui): hide standalone 跨藏对照 board from public nav (not polished yet)

### DIFF
--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import Layout from "./Layout";
 
@@ -21,14 +21,13 @@ function renderLayout() {
 }
 
 describe("Layout 顶部导航", () => {
-  // 跨藏对照（1,016 部经 · 91 万组逐段对照）此前只能靠猜 URL 到达：
-  // 页面早就建好并跑在生产上，但导航里没有任何入口。
-  it("跨藏对照有导航入口，点击进入 /cross-canon", () => {
+  // 跨藏对照独立浏览页(/cross-canon)暂从导航撤下：板块呈现效果待打磨，打磨后再
+  // 对外公开。路由仍可 URL 直达，但顶部导航不应出现入口(与 dashboard/research 等
+  // 隐藏项一致)。取消 Layout 中对应注释即可恢复本入口——届时把此断言改回点击导航。
+  it("跨藏对照暂不在顶部导航出现（板块待打磨）", () => {
     renderLayout();
 
-    fireEvent.click(screen.getByText("跨藏对照"));
-
-    expect(screen.getByTestId("pathname")).toHaveTextContent("/cross-canon");
+    expect(screen.queryByText("跨藏对照")).not.toBeInTheDocument();
   });
 
   // 开放数据(/exports)已从导航撤下：后端 /api/exports/* 由 ENABLE_OPEN_DATA_EXPORTS

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,7 +15,7 @@ import {
   RobotOutlined,
   GithubOutlined,
   GlobalOutlined,
-  TranslationOutlined,
+  // TranslationOutlined,  // cross-canon nav hidden (板块待打磨；路由仍可直达 /cross-canon)
   // DownloadOutlined,   // exports nav hidden (开放数据 暂不对外公开)
   // ExperimentOutlined,  // research nav hidden (研究助手 待重构后再上线)
   // BarChartOutlined,   // dashboard nav hidden (数据总览 暂不对外公开)
@@ -82,10 +82,10 @@ export default function Layout() {
   }> = [
     { icon: <DatabaseOutlined />, label: t("nav.sources"), path: "/sources" },
     { icon: <RobotOutlined />, label: t("nav.chat"), path: "/chat" },
-    // 跨藏对照(/cross-canon)：1,016 部经 · 91 万组逐段跨语对照，是相对 CBETA /
-    // SuttaCentral 最硬的差异化。此前页面早就跑在生产上，导航里却没有入口，
-    // 只能靠 /collections 里的对照表或手敲 URL 到达。
-    { icon: <TranslationOutlined />, label: t("nav.cross_canon"), path: "/cross-canon" },
+    // 跨藏对照(/cross-canon)专属浏览页暂从导航撤下：独立板块当前呈现效果不佳，
+    // 打磨后再对外公开。路由仍可直达 /cross-canon（供直达/测试），阅读器内的
+    // 跨藏对照面板、文本详情段级入口、搜索藏/梵徽章等集成功能不受影响。
+    // { icon: <TranslationOutlined />, label: t("nav.cross_canon"), path: "/cross-canon" },
     // 研究助手(/research)暂从导航撤下：当前输出偏"更长的问答"，未凸显跨藏对比这一
     // 差异化，等重构(跨藏对比表 + 内联可点证据 + 流式)后再上线。后端 API 与
     // fojin-mcp 保留，/research 路由仍可直达。

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -370,13 +370,15 @@ function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useN
             </tbody>
           </table>
         </div>
+        {/* 「查看全部」原跳转独立跨藏对照浏览页(/cross-canon)；该板块暂从对外入口
+            撤下(待打磨)，故隐藏此链接。上方表格各行仍跳阅读器逐段对照(集成功能，保留)。
         {groups.length > TOP_N && (
           <p style={{ fontSize: 12, margin: "12px 0 0" }}>
             <a onClick={() => navigate("/cross-canon")} style={{ cursor: "pointer", color: "var(--fj-accent)" }}>
               {t("collections.alignment_more", { n: TOP_N, total: groups.length })} →
             </a>
           </p>
-        )}
+        )} */}
       </div>
     </div>
   );


### PR DESCRIPTION
The standalone **跨藏对照** browse page (`/cross-canon`) isn't visually polished enough to expose publicly yet. This removes its two discoverable entry points:
- header **nav item** (Layout.tsx)
- the **'查看全部'** link on /collections that pointed to the board

Follows the repo's established hidden-nav pattern (dashboard/research/exports): the `/cross-canon` **route stays reachable by URL** for direct access/testing — just not discoverable.

**Deliberately untouched** (contextual features, not the standalone board): the reader's cross-canon parallel panel, the text-detail segment-entry card, search 藏/梵 parallel badges, citation-drawer parallels, and the /collections alignment discovery table (its rows open the reader, not the board).

tsc/lint/build/i18n green. Verified in-browser: nav no longer shows 跨藏对照; /cross-canon still loads by URL.