### PR TITLE
fix(ui): 修复暗色下读不清的文字——筛选条灰字 + accent/gold 实底白字

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -168,7 +168,9 @@ export default function Layout() {
           e.currentTarget.style.width = "auto";
           e.currentTarget.style.height = "auto";
           e.currentTarget.style.overflow = "visible";
-          e.currentTarget.style.background = "#fff";
+          e.currentTarget.style.background = "var(--fj-surface)";
+          e.currentTarget.style.color = "var(--fj-ink)";
+          e.currentTarget.style.border = "1px solid var(--fj-gold)";
           e.currentTarget.style.padding = "8px 16px";
           e.currentTarget.style.borderRadius = "4px";
           e.currentTarget.style.boxShadow = "0 2px 8px rgba(0,0,0,0.15)";
@@ -358,7 +360,7 @@ export default function Layout() {
               type="text"
               icon={<LoginOutlined />}
               style={{
-                color: "#fff",
+                color: "var(--fj-on-accent)",
                 background: accent,
                 borderRadius: 4,
                 fontSize: 12,

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -74,7 +74,7 @@ export default function ResearchPage() {
       {!user ? (
         <div className="rp-login">
           <p>{t("research.login_required")}</p>
-          <Link className="rp-login-btn" to="/login">{t("nav.login")}</Link>
+          <Link className="rp-login-btn" to="/login">{t("auth.login")}</Link>
         </div>
       ) : (
         <>

--- a/frontend/src/pages/SharedQAPage.tsx
+++ b/frontend/src/pages/SharedQAPage.tsx
@@ -112,7 +112,7 @@ export default function SharedQAPage() {
           style={{
             display: "inline-block",
             fontSize: 12,
-            color: "#fff",
+            color: "var(--fj-on-accent)",
             background: "var(--fj-accent, #8b2500)",
             padding: "3px 12px",
             marginBottom: 12,
@@ -143,7 +143,7 @@ export default function SharedQAPage() {
             alignItems: "center",
             gap: 6,
             fontSize: 12,
-            color: "#fff",
+            color: "var(--fj-on-gold)",
             background: "var(--fj-gold, #b08d57)",
             padding: "3px 12px",
             marginBottom: 12,

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -215,7 +215,7 @@ export default function TextDetailPage() {
               href={cbetaUrl}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ background: "var(--fj-accent)", borderColor: "var(--fj-accent)", color: "#fff" }}
+              style={{ background: "var(--fj-accent)", borderColor: "var(--fj-accent)", color: "var(--fj-on-accent)" }}
             >
               {t("textDetail.readOnCbeta")}
             </Button>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -27,6 +27,13 @@
   --fj-sand-light:      #faf7f2;  /* search result/empty-state panels */
   --fj-text-secondary:  #999999;  /* reader secondary text */
   --fj-accent-hover:    #a03000;  /* dictionary/search button hover (darker maroon) */
+  /* Text/icon placed ON a solid accent or gold background. Light: the accent is a
+     deep maroon, so white reads (8.9:1). Dark: the accent/gold are BRIGHT, so white
+     would fail (2.99:1 / 1.95:1) — use a deep warm ink instead (5.6:1 / 8.5:1). */
+  --fj-on-accent:       #ffffff;
+  /* Text ON a solid GOLD background. Gold is light in BOTH themes, so white never
+     works there (3.09:1 light / 1.95:1 dark) — both sides take a deep warm ink. */
+  --fj-on-gold:         #2e2415;
 }
 
 :root[data-theme="dark"] {
@@ -48,6 +55,8 @@
   --fj-sand-light:      #3d342a;
   --fj-text-secondary:  #c6bca6;
   --fj-accent-hover:    #ef8a5f;
+  --fj-on-accent:       #17120d;
+  --fj-on-gold:         #17120d;
   color-scheme: dark;
 }
 

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -276,7 +276,7 @@
   height: 100%;
   padding: 0 24px;
   background: var(--fj-accent);
-  color: #fff;
+  color: var(--fj-on-accent);
   border: none;
   cursor: pointer;
   font-family: "Noto Serif SC", serif;

--- a/frontend/src/styles/kg.css
+++ b/frontend/src/styles/kg.css
@@ -246,7 +246,7 @@
 .kg-chip.active {
   background: var(--fj-gold);
   border-color: var(--fj-gold);
-  color: #fff;
+  color: var(--fj-on-gold);
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/styles/master-gallery.css
+++ b/frontend/src/styles/master-gallery.css
@@ -48,7 +48,7 @@
 .mg-chip[aria-pressed="true"] {
   background: var(--fj-accent, var(--fj-accent));
   border-color: var(--fj-accent, var(--fj-accent));
-  color: #fff;
+  color: var(--fj-on-accent);
 }
 
 .mg-chip-n {

--- a/frontend/src/styles/research.css
+++ b/frontend/src/styles/research.css
@@ -28,7 +28,7 @@
   align-items: center;
   gap: 6px;
   background: var(--fj-gold);
-  color: #fff;
+  color: var(--fj-on-gold);
   border: none;
   border-radius: 8px;
   padding: 10px 18px;

--- a/frontend/src/styles/search.css
+++ b/frontend/src/styles/search.css
@@ -258,7 +258,7 @@
 
 .s-card-btn-primary {
   background: var(--fj-accent);
-  color: #fff;
+  color: var(--fj-on-accent);
   border: 1px solid var(--fj-accent);
 }
 

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -42,11 +42,11 @@
   gap: 6px;
   padding: 6px 12px;
   border-radius: 999px;
-  border: 1px solid #e5dccb;
+  border: 1px solid var(--fj-border);
   background: var(--fj-surface);
   cursor: pointer;
   font-size: 13px;
-  color: #595959;
+  color: var(--fj-ink-light);
   transition: all 0.18s;
   line-height: 1.2;
 }
@@ -71,11 +71,11 @@
 .sources-cap-chip.is-active {
   background: var(--fj-gold, var(--fj-gold));
   border-color: var(--fj-gold, var(--fj-gold));
-  color: #fff;
+  color: var(--fj-on-gold);
 }
 
 .sources-cap-chip.is-active strong {
-  color: #fff;
+  color: var(--fj-on-gold);
 }
 
 /* color hints (inactive only — left border accent matches the badge color) */
@@ -592,11 +592,11 @@
 .sources-toggle-chip {
   height: 32px;
   padding: 0 14px;
-  border: 1px solid #d9d9d9;
+  border: 1px solid var(--fj-border);
   border-radius: 6px;
   background: var(--fj-surface);
   font-size: 13px;
-  color: #595959;
+  color: var(--fj-ink-light);
   cursor: pointer;
   transition: all 0.18s;
   white-space: nowrap;
@@ -610,7 +610,7 @@
 .sources-toggle-chip.is-active {
   background: var(--fj-gold);
   border-color: var(--fj-gold);
-  color: #fff;
+  color: var(--fj-on-gold);
   font-weight: 500;
 }
 

--- a/frontend/src/theme/antdTheme.ts
+++ b/frontend/src/theme/antdTheme.ts
@@ -19,6 +19,10 @@ export function buildAntdTheme(isDark: boolean): ThemeConfig {
       colorBorder: "#60553f",
       colorText: "#efe8db",
       colorTextSecondary: "#c6bca6",
+      // Text on SOLID primary (buttons): the dark accent is bright, so antd's
+      // default white label only reaches 2.99:1. A deep warm ink gives 6.2:1 — and
+      // still 4.6:1 on the duller #c16642 the dark algorithm derives for Search.
+      colorTextLightSolid: "#17120d",
     },
     components: {
       // antd's Layout Header/Footer do NOT follow colorBgBase — they need their


### PR DESCRIPTION
## 起因

用户反馈 https://fojin.app/sources "有些字太浅了 看不清"。在**生产页面**跑了一遍 WCAG 对比度审计（Chromium 计算值，逐元素取实际前景/背景），暗色下 **14 项不达标**，并顺着根因把**同类问题全站清了一遍**。

## 两类根因

**① 硬编码浅色灰压会翻转的背景**

`sources.css` 的筛选 chip 写死 `color:#595959`，背景却用 `var(--fj-surface)`（暗色会翻成 #4a4133）→ **1.43:1**。边框同样写死 `#e5dccb`/`#d9d9d9`。

**② 白字压亮底**

浅色下 accent 是深枣红，白字 8.89:1 没问题；但暗色下 accent 变亮（#e5764a），而 **gold 在两个主题下都是亮色**，白字只有 2.99:1 / 1.95:1。

## 解法：按底色分流的两个语义 token

| token | 浅色 | 暗色 | 用在 |
|---|---|---|---|
| `--fj-on-accent` | `#ffffff` | `#17120d` | 枣红/橙色实底（浅色下白字本来就对，保持不动） |
| `--fj-on-gold` | `#2e2415` | `#17120d` | 金色实底（两个主题都亮，两边都要深墨） |

暗色墨色取 `#17120d` 而非 `#241d15`：antd 的 `darkAlgorithm` 会把种子色 `#e0754a` 压成更暗的 `#c16642`（Search 的 `enterButton`），`#241d15` 在那上面只有 4.16:1，仍不达标。`#17120d` 三种底色全过：**4.62 / 6.16 / 9.43**。同时补 antd `colorTextLightSolid`，覆盖所有 primary 按钮。

## 实测对比（浏览器计算值）

| 元素 | 改前 | 改后 |
|---|---|---|
| 筛选 chip 文字/数字（暗） | 1.43 ✗ | **5.99** ✓ |
| 选中 chip 白字压金（暗） | 1.95 ✗ | **9.52** ✓ |
| 选中 chip 白字压金（**浅**） | 3.09 ✗ | **4.93** ✓ |
| 顶栏登录按钮（暗） | 2.99 ✗ | **6.22** ✓ |
| `生成直达` enterButton（暗） | 4.00 ✗ | **4.65** ✓ |
| 筛选 chip（浅，回归检查） | 7.00 | **7.95** ✓ |

**整页 AA 失败项：暗色 14 → 0，浅色 0。**

## 波及范围（不止 /sources）

首页搜索按钮、搜索结果卡按钮、知识图谱 chip、祖师长廊 chip、研究助手按钮、分享问答徽标、TextDetail 按钮、顶栏登录按钮，外加 skip link 聚焦态（原先写死白底又没设文字色，暗色下是链接蓝压深底）。

**刻意没动**：`ShareCard.tsx` 的 `#8b2500`/`#b08d57` 是固定浅色分享图，不随主题翻转，白字保持原样。

## 验证方式与一个坑

- 本地无后端 ⇒ chips 根本不渲染，页面审计"通过"是假象；改用把真实 chip 标记注入 DOM 量改后 CSS 的计算值。
- 路由级 CSS 分包 ⇒ `kg/master-gallery/research` 的样式在 /sources 上没加载，必须去各自路由验（已在 /research 实测 9.52 / 4.93）。
- `getComputedStyle` 对 `<a>` 的颜色有 **:visited 隐私谎报**，连内联 `!important` 都"改不动"读数——skip link 以截图渲染为准（深底+金边+浅字，正确）。

## 门禁

tsc ✓ · eslint ✓ · i18n ratchet ✓ · **vitest 250/250 ✓** · vite build ✓

## 附带（独立 commit）

`nav.login` 这个词条根本不存在，未登录访问 /research 时按钮直接显示字面量 `nav.login`。改用 `auth.login`。与配色无关，单独成一个 commit 便于回退。