### PR TITLE
fix(ui): 暗色下 antd 紫色 Tag 提亮至达标（/sources 的「影像」标签）

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -69,6 +69,14 @@
   background: var(--fj-surface) !important;
 }
 
+/* antd's dark purple preset is the one Tag colour that misses AA against its own
+   tag background (3.39:1 — the other presets land between 4.9:1 and 8.2:1), and
+   /sources paints every 影像 source with it. Lift the text to antd's purple-4,
+   which clears AA at 6.15:1 and sits in the same brightness band as its siblings. */
+:root[data-theme="dark"] .ant-tag-purple {
+  color: #b37feb;
+}
+
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
#1045 的收尾。合并后在**生产**上复验（本地没有后端 ⇒ 没有数据 ⇒ Tag 根本不渲染，这类问题本地跑不出来），发现一处残留。

## 问题

/sources 上每个「影像」类数据源都带一个 `ant-tag-purple`，暗色下文字 `#854eca` 压在自身底色 `#1a1325` 上只有 **3.39:1**（10px 小字，AA 要 4.5:1）。当前页面上有 **23 个**。

## 逐个量了 antd 暗色预设 Tag —— 紫色是唯一离群点

| 预设 | 示例 | 对比度 |
|---|---|---|
| **purple** | 影像 | **3.39** ✗ |
| blue | 可搜索 | 4.91 ✓ |
| cyan | 外站全文 | 7.13 ✓ |
| orange | API | 7.09 ✓ |
| green | 已入库 | 7.04 ✓ |
| default | 巡检未达 | 7.28 ✓ |
| gold | 访问受限 | 8.23 ✓ |

## 解法

文字提到 antd 自家的 **purple-4 `#b37feb`** → **6.15:1**。选它而不是刚好压线的 `#9a6ddb`（4.80），是因为 6.15 能回到其余 Tag 的 7.0–8.2 亮度区间，视觉上是一家人；蓝色 4.91 已达标，未动。

只加了一条 `:root[data-theme="dark"] .ant-tag-purple` 覆盖，浅色不受影响。

## 门禁

tsc ✓ · eslint ✓ · i18n ✓ · **vitest 250/250** ✓ · build ✓