### PR TITLE
fix(ui): 浅色下 antd 预设 Tag 提亮至达标（/sources 能力徽标）

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -77,6 +77,25 @@
   color: #b37feb;
 }
 
+/* The same problem, mirrored, in the DEFAULT theme: antd's light preset Tags put
+   colour-7 text on a colour-1 tint, which lands at 2.8–3.4:1 — under AA for the
+   10px badges /sources paints on all 617 source cards. Drop the four failing hues
+   one step down antd's own ramp (gold needs two; colour-8 only gets it to 3.1:1).
+   Blue (5.5:1), purple (8.9:1) and default (20:1) already clear AA — left alone so
+   the badges keep as much of antd's palette as legibility allows. */
+:root[data-theme="light"] .ant-tag-cyan {
+  color: #006d75; /* cyan-8   3.39 -> 5.82 */
+}
+:root[data-theme="light"] .ant-tag-orange {
+  color: #ad4e00; /* orange-8 3.34 -> 5.09 */
+}
+:root[data-theme="light"] .ant-tag-green {
+  color: #237804; /* green-8  3.37 -> 5.44 */
+}
+:root[data-theme="light"] .ant-tag-gold {
+  color: #874d00; /* gold-9   2.76 -> 6.53 */
+}
+
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
#1046 的镜像问题,而且影响更大——**浅色是默认主题**。

## 问题

antd 的浅色预设 Tag 用 **color-7 文字压 color-1 浅底**,10px 小字全线不达标(AA 要 4.5:1):

| 徽标 | 现状 | 数量 |
|---|---|---|
| cyan 外站全文 | 3.39 | ×57 |
| orange API | 3.34 | ×12 |
| green 已入库 | 3.37 | ×4 |
| orange 证书异常 | 3.34 | ×3 |
| gold 访问受限 | **2.76** | ×1 |

## 解法：沿 antd 自己的色阶下沉一档

| 色系 | 改为 | 改后 |
|---|---|---|
| cyan | `#006d75` (cyan-8) | **5.82** |
| orange | `#ad4e00` (orange-8) | **5.09** |
| green | `#237804` (green-8) | **5.44** |
| gold | `#874d00` (gold-**9**) | **6.53** |

gold 特意沉两档:gold-8 `#ad8b00` 只到 3.12,仍不达标。

blue 5.50 / purple 8.88 / default 20.12 本来就达标,**保持 antd 原色不动**,让徽标尽量留在 antd 调色板里。

## 验证

在生产页面注入这四条规则实测:**浅色整页 AA 失败项 → 0**,全族落在 5.09–8.88 的均匀区间。截图确认观感无异常。

选择器沿用 #1046 已验证可行的 `:root[data-theme="…"] + 类` 写法,**不用 `!important`**——这个组合的优先级足以压过 antd cssinjs 的 `:where()` 规则(#1046 上线后已在生产验证)。

## 门禁

tsc ✓ · eslint ✓ · i18n ✓ · **vitest 250/250** ✓ · build ✓