### PR TITLE
fix(ui): 管理后台趋势图与状态色在暗色下不可读（并修好浅色下同一批）

### DIFF
--- a/frontend/src/components/ReaderParallelPanel.tsx
+++ b/frontend/src/components/ReaderParallelPanel.tsx
@@ -70,7 +70,7 @@ function ParallelCardBody({ p }: { p: import("../api/client").CanonicalParallel 
           <div style={{ fontSize: 11, color: "#5b8c6b", marginBottom: 4, fontWeight: 500, display: "flex", justifyContent: "space-between" }}>
             <span>{t("reader.parallel.pali_original")}</span>
             {full?.pali_chars ? (
-              <span style={{ color: "#999", fontWeight: 400 }}>
+              <span style={{ color: "var(--fj-text-secondary)", fontWeight: 400 }}>
                 {t("reader.parallel.char_count", { n: full.pali_chars.toLocaleString() })}
               </span>
             ) : null}
@@ -93,7 +93,7 @@ function ParallelCardBody({ p }: { p: import("../api/client").CanonicalParallel 
         <div style={{ marginBottom: 10, padding: "8px 10px", background: "#fafafa", borderRadius: 4 }}>
           <div style={{ fontSize: 11, color: "#666", marginBottom: 4, fontWeight: 500, display: "flex", justifyContent: "space-between" }}>
             <span>English (Sujato)</span>
-            {full?.english_chars ? <span style={{ color: "#999", fontWeight: 400 }}>{full.english_chars.toLocaleString()} chars</span> : null}
+            {full?.english_chars ? <span style={{ color: "var(--fj-text-secondary)", fontWeight: 400 }}>{full.english_chars.toLocaleString()} chars</span> : null}
           </div>
           <div
             lang="en"
@@ -194,7 +194,7 @@ function CanonicalView({ textId }: { textId: number }) {
                   </span>
                 </div>
                 {p.note && (
-                  <div style={{ fontSize: 11, color: "#999" }}>{p.note}</div>
+                  <div style={{ fontSize: 11, color: "var(--fj-text-secondary)" }}>{p.note}</div>
                 )}
               </div>
             ),
@@ -324,7 +324,7 @@ function ChunkView({ textId, juanNum }: Props) {
                           </span>
                         )}
                         {hasDisplayConfidence(p) && (
-                          <span style={{ fontSize: 11, color: "#999", marginLeft: "auto" }}>
+                          <span style={{ fontSize: 11, color: "var(--fj-text-secondary)", marginLeft: "auto" }}>
                             {t("reader.parallel.confidence", { n: (p.confidence * 100).toFixed(0) })}
                           </span>
                         )}
@@ -352,7 +352,7 @@ function ChunkView({ textId, juanNum }: Props) {
                         </div>
                       )}
                       {isMitra ? (
-                        <div style={{ marginTop: 8, fontSize: 11, color: "#999" }}>
+                        <div style={{ marginTop: 8, fontSize: 11, color: "var(--fj-text-secondary)" }}>
                           MITRA · CC BY-SA 4.0
                         </div>
                       ) : (

--- a/frontend/src/components/kg-map/MapEntityPopup.tsx
+++ b/frontend/src/components/kg-map/MapEntityPopup.tsx
@@ -67,7 +67,7 @@ export default function MapEntityPopup({
         </div>
 
         {address && (
-          <div style={{ fontSize: 12, color: "#999", padding: "4px 14px 0", display: "flex", alignItems: "center", gap: 4 }}>
+          <div style={{ fontSize: 12, color: "var(--fj-text-secondary)", padding: "4px 14px 0", display: "flex", alignItems: "center", gap: 4 }}>
             <EnvironmentOutlined style={{ fontSize: 11 }} />
             {address}
           </div>

--- a/frontend/src/components/parallel/SentenceParallelView.tsx
+++ b/frontend/src/components/parallel/SentenceParallelView.tsx
@@ -87,7 +87,7 @@ function SentencePairCard({
           gap: 6,
           flexWrap: "wrap",
           fontSize: 12,
-          color: "#999",
+          color: "var(--fj-text-secondary)",
         }}
       >
         <Tag color={LANG_COLOR[pair.side_b.lang] || "default"} style={{ margin: 0 }}>

--- a/frontend/src/pages/AdminAuditLogPage.tsx
+++ b/frontend/src/pages/AdminAuditLogPage.tsx
@@ -34,7 +34,7 @@ function renderValue(t: TFunction, v: unknown): string {
 }
 
 function renderDetail(t: TFunction, detail: Record<string, unknown> | null) {
-  if (!detail || Object.keys(detail).length === 0) return <span style={{ color: "#999" }}>—</span>;
+  if (!detail || Object.keys(detail).length === 0) return <span style={{ color: "var(--fj-text-secondary)" }}>—</span>;
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
       {Object.entries(detail).map(([key, value]) => {
@@ -103,7 +103,7 @@ export default function AdminAuditLogPage() {
       title: t("admin_crud.column.actor"),
       dataIndex: "actor_username",
       width: 130,
-      render: (name: string | null) => name || <span style={{ color: "#999" }}>{t("admin_crud.audit.deleted_user")}</span>,
+      render: (name: string | null) => name || <span style={{ color: "var(--fj-text-secondary)" }}>{t("admin_crud.audit.deleted_user")}</span>,
     },
     {
       title: t("admin_crud.column.action"),

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -32,6 +32,7 @@ import {
   type ActiveUserDetail,
 } from "../api/client";
 import { getPlatformActivity } from "../api/feed";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { adminLabel, formatAdminDate } from "./adminI18n";
 
 const { Text } = Typography;
@@ -48,8 +49,9 @@ function DeltaSuffix({ today, yesterday }: { today: number; yesterday: number })
   const { t } = useTranslation();
   const diff = today - yesterday;
   const Arrow = diff >= 0 ? ArrowUpOutlined : ArrowDownOutlined;
-  const todayColor = today > 0 ? "#52c41a" : "#999";
-  const diffColor = diff > 0 ? "#52c41a" : diff < 0 ? "#ff4d4f" : "#999";
+  const todayColor = today > 0 ? "var(--fj-success)" : "var(--fj-text-secondary)";
+  const diffColor =
+    diff > 0 ? "var(--fj-success)" : diff < 0 ? "var(--fj-danger)" : "var(--fj-text-secondary)";
   return (
     <Tooltip title={t("admin_dashboard.delta.tooltip", { today, yesterday })}>
       <span style={{ fontSize: 13, color: todayColor, marginLeft: 4 }}>+{today}</span>
@@ -74,7 +76,7 @@ function PendingCard({ overview }: { overview: AdminOverview }) {
           title={t("admin_dashboard.pending.title")}
           value={total}
           prefix={<WarningOutlined />}
-          valueStyle={{ color: total > 0 ? "#faad14" : undefined }}
+          valueStyle={{ color: total > 0 ? "var(--fj-warning)" : undefined }}
           suffix={
             total > 0 ? (
               <Text type="secondary" style={{ fontSize: 12 }}>
@@ -193,6 +195,7 @@ function ActiveUsersCard({ date, onDateChange }: { date: string | null; onDateCh
 
 export default function AdminDashboardPage() {
   const { t, i18n } = useTranslation();
+  const isDark = useEffectiveTheme() === "dark";
   const [activeDate, setActiveDate] = useState<string | null>(null);
   const overviewQuery = useQuery({
     queryKey: ["adminOverview"],
@@ -269,11 +272,27 @@ export default function AdminDashboardPage() {
     domain: [S_MESSAGES, S_NEW_USERS, S_ACTIVE_USERS],
     range: ["#1677ff", "#fa8c16", "#52c41a"],
   };
+  // G2 draws into a <canvas>, so the --fj-* custom properties never reach it: the
+  // chart kept G2's light theme and painted its axis labels a dark grey that is
+  // unreadable on the dark card. Switch G2's own theme (which also carries the
+  // legend and tooltip, and keeps the plot background transparent) and hand the
+  // axis colours over as literals, warm ones rather than G2's cool blue-grey.
+  const axisStyle = isDark
+    ? {
+        labelFill: "#d2c7b1", // --fj-ink-light, 5.99:1 on the card
+        titleFill: "#d2c7b1",
+        lineStroke: "#60553f", // --fj-border
+        tickStroke: "#60553f",
+        gridStroke: "#3c342a",
+      }
+    : {};
   const chartConfig = {
+    // Light stays on G2's default theme — untouched, byte for byte.
+    ...(isDark ? { theme: "classicDark" } : {}),
     xField: "date",
     height: 360,
     legend: { color: { itemMarker: "round" } },
-    axis: { x: { labelAutoRotate: false } },
+    axis: { x: { labelAutoRotate: false, ...axisStyle } },
     children: [
       {
         data: messagesData,
@@ -281,6 +300,7 @@ export default function AdminDashboardPage() {
         yField: "count",
         colorField: "type",
         smooth: true,
+        axis: { y: { ...axisStyle } },
         scale: { color: seriesColor },
       },
       {
@@ -289,7 +309,7 @@ export default function AdminDashboardPage() {
         yField: "count",
         colorField: "type",
         smooth: true,
-        axis: { y: { position: "right" } },
+        axis: { y: { position: "right", ...axisStyle } },
         scale: { color: seriesColor },
       },
     ],
@@ -482,7 +502,7 @@ function ModuleUsageCard() {
                       title={t("admin_dashboard.answer_quality.retry_rate")}
                       value={data.answer_quality.retry_rate ?? "—"}
                       suffix={data.answer_quality.retry_rate == null ? "" : "%"}
-                      valueStyle={{ color: (data.answer_quality.retry_rate ?? 0) > 5 ? "#e74c3c" : undefined }}
+                      valueStyle={{ color: (data.answer_quality.retry_rate ?? 0) > 5 ? "var(--fj-danger)" : undefined }}
                     />
                   </Tooltip>
                 </Col>
@@ -514,7 +534,7 @@ function ModuleUsageCard() {
                       </Text>
                       {kw.keyword}
                     </span>
-                    <span style={{ color: "#999" }}>{t("admin_dashboard.unit.times", { count: kw.count })}</span>
+                    <span style={{ color: "var(--fj-text-secondary)" }}>{t("admin_dashboard.unit.times", { count: kw.count })}</span>
                   </div>
                 ))}
               </div>
@@ -602,7 +622,7 @@ function PlatformActivityCard() {
             <Statistic
               title={t("admin_dashboard.platform_activity.returning_users")}
               value={data.users.returning_users}
-              valueStyle={{ color: data.users.returning_users > data.users.new_users ? "#52c41a" : undefined }}
+              valueStyle={{ color: data.users.returning_users > data.users.new_users ? "var(--fj-success)" : undefined }}
             />
           </Tooltip>
         </Col>
@@ -649,7 +669,7 @@ function PlatformActivityCard() {
             <Statistic
               title={t("admin_dashboard.platform_activity.positive_rate")}
               value={positiveRate}
-              valueStyle={{ color: ratedCount > 0 && data.chat.positive_feedback >= data.chat.negative_feedback ? "#52c41a" : undefined }}
+              valueStyle={{ color: ratedCount > 0 && data.chat.positive_feedback >= data.chat.negative_feedback ? "var(--fj-success)" : undefined }}
             />
           </Tooltip>
         </Col>
@@ -685,7 +705,7 @@ function PlatformActivityCard() {
               style={{ display: "flex", justifyContent: "space-between", padding: "4px 0" }}
             >
               <Link to={`/texts/${text.text_id}`}>{text.title_zh}</Link>
-              <span style={{ color: "#999" }}>{t("admin_dashboard.unit.times", { count: text.read_count })}</span>
+              <span style={{ color: "var(--fj-text-secondary)" }}>{t("admin_dashboard.unit.times", { count: text.read_count })}</span>
             </div>
           ))}
         </div>

--- a/frontend/src/pages/AdminFeedbacksPage.tsx
+++ b/frontend/src/pages/AdminFeedbacksPage.tsx
@@ -222,7 +222,7 @@ export default function AdminFeedbacksPage() {
               {replyModal.content}
             </div>
             {replyModal.contact && (
-              <div style={{ marginTop: 8, fontSize: 12, color: "#999" }}>
+              <div style={{ marginTop: 8, fontSize: 12, color: "var(--fj-text-secondary)" }}>
                 {t("admin_crud.feedback.contact_label", { contact: replyModal.contact })}
               </div>
             )}
@@ -239,7 +239,7 @@ export default function AdminFeedbacksPage() {
           style={{ marginTop: 4 }}
         />
         {replyModal?.replied_at && (
-          <div style={{ marginTop: 8, fontSize: 12, color: "#999" }}>
+          <div style={{ marginTop: 8, fontSize: 12, color: "var(--fj-text-secondary)" }}>
             {t("admin_crud.feedback.last_reply_at", { date: formatAdminDate(replyModal.replied_at, i18n.language) })}
           </div>
         )}

--- a/frontend/src/pages/KGMapPage.tsx
+++ b/frontend/src/pages/KGMapPage.tsx
@@ -110,7 +110,7 @@ export default function KGMapPage() {
         <div style={{ display: "flex", alignItems: "baseline", gap: 6, padding: "2px 0" }}>
           <SearchOutlined style={{ color: "#bbb", fontSize: 12, flexShrink: 0, position: "relative", top: 2 }} />
           <span style={{ fontWeight: 600, color: "#1677ff", flexShrink: 0 }}>{e.name_zh}</span>
-          <span style={{ color: "#999", fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          <span style={{ color: "var(--fj-text-secondary)", fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {addr(e) || e.name_en || ""}
           </span>
         </div>
@@ -187,7 +187,7 @@ export default function KGMapPage() {
             allowClear
             style={{ width: 280, marginLeft: "auto" }}
             popupMatchSelectWidth={380}
-            suffixIcon={<SearchOutlined style={{ color: "#999" }} />}
+            suffixIcon={<SearchOutlined style={{ color: "var(--fj-text-secondary)" }} />}
           />
         </div>
       </div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -345,7 +345,7 @@ export default function ProfilePage() {
                       <Alert
                         message={
                           <Space>
-                            <CheckCircleOutlined style={{ color: "#52c41a" }} />
+                            <CheckCircleOutlined style={{ color: "var(--fj-success)" }} />
                             {t("profile.api_key_configured", {
                               provider: keyStatus.provider,
                               preview: keyStatus.key_preview,

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -293,7 +293,7 @@ function ApparatusMarker({ no, entry, t }: { no: number; entry: ApparatusEntryIt
           ))}
           <span>{r.is_omission ? t("reader.apparatus.omission") : r.reading}</span>
           {r.resp && (
-            <span style={{ color: "#999", fontSize: 12, marginInlineStart: 4 }}>
+            <span style={{ color: "var(--fj-text-secondary)", fontSize: 12, marginInlineStart: 4 }}>
               {t("reader.apparatus.corrector", { resp: r.resp })}
             </span>
           )}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -25,7 +25,7 @@
   /* Previously-undefined tokens that only ever hit their light fallback (so they
      never adapted to dark). Light values = the old fallbacks (byte-identical). */
   --fj-sand-light:      #faf7f2;  /* search result/empty-state panels */
-  --fj-text-secondary:  #999999;  /* reader secondary text */
+  --fj-text-secondary:  #767676;  /* reader secondary text — #999 was 2.85:1 on white, under AA */
   --fj-accent-hover:    #a03000;  /* dictionary/search button hover (darker maroon) */
   /* Text/icon placed ON a solid accent or gold background. Light: the accent is a
      deep maroon, so white reads (8.9:1). Dark: the accent/gold are BRIGHT, so white
@@ -34,6 +34,12 @@
   /* Text ON a solid GOLD background. Gold is light in BOTH themes, so white never
      works there (3.09:1 light / 1.95:1 dark) — both sides take a deep warm ink. */
   --fj-on-gold:         #2e2415;
+  /* Status text. The antd defaults (#52c41a / #ff4d4f) are tuned for solid fills,
+     not for text: on white they are 2.27:1 and 3.27:1, and on the dark card they
+     are 4.42:1 and 3.07:1. Each theme gets the shade that actually reads. */
+  --fj-success:         #237804;
+  --fj-danger:          #cf1322;
+  --fj-warning:         #ad4e00;
 }
 
 :root[data-theme="dark"] {
@@ -57,6 +63,9 @@
   --fj-accent-hover:    #ef8a5f;
   --fj-on-accent:       #17120d;
   --fj-on-gold:         #17120d;
+  --fj-success:         #73d13d;
+  --fj-danger:          #ffa39e;
+  --fj-warning:         #ffc069;
   color-scheme: dark;
 }
 
@@ -94,6 +103,15 @@
 }
 :root[data-theme="light"] .ant-tag-gold {
   color: #874d00; /* gold-9   2.76 -> 6.53 */
+}
+
+/* antd's Typography success/danger colours are the same fill-tuned greens and reds
+   as above (2.27:1 on white, 3.36:1 on the dark card). Point them at the tokens. */
+.ant-typography-success {
+  color: var(--fj-success) !important;
+}
+.ant-typography-danger {
+  color: var(--fj-danger) !important;
 }
 
 * {


### PR DESCRIPTION
## 图表(你指出的问题)

趋势图用 `@ant-design/charts` 的 `DualAxes`(G2 5.x),**配置里没有任何主题设置** —— 一直跑 G2 的浅色主题,坐标轴标签是深灰,压在暗色卡片上几乎读不出来。

G2 渲染到 `<canvas>`,`--fj-*` 这些 CSS 变量**进不去**,颜色必须在 JS 里给字面量:

- 暗色切到 G2 自带的 `classicDark` —— 它的画布底色是 `transparent`(不会糊成一块近黑),且顺带管住图例和 tooltip
- 轴线/标签覆盖成**暖色**,而不是 G2 那套冷蓝灰 `#416180`:标签 `#d2c7b1`(卡片上 **5.99:1**)、轴线刻度 `#60553f`、网格 `#3c342a`
- **浅色分支不传 theme**,与现状完全一致

## 顺着量了整页 DOM,又是同一类硬编码

| 颜色 | 暗色 | 浅色 |
|---|---|---|
| `#52c41a` 增量 | 4.42 ✗ | **2.27** ✗ ×7 |
| `#ff4d4f` 降幅 | 3.07 ✗ | 3.27 ✗ |
| antd success `#49aa19` | 3.36 ✗ | 2.27 ✗ |
| `#999` 计数/次数 | 3.52 ✗ | 2.85 ✗ ×20 |

外加两条**当前没触发**的条件分支:`#faad14` 压白底 **1.90**(待处理>0 时)、`#e74c3c` 压暗卡 **2.62**(重试率>5 时)。

根因一样:这些是给**色块填充**调的颜色,不是给**文字**调的。

## 解法：三个语义 token

| token | 浅色 | 暗色 |
|---|---|---|
| `--fj-success` | `#237804` (5.59) | `#73d13d` (5.21) |
| `--fj-danger` | `#cf1322` (5.57) | `#ffa39e` (5.24) |
| `--fj-warning` | `#ad4e00` (5.43) | `#ffc069` (6.20) |

另把 `--fj-text-secondary` 浅色值 `#999999` → `#767676`(**2.85 → 4.54**)。`#999` 压白底本来就不达标,暗色值 `#c6bca6` 不变。

共替换 **21 处**硬编码文字色 / 9 个文件(管理后台三页、阅读器对照面板、地图弹窗、TextReader、Profile)。进度条 `strokeColor`、图表线色、活动流圆点属**图形色**(按 3:1 判定且已达标),**保持不动**。

antd 的 `Typography` success/danger 同样是填充色,用 CSS 指到 token。

## 验证

- 在生产 /admin 上量的两个主题:失败项如上表
- 改后本地门禁全绿;**图表标签待部署后在生产复验**(本地无后端,/admin 打不开)

## 一个说明

跑对照时发现 `CollectionsPage.test.tsx` 的繁简用例偶发失败(全量里 9 次中 2 次;单独跑 12/12 全过;clean 分支 8 次 0 失败)。与本次改动无因果关系——它测的是繁简转换,和配色无关——属该文件既有的跨用例时序竞争。同理 `antdStaticMethods.test.tsx` 的 `window is not defined` 在 clean 分支上也复现(2/1/0)。

## 门禁

tsc ✓ · eslint ✓ · i18n ✓ · vitest 250/250 ✓ · build ✓