### PR TITLE
fix(ui): 搜索页对比度 + 补齐 antd 预设 Tag 全家族

### DIFF
--- a/frontend/src/components/search/SemanticCard.tsx
+++ b/frontend/src/components/search/SemanticCard.tsx
@@ -11,8 +11,10 @@ export default function SemanticCard({ hit, rank }: { hit: SemanticSearchHit; ra
   const cbetaUrl = hit.cbeta_id ? buildCbetaReadUrl(hit.cbeta_id) : null;
   const scorePercent = Math.round(hit.similarity_score * 100);
 
-  // 相似度颜色：>70% 绿色，>50% 蓝色，其余橙色
-  const scoreColor = scorePercent >= 70 ? "#52c41a" : scorePercent >= 50 ? "#1890ff" : "#fa8c16";
+  // 相似度颜色：>70% 绿色，>50% 蓝色，其余橙色。用语义 token 而非 antd 的填充色——
+  // 后者是给色块调的，画成 40px 圆环压在浅色卡片上只有 2.27:1 / 2.2:1（图形元素需 3:1）。
+  const scoreColor =
+    scorePercent >= 70 ? "var(--fj-success)" : scorePercent >= 50 ? "var(--fj-info)" : "var(--fj-warning)";
 
   return (
     <div className="s-card">

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -40,6 +40,10 @@
   --fj-success:         #237804;
   --fj-danger:          #cf1322;
   --fj-warning:         #ad4e00;
+  --fj-info:            #0958d9;
+  /* Search-result keyword highlight. It sits as bold 18px body text on the card,
+     which the brand accent is not tuned for: in dark it only reaches 3.35:1. */
+  --fj-highlight:       #8b2500;
 }
 
 :root[data-theme="dark"] {
@@ -66,6 +70,8 @@
   --fj-success:         #73d13d;
   --fj-danger:          #ffa39e;
   --fj-warning:         #ffc069;
+  --fj-info:            #91caff;
+  --fj-highlight:       #f2a07a;
   color-scheme: dark;
 }
 
@@ -85,6 +91,15 @@
 :root[data-theme="dark"] .ant-tag-purple {
   color: #b37feb;
 }
+:root[data-theme="dark"] .ant-tag-geekblue {
+  color: #85a5ff; /* geekblue-4  4.16 -> 7.51 */
+}
+
+/* antd derives the dark primary as a duller #c16642, which leaves the active tab
+   label at 3.63:1 against the page. Pin it to the accent itself (4.86:1). */
+:root[data-theme="dark"] .ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--fj-accent);
+}
 
 /* The same problem, mirrored, in the DEFAULT theme: antd's light preset Tags put
    colour-7 text on a colour-1 tint, which lands at 2.8–3.4:1 — under AA for the
@@ -103,6 +118,18 @@
 }
 :root[data-theme="light"] .ant-tag-gold {
   color: #874d00; /* gold-9   2.76 -> 6.53 */
+}
+/* Completing the sweep: every preset was measured in both themes, and these are
+   the rest of the ones that miss AA. yellow/lime are unused today — fixed so the
+   next person who reaches for them doesn't inherit a 2:1 tag. */
+:root[data-theme="light"] .ant-tag-volcano {
+  color: #ad2102; /* volcano-8  4.37 -> 6.38 */
+}
+:root[data-theme="light"] .ant-tag-yellow {
+  color: #876800; /* yellow-9   2.05 -> 5.15 */
+}
+:root[data-theme="light"] .ant-tag-lime {
+  color: #3f6600; /* lime-9     2.48 -> 6.62 */
 }
 
 /* antd's Typography success/danger colours are the same fill-tuned greens and reds
@@ -157,7 +184,7 @@ body {
 /* Search highlight */
 em {
   font-style: normal;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   font-weight: 600;
 }
 

--- a/frontend/src/styles/search.css
+++ b/frontend/src/styles/search.css
@@ -361,6 +361,10 @@
   color: #8b6914;
   margin-bottom: 4px;
 }
+/* The dark-gold above reads fine on the light panel but only 2.40:1 on the dark one. */
+:root[data-theme="dark"] .s-content-juan-label {
+  color: var(--fj-gold);
+}
 
 /* ---------- 辞典知识卡片 ---------- */
 .s-dict-knowledge {

--- a/frontend/src/theme/antdTheme.ts
+++ b/frontend/src/theme/antdTheme.ts
@@ -4,7 +4,8 @@ export function buildAntdTheme(isDark: boolean): ThemeConfig {
   if (!isDark) {
     return {
       algorithm: antdTheme.defaultAlgorithm,
-      token: { colorPrimary: "#8b2500", borderRadius: 2 },
+      // colorLink: antd's default #1677ff is 4.10:1 on white — just under AA.
+      token: { colorPrimary: "#8b2500", borderRadius: 2, colorLink: "#0958d9" },
     };
   }
   return {
@@ -23,6 +24,8 @@ export function buildAntdTheme(isDark: boolean): ThemeConfig {
       // default white label only reaches 2.99:1. A deep warm ink gives 6.2:1 — and
       // still 4.6:1 on the duller #c16642 the dark algorithm derives for Search.
       colorTextLightSolid: "#17120d",
+      // antd's dark link blue lands at 1.93:1 on the card — unreadable.
+      colorLink: "#91caff",
     },
     components: {
       // antd's Layout Header/Footer do NOT follow colorBgBase — they need their


### PR DESCRIPTION
起因是你问的语义卡匹配度圆环,但去生产搜索页实测后,发现问题比预想的多。

## 先纠正我自己的一处判断

`SemanticCard` 的 `scoreColor` 是 `Progress` 的 **`strokeColor`**(圆环描边),属**图形元素**、门槛 3:1,不是文字的 4.5:1。按这个口径是**三档里两档**不达标(绿 2.27 ✗ / 蓝 3.24 ✓ 勉强 / 橙 2.2 ✗),不是我上一条说的"三档全部不达标"。

## 生产实测：搜索页问题比 /admin 多

**暗色**

| 元素 | 对比度 | 数量 |
|---|---|---|
| `em` 关键词高亮 | **3.35** ✗ | ~60 |
| 「展开其他 N 卷」链接 | **1.93** ✗ | ×3 |
| 「第N卷(最佳匹配)」 | **2.40** ✗ | ×3 |
| geekblue 标签 | 4.16 ✗ | |
| 激活页签 | 3.63 ✗ | |

**浅色**:volcano 标签 4.37 ✗ ×5 · 链接 4.10 ✗ ×3

关键词高亮用的是**品牌 accent** —— 它是给按钮/链接调的,当 18px 粗体正文用,暗色下只有 3.35。所以从 accent 里独立出 `--fj-highlight`。

## Tag 这块不再撞一个修一个

此前 #1046 修暗色 purple、#1047 修浅色四色,都是撞见才修。这次**把 17 种预设在两个主题下一次量全** —— antd 的预设样式是一次性全量生成的,给探针补上 cssinjs 哈希类就能注入测出来:

- 暗色:仅 **geekblue 4.16** ✗
- 浅色:**volcano 4.37** ✗ · **yellow 2.05** ✗ · **lime 2.48** ✗

yellow/lime 现在没用到,一并修掉——免得下次谁用到就继承一个 2:1 的标签。

## 改动

| 项 | 现状 | 改后 |
|---|---|---|
| `--fj-highlight`(新) | accent 3.35 | 暗 `#f2a07a` **4.81** |
| `--fj-info`(新) | — | 浅 `#0958d9` / 暗 `#91caff` |
| antd `colorLink` | 4.10 / **1.93** | **6.16 / 5.77** |
| 暗色卷号标签 | 2.40 | `--fj-gold` **6.24** |
| 暗色激活页签 | 3.63 | `--fj-accent` **4.86** |
| 暗 geekblue 标签 | 4.16 | `#85a5ff` **7.51** |
| 浅 volcano / yellow / lime | 4.37 / 2.05 / 2.48 | **6.38 / 5.15 / 6.62** |
| SemanticCard 环色 | 2.27 / 3.24 / 2.2 | success/info/warning token |

暗色激活页签那条是老问题的另一面:antd 的 `darkAlgorithm` 把主色派生成更暗的 `#c16642`,所以钉回 accent 本身。

## 一个前置验证

`var()` 能否作用于 antd `Progress` 的 stroke 是本次的关键未知——**实测可以**(注入 `var(--fj-success)` 解析出 `rgb(35,120,4)`),否则 token 方案在圆环上会静默失效。

## 门禁

tsc ✓ · eslint ✓ · i18n ✓ · vitest 250/250 ✓ · build ✓

改后效果待部署到生产复验(本地无后端,搜索页出不来结果)。