### PR TITLE
fix(ui): 补上 #1049 漏掉的搜索高亮与展开链接

### DIFF
--- a/frontend/src/components/search/ContentCard.tsx
+++ b/frontend/src/components/search/ContentCard.tsx
@@ -77,7 +77,9 @@ export default function ContentCard({ hit, rank }: { hit: ContentSearchHit; rank
           ))}
         {hasMore && (
           <Button type="link" size="small" onClick={() => setExpanded(!expanded)}
-            style={{ padding: 0, fontSize: 12, marginTop: 4 }}>
+            // antd 会把 colorLink 当种子色再派生一遍，给什么值都不是最终色（暗色下
+            // 派生成 #7eafdc，只有 4.32:1）。内联指定，跳过派生。
+            style={{ padding: 0, fontSize: 12, marginTop: 4, color: "var(--fj-info)" }}>
             {expanded ? t("search.collapse") : t("search.expand_juans", { n: hit.matched_juan_count - 1 })}
           </Button>
         )}

--- a/frontend/src/styles/search.css
+++ b/frontend/src/styles/search.css
@@ -185,7 +185,7 @@
 }
 
 .s-card-title em {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   font-style: normal;
   font-weight: 700;
 }
@@ -204,7 +204,7 @@
 }
 
 .s-card-meta em {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   font-style: normal;
   font-weight: 600;
 }
@@ -217,7 +217,7 @@
 }
 
 .s-card-preview em {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   font-style: normal;
   font-weight: 600;
 }


### PR DESCRIPTION
#1049 部署后在生产复验,发现两处没修到 —— 我的疏漏。

## 1. 关键词高亮(约 66 处)仍是旧色

我只改了 `global.css` 的基础 `em` 规则,但 `search.css` 里 `.s-card-title em` / `.s-card-meta em` / `.s-card-preview em` 三条覆盖仍指向 `var(--fj-accent)`,优先级更高,把 `--fj-highlight` 整个挡掉了。

改这三条规则本身即可(不需要提权):

| | 改前 | 改后 |
|---|---|---|
| `.s-card-title em` ×5 | 3.35 | **4.81** |
| `.s-card-meta em` ×61 | 4.08 | **5.85** |

## 2. 「展开其他 N 卷」链接只到 4.32

`colorLink` 我设的是 `#91caff`(应得 5.77),但 antd 的 `darkAlgorithm` 把它**当种子色又派生了一遍**,实际渲染成 `#7eafdc` —— 给什么值都不是最终色。已确认 `91caff` 确实在部署包里,所以不是没生效,是被派生了。

反推 antd 的派生规则太脆,改为在 `ContentCard` 的 Button 上**内联**指定 `color: var(--fj-info)`:内联优先级高于 antd 的 CSS,且不经派生。暗 **5.77** / 浅 **6.16**。

## 排查中的一个坑

`getComputedStyle` 对这个 button 表现异常——连**内联 `!important`** 都读不出变化,和之前 skip link 那次同一个signature。最可能是 React 在我读取前重渲染、覆盖了探针。所以最终方案选了由 React 自己拥有的内联样式,不依赖运行时探针的结论。

## 门禁

tsc ✓ · eslint ✓ · i18n ✓ · vitest 250/250 ✓ · build ✓