### PR TITLE
fix(ui): 暗色下把「accent 当正文」统一改用 --fj-highlight

### DIFF
--- a/frontend/src/styles/activity-feed.css
+++ b/frontend/src/styles/activity-feed.css
@@ -121,7 +121,7 @@
 }
 
 .feed-item-title a:hover {
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
   text-decoration: underline;
 }
 
@@ -230,7 +230,7 @@
 
 .platform-stat-card .stat-row .stat-value {
   font-weight: 600;
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
   font-family: "Noto Serif SC", serif;
 }
 
@@ -258,7 +258,7 @@
 }
 
 .top-text-item a:hover {
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
   text-decoration: underline;
 }
 

--- a/frontend/src/styles/collections.css
+++ b/frontend/src/styles/collections.css
@@ -83,7 +83,7 @@
 .coll-card-toggle {
   display: inline-block;
   font-size: 13px;
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
   margin-top: 4px;
 }
 
@@ -147,7 +147,7 @@
 
 /* Indexed titles are anchors now; keep the previous inline-styled look. */
 .coll-text-title-link {
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
   text-decoration: none;
 }
 
@@ -210,7 +210,7 @@
 }
 
 .coll-res-tab.active {
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
   border-bottom-color: var(--fj-accent, var(--fj-accent));
   font-weight: 500;
 }
@@ -233,7 +233,7 @@
 
 .coll-res-tab.active .coll-res-tab-count {
   background: rgba(139, 37, 0, 0.12);
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
 }
 
 .coll-res-content {
@@ -261,7 +261,7 @@
 .coll-link-name {
   font-size: 13px;
   font-weight: 500;
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
 }
 
 .coll-link-desc {

--- a/frontend/src/styles/dictionary.css
+++ b/frontend/src/styles/dictionary.css
@@ -104,7 +104,7 @@
 }
 
 .dict-hot-terms .ant-tag:hover {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   border-color: var(--fj-accent);
 }
 
@@ -173,7 +173,7 @@
 }
 
 .dict-result-stats strong {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 /* ---------- Grouped results ---------- */

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -98,7 +98,7 @@
 /* antd derives the dark primary as a duller #c16642, which leaves the active tab
    label at 3.63:1 against the page. Pin it to the accent itself (4.86:1). */
 :root[data-theme="dark"] .ant-tabs-tab-active .ant-tabs-tab-btn {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 /* The same problem, mirrored, in the DEFAULT theme: antd's light preset Tags put

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -140,7 +140,7 @@
 }
 
 .home-title-accent {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 /* ---------- 副标题 ---------- */
@@ -205,7 +205,7 @@
   font-family: "Noto Serif SC", serif;
   font-size: 13px;
   font-weight: 600;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   white-space: nowrap;
   transition: background 0.15s;
   flex-shrink: 0;
@@ -325,7 +325,7 @@
 }
 
 .home-hot-tag:hover {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   border-color: var(--fj-gold);
   background: var(--fj-surface);
 }
@@ -362,7 +362,7 @@
   line-height: 1.6;
 }
 .home-tip a {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 /* ---------- 可信度说明 ---------- */
@@ -376,7 +376,7 @@
 }
 
 .home-trust-link {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   cursor: pointer;
   transition: opacity 0.2s;
 }
@@ -541,7 +541,7 @@
 }
 
 .src-item-link:hover {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   background: rgba(139,37,0,0.06);
 }
 
@@ -612,7 +612,7 @@
 }
 
 .ext-link:hover {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   border-color: var(--fj-gold);
   background: var(--fj-surface);
 }
@@ -624,7 +624,7 @@
   margin-top: 12px;
   padding: 6px 12px;
   font-size: 12px;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   background: none;
   border: 1px solid #e8e0d4;
   border-radius: 4px;
@@ -809,4 +809,10 @@
   .home-feature-card { padding: 12px 8px; }
   .home-feature-icon { font-size: 20px; margin-bottom: 4px; }
   .home-feature-title { font-size: 12px; }
+}
+
+/* 卡片底色为了"跳"出来提亮到 #625742 后，副文案的 --fj-ink-light 被挤到 4.24:1。
+   给它一档更亮的暖白（4.92:1），仍比卡片标题（5.82:1）柔和，层次不变。 */
+:root[data-theme="dark"] .home-feature-desc {
+  color: #e0d6c2;
 }

--- a/frontend/src/styles/kg-map.css
+++ b/frontend/src/styles/kg-map.css
@@ -412,7 +412,7 @@
 }
 
 .kg-map-stats-filter {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   font-weight: 500;
 }
 

--- a/frontend/src/styles/kg.css
+++ b/frontend/src/styles/kg.css
@@ -618,7 +618,7 @@
   transition: color 0.2s;
 }
 .kg-timeline-toggle:hover { color: var(--fj-ink); }
-.kg-timeline-toggle.active { color: var(--fj-accent); }
+.kg-timeline-toggle.active { color: var(--fj-highlight); }
 
 /* ---------- 响应式 ---------- */
 @media (max-width: 1200px) {
@@ -873,12 +873,12 @@
 }
 
 /* ---- Dark mode: entity-type tags → hue-tinted dark chips (light unchanged) ---- */
-:root[data-theme="dark"] .kg-type-tag--person    { background: rgba(245, 34, 45, 0.16);  color: #ff7875; border-color: rgba(245, 34, 45, 0.38); }
-:root[data-theme="dark"] .kg-type-tag--text      { background: rgba(47, 84, 235, 0.20);  color: #85a5ff; border-color: rgba(47, 84, 235, 0.42); }
-:root[data-theme="dark"] .kg-type-tag--monastery { background: rgba(82, 196, 26, 0.16);  color: #95de64; border-color: rgba(82, 196, 26, 0.38); }
-:root[data-theme="dark"] .kg-type-tag--school    { background: rgba(114, 46, 209, 0.22); color: #b37feb; border-color: rgba(114, 46, 209, 0.42); }
-:root[data-theme="dark"] .kg-type-tag--place     { background: rgba(250, 140, 22, 0.16); color: #ffc069; border-color: rgba(250, 140, 22, 0.38); }
-:root[data-theme="dark"] .kg-type-tag--concept   { background: rgba(19, 194, 194, 0.16); color: #5cdbd3; border-color: rgba(19, 194, 194, 0.38); }
+:root[data-theme="dark"] .kg-type-tag--person    { background: rgba(245, 34, 45, 0.16);  color: #ffccc7; border-color: rgba(245, 34, 45, 0.38); }
+:root[data-theme="dark"] .kg-type-tag--text      { background: rgba(47, 84, 235, 0.20);  color: #adc6ff; border-color: rgba(47, 84, 235, 0.42); }
+:root[data-theme="dark"] .kg-type-tag--monastery { background: rgba(82, 196, 26, 0.16);  color: #b7eb8f; border-color: rgba(82, 196, 26, 0.38); }
+:root[data-theme="dark"] .kg-type-tag--school    { background: rgba(114, 46, 209, 0.22); color: #d3adf7; border-color: rgba(114, 46, 209, 0.42); }
+:root[data-theme="dark"] .kg-type-tag--place     { background: rgba(250, 140, 22, 0.16); color: #ffd591; border-color: rgba(250, 140, 22, 0.38); }
+:root[data-theme="dark"] .kg-type-tag--concept   { background: rgba(19, 194, 194, 0.16); color: #87e8de; border-color: rgba(19, 194, 194, 0.38); }
 
 /* ---- Dark mode: fixes for stateful cream backgrounds the sweep missed ---- */
 /* Selected KG result: cream bg didn't flip while the name/desc use ink tokens
@@ -888,10 +888,17 @@
 }
 /* 7th entity-type tag (dynasty) was omitted from the dark override set. */
 :root[data-theme="dark"] .kg-type-tag--dynasty {
-  background: rgba(235, 47, 150, 0.16); color: #ff85c0; border-color: rgba(235, 47, 150, 0.4);
+  background: rgba(235, 47, 150, 0.16); color: #ffadd2; border-color: rgba(235, 47, 150, 0.4);
 }
 /* "results truncated" alert: near-white amber box glowing in the dark graph. */
 :root[data-theme="dark"] .kg-truncated-bar .ant-alert {
   background: rgba(214, 152, 60, 0.16);
   border-color: var(--fj-gold);
+}
+
+/* 类型标签的底是半透明色叠在同样带色的结果行上，合成后文字只有 3.1–4.1:1；
+   上面已把 7 种的暗色文字统一提高一档。结果行的描述与关系数同理。 */
+:root[data-theme="dark"] .kg-result-desc,
+:root[data-theme="dark"] .kg-result-degree {
+  color: var(--fj-ink-light);
 }

--- a/frontend/src/styles/master-gallery.css
+++ b/frontend/src/styles/master-gallery.css
@@ -37,7 +37,7 @@
 
 .mg-chip:hover {
   border-color: var(--fj-accent, var(--fj-accent));
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
 }
 
 .mg-chip:focus-visible {
@@ -240,7 +240,7 @@
 
 .mg-open {
   margin-left: auto;
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
   font-size: 12px;
   cursor: pointer;
   padding: 0 2px;

--- a/frontend/src/styles/person.css
+++ b/frontend/src/styles/person.css
@@ -28,7 +28,7 @@
   cursor: pointer;
   transition: color 0.15s;
 }
-.person-breadcrumb-link:hover { color: var(--fj-accent); }
+.person-breadcrumb-link:hover { color: var(--fj-highlight); }
 
 .person-breadcrumb-sep { color: var(--fj-border); }
 
@@ -142,7 +142,7 @@
 
 .person-extlink {
   font-size: 12px;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   text-decoration: none;
   display: inline-flex;
   align-items: center;
@@ -230,7 +230,7 @@
 }
 .person-rel-item:hover {
   background: var(--fj-surface-alt);
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 .person-rel-arrow {

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -570,7 +570,7 @@
 
 .reader-ai-suggestion:hover {
   background: rgba(139, 105, 20, 0.12);
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 .reader-ai-input-area {

--- a/frontend/src/styles/research.css
+++ b/frontend/src/styles/research.css
@@ -152,7 +152,7 @@
 .rp-trust {
   margin-top: 10px;
   font-size: 12px;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 /* Sources */
@@ -173,7 +173,7 @@
   font-size: 14px;
 }
 .rp-source-link {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   font-weight: 600;
   text-decoration: none;
 }
@@ -209,7 +209,7 @@
   background: none;
   border: none;
   padding: 0;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   font-weight: 600;
   cursor: pointer;
   font-size: 13px;

--- a/frontend/src/styles/search.css
+++ b/frontend/src/styles/search.css
@@ -66,7 +66,7 @@
 }
 
 .s-filter-item:hover {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 .s-filter-name {
@@ -107,7 +107,7 @@
 
 .s-result-count {
   font-size: 14px;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 .s-result-count strong {
@@ -132,7 +132,7 @@
 }
 
 .s-did-you-mean-link {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   font-weight: 600;
   cursor: pointer;
   text-decoration: none;
@@ -448,7 +448,7 @@
 
 .s-dict-knowledge-footer a {
   font-size: 12px;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   text-decoration: none;
   font-weight: 500;
 }

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -244,7 +244,7 @@
 }
 
 .sources-stats-bar strong {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 /* ---------- 分组 ---------- */
@@ -393,7 +393,7 @@
 .source-dist-link:hover {
   border-color: #d4a574;
   background: var(--fj-surface);
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
 }
 
 .source-dist-link.is-primary {
@@ -449,13 +449,13 @@
 }
 
 .source-btn:hover {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   border-color: var(--fj-gold);
   background: var(--fj-surface);
 }
 
 .source-btn-search {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   border-color: #d4a574;
   background: var(--fj-surface-alt);
 }
@@ -548,7 +548,7 @@
 .sources-suggest-success {
   font-family: "Noto Serif SC", serif;
   font-size: 15px;
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   text-align: center;
   padding: 24px 0;
   letter-spacing: 1px;
@@ -579,7 +579,7 @@
 }
 
 .sources-back-top:hover {
-  color: var(--fj-accent);
+  color: var(--fj-highlight);
   border-color: var(--fj-gold);
   box-shadow: 0 2px 12px rgba(176, 141, 87, 0.15);
 }

--- a/frontend/src/styles/topics.css
+++ b/frontend/src/styles/topics.css
@@ -61,7 +61,7 @@
 .topic-card-toggle {
   display: inline-block;
   font-size: 12px;
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
   margin-top: 4px;
 }
 
@@ -104,7 +104,7 @@
 }
 
 .topic-text-clickable .topic-text-title {
-  color: var(--fj-accent, var(--fj-accent));
+  color: var(--fj-highlight);
 }
 
 .topic-text-desc {


### PR DESCRIPTION
把同一套审计跑遍**其余公开页面**后,暗色下的失败几乎收敛到**同一个病根**:`--fj-accent`(#e5764a)被当小号文字用,压在卡片上只有 **3.35:1**。它是给按钮、边框这类填充调的品牌色,从来没为正文调过。

#1049 已经为搜索高亮建了 `--fj-highlight`,这次把它用到位。

## 关键前提：浅色零变化

`--fj-highlight` 的**浅色值就是 `#8b2500`,与 `--fj-accent` 浅色完全相同**。所以这次替换在浅色下**逐像素不变**,只在暗色把 3.35 提到 **4.81**。

## 生产实测（暗色）

| 页面 | 问题 |
|---|---|
| `/` | `.search-combo-src-text` 3.35 · `.home-feature-desc` 4.24 |
| `/topics` | `.topic-card-toggle` 3.35 ×8 |
| `/kg` | 类型标签 3.12–4.05(7 种里 4 种) · 描述/关系数 4.4 · 人物主页 3.35 |
| `/dictionary` | 无 |

浅色首页、辞典均为 0。

## 改动

- **42 条** `color: var(--fj-accent)` 文字用法 → `var(--fj-highlight)`
- **跳过 9 条**图标与 ≥18px 用法(按 3:1 判定已达标,且是你调过的视觉,不动)
- `.home-feature-desc` 暗色 → `#e0d6c2`(**4.92**):卡片为了"跳"出来提亮到 `#625742` 之后,`--fj-ink-light` 被挤到 4.24;新值仍比标题(5.82)柔和,**层次不变**
- kg **7 种**实体类型标签暗色文字统一提高一档(3.12–4.87 → **5.11–5.73**)
- kg 结果行描述/关系数 → `--fj-ink-light`(4.4 → **5.06**)

## 两个我自己的错误，都已修正

**1. 审计方法有缺陷。** 原先取底色只取第一个非透明背景,把 `rgba(...)` 的数字当不透明色用。kg 的标签底是**半透明色叠在同样带色的结果行上**,所以先前读出的 1.59 / 2.45 是**误报**;补上 alpha 合成后真实值是 3.12–4.05。

**2. 第一版清扫正则写错了。** `var\(--fj-accent[^)]*\)` 会误吞 `--fj-accent-hover`,并把嵌套写法 `var(--fj-accent, var(--fj-accent))` 截断成多余右括号 —— **被 vite 构建当场报错拦下**。已改为要求 `--fj-accent` 后紧跟 `)` 或 `,`,从根上排除这两种情况。

## 门禁

tsc ✓ · eslint ✓ · i18n ✓ · vitest 251/251 ✓ · build ✓