### PR TITLE
fix(ui): 内联样式里剩余的「accent 当正文」也改用 --fj-highlight

### DIFF
--- a/frontend/src/components/EntityCard.tsx
+++ b/frontend/src/components/EntityCard.tsx
@@ -151,7 +151,7 @@ export default function EntityCard({ entity, onEntityClick }: EntityCardProps) {
           type="link"
           size="small"
           icon={<BookOutlined />}
-          style={{ padding: 0, marginBottom: 10, color: "var(--fj-accent)", fontSize: 12 }}
+          style={{ padding: 0, marginBottom: 10, color: "var(--fj-highlight)", fontSize: 12 }}
           onClick={() => navigate(`/texts/${entity.text_id}`)}
         >
           {t("entity.view_linked_text")}
@@ -162,7 +162,7 @@ export default function EntityCard({ entity, onEntityClick }: EntityCardProps) {
           type="link"
           size="small"
           icon={<ReadOutlined />}
-          style={{ padding: 0, marginBottom: 10, color: "var(--fj-accent)", fontSize: 12 }}
+          style={{ padding: 0, marginBottom: 10, color: "var(--fj-highlight)", fontSize: 12 }}
           onClick={() =>
             navigate(`/dict/${encodeURIComponent(entity.name_zh)}`)
           }
@@ -175,7 +175,7 @@ export default function EntityCard({ entity, onEntityClick }: EntityCardProps) {
           type="link"
           size="small"
           icon={<UserOutlined />}
-          style={{ padding: 0, marginBottom: 10, color: "var(--fj-accent)", fontSize: 12 }}
+          style={{ padding: 0, marginBottom: 10, color: "var(--fj-highlight)", fontSize: 12 }}
           onClick={() => navigate(`/person/${entity.id}`)}
         >
           {t("entity.person_page")}
@@ -254,7 +254,7 @@ export default function EntityCard({ entity, onEntityClick }: EntityCardProps) {
                   href={value}
                   target="_blank"
                   rel="noopener noreferrer"
-                  style={{ color: "var(--fj-accent)" }}
+                  style={{ color: "var(--fj-highlight)" }}
                 >
                   {value}
                 </a>

--- a/frontend/src/components/ReaderAIPanel.tsx
+++ b/frontend/src/components/ReaderAIPanel.tsx
@@ -236,7 +236,7 @@ export default function ReaderAIPanel({
     a: ({ href, children }: { href?: string; children?: ReactNode }) => {
       if (href && href.startsWith("/texts/")) {
         return (
-          <Link to={href} style={{ color: "var(--fj-accent)", textDecoration: "none", borderBottom: "1px dashed var(--fj-accent)", fontWeight: 500 }}>
+          <Link to={href} style={{ color: "var(--fj-highlight)", textDecoration: "none", borderBottom: "1px dashed var(--fj-accent)", fontWeight: 500 }}>
             {children}
           </Link>
         );

--- a/frontend/src/components/search/UnifiedResults.tsx
+++ b/frontend/src/components/search/UnifiedResults.tsx
@@ -112,7 +112,7 @@ export default function UnifiedResults({ data }: Props) {
           {dictionary.length > 2 && (
             <Link
               to={`/dictionary?q=${encodeURIComponent(data.query)}`}
-              style={{ display: "inline-block", marginTop: 8, fontSize: 13, color: "var(--fj-accent)" }}
+              style={{ display: "inline-block", marginTop: 8, fontSize: 13, color: "var(--fj-highlight)" }}
             >
               {t("search.view_all_dict_count", { n: dictionary.length })}
             </Link>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -785,7 +785,7 @@ export default function ChatPage() {
                 border: 0,
                 padding: 0,
                 font: "inherit",
-                color: "var(--fj-accent)",
+                color: "var(--fj-highlight)",
                 borderBottom: "1px dashed var(--fj-accent)",
                 fontWeight: 500,
                 cursor: "pointer",
@@ -801,7 +801,7 @@ export default function ChatPage() {
           <Link
             to={href}
             style={{
-              color: "var(--fj-accent)",
+              color: "var(--fj-highlight)",
               textDecoration: "none",
               borderBottom: "1px dashed var(--fj-accent)",
               fontWeight: 500,
@@ -1447,7 +1447,7 @@ export default function ChatPage() {
                         padding: "2px 8px",
                         borderRadius: 10,
                         background: "rgba(176,141,87,0.1)",
-                        color: "var(--fj-accent)",
+                        color: "var(--fj-highlight)",
                         fontFamily: '"Noto Serif SC", serif',
                         letterSpacing: "0.02em",
                       }}>

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -374,7 +374,7 @@ function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useN
             撤下(待打磨)，故隐藏此链接。上方表格各行仍跳阅读器逐段对照(集成功能，保留)。
         {groups.length > TOP_N && (
           <p style={{ fontSize: 12, margin: "12px 0 0" }}>
-            <a onClick={() => navigate("/cross-canon")} style={{ cursor: "pointer", color: "var(--fj-accent)" }}>
+            <a onClick={() => navigate("/cross-canon")} style={{ cursor: "pointer", color: "var(--fj-highlight)" }}>
               {t("collections.alignment_more", { n: TOP_N, total: groups.length })} →
             </a>
           </p>

--- a/frontend/src/pages/DictionaryPage.tsx
+++ b/frontend/src/pages/DictionaryPage.tsx
@@ -124,7 +124,7 @@ function DictGroup({ group, defaultExpanded = false }: { group: DictGroupedResul
             size="small"
             icon={expanded ? <UpOutlined /> : <DownOutlined />}
             onClick={() => setExpanded(!expanded)}
-            style={{ color: "var(--fj-accent)", fontSize: 13 }}
+            style={{ color: "var(--fj-highlight)", fontSize: 13 }}
           >
             {expanded ? t("dict.collapse") : t("dict.expand_all", { n: group.entries.length })}
           </Button>
@@ -316,7 +316,7 @@ export default function DictionaryPage() {
                 setSourceFilter("");
                 setSearchParams({});
               }}
-              style={{ color: "var(--fj-accent)", fontSize: 13, padding: 0, marginRight: 16 }}
+              style={{ color: "var(--fj-highlight)", fontSize: 13, padding: 0, marginRight: 16 }}
             >
               {t("dict.back_to_list")}
             </Button>


### PR DESCRIPTION
#1052 的补齐。那次只清扫了 **CSS 文件**,TSX 里的**内联样式**没覆盖到,所以 /kg 的「人物主页」部署后仍是 **3.35:1**。

## 改动

补齐 **12 处**内联文字用法:辞典、实体卡(EntityCard)、统一结果、聊天、合集、阅读器 AI 面板。

与 #1052 同一口径,**跳过 4 处图标**(`TranslationOutlined` / `RobotOutlined` / `HeartFilled`)——图形元素按 3:1 判定已达标,且是调过的视觉。

浅色仍为**零变化**:`--fj-highlight` 与 `--fj-accent` 的浅色值同为 `#8b2500`。

## 关于本地测试

本地全量偶发 ~10s 超时,查下来是我自己反复跑测试把机器压满了(**load average 25.9 / 24 核**)。做了 A/B:clean 分支 3 次里挂 2 次,本分支 3 次全绿——与改动无关。

## 门禁

tsc ✓ · eslint ✓ · vitest 251/251 ✓ · build ✓