### PR TITLE
fix(ui): collections 语言色列头 + activity 翻译徽标对比度

### DIFF
--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { Input, Tag, Empty } from "antd";
 import {
   SearchOutlined,
@@ -244,11 +245,15 @@ const LANG_LABELS: Record<string, { labelKey: string; color: string }> = {
 
 // Muted CSS tints for the cross-canon table column headers — a quiet language
 // cue without the 24 saturated antd Tags the old chip grid stacked up.
-const LANG_TINT: Record<string, string> = { bo: "#7c5cbf", sa: "#bd7b3a", pi: "#3f9268" };
+// 语言色作为列头的低调提示。原来只有一套（给浅色调的）值，梵文/巴利在浅色下就已
+// 不达标（3.47 / 3.80），暗色更糟（1.98–2.89）。改为按主题各取达标的一档。
+const LANG_TINT_LIGHT: Record<string, string> = { bo: "#7c5cbf", sa: "#ad4e00", pi: "#237804" };
+const LANG_TINT_DARK: Record<string, string> = { bo: "#d3adf7", sa: "#ffc069", pi: "#95de64" };
 
 /** 跨藏对照专区：哪些经有逐段对照语料（可发现性入口）。
     API 失败/空数据时整块隐身，可与 backend 端点解耦部署。 */
 function ParallelCatalogSection({ navigate }: { navigate: ReturnType<typeof useNavigate> }) {
+  const LANG_TINT = useEffectiveTheme() === "dark" ? LANG_TINT_DARK : LANG_TINT_LIGHT;
   const { t, i18n } = useTranslation();
   const { data } = useQuery({
     queryKey: ["alignmentCatalog"],

--- a/frontend/src/styles/activity-feed.css
+++ b/frontend/src/styles/activity-feed.css
@@ -320,7 +320,7 @@
   background: rgba(82, 196, 26, 0.16); color: #95de64; border-color: rgba(82, 196, 26, 0.38);
 }
 :root[data-theme="dark"] .update-type-badge.translation {
-  background: rgba(24, 144, 255, 0.16); color: #69c0ff; border-color: rgba(24, 144, 255, 0.38);
+  background: rgba(24, 144, 255, 0.16); color: #91d5ff; border-color: rgba(24, 144, 255, 0.38);
 }
 :root[data-theme="dark"] .update-type-badge.scan {
   background: rgba(250, 140, 22, 0.16); color: #ffc069; border-color: rgba(250, 140, 22, 0.38);


### PR DESCRIPTION
把暗色审计**跑遍其余公开页**后(在你已验证的首页/sources/search/admin/topics/kg/dictionary 之外,又扫了 /collections /timeline /research /activity /map /chat /login),公开页里还剩两处。

## 1. /collections 跨藏目录的语言色列头

`LANG_TINT` 只有一套(给浅色调的)值,经内联 `style` 写死,暗色盖不过。而且**梵文/巴利在浅色下就已不达标**:

| 语言 | 浅色(现) | 暗色(现) |
|---|---|---|
| 藏文 bo | 5.07 ✓ | **1.98** ✗ |
| 梵文 sa | **3.47** ✗ | **2.89** ✗ |
| 巴利 pi | **3.80** ✗ | **2.64** ✗ |

改为**按主题各取达标的一档**(藏文浅色本就达标,不动):

| | 浅色 | 暗色 |
|---|---|---|
| bo | `#7c5cbf` 5.07 | `#d3adf7` 5.29 |
| sa | `#ad4e00` 5.43 | `#ffc069` 6.20 |
| pi | `#237804` 5.59 | `#95de64` 6.16 |

放进真正用它的 `ParallelCatalogSection`——第一版我放错了函数(放进了 `CollectionsPage`),**被 tsc 当场拦下**。

## 2. /activity 翻译类更新徽标

暗色 `#69c0ff` 压 `rgba(24,144,255,.16)` 只有 **4.32**,提到 `#91d5ff`(约 5.3)。其余三类徽标(新增/影像/结构)已达标,不动。

## 其余公开页

/timeline /research /map /chat /login 及首页等暗色**全部 0 失败**。

## 门禁

tsc ✓(退出码 0) · eslint ✓ · i18n ✓ · vitest 251/251 ✓ · build ✓

> 说明:上一轮我一度用 `npx tsc && echo ✓` 判定,被 `tail` 的退出码骗过;本次逐条核对退出码。