### PR TITLE
ci(security): 记录豁免 react-router RSC-mode CSRF，解除全仓 CI 阻塞

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,10 +141,14 @@ jobs:
         run: npm ci
 
       - name: Run npm audit
-        # Strict gate restored: the react-router moderates that #1038 waived
-        # (GHSA-wrjc-x8rr-h8h6 / GHSA-337j-9hxr-rhxg) are fixed by the v7 upgrade
-        # (react-router-dom 7.18.1), so `npm audit --omit=dev` is clean again.
-        run: npm audit --omit=dev
+        # npm audit has no built-in per-advisory ignore, so the gate runs through a
+        # small filter that waives ONE documented advisory and fails on any other.
+        # Waived: GHSA-qwww-vcr4-c8h2 (react-router RSC-mode CSRF, 7.12.0–8.2.0) —
+        # only exploitable in RSC/framework mode; FoJin runs library mode, so it is
+        # not exposed. No patched release exists yet and the only npm "fix" downgrades
+        # to 7.11.0, re-introducing the vulns #1042 fixed. See the script header for
+        # the full rationale; drop the waiver once react-router ships a fix.
+        run: node scripts/npm-audit-waiver.mjs
 
       - name: Run npm audit (JSON report)
         if: always()

--- a/frontend/scripts/npm-audit-waiver.mjs
+++ b/frontend/scripts/npm-audit-waiver.mjs
@@ -1,0 +1,43 @@
+// CI gate: `npm audit` for production deps, with a documented per-advisory waiver.
+// npm audit has no built-in per-advisory ignore (unlike pip-audit's --ignore-vuln),
+// so we parse its JSON and fail on any advisory NOT in the waiver list below.
+import { execSync } from "node:child_process";
+
+// GHSA-qwww-vcr4-c8h2 — React Router "RSC Mode CSRF" (affects react-router 7.12.0–8.2.0).
+// Only exploitable in React Router's RSC / framework mode. FoJin runs LIBRARY mode
+// (<BrowserRouter> + ReactDOM.createRoot in src/main.tsx; no react-router.config,
+// no @react-router/dev), so the RSC action path does not exist here — not exposed.
+// No patched 7.x/8.x is published yet (latest 7.18.1 is still in-range); npm's only
+// "fix" downgrades to 7.11.0, which re-introduces GHSA-wrjc-x8rr-h8h6 /
+// GHSA-337j-9hxr-rhxg that the v7 upgrade (#1042) fixed. Re-audit and drop this
+// waiver once react-router ships a fixed release (>8.2.0 or a 7.x patch).
+const WAIVED = new Set(["GHSA-qwww-vcr4-c8h2"]);
+
+let json;
+try {
+  json = execSync("npm audit --omit=dev --json", { encoding: "utf8" });
+} catch (e) {
+  // npm audit exits non-zero when vulnerabilities exist; the JSON is still on stdout.
+  json = e.stdout;
+}
+
+const report = JSON.parse(json);
+const vulns = report.vulnerabilities || {};
+const unwaived = new Set();
+for (const [name, v] of Object.entries(vulns)) {
+  for (const via of v.via) {
+    if (typeof via !== "object" || !via.url) continue; // string via = transitive dep name
+    const id = via.url.split("/").pop();
+    if (!WAIVED.has(id)) unwaived.add(`${id} (${via.severity}) via ${name}`);
+  }
+}
+
+if (unwaived.size) {
+  console.error("npm audit: un-waived advisories found:\n  " + [...unwaived].join("\n  "));
+  process.exit(1);
+}
+console.log(
+  Object.keys(vulns).length
+    ? "npm audit: only the waived advisory (GHSA-qwww-vcr4-c8h2) is present — OK."
+    : "npm audit: no vulnerabilities — OK.",
+);


### PR DESCRIPTION
## 背景

**GHSA-qwww-vcr4-c8h2**(react-router "RSC Mode CSRF",影响 7.12.0–8.2.0)新披露后,`npm audit` 把**所有 PR 和 master CD 全卡红**了。

## FoJin 不受影响

- 漏洞**只在 React Router 的 RSC / 框架模式**下可利用。
- FoJin 用的是 **library mode**:`src/main.tsx` 里 `<BrowserRouter>` + `ReactDOM.createRoot`,没有 `react-router.config`、没有 `@react-router/dev` —— RSC action 路径根本不存在。
- **暂无已修复版本**(最新 7.18.1 仍在受影响区间),npm 给的唯一"修复"是**降级到 7.11.0**,那会把 #1042 升级 v7 才修掉的 `GHSA-wrjc-x8rr-h8h6` / `GHSA-337j-9hxr-rhxg` 又装回来。

## 做法

npm audit 没有 pip-audit 那种 `--ignore-vuln`,所以加一个带说明的过滤脚本 `frontend/scripts/npm-audit-waiver.mjs`:解析 `npm audit --json`,**只放行这一条 advisory,任何其它漏洞照常退出 1**。

**变异测试验证过门没被拆掉**:把豁免 ID 改成错误值时,react-router 那条会立刻让脚本退出 1。

react-router 出 >8.2.0 或 7.x 补丁后,删掉 `WAIVED` 里这一条即可恢复严格 audit。

## 决策来源

安全门政策是仓库所有者的取舍(你在 #1038 waive、#1042 un-waive 有过先例)。本次是你在会话中明确选择"记录豁免、立即解红"。