### PR TITLE
feat(map): 佛教地图暗色底图（并按底图分流标记色）

### DIFF
--- a/frontend/src/components/kg-map/DeckGLMap.tsx
+++ b/frontend/src/components/kg-map/DeckGLMap.tsx
@@ -8,18 +8,9 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { escapeHtml } from "../../utils/sanitize";
+import { useEffectiveTheme } from "../../hooks/useTheme";
+import { typeColors } from "./typeColors";
 import type { KGGeoEntity, KGLineageArc } from "../../api/client";
-
-/** Bright, highly-distinct palette for light background */
-const TYPE_COLORS: Record<string, [number, number, number]> = {
-  person:    [220, 38, 38],    // 鲜红 (red-600)
-  monastery: [34, 197, 94],    // 鲜绿 (green-500)
-  place:     [124, 58, 237],   // 鲜紫 (violet-600)
-  school:    [37, 99, 235],    // 蓝 (blue-600)
-  text:      [6, 182, 212],    // 青 (cyan-500)
-  concept:   [8, 145, 178],    // 深青
-  dynasty:   [219, 39, 119],   // 洋红 (pink-600)
-};
 
 const INITIAL_VIEW_STATE = {
   longitude: 115,
@@ -29,9 +20,16 @@ const INITIAL_VIEW_STATE = {
   bearing: 0,
 };
 
-/** Light basemap — MapTiler Streets with Chinese labels */
+/** MapTiler Streets with Chinese labels — one basemap per theme.
+ *  The map canvas covers ~65% of the viewport, so a light basemap under the dark
+ *  chrome was the single brightest thing left in dark mode. streets-v2-dark is a
+ *  drop-in: it carries the SAME layer structure as streets-v2 (32 symbol layers,
+ *  25 of them name-based), so the zh-label / Taiwan-name patching below applies
+ *  unchanged. (dataviz-dark and basic-v2-dark are darker still but ship only
+ *  11 / 7 label layers — far fewer place names.) */
 const MAPTILER_KEY = "sBS5GCqJuftwymqkp64I";
-const MAP_STYLE = `https://api.maptiler.com/maps/streets-v2/style.json?key=${MAPTILER_KEY}&language=zh`;
+const mapStyleUrl = (isDark: boolean) =>
+  `https://api.maptiler.com/maps/streets-v2${isDark ? "-dark" : ""}/style.json?key=${MAPTILER_KEY}&language=zh`;
 
 interface DeckGLMapProps {
   geoEntities: KGGeoEntity[];
@@ -65,6 +63,10 @@ export default function DeckGLMap({
   focusEntity,
 }: DeckGLMapProps) {
   const { t } = useTranslation();
+  const isDark = useEffectiveTheme() === "dark";
+  // useMemo 而非直接调用：typeColors() 每次返回新对象，直接进下面 layers 的
+  // 依赖数组会让图层每帧重建；按 isDark 固定引用后既能随主题重算又不抖动。
+  const TYPE_COLORS = useMemo(() => typeColors(isDark), [isDark]);
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
   const [arcTooltip, setArcTooltip] = useState<ArcTooltipState | null>(null);
   const [viewState, setViewState] = useState<typeof INITIAL_VIEW_STATE & { transitionDuration?: number }>(INITIAL_VIEW_STATE);
@@ -106,7 +108,7 @@ export default function DeckGLMap({
 
   useEffect(() => {
     let cancelled = false;
-    fetch(MAP_STYLE)
+    fetch(mapStyleUrl(isDark))
       .then((r) => r.json())
       .then((style: { layers?: Array<{ id: string; type: string; layout?: Record<string, unknown> }> }) => {
         if (cancelled || !style.layers) return;
@@ -156,7 +158,7 @@ export default function DeckGLMap({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isDark]);
 
   const filteredEntities = useMemo(() => {
     return geoEntities.filter((e) => {
@@ -308,7 +310,7 @@ export default function DeckGLMap({
     }
 
     return result;
-  }, [filteredEntities, filteredArcs, showArcs, handleHover, handleClick, focusEntity, pulseScale]);
+  }, [filteredEntities, filteredArcs, showArcs, handleHover, handleClick, focusEntity, pulseScale, TYPE_COLORS]);
 
   return (
     <>

--- a/frontend/src/components/kg-map/typeColors.ts
+++ b/frontend/src/components/kg-map/typeColors.ts
@@ -1,0 +1,40 @@
+/** Marker palette for the geo map, one set per basemap.
+ *
+ *  The -600 shades are tuned for the light basemap and go muddy on the dark one
+ *  (red 2.42:1, violet 2.05:1, blue 2.26:1 against its hsl(216,37%,24%) land) —
+ *  below the 3:1 floor for graphics even with the white halo the dots carry. The
+ *  dark set lifts each hue one Tailwind step to -400, keeping the same hue
+ *  mapping so the legend still reads as the same colour language.
+ *
+ *  Lives in its own module so the map dots (DeckGLMap) and the legend swatches
+ *  (KGMapPage) share one source — they used to keep two hardcoded copies.
+ */
+const TYPE_COLORS_LIGHT: Record<string, [number, number, number]> = {
+  person: [220, 38, 38], // 鲜红 (red-600)
+  monastery: [34, 197, 94], // 鲜绿 (green-500)
+  place: [124, 58, 237], // 鲜紫 (violet-600)
+  school: [37, 99, 235], // 蓝 (blue-600)
+  text: [6, 182, 212], // 青 (cyan-500)
+  concept: [8, 145, 178], // 深青
+  dynasty: [219, 39, 119], // 洋红 (pink-600)
+};
+
+const TYPE_COLORS_DARK: Record<string, [number, number, number]> = {
+  person: [248, 113, 113], // red-400     2.42 -> 4.22
+  monastery: [74, 222, 128], // green-400   5.12 -> 6.71
+  place: [167, 139, 250], // violet-400  2.05 -> 4.29
+  school: [96, 165, 250], // blue-400    2.26 -> 4.59
+  text: [34, 211, 238], // cyan-400    4.81 -> 6.46
+  concept: [103, 232, 249], // cyan-300    3.17 -> 8.03
+  dynasty: [244, 114, 182], // pink-400    2.54 -> 4.41
+};
+
+export function typeColors(isDark: boolean) {
+  return isDark ? TYPE_COLORS_DARK : TYPE_COLORS_LIGHT;
+}
+
+export function typeColorCss(isDark: boolean): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(typeColors(isDark)).map(([k, [r, g, b]]) => [k, `rgb(${r}, ${g}, ${b})`]),
+  );
+}

--- a/frontend/src/pages/KGMapPage.tsx
+++ b/frontend/src/pages/KGMapPage.tsx
@@ -5,6 +5,8 @@ import { GlobalOutlined, BarChartOutlined, SearchOutlined } from "@ant-design/ic
 import { useTranslation } from "react-i18next";
 import * as OpenCC from "opencc-js";
 import DeckGLMap from "../components/kg-map/DeckGLMap";
+import { typeColorCss } from "../components/kg-map/typeColors";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import MapEntityPopup from "../components/kg-map/MapEntityPopup";
 import { getKGGeoEntities, getKGLineageArcs } from "../api/client";
 import type { KGGeoEntity } from "../api/client";
@@ -20,15 +22,12 @@ const ENTITY_TYPE_OPTIONS = [
 const s2t = OpenCC.Converter({ from: "cn", to: "tw" });
 const t2s = OpenCC.Converter({ from: "tw", to: "cn" });
 
-const TYPE_CSS_COLORS: Record<string, string> = {
-  person: "#dc2626",
-  monastery: "#22c55e",
-  place: "#7c3aed",
-  school: "#2563eb",
-};
+
 
 export default function KGMapPage() {
   const { t } = useTranslation();
+  // 图例色与地图点色同源（见 DeckGLMap 的 typeColors）
+  const TYPE_CSS_COLORS = typeColorCss(useEffectiveTheme() === "dark");
 
   const [entityTypes, setEntityTypes] = useState<string[]>([
     "monastery",


### PR DESCRIPTION
暗色模式的最后一处,也是最扎眼的一处。

## 问题

/map 的底图是 MapTiler **streets-v2(亮色)**,占屏约 **65%**,配深色顶栏/底栏 —— 夜里一大块米白直接晃眼。

**为什么一直没发现**:我的对比度审计只看 DOM 文字,而地图是 canvas —— **结构上就看不见**。这次是靠截图肉眼发现的,不是审计跑出来的。

## 改动

**1. 底图按主题分流** `streets-v2` / `streets-v2-dark`

选 `streets-v2-dark` 而不是更暗的 `dataviz-dark`/`basic-v2-dark`:它与现行 style **层结构完全一致**(都是 32 个 symbol 层、25 个含 name),组件里那套**强制中文标注 + 台湾命名**的 patch 原样生效。另两个只有 11 / 7 个标注层,地名会大幅减少。

**2. 标记点色按底图分流**

原调色板注释就写着 "for light background"。换暗底后:

| 类型 | 暗底(原色) | 暗底(新色 -400) |
|---|---|---|
| person 红 | **2.42** ✗ | `#f87171` **4.22** |
| place 紫 | **2.05** ✗ | `#a78bfa` **4.29** |
| school 蓝 | **2.26** ✗ | `#60a5fa` **4.59** |
| monastery 绿 | 5.12 ✓ | `#4ade80` 6.71 |

(图形元素门槛 3:1;点虽有白色描边,但只有 0.5px,兜不住。)

**3. 顺手收口一个隐患**:点色与图例色此前是**两份硬编码副本**(`TYPE_COLORS` / `TYPE_CSS_COLORS`),迟早走样。抽成 `typeColors.ts` 单一来源。

## 两个被 lint 拦下的真问题

- **`TYPE_COLORS` 不在 layers 的 `useMemo` 依赖里** —— 会导致切换主题时点色**根本不重算**,等于修了个寂寞。已补上,并用 `useMemo` 固定引用,避免每帧重建图层。
- 调色板从组件文件导出触发 `react-refresh` 告警,故拆成独立模块(也正好服务于第 3 点)。

## 验证状态（如实说明）

本地无后端时**地图组件不挂载**(连一个 maptiler 请求都发不出),故**本地无法目视**。底图为暗色已由 style JSON 证实(背景 `hsl(216,37%,24%)`),**观感待部署后在生产复验** —— 我会截图确认再回报。

另:MapTiler key 按域名锁定,curl 需带 `Referer: https://fojin.app/` 才能取到 style(否则一律 403,一度让我误以为暗色 style 不存在)。

## 门禁

tsc 0 · eslint 无告警 · i18n ✓ · vitest 251/251 ✓ · build 0