### PR TITLE
test(ci): 精准忽略 React 拆除竞争产生的未处理异常

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -149,6 +149,29 @@ export default defineConfig({
     include: ["src/**/*.test.{ts,tsx}"],
     css: false,
     testTimeout: 10000,
+    // React 19's scheduler runs on setImmediate under Node. When a render or
+    // unmount lands late, `performWorkUntilDeadline` is still queued as vitest
+    // destroys the file's jsdom environment; the callback then fires with
+    // `window` already gone. Every test passes (251/251) but the run is marked
+    // failed, measured at ~29% of full-suite runs — roughly one CI rerun in
+    // three, for a race that happens strictly after the tests are done.
+    //
+    // Ignore that one signature and nothing else: all three conditions must
+    // hold, so a genuine unhandled error — including any *other* ReferenceError,
+    // or this same message from application code rather than React's scheduler —
+    // still fails the run. Drop this once React/vitest stop racing at teardown.
+    //
+    // Not fixed in test code: draining the setImmediate queue in afterAll was
+    // tried and measured (paired A/B, 14 pairs) — it did not help (baseline 4/14
+    // vs 7/14 with the drain), so the config-level filter is the honest option.
+    onUnhandledError(error) {
+      const isTeardownRace =
+        error.type === "Uncaught Exception" &&
+        error.name === "ReferenceError" &&
+        error.message === "window is not defined" &&
+        (error.stack ?? "").includes("performWorkUntilDeadline");
+      if (isTeardownRace) return false;
+    },
   },
   server: {
     port: 3000,


### PR DESCRIPTION
## 问题

CI 的 `Frontend build` 有约 **24%** 的概率变红,但 **251 个测试全部通过**。

红的是测试跑完**之后**的事:React 19 的调度器在 Node 下走 `setImmediate`,渲染/卸载排得晚时 `performWorkUntilDeadline` 还在队列里,而 vitest 已经拆掉该文件的 jsdom 环境 —— 回调触发时 `window` 已经没了,抛 `ReferenceError`。vitest 把它算作失败。

本次会话它卡了 **3 次** CI。既然每个 PR 都要过 CI,这是持续性的税;更麻烦的是"红成常态 → 条件反射重跑",哪天真出问题也会被当成 flake 跳过。

## 做法：只放行这一种签名，不是笼统关掉

用 vitest 的 `onUnhandledError`,**三个条件必须同时成立**才忽略:

```
type    === "Uncaught Exception"
name    === "ReferenceError"  且  message === "window is not defined"
stack   含 performWorkUntilDeadline   ← 确实来自 React 调度器
```

**变异测试验过窄度** —— 注入的三种真错误全部仍然让 CI 红:

| 注入 | 结果 |
|---|---|
| `ReferenceError: some other thing is not defined` | **红** ✓ |
| `ReferenceError: window is not defined`(非调度器栈) | **红** ✓ |
| `Error: generic unhandled failure` | **红** ✓ |

第二条尤其关键:**同样的消息**,只要不是来自调度器就不放行。

## 有效性：交错配对测量

基线/过滤交替跑,两组条件完全相同:

| | 失败次数 |
|---|---|
| 基线 | **3/14** |
| 加过滤器 | **0/14** |

帮上忙 3 次、帮倒忙 0 次。McNemar 双侧 p ≈ 0.25(不一致对只有 3 个,受样本量限制)。累计基线 **8/34 ≈ 24%**;若真实失败率仍是 24%,连续 14 次全清的概率只有 **2.1%**。

## 先试过根治，量过之后放弃了

在 `afterAll` 里排空 `setImmediate` 队列 —— **配对测量证明无效**(基线 4/14 vs 排空后 7/14,没有任何改善迹象),已撤销,不在本 PR 中。

那次尝试倒是抓出一个真问题记录在此:`useSyncScroll.test.tsx` 用假定时器会把 `setImmediate` 一起 mock 掉,**任何在 `afterAll` 等宏任务的方案都会在那里永久挂起**。

## 方法上的一个纠正

我早先两次判断这个 flake 都用了错误的比较方式(拿不同时刻、不同负载的两组数字对比),得出过"基线 9%"和"我的修复让它变成 8/8"两个错误结论。本 PR 的所有数字都来自交错配对测量。

## 门禁

tsc 0 · eslint 0 问题 · i18n ✓ · vitest 251/251 ✓ · build 0