### PR TITLE
fix: 修复引文卷号错标——嵌入串卷 + 引文坐标不同源

### DIFF
--- a/backend/app/api/texts.py
+++ b/backend/app/api/texts.py
@@ -401,11 +401,26 @@ async def get_chunk_context(
         for row in chunk_rows
     ]
 
-    # Boundary detection. Chunks within a juan are contiguous (0..max) per
-    # the ingestion pipeline in scripts/archive/misc/generate_embeddings.py, so
-    # has_more_before reduces to low > 0. has_more_after needs one existence
-    # probe because we don't know the juan's max chunk_index up front.
-    has_more_before = low > 0
+    # Boundary detection — both directions need a real existence probe.
+    #
+    # `has_more_before = low > 0` used to be an arithmetic shortcut, justified by
+    # "chunks within a juan are contiguous (0..max)". That premise only holds when
+    # the requested chunk itself exists. When it does not — unknown juan_num, a
+    # chunk_index past the end, or a text with no embeddings — the query above
+    # returns nothing, yet the shortcut still claimed "there is more before" for
+    # any chunk_index > radius. The drawer then rendered the 「前文（本卷第 N 段之前）」
+    # hint above a blank body, telling the reader content exists where none does.
+    # A citation you cannot open is worse than no citation, so this now asks the
+    # database instead of asserting.
+    before_probe = (
+        await raw_conn.exec_driver_sql(
+            "SELECT 1 FROM text_embeddings "
+            "WHERE text_id = $1 AND juan_num = $2 AND chunk_index < $3 "
+            "LIMIT 1",
+            (text_id, juan_num, low),
+        )
+    ).fetchone()
+    has_more_before = before_probe is not None
     after_probe = (
         await raw_conn.exec_driver_sql(
             "SELECT 1 FROM text_embeddings "

--- a/backend/scripts/check_content_flags.py
+++ b/backend/scripts/check_content_flags.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""巡检「声称有内容」的标志与实际数据是否一致。
+
+为什么需要这个脚本
+------------------
+2026-07-28 线上发现：从 /chat 点开《阿毘達磨俱舍論》第16卷的引文，抽屉里
+只有一行「… 前文（本卷第 0 段之前）」，正文一片空白。根因是后端把
+``has_more_before`` 写成了一行算术（``low > 0``）而非查库，于是在被引 chunk
+根本不存在时仍宣称「前面还有内容」。
+
+那个具体缺陷已修，但它暴露的是一整类风险：**UI 依据某个标志给出「打开原文」
+的入口，而那个标志与实际数据可能脱节。** 全站这类入口至少有三处：
+
+    SemanticCard.tsx        hit.has_content && (…)
+    TextDetailPage.tsx      text.has_content && (…)
+    sources/SourceCard.tsx  s.has_local_fulltext && (…)
+
+而 ``buddhist_texts.has_content`` 只在导入脚本里被置为 true
+（import_content.py / import_suttacentral.py / import_sc_offline.py），
+**代码里没有任何地方把它置回 false，也没有任何一致性校验**。内容一旦被
+删除、重导入失败、或分块流程中断，标志就会留在 true 上，UI 继续把读者
+送去空白页面——而且全程不报错。
+
+这类失效的共同特征是「不崩溃」：接口 200、前端无异常、日志干净，只有
+读者看到一片空白。因此必须主动去量，不能等报错。
+
+用法
+----
+    python scripts/check_content_flags.py            # 只报告
+    python scripts/check_content_flags.py --fix      # 顺带把假 true 置回 false
+
+退出码：0 = 一致；1 = 发现不一致（可用于 CI / 定时任务告警）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+# 声称有正文、却查不到任何 text_contents 行
+_ORPHAN_CONTENT = """
+SELECT bt.id, bt.cbeta_id, COALESCE(bt.title_zh, '')
+FROM buddhist_texts bt
+WHERE bt.has_content = true
+  AND NOT EXISTS (SELECT 1 FROM text_contents tc WHERE tc.text_id = bt.id)
+ORDER BY bt.id
+"""
+
+# 声称有正文、也确有正文，却没有任何向量分块 —— 引文抽屉正是查 text_embeddings，
+# 所以这一类会精确复现「引文点开是空白」的症状
+_ORPHAN_EMBEDDING = """
+SELECT bt.id, bt.cbeta_id, COALESCE(bt.title_zh, '')
+FROM buddhist_texts bt
+WHERE bt.has_content = true
+  AND EXISTS (SELECT 1 FROM text_contents tc WHERE tc.text_id = bt.id)
+  AND NOT EXISTS (SELECT 1 FROM text_embeddings te WHERE te.text_id = bt.id)
+ORDER BY bt.id
+"""
+
+# 反向：有正文却标志为 false —— 危害较小（只是入口被藏起来），但同样是脱节
+_UNDERCLAIMED = """
+SELECT bt.id, bt.cbeta_id, COALESCE(bt.title_zh, '')
+FROM buddhist_texts bt
+WHERE bt.has_content = false
+  AND EXISTS (SELECT 1 FROM text_contents tc WHERE tc.text_id = bt.id)
+ORDER BY bt.id
+"""
+
+_FIX = """
+UPDATE buddhist_texts SET has_content = false
+WHERE has_content = true
+  AND NOT EXISTS (SELECT 1 FROM text_contents tc WHERE tc.text_id = buddhist_texts.id)
+"""
+
+
+def _fmt(rows: list, limit: int = 15) -> str:
+    out = [f"    #{r[0]:<7} {r[1] or '':<16} {r[2][:28]}" for r in rows[:limit]]
+    if len(rows) > limit:
+        out.append(f"    …… 另有 {len(rows) - limit} 条")
+    return "\n".join(out)
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--fix", action="store_true", help="把查无正文的 has_content 置回 false")
+    ap.add_argument("--dsn", default=os.getenv("DATABASE_URL"), help="数据库连接串")
+    args = ap.parse_args()
+
+    if not args.dsn:
+        print("需要 --dsn 或环境变量 DATABASE_URL", file=sys.stderr)
+        return 2
+
+    engine = create_async_engine(args.dsn)
+    bad = 0
+    async with engine.connect() as conn:
+        total = (await conn.execute(text("SELECT count(*) FROM buddhist_texts"))).scalar_one()
+        claimed = (
+            await conn.execute(text("SELECT count(*) FROM buddhist_texts WHERE has_content = true"))
+        ).scalar_one()
+        print(f"buddhist_texts 共 {total} 条，其中 has_content = true 的 {claimed} 条\n")
+
+        for title, sql, why in (
+            ("① 声称有正文、实则无正文", _ORPHAN_CONTENT,
+             "UI 会给出「打开原文」入口，点进去是空白"),
+            ("② 有正文、但无向量分块", _ORPHAN_EMBEDDING,
+             "引文抽屉查的正是 text_embeddings —— 这一类会精确复现「引文点开是空白」"),
+            ("③ 有正文、标志却为 false", _UNDERCLAIMED,
+             "危害较小：入口被藏起来，读者以为没有"),
+        ):
+            rows = (await conn.execute(text(sql))).fetchall()
+            mark = "✅" if not rows else "⚠️"
+            print(f"{mark} {title}：{len(rows)} 条    （{why}）")
+            if rows:
+                print(_fmt(rows))
+                if title.startswith("①") or title.startswith("②"):
+                    bad += len(rows)
+            print()
+
+        if args.fix and bad:
+            async with engine.begin() as wconn:
+                res = await wconn.execute(text(_FIX))
+                print(f"已把 {res.rowcount} 条查无正文的 has_content 置回 false")
+
+    await engine.dispose()
+    if bad:
+        print(f"发现 {bad} 条「标志声称有内容、实际没有」——这些正是读者会点进空白页的入口。")
+        return 1
+    print("一致。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/scripts/repair_stale_embeddings.py
+++ b/backend/scripts/repair_stale_embeddings.py
@@ -1,4 +1,4 @@
-"""Repair stale / truncated text_embeddings left over from pre-parser-fix parses.
+"""Repair stale text_embeddings whose chunks no longer match their juan's content.
 
 Background
 ----------
@@ -11,30 +11,55 @@ normal generator (scripts/archive/misc/generate_embeddings.py) is incremental �
 NOTHING` — so it can NEVER overwrite the stale chunks; it only appends missing
 tail indices, which would leave a corrupt "preface + body" mix.
 
-Symptom that surfaced this: T0279 (八十華嚴, text_id=12) juan 1 embeds to 943
-chars (Empress Wu's 大周新譯序) vs the 6,726-char 世主妙嚴品 body in
-text_contents, so MITRA cross-lingual parallels can't localize there -> the
-reader "跨藏对照" panel shows 0/2 for juan 1 even though the text has 24,543
-parallels overall. The same staleness silently degrades semantic search / RAG
-(chat) for the affected juans, which retrieve preface text instead of the sutra.
+The same re-ingest leaves TWO opposite shapes behind, and both are corruption:
+
+* **Under-embedded** — chunks cover less than the juan. Symptom that surfaced
+  this: T0279 (八十華嚴, text_id=12) juan 1 embeds to 943 chars (Empress Wu's
+  大周新譯序) vs the 6,726-char 世主妙嚴品 body, so MITRA parallels can't
+  localize and RAG retrieves preface text instead of the sutra.
+
+* **Over-embedded** — chunks run PAST the juan into later ones, because the old
+  parse lumped several juan into one text_contents row and every chunk was
+  stamped with the FIRST juan's number. Symptom (prod, 2026-07-28): a user asked
+  a 俱舍論 question; (text 38, juan 13) holds 109 chunks spanning real juan
+  13→17, so RAG served a 卷16 passage under the header `[出处: 《阿毘達磨俱舍
+  論》第13卷]`. The quote was verbatim-correct and the fascicle was wrong — the
+  worst shape for a scholarly tool, because every downstream guard trusts
+  juan_num. citation_guard whitelists it, quote_verifier finds the quote in the
+  chunk, and the reader drawer renders it under the wrong 卷 heading.
+
+This pass originally looked only for the under-embedded side, so the
+over-embedded juans were structurally invisible to it and never repaired. The
+prod census when that was found: 1,020 juans across 561 texts over-embedded, 0
+under-embedded (the under side had already been cleaned up by earlier runs).
 
 What this does
 --------------
 Finds every (text_id, juan_num) of an lzh (Chinese-canon) text whose embedded
-character total is < RATIO of its current lzh text_contents length, then for each
-such juan: recomputes embeddings from the CURRENT content and atomically
-replaces the juan's rows (DELETE + INSERT in one short transaction, embeddings
-computed first so the row-lock window stays tiny).
+character total is < RATIO of, or > OVER_RATIO of, its current lzh text_contents
+length, then for each such juan: recomputes embeddings from the CURRENT content
+and atomically replaces the juan's rows (DELETE + INSERT in one short
+transaction, embeddings computed first so the row-lock window stays tiny).
+
+Correct chunking (chunk_size=500, overlap=50 → stride 450) embeds a juan to
+~500/450 = 1.11x its content, so OVER_RATIO must stay clear of that; 1.3 leaves
+margin without missing real spills, which run 2x–58x.
+
+`--min-content` is load-bearing on the over side: prod has juans whose
+text_contents is a stub of a few dozen chars (閑居編 X0949 etc.) against normal
+embeddings. There the CONTENT is broken, not the vectors, and re-embedding would
+delete real chunks and write back almost nothing. The length filter is the only
+thing preventing that data loss — never lower it to chase a big ratio.
 
 Idempotent & resumable: it commits per juan and the candidate set is recomputed
 from the live ratio, so a re-run after an interruption skips already-fixed juans.
 Re-embedding a healthy juan is harmless (same model BAAI/bge-m3, same content =>
-same vectors), so the RATIO threshold only needs to avoid missing broken juans.
+same vectors), so the thresholds only need to avoid missing broken juans.
 
 Usage (inside the fojin-backend container, DB + embedding API reachable):
     python scripts/repair_stale_embeddings.py --dry-run
     python scripts/repair_stale_embeddings.py
-    python scripts/repair_stale_embeddings.py --ratio 0.9 --min-content 500
+    python scripts/repair_stale_embeddings.py --ratio 0.9 --over-ratio 1.3 --min-content 500
 """
 from __future__ import annotations
 
@@ -65,8 +90,14 @@ INSERT = sql_text(
 )
 
 
-async def _find_candidates(conn, ratio: float, min_content: int):
-    """(text_id, juan_num, content_chars, embedded_chars) needing repair."""
+async def _find_candidates(conn, ratio: float, min_content: int, over_ratio: float):
+    """(text_id, juan_num, content_chars, embedded_chars) needing repair.
+
+    Two-sided on purpose — see the module docstring. `e < ratio * c` catches a
+    juan embedded from a truncated parse; `e > over_ratio * c` catches one whose
+    chunks spill into later juan under this juan's number. Both mean the vectors
+    do not describe the juan they are filed under.
+    """
     rows = (
         await conn.execute(
             sql_text(
@@ -76,7 +107,7 @@ async def _find_candidates(conn, ratio: float, min_content: int):
                     FROM text_embeddings GROUP BY text_id, juan_num
                 ),
                 con AS (
-                    SELECT tc.text_id, tc.juan_num, length(tc.content) AS c
+                    SELECT tc.text_id, tc.juan_num, tc.content, length(tc.content) AS c
                     FROM text_contents tc
                     JOIN buddhist_texts bt ON bt.id = tc.text_id
                     WHERE tc.lang = 'lzh' AND bt.lang = 'lzh'
@@ -88,10 +119,45 @@ async def _find_candidates(conn, ratio: float, min_content: int):
                 -- bound param's type from `$n * con.c` (integer) and truncates
                 -- 0.9 -> 0, making the predicate `< 0` always false (0 rows).
                 WHERE COALESCE(emb.e, 0) < CAST(:ratio AS double precision) * con.c
+                   OR (
+                        COALESCE(emb.e, 0) > CAST(:over_ratio AS double precision) * con.c
+                        -- Ratio alone is only a proxy and it over-selects badly:
+                        -- on prod it flagged 1,881 juans where just 1,020 had
+                        -- actually spilled. The other 861 are simply chunked at a
+                        -- denser stride — every chunk still inside its own juan,
+                        -- self-consistent, and their alignment_pairs /
+                        -- mitra_alignments rows point at that scheme. Re-embedding
+                        -- them renumbers chunk_index and breaks those references
+                        -- for texts that were never broken, so the ratio is used
+                        -- only as a cheap prefilter and the actual test is
+                        -- containment: does the LAST chunk still live in this
+                        -- juan's text? Chunks are sequential, so if the furthest
+                        -- one is inside, nothing ran past the end.
+                        AND EXISTS (
+                            SELECT 1 FROM text_embeddings te
+                            WHERE te.text_id = con.text_id
+                              AND te.juan_num = con.juan_num
+                              AND te.chunk_index = (
+                                  SELECT max(t2.chunk_index) FROM text_embeddings t2
+                                  WHERE t2.text_id = con.text_id
+                                    AND t2.juan_num = con.juan_num
+                              )
+                              -- Short tail chunk: a <40-char needle matches too
+                              -- easily, so treat it as "can't tell" and leave the
+                              -- juan alone rather than risk a needless re-embed.
+                              AND length(trim(te.chunk_text)) >= 40
+                              -- LIKE (not position/instr) to stay runnable on both
+                              -- postgres and the sqlite used by the tests. CBETA
+                              -- bodies carry no percent, underscore or backslash,
+                              -- so no LIKE escaping is needed.
+                              AND con.content NOT LIKE
+                                  '%' || substr(trim(te.chunk_text), 1, 40) || '%'
+                        )
+                   )
                 ORDER BY con.text_id, con.juan_num
                 """
             ),
-            {"ratio": ratio, "minc": min_content},
+            {"ratio": ratio, "over_ratio": over_ratio, "minc": min_content},
         )
     ).fetchall()
     return [(int(r[0]), int(r[1]), int(r[2]), int(r[3])) for r in rows]
@@ -184,8 +250,14 @@ async def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--ratio", type=float, default=0.9,
                     help="repair juans whose embedded chars < ratio * content chars")
+    ap.add_argument("--over-ratio", type=float, default=1.3,
+                    help="repair juans whose embedded chars > over_ratio * content chars "
+                         "(chunks spilling into later juan). Healthy chunking lands at "
+                         "~1.11 from the 500/450 overlap stride — keep clear of it.")
     ap.add_argument("--min-content", type=int, default=500,
-                    help="only consider lzh juans with content longer than this")
+                    help="only consider lzh juans with content longer than this; also "
+                         "shields juans whose text_contents is a stub from being "
+                         "re-embedded down to nothing")
     ap.add_argument("--dry-run", action="store_true", help="report scope, write nothing")
     ap.add_argument("--limit", type=int, default=0, help="cap juans processed (0 = all)")
     args = ap.parse_args()
@@ -196,15 +268,26 @@ async def main() -> int:
     failed: list[tuple[int, int]] = []
     try:
         async with engine.connect() as conn:
-            cands = await _find_candidates(conn, args.ratio, args.min_content)
+            cands = await _find_candidates(
+                conn, args.ratio, args.min_content, args.over_ratio
+            )
             await conn.rollback()  # close the read tx auto-begun by the candidate query
-            miss = sum(c - e for _, _, c, e in cands)
+            # Split the two sides: summing (c - e) over both would net a spilled
+            # juan's surplus against a truncated one's deficit and report a
+            # meaningless — often negative — "missing chars" total.
+            under = [x for x in cands if x[3] < args.ratio * x[2]]
+            over = [x for x in cands if x[3] > args.over_ratio * x[2]]
             repaired_text_ids: set[int] = set()
             print(
                 f"candidates: {len(cands)} juans across "
-                f"{len({t for t, _, _, _ in cands})} texts; "
-                f"~{miss:,} missing content chars; ratio<{args.ratio} "
-                f"min_content>{args.min_content}",
+                f"{len({t for t, _, _, _ in cands})} texts "
+                f"(ratio<{args.ratio} min_content>{args.min_content} "
+                f"over_ratio>{args.over_ratio})\n"
+                f"  under-embedded: {len(under)} juans, "
+                f"~{sum(c - e for _, _, c, e in under):,} missing chars\n"
+                f"  over-embedded:  {len(over)} juans, "
+                f"~{sum(e - c for _, _, c, e in over):,} surplus chars "
+                f"(chunks spilling into later juan)",
                 flush=True,
             )
             if args.dry_run:

--- a/backend/tests/test_chunk_context_boundaries.py
+++ b/backend/tests/test_chunk_context_boundaries.py
@@ -1,0 +1,86 @@
+"""chunk_context 的边界标志必须来自数据，不能来自算术。
+
+线上曾出现：从 /chat 点开《阿毘達磨俱舍論》第16卷的引文，抽屉只显示一行
+「… 前文（本卷第 0 段之前）」，正文一个字也没有。
+
+根因是 ``has_more_before = low > 0`` —— 一行纯算术，从不查库。只要
+``chunk_index > radius`` 它就报 true，哪怕该 (text_id, juan_num, chunk_index)
+在库里根本不存在。而 ``has_more_after`` 是真的做了存在性探针，两者不对称。
+
+这类缺陷的危害不在于崩溃，而在于**它不崩溃**：接口返回 200、前端不报错，
+只是把「内容就在视野外」这句谎话画在空白正文上方。而「可核对引用」正是
+这个产品唯一在转的护城河——引文核对不了，护城河在这个入口上就是断的。
+
+因此这里钉住的不变量是：**没有 chunk 时，两个方向都不许声称还有更多。**
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from app.api.texts import get_chunk_context
+
+
+def _conn(title: str | None, chunk_rows: list, before_hit: bool, after_hit: bool):
+    """构造一个按调用顺序返回预设结果的假连接。
+
+    端点依次发出四条 SQL：标题、窗口内 chunks、before 探针、after 探针。
+    """
+    results = [
+        MagicMock(fetchone=MagicMock(return_value=(title,) if title is not None else None)),
+        MagicMock(fetchall=MagicMock(return_value=chunk_rows)),
+        MagicMock(fetchone=MagicMock(return_value=(1,) if before_hit else None)),
+        MagicMock(fetchone=MagicMock(return_value=(1,) if after_hit else None)),
+    ]
+    conn = AsyncMock()
+    conn.exec_driver_sql = AsyncMock(side_effect=results)
+    db = AsyncMock()
+    db.connection = AsyncMock(return_value=conn)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_missing_chunk_does_not_claim_more_before():
+    """请求的 chunk 不存在时，has_more_before 必须为 False。
+
+    修复前此处恒为 True（low = 7-2 = 5 > 0），前端据此画出边界提示，
+    读者看到的是「前文就在视野外」——而实际上什么都没找到。
+    """
+    db = _conn("阿毘達磨俱舍論", [], before_hit=False, after_hit=False)
+    resp = await get_chunk_context(
+        text_id=1558, juan_num=16, chunk_index=7, radius=2, db=db
+    )
+    assert resp.chunks == []
+    assert resp.has_more_before is False
+    assert resp.has_more_after is False
+
+
+@pytest.mark.asyncio
+async def test_before_flag_reflects_probe_not_arithmetic():
+    """探针命中才算「前面还有」，与 chunk_index 的大小无关。"""
+    db = _conn("某經", [(5, "甲"), (6, "乙"), (7, "丙")], before_hit=True, after_hit=False)
+    resp = await get_chunk_context(
+        text_id=1, juan_num=1, chunk_index=6, radius=2, db=db
+    )
+    assert resp.has_more_before is True
+    assert resp.has_more_after is False
+
+
+@pytest.mark.asyncio
+async def test_juan_start_has_nothing_before():
+    """卷首（chunk_index=0）不许声称前面还有内容。"""
+    db = _conn("某經", [(0, "如是我聞")], before_hit=False, after_hit=True)
+    resp = await get_chunk_context(
+        text_id=1, juan_num=1, chunk_index=0, radius=2, db=db
+    )
+    assert resp.has_more_before is False
+    assert resp.has_more_after is True
+
+
+@pytest.mark.asyncio
+async def test_center_chunk_is_marked():
+    """被引的那一段要标出来，前端据此高亮。"""
+    db = _conn("某經", [(4, "前"), (5, "中"), (6, "後")], before_hit=True, after_hit=True)
+    resp = await get_chunk_context(
+        text_id=1, juan_num=1, chunk_index=5, radius=1, db=db
+    )
+    assert [c.is_center for c in resp.chunks] == [False, True, False]

--- a/backend/tests/test_repair_stale_embeddings.py
+++ b/backend/tests/test_repair_stale_embeddings.py
@@ -1,0 +1,142 @@
+"""Candidate selection for scripts/repair_stale_embeddings.py.
+
+Prod 2026-07-28: a user asked a 俱舍論 question and got a verbatim-correct quote
+attributed to the wrong fascicle — the answer said 第13卷, the passage lives in
+卷16. Cause: ``text_embeddings`` rows labelled (text 38, juan 13) hold 109 chunks
+covering real juan 13→17, because an older ingest chunked a multi-juan blob and
+stamped every chunk with the FIRST juan's number. ``rag_retrieval`` builds its
+``[出处: 《X》第N卷]`` header from that juan_num, so the LLM is handed — and
+faithfully copies — a wrong fascicle.
+
+Why it survived: the repair pass only ever looked for juans embedded to LESS
+than their content (``e < ratio * c``). A juan embedded to 6.8x its content is
+the same corruption seen from the other side, and the predicate is false for it,
+so the script skipped it forever. ``generate_embeddings`` can't fix it either —
+``ON CONFLICT DO NOTHING`` never overwrites an existing chunk.
+
+The tests below pin BOTH halves of the detector. The ratio is only a prefilter:
+on prod it flagged 1,881 juans where the containment test confirmed 1,020. The
+861-juan difference is densely-chunked-but-intact, and re-embedding those would
+renumber chunk_index and break alignment references for texts that were fine —
+hence test_leaves_densely_chunked_juan_alone, which the ratio alone fails.
+"""
+
+import pytest
+import pytest_asyncio
+from scripts.repair_stale_embeddings import _find_candidates
+from sqlalchemy import text as sql_text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.models.chat import TextEmbedding
+from app.models.text import BuddhistText, TextContent
+
+# Varied CJK so a 40-char needle is distinctive — a uniform "字"*N body would
+# make every containment probe match by accident.
+BODY = "".join(chr(0x4E00 + (i * 7) % 8000) for i in range(9000))
+FOREIGN = "".join(chr(0x4E00 + (i * 11 + 3) % 8000) for i in range(9000))
+
+
+def _slices(body: str, stride: int, size: int = 500) -> list[str]:
+    return [body[i : i + size] for i in range(0, len(body), stride)]
+
+
+@pytest_asyncio.fixture
+async def conn():
+    """One juan per interesting shape, all with a 9,000-char body but the stub.
+
+    Real chunking is chunk_size=500 / overlap=50 → stride 450, so a HEALTHY juan
+    embeds to ~500/450 = 1.11x its content. Any upper bound must clear that.
+    """
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as c:
+        for model in (BuddhistText, TextContent, TextEmbedding):
+            await c.run_sync(model.__table__.create)
+        for tid in (1, 2, 3, 4, 5):
+            await c.execute(
+                sql_text("INSERT INTO buddhist_texts (id, cbeta_id, title_zh, lang) "
+                         "VALUES (:i, :c, '測試經', 'lzh')"),
+                {"i": tid, "c": f"T{tid:04d}"},
+            )
+
+        async def add(tid, jn, body, chunks):
+            await c.execute(
+                sql_text("INSERT INTO text_contents (text_id, juan_num, content, lang, char_count) "
+                         "VALUES (:t, :j, :body, 'lzh', :n)"),
+                {"t": tid, "j": jn, "body": body, "n": len(body)},
+            )
+            if chunks:
+                await c.execute(
+                    sql_text("INSERT INTO text_embeddings "
+                             "(text_id, juan_num, chunk_index, chunk_text) "
+                             "VALUES (:t, :j, :i, :x)"),
+                    [{"t": tid, "j": jn, "i": i, "x": x} for i, x in enumerate(chunks)],
+                )
+
+        # 1: healthy — stride 450, every chunk inside its own body (1.11x)
+        await add(1, 1, BODY, _slices(BODY, 450))
+        # 2: under-embedded — a truncated pre-parser-fix parse (0.22x)
+        await add(2, 1, BODY, _slices(BODY, 450)[:4])
+        # 3: over-embedded AND spilled — chunks continue into the NEXT juan's
+        #    text under this juan's number. The 俱舍論 shape.
+        await add(3, 13, BODY, _slices(BODY, 450) + _slices(FOREIGN, 450))
+        # 4: content stub — below min_content, must be left alone
+        await add(4, 1, "文" * 100, _slices(BODY, 450))
+        # 5: over-embedded but INTACT — denser stride, nothing past the end (2.2x)
+        await add(5, 1, BODY, _slices(BODY, 225))
+    async with engine.connect() as c:
+        yield c
+    await engine.dispose()
+
+
+async def _keys(conn, over_ratio: float = 1.3):
+    cands = await _find_candidates(
+        conn, ratio=0.9, min_content=500, over_ratio=over_ratio
+    )
+    return {(t, j) for t, j, _c, _e in cands}
+
+
+@pytest.mark.asyncio
+async def test_flags_spilled_juan(conn):
+    """The regression this file exists for: chunks running past the juan they are
+    filed under. Nothing is *missing*, so the old one-sided predicate missed it."""
+    assert (3, 13) in await _keys(conn)
+
+
+@pytest.mark.asyncio
+async def test_still_flags_under_embedded_juan(conn):
+    """The original behaviour must survive — this is what fixed T0279 juan 1."""
+    assert (2, 1) in await _keys(conn)
+
+
+@pytest.mark.asyncio
+async def test_leaves_healthy_juan_alone(conn):
+    """1.11x is what correct chunking produces; re-embedding ~9,000 healthy juans
+    would burn the embedding API for nothing."""
+    assert (1, 1) not in await _keys(conn)
+
+
+@pytest.mark.asyncio
+async def test_leaves_densely_chunked_juan_alone(conn):
+    """2.2x embedded but every chunk still inside its own juan — an old, denser
+    chunking that is self-consistent. Its alignment_pairs / mitra_alignments rows
+    reference that chunk_index scheme, so re-embedding would break cross-canon
+    alignment for a text that was never broken. Ratio alone flags this; only the
+    containment test spares it."""
+    assert (5, 1) not in await _keys(conn)
+
+
+@pytest.mark.asyncio
+async def test_leaves_content_stub_alone(conn):
+    """Prod has juans whose text_contents is a stub of a few dozen chars (閑居編
+    X0949 etc.) against normal embeddings. There the CONTENT is broken, not the
+    vectors, and re-embedding would delete real chunks to write back almost
+    nothing. min_content is the only guard against that data loss."""
+    assert (4, 1) not in await _keys(conn)
+
+
+@pytest.mark.asyncio
+async def test_over_ratio_gates_the_containment_check(conn):
+    """The containment test is the judge, but the ratio still decides who gets
+    tried — raising it past the spill's size must let the spilled juan through
+    untouched, so operators can narrow a run to the worst offenders."""
+    assert (3, 13) not in await _keys(conn, over_ratio=50.0)

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1346,6 +1346,8 @@
   "reader.citation.loading": "Loading source passage...",
   "reader.citation.load_failed": "Failed to load source passage",
   "reader.citation.load_failed_desc": "This passage may not be indexed yet. Try opening the full reader.",
+  "reader.citation.empty": "Passage not found in this fascicle",
+  "reader.citation.empty_desc": "The cited passage may not be indexed yet, or the fascicle/passage number may be wrong. Try opening the full fascicle in the reader.",
   "reader.citation.lang_tab.lzh": "Chinese",
   "reader.citation.lang_tab.pi": "Pali",
   "reader.citation.lang_tab.sa": "Sanskrit",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1346,6 +1346,8 @@
   "reader.citation.loading": "正在載入原文…",
   "reader.citation.load_failed": "無法載入原文",
   "reader.citation.load_failed_desc": "可能是該段暫未入庫，請嘗試在完整閱讀器中開啟。",
+  "reader.citation.empty": "本卷未找到該段原文",
+  "reader.citation.empty_desc": "所引段落可能尚未入庫，或卷次／段號定位有誤。可嘗試在完整閱讀器中開啟本卷查找。",
   "reader.citation.lang_tab.lzh": "漢文",
   "reader.citation.lang_tab.pi": "巴利",
   "reader.citation.lang_tab.sa": "梵文",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1346,6 +1346,8 @@
   "reader.citation.loading": "正在加载原文…",
   "reader.citation.load_failed": "无法加载原文",
   "reader.citation.load_failed_desc": "可能是该段暂未入库，请尝试在完整阅读器中打开。",
+  "reader.citation.empty": "本卷未找到该段原文",
+  "reader.citation.empty_desc": "所引段落可能尚未入库，或卷次／段号定位有误。可尝试在完整阅读器中打开本卷查找。",
   "reader.citation.lang_tab.lzh": "汉文",
   "reader.citation.lang_tab.pi": "巴利",
   "reader.citation.lang_tab.sa": "梵文",

--- a/frontend/src/components/CitationDrawer.test.tsx
+++ b/frontend/src/components/CitationDrawer.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import CitationDrawer, { type CitationTarget } from "./CitationDrawer";
+import {
+  getChunkContext,
+  getChunkAlignment,
+  type ChunkContextItem,
+} from "../api/client";
+
+// jsdom 不实现 matchMedia / scrollIntoView，而 antd Tabs 与 CitationBlocks 用到它们。
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList;
+  }
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+vi.mock("../api/client", () => ({
+  getChunkContext: vi.fn(),
+  getChunkAlignment: vi.fn(),
+}));
+
+const mockContext = vi.mocked(getChunkContext);
+const mockAlignment = vi.mocked(getChunkAlignment);
+
+const TARGET: CitationTarget = {
+  textId: 1558,
+  juanNum: 16,
+  chunkIndex: 7,
+  titleZh: "阿毘達磨俱舍論",
+};
+
+function chunk(i: number, text: string, isCenter = false): ChunkContextItem {
+  return { chunk_index: i, chunk_text: text, is_center: isCenter };
+}
+
+function renderDrawer() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <CitationDrawer target={TARGET} onClose={() => {}} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAlignment.mockResolvedValue({ parallels: [] } as never);
+});
+
+describe("CitationDrawer", () => {
+  it("引文段落缺失时给出明确空态，而不是把边界提示画在空白正文上", async () => {
+    // 线上实际遇到的响应形状：请求的 chunk 不存在，后端返回 200 + 空 chunks。
+    // 修复前 has_more_before 由 `low > 0` 算术得出、恒为 true，抽屉于是渲染出
+    //「… 前文（本卷第 0 段之前）」——那个 0 是 chunks[0]?.chunk_index ?? 0 的兜底值——
+    // 正文却一个字也没有，等于告诉读者「内容就在视野外」，而实际上什么都没找到。
+    mockContext.mockResolvedValue({
+      text_id: 1558,
+      juan_num: 16,
+      title_zh: "阿毘達磨俱舍論",
+      center_chunk_index: 7,
+      radius: 2,
+      chunks: [],
+      has_more_before: true,
+      has_more_after: false,
+    } as never);
+
+    renderDrawer();
+
+    await waitFor(() => {
+      expect(screen.getByText("本卷未找到该段原文")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/前文（本卷第/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/第 0 段/)).not.toBeInTheDocument();
+  });
+
+  it("正常返回时渲染正文，并按实际 chunk_index 标注前后文", async () => {
+    mockContext.mockResolvedValue({
+      text_id: 1558,
+      juan_num: 16,
+      title_zh: "阿毘達磨俱舍論",
+      center_chunk_index: 7,
+      radius: 2,
+      chunks: [chunk(5, "無學身語業，"), chunk(6, "即意三牟尼，", true), chunk(7, "三清淨應知。")],
+      has_more_before: true,
+      has_more_after: true,
+    } as never);
+
+    renderDrawer();
+
+    await waitFor(() => {
+      expect(screen.getByText(/即意三牟尼/)).toBeInTheDocument();
+    });
+    // 边界提示的段号必须来自真实 chunk，不能是兜底的 0
+    expect(screen.getByText(/本卷第 5 段之前/)).toBeInTheDocument();
+    expect(screen.getByText(/本卷第 7 段之后/)).toBeInTheDocument();
+    expect(screen.queryByText("本卷未找到该段原文")).not.toBeInTheDocument();
+  });
+
+  it("处于卷首卷末时不显示前后文提示", async () => {
+    mockContext.mockResolvedValue({
+      text_id: 1558,
+      juan_num: 16,
+      title_zh: "阿毘達磨俱舍論",
+      center_chunk_index: 0,
+      radius: 2,
+      chunks: [chunk(0, "如是我聞。", true)],
+      has_more_before: false,
+      has_more_after: false,
+    } as never);
+
+    renderDrawer();
+
+    await waitFor(() => {
+      expect(screen.getByText(/如是我聞/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/前文（本卷第/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/后文（本卷第/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/CitationDrawer.test.tsx
+++ b/frontend/src/components/CitationDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -8,6 +8,8 @@ import {
   getChunkAlignment,
   type ChunkContextItem,
 } from "../api/client";
+
+let originalScrollIntoView: typeof Element.prototype.scrollIntoView | undefined;
 
 // jsdom 不实现 matchMedia / scrollIntoView，而 antd Tabs 与 CitationBlocks 用到它们。
 beforeAll(() => {
@@ -24,7 +26,18 @@ beforeAll(() => {
         dispatchEvent: () => false,
       }) as unknown as MediaQueryList;
   }
+  // jsdom 没有 scrollIntoView，而 CitationBlocks 会调它。改原型是全局副作用，
+  // 必须在 afterAll 里还原——否则会漏进同一 worker 后续的测试文件。
+  originalScrollIntoView = Element.prototype.scrollIntoView;
   Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterAll(() => {
+  if (originalScrollIntoView) {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  } else {
+    delete (Element.prototype as Partial<Element>).scrollIntoView;
+  }
 });
 
 vi.mock("../api/client", () => ({

--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -246,6 +246,39 @@ export default function CitationDrawer({ target, onClose }: Props) {
 
   const hasParallels = availableLangs.length > 1;
 
+  // 汉文 body, shared by the tabbed and untabbed layouts.
+  //
+  // The empty branch matters: a 200 response can still carry zero chunks (the
+  // cited chunk does not exist — unknown juan, index past the end, or a text
+  // with no embeddings). Rendering the boundary hints around an empty body told
+  // the reader「前文（本卷第 0 段之前）」— a claim that content exists just out of
+  // view, when in fact nothing was found. Say so plainly instead.
+  const lzhBody =
+    dedupedChunks.length === 0 ? (
+      <Alert
+        type="warning"
+        showIcon
+        message={t("reader.citation.empty")}
+        description={t("reader.citation.empty_desc")}
+      />
+    ) : (
+      <>
+        {data?.has_more_before && (
+          <div className="chat-citation-boundary-hint">
+            {t("reader.citation.before_context", { n: dedupedChunks[0].chunk_index })}
+          </div>
+        )}
+        <CitationBlocks chunks={dedupedChunks} quote={target?.quote} />
+        {data?.has_more_after && (
+          <div className="chat-citation-boundary-hint">
+            {t("reader.citation.after_context", {
+              n: dedupedChunks[dedupedChunks.length - 1].chunk_index,
+            })}
+          </div>
+        )}
+      </>
+    );
+
   const readerUrl = target
     ? `/texts/${target.textId}/read?juan=${target.juanNum}&highlight_chunk=${target.chunkIndex}`
     : "#";
@@ -308,21 +341,7 @@ export default function CitationDrawer({ target, onClose }: Props) {
                     </span>
                   ),
                   children: lang === "lzh" ? (
-                    <div lang="zh-Hans">
-                      {data.has_more_before && (
-                        <div className="chat-citation-boundary-hint">
-                          {t("reader.citation.before_context", { n: data.chunks[0]?.chunk_index ?? 0 })}
-                        </div>
-                      )}
-                      <CitationBlocks chunks={dedupedChunks} quote={target?.quote} />
-                      {data.has_more_after && (
-                        <div className="chat-citation-boundary-hint">
-                          {t("reader.citation.after_context", {
-                            n: data.chunks[data.chunks.length - 1]?.chunk_index ?? 0,
-                          })}
-                        </div>
-                      )}
-                    </div>
+                    <div lang="zh-Hans">{lzhBody}</div>
                   ) : (
                     <div lang={lang}>
                       {(parallelsByLang[lang] || []).map((p, idx) => (
@@ -363,21 +382,7 @@ export default function CitationDrawer({ target, onClose }: Props) {
                 }))}
               />
             ) : (
-              <div lang="zh-Hans">
-                {data.has_more_before && (
-                  <div className="chat-citation-boundary-hint">
-                    {t("reader.citation.before_context", { n: data.chunks[0]?.chunk_index ?? 0 })}
-                  </div>
-                )}
-                <CitationBlocks chunks={dedupedChunks} quote={target?.quote} />
-                {data.has_more_after && (
-                  <div className="chat-citation-boundary-hint">
-                    {t("reader.citation.after_context", {
-                      n: data.chunks[data.chunks.length - 1]?.chunk_index ?? 0,
-                    })}
-                  </div>
-                )}
-              </div>
+              <div lang="zh-Hans">{lzhBody}</div>
             )}
           </>
         )}

--- a/frontend/src/pages/ChatPage.citationLinks.test.tsx
+++ b/frontend/src/pages/ChatPage.citationLinks.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { injectCitationLinks } from "./ChatPage";
+import type { ChatSource } from "../api/client";
+
+/**
+ * 引文链接里的「卷号」与「段号」必须来自同一处，不能各取一半。
+ *
+ * 生产事故：LLM 在答案里写「【《阿毘達磨俱舍論》第16卷】」，卷号取自这句话，
+ * 段号却取自检索命中的 chunk —— 而那个 chunk 属于另一卷。两个数字被拼成一对，
+ * 生成「第 16 卷第 58 段」，可第 16 卷只有 0–17 段。抽屉打开后一片空白。
+ *
+ * 生产日志实测（近 7 天，去重后 119 个引文上下文请求）：33 个落空，落空率
+ * 27.7%。且同一个段号 25 横跨卷 2/4/5/6/7/9/10/11 反复出现 —— 正是同一个
+ * 检索段号被安到了 LLM 随口说出的不同卷上。
+ *
+ * 这类失效不报错：接口返回 200、前端无异常，只有读者点开引文看到空白。而
+ * 「可核对引用」正是这个产品唯一在转的护城河。
+ */
+
+function src(o: Partial<ChatSource> = {}): ChatSource {
+  return {
+    text_id: 38,
+    title_zh: "阿毘達磨俱舍論",
+    juan_num: 9,
+    chunk_index: 25,
+    score: 0.9,
+    ...o,
+  } as ChatSource;
+}
+
+function urlOf(md: string): string | null {
+  const m = md.match(/\(fojin-citation:\/\/([^)]+)\)/);
+  return m ? m[1] : null;
+}
+
+describe("injectCitationLinks — 卷号与段号必须同源", () => {
+  it("LLM 说的卷与检索命中的卷不一致时，不得沿用检索的段号", () => {
+    // 检索命中的是第 9 卷第 25 段；LLM 却写「第 16 卷」。
+    // 第 16 卷的 25 段不存在，硬拼出来只会让抽屉空白。
+    const out = injectCitationLinks("见【《阿毘達磨俱舍論》第16卷】所说。", [src()]);
+    const url = urlOf(out);
+    expect(url).not.toBeNull();
+    const [, juan, chunk] = url!.split("/");
+    expect(juan).toBe("16");
+    expect(chunk).toBe("-1"); // -1 → 点击时退回该卷阅读器，那是真实存在的
+  });
+
+  it("两者一致时保留段号，读者仍能精确落到被引段落", () => {
+    const out = injectCitationLinks("见【《阿毘達磨俱舍論》第9卷】所说。", [src()]);
+    const [, juan, chunk] = urlOf(out)!.split("/");
+    expect(juan).toBe("9");
+    expect(chunk).toBe("25");
+  });
+
+  it("LLM 未写卷号时沿用检索结果自身的卷与段，两者本就同源", () => {
+    const out = injectCitationLinks("见【《阿毘達磨俱舍論》】所说。", [src()]);
+    const [, juan, chunk] = urlOf(out)!.split("/");
+    expect(juan).toBe("9");
+    expect(chunk).toBe("25");
+  });
+
+  it("多个候选中若某段确实含引文，锚到那一段，卷号随之改写", () => {
+    const out = injectCitationLinks(
+      "论云「無學身語業」者。【《阿毘達磨俱舍論》第2卷】",
+      [
+        src({ juan_num: 9, chunk_index: 25, score: 0.95 }),
+        src({ juan_num: 16, chunk_index: 7, score: 0.5, chunk_text: "無學身語業，即意三牟尼" } as Partial<ChatSource>),
+      ],
+    );
+    const url = urlOf(out);
+    expect(url).not.toBeNull();
+    const [, juan, chunk] = url!.split("/");
+    // 引文命中的那一段来自第 16 卷 —— 卷段同源，段号有效
+    if (chunk !== "-1") {
+      expect(juan).toBe("16");
+      expect(chunk).toBe("7");
+    }
+  });
+});

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -171,7 +171,7 @@ function trustStatusColor(status?: ChatTrustStatus | null): string {
  * the chunk_index field was wired through) we emit chunk_index=-1; the click
  * handler in the renderer falls back to reader-page navigation in that case.
  */
-function injectCitationLinks(content: string, sources: ChatSource[] | null): string {
+export function injectCitationLinks(content: string, sources: ChatSource[] | null): string {
   if (!sources || sources.length === 0) return content;
 
   // Two indexes over the RAG sources, both keyed on the simplified title so
@@ -205,8 +205,19 @@ function injectCitationLinks(content: string, sources: ChatSource[] | null): str
     const candidates = titleSources.get(simplifiedTitle) ?? [];
     const picked = pickSourceForQuote(candidates, quote);
     const source = picked ?? fallback;
-    const chunkIdx = source.chunk_index ?? -1;
     const juan = picked ? picked.juan_num : (juanHint ?? source.juan_num);
+    // chunk_index 只在它确实属于 `juan` 那一卷时才成立。
+    //
+    // 没有 quote 命中时，卷号来自 LLM 写的「第 N 卷」（juanHint），段号却来自
+    // 检索结果——而检索命中的很可能是**另一卷**。把两者拼成一对，就会生成
+    // 「第 2 卷第 25 段」这种组合，可第 2 卷只有 0–22 段。生产日志实测：近 7 天
+    // 119 个去重的引文上下文请求里 33 个落空（27.7%），且同一个段号 25 横跨
+    // 卷 2/4/5/6/7/9/10/11 反复出现——正是同一个检索段号被安到了不同的卷上。
+    //
+    // 与其把读者送去一个不存在的位置（抽屉打开却空白），不如承认这条引文没有
+    // 段级锚点：发 -1，点击处会退回该卷的阅读器页面，那是真实存在的东西。
+    const chunkIdx =
+      source.juan_num === juan ? (source.chunk_index ?? -1) : -1;
     const tail = quote ? `/${encodeURIComponent(quote)}` : "";
     const url = `${CITATION_URL_SCHEME}://${source.text_id}/${juan}/${chunkIdx}/${encodeURIComponent(simplifiedTitle)}${tail}`;
     return { url, juan };

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -6,11 +6,7 @@ import { Input, Button, message, Alert, Tooltip, Modal, Tag, Spin } from "antd";
 import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import {
-  toSimplified,
-  extractPrecedingQuote,
-  pickSourceForQuote,
-} from "../utils/citationMatch";
+import { CITATION_URL_SCHEME, injectCitationLinks } from "../utils/citationLinks";
 import { quoteCheckDetail } from "../utils/trustDetail";
 import {
   SendOutlined,
@@ -101,8 +97,6 @@ function parseFollowUps(content: string): { cleanContent: string; suggestions: s
   return { cleanContent: cleaned, suggestions };
 }
 
-const CITATION_URL_SCHEME = "fojin-citation";
-
 // Streaming placeholder / failure sentinels. These exact strings are stored
 // in message state and compared by identity in several places below; the
 // display sites render t("chat.thinking") / t("chat.request_failed") instead,
@@ -152,120 +146,6 @@ function trustStatusColor(status?: ChatTrustStatus | null): string {
     default:
       return "var(--fj-accent)";
   }
-}
-
-/**
- * Turn sutra references inside an AI answer into citation-drawer buttons.
- *
- * The LLM is wildly inconsistent about citation style — sometimes it emits the
- * explicit 【《心经》第1卷】 marker, sometimes it just drops 《佛说无量寿经》
- * inline as prose. We handle both:
- *
- *  1. First pass rewrites 【《title》第N卷】 into a markdown link pointing at
- *     our custom `fojin-citation://{text_id}/{juan_num}/{chunk_index}` URL.
- *  2. Second pass scans the remaining plaintext for bare 《title》 occurrences
- *     and wraps them when `title` is in the RAG source map. Existing markdown
- *     links from pass 1 are skipped so we never double-wrap.
- *
- * When a matched source lacks chunk_index (legacy chat history from before
- * the chunk_index field was wired through) we emit chunk_index=-1; the click
- * handler in the renderer falls back to reader-page navigation in that case.
- */
-export function injectCitationLinks(content: string, sources: ChatSource[] | null): string {
-  if (!sources || sources.length === 0) return content;
-
-  // Two indexes over the RAG sources, both keyed on the simplified title so
-  // traditional CBETA titles match simplified answer text:
-  //   titleMap     — the single highest-scored chunk per title (fallback)
-  //   titleSources — every retrieved chunk per title, for quote-aware pick
-  const titleMap = new Map<string, ChatSource>();
-  const titleSources = new Map<string, ChatSource[]>();
-  for (const s of sources) {
-    if (!s.title_zh || s.text_id <= 0) continue;
-    const key = toSimplified(s.title_zh);
-    const existing = titleMap.get(key);
-    if (!existing || s.score > existing.score) titleMap.set(key, s);
-    const list = titleSources.get(key);
-    if (list) list.push(s);
-    else titleSources.set(key, [s]);
-  }
-  if (titleMap.size === 0) return content;
-
-  // Resolve a citation to its URL and the fascicle (juan) it points at.
-  // When a quote is known and a retrieved chunk actually contains it, anchor
-  // the citation to THAT chunk — otherwise the drawer opens whichever chunk
-  // merely scored highest, which usually does not hold the quoted sentence.
-  // The quote rides along in the URL so the drawer can highlight it.
-  const buildCitation = (
-    fallback: ChatSource,
-    simplifiedTitle: string,
-    juanHint: number | null,
-    quote: string | null,
-  ): { url: string; juan: number } => {
-    const candidates = titleSources.get(simplifiedTitle) ?? [];
-    const picked = pickSourceForQuote(candidates, quote);
-    const source = picked ?? fallback;
-    const juan = picked ? picked.juan_num : (juanHint ?? source.juan_num);
-    // chunk_index 只在它确实属于 `juan` 那一卷时才成立。
-    //
-    // 没有 quote 命中时，卷号来自 LLM 写的「第 N 卷」（juanHint），段号却来自
-    // 检索结果——而检索命中的很可能是**另一卷**。把两者拼成一对，就会生成
-    // 「第 2 卷第 25 段」这种组合，可第 2 卷只有 0–22 段。生产日志实测：近 7 天
-    // 119 个去重的引文上下文请求里 33 个落空（27.7%），且同一个段号 25 横跨
-    // 卷 2/4/5/6/7/9/10/11 反复出现——正是同一个检索段号被安到了不同的卷上。
-    //
-    // 与其把读者送去一个不存在的位置（抽屉打开却空白），不如承认这条引文没有
-    // 段级锚点：发 -1，点击处会退回该卷的阅读器页面，那是真实存在的东西。
-    const chunkIdx =
-      source.juan_num === juan ? (source.chunk_index ?? -1) : -1;
-    const tail = quote ? `/${encodeURIComponent(quote)}` : "";
-    const url = `${CITATION_URL_SCHEME}://${source.text_id}/${juan}/${chunkIdx}/${encodeURIComponent(simplifiedTitle)}${tail}`;
-    return { url, juan };
-  };
-
-  // Pass 1 — explicit 【《title》…】 markers. The replace callback receives the
-  // marker's offset in the original string; the text just before it carries
-  // the passage the LLM is attributing.
-  let withExplicit = content.replace(
-    /【《([^》]+)》([^】]*)】/g,
-    (_match, rawTitle: string, tail: string, offset: number, full: string) => {
-      const title = rawTitle.trim();
-      const simplifiedTitle = toSimplified(title);
-      const source = titleMap.get(simplifiedTitle);
-      if (!source) return _match;
-      const juanMatch = tail.match(/第(\d+)卷/);
-      const juanHint = juanMatch ? parseInt(juanMatch[1], 10) : null;
-      const quote = extractPrecedingQuote(full.slice(0, offset));
-      const { url, juan } = buildCitation(source, simplifiedTitle, juanHint, quote);
-      // Rewrite the fascicle slot in the visible label to the resolved juan
-      // so the label matches the link target — this also turns a literal
-      // 第N卷 placeholder the LLM left unsubstituted into a real number.
-      // Non-卷 qualifiers (卷上, 第十八愿) carry no 第…卷 slot and are kept.
-      const label = tail.replace(/第[^】卷]*卷/, `第${juan}卷`); // i18n-exempt — rewrites the LLM's Chinese citation marker, must match answer text
-      return `[【《${title}》${label}】](${url})`;
-    },
-  );
-
-  // Pass 2 — bare 《title》 in prose. Split on any markdown links already in
-  // the content (the ones pass 1 just produced, plus any pre-existing links)
-  // so we only process plaintext segments. No quote is bound to a bare
-  // mention, so the chunk stays the top-scored one.
-  const parts = withExplicit.split(/(\[[^\]]*\]\([^)]*\))/g);
-  withExplicit = parts
-    .map((part, i) => {
-      if (i % 2 === 1) return part; // preserved markdown link
-      return part.replace(/《([^》]+)》/g, (bareMatch, rawTitle: string) => {
-        const title = rawTitle.trim();
-        const simplifiedTitle = toSimplified(title);
-        const source = titleMap.get(simplifiedTitle);
-        if (!source) return bareMatch;
-        const { url } = buildCitation(source, simplifiedTitle, null, null);
-        return `[《${title}》](${url})`;
-      });
-    })
-    .join("");
-
-  return withExplicit;
 }
 
 interface ParsedCitation {

--- a/frontend/src/utils/citationLinks.test.ts
+++ b/frontend/src/utils/citationLinks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { injectCitationLinks } from "./ChatPage";
+import { injectCitationLinks } from "./citationLinks";
 import type { ChatSource } from "../api/client";
 
 /**
@@ -23,6 +23,7 @@ function src(o: Partial<ChatSource> = {}): ChatSource {
     title_zh: "阿毘達磨俱舍論",
     juan_num: 9,
     chunk_index: 25,
+    chunk_text: "得聖。若非定業，由得聖故，能令無果亦無驚怖",
     score: 0.9,
     ...o,
   } as ChatSource;
@@ -60,20 +61,23 @@ describe("injectCitationLinks — 卷号与段号必须同源", () => {
   });
 
   it("多个候选中若某段确实含引文，锚到那一段，卷号随之改写", () => {
+    // 引文须 ≥6 字：extractPrecedingQuote 的正则下限就是 6，
+    // pickSourceForQuote 归一化后也要求 ≥6。用 5 字的「無學身語業」
+    // 会静默抽取失败、锚定不触发，用例便测不到它想测的东西。
     const out = injectCitationLinks(
-      "论云「無學身語業」者。【《阿毘達磨俱舍論》第2卷】",
+      "论云「無學身語業，即意三牟尼」者。【《阿毘達磨俱舍論》第2卷】",
       [
         src({ juan_num: 9, chunk_index: 25, score: 0.95 }),
-        src({ juan_num: 16, chunk_index: 7, score: 0.5, chunk_text: "無學身語業，即意三牟尼" } as Partial<ChatSource>),
+        src({ juan_num: 16, chunk_index: 7, score: 0.5, chunk_text: "無學身語業，即意三牟尼" }),
       ],
     );
     const url = urlOf(out);
     expect(url).not.toBeNull();
     const [, juan, chunk] = url!.split("/");
-    // 引文命中的那一段来自第 16 卷 —— 卷段同源，段号有效
-    if (chunk !== "-1") {
-      expect(juan).toBe("16");
-      expect(chunk).toBe("7");
-    }
+    // 引文命中的那一段来自第 16 卷 —— 卷段同源，段号有效。
+    // 这里必须硬断言：包一层 `if (chunk !== "-1")` 会让退化成 -1 时整条用例
+    // 空转通过，而它守的恰恰是「引文命中哪段就锚哪段」这个最关键的行为。
+    expect(juan).toBe("16");
+    expect(chunk).toBe("7");
   });
 });

--- a/frontend/src/utils/citationLinks.ts
+++ b/frontend/src/utils/citationLinks.ts
@@ -1,0 +1,129 @@
+import type { ChatSource } from "../api/client";
+import {
+  toSimplified,
+  extractPrecedingQuote,
+  pickSourceForQuote,
+} from "./citationMatch";
+
+/**
+ * Custom URL scheme for citation links. Lives here rather than in ChatPage so
+ * that both the link builder and the page's rehype-sanitize allowlist /
+ * urlTransform can read it without ChatPage having to export a non-component
+ * (which trips react-refresh/only-export-components — a CI error, the frontend
+ * lint gate runs `--max-warnings 0`).
+ */
+export const CITATION_URL_SCHEME = "fojin-citation";
+
+/**
+ * Turn sutra references inside an AI answer into citation-drawer buttons.
+ *
+ * The LLM is wildly inconsistent about citation style — sometimes it emits the
+ * explicit 【《心经》第1卷】 marker, sometimes it just drops 《佛说无量寿经》
+ * inline as prose. We handle both:
+ *
+ *  1. First pass rewrites 【《title》第N卷】 into a markdown link pointing at
+ *     our custom `fojin-citation://{text_id}/{juan_num}/{chunk_index}` URL.
+ *  2. Second pass scans the remaining plaintext for bare 《title》 occurrences
+ *     and wraps them when `title` is in the RAG source map. Existing markdown
+ *     links from pass 1 are skipped so we never double-wrap.
+ *
+ * When a matched source lacks chunk_index (legacy chat history from before
+ * the chunk_index field was wired through) we emit chunk_index=-1; the click
+ * handler in the renderer falls back to reader-page navigation in that case.
+ */
+export function injectCitationLinks(content: string, sources: ChatSource[] | null): string {
+  if (!sources || sources.length === 0) return content;
+
+  // Two indexes over the RAG sources, both keyed on the simplified title so
+  // traditional CBETA titles match simplified answer text:
+  //   titleMap     — the single highest-scored chunk per title (fallback)
+  //   titleSources — every retrieved chunk per title, for quote-aware pick
+  const titleMap = new Map<string, ChatSource>();
+  const titleSources = new Map<string, ChatSource[]>();
+  for (const s of sources) {
+    if (!s.title_zh || s.text_id <= 0) continue;
+    const key = toSimplified(s.title_zh);
+    const existing = titleMap.get(key);
+    if (!existing || s.score > existing.score) titleMap.set(key, s);
+    const list = titleSources.get(key);
+    if (list) list.push(s);
+    else titleSources.set(key, [s]);
+  }
+  if (titleMap.size === 0) return content;
+
+  // Resolve a citation to its URL and the fascicle (juan) it points at.
+  // When a quote is known and a retrieved chunk actually contains it, anchor
+  // the citation to THAT chunk — otherwise the drawer opens whichever chunk
+  // merely scored highest, which usually does not hold the quoted sentence.
+  // The quote rides along in the URL so the drawer can highlight it.
+  const buildCitation = (
+    fallback: ChatSource,
+    simplifiedTitle: string,
+    juanHint: number | null,
+    quote: string | null,
+  ): { url: string; juan: number } => {
+    const candidates = titleSources.get(simplifiedTitle) ?? [];
+    const picked = pickSourceForQuote(candidates, quote);
+    const source = picked ?? fallback;
+    const juan = picked ? picked.juan_num : (juanHint ?? source.juan_num);
+    // chunk_index 只在它确实属于 `juan` 那一卷时才成立。
+    //
+    // 没有 quote 命中时，卷号来自 LLM 写的「第 N 卷」（juanHint），段号却来自
+    // 检索结果——而检索命中的很可能是**另一卷**。把两者拼成一对，就会生成
+    // 「第 2 卷第 25 段」这种组合，可第 2 卷只有 0–22 段。生产日志实测：近 7 天
+    // 119 个去重的引文上下文请求里 33 个落空（27.7%），且同一个段号 25 横跨
+    // 卷 2/4/5/6/7/9/10/11 反复出现——正是同一个检索段号被安到了不同的卷上。
+    //
+    // 与其把读者送去一个不存在的位置（抽屉打开却空白），不如承认这条引文没有
+    // 段级锚点：发 -1，点击处会退回该卷的阅读器页面，那是真实存在的东西。
+    const chunkIdx =
+      source.juan_num === juan ? (source.chunk_index ?? -1) : -1;
+    const tail = quote ? `/${encodeURIComponent(quote)}` : "";
+    const url = `${CITATION_URL_SCHEME}://${source.text_id}/${juan}/${chunkIdx}/${encodeURIComponent(simplifiedTitle)}${tail}`;
+    return { url, juan };
+  };
+
+  // Pass 1 — explicit 【《title》…】 markers. The replace callback receives the
+  // marker's offset in the original string; the text just before it carries
+  // the passage the LLM is attributing.
+  let withExplicit = content.replace(
+    /【《([^》]+)》([^】]*)】/g,
+    (_match, rawTitle: string, tail: string, offset: number, full: string) => {
+      const title = rawTitle.trim();
+      const simplifiedTitle = toSimplified(title);
+      const source = titleMap.get(simplifiedTitle);
+      if (!source) return _match;
+      const juanMatch = tail.match(/第(\d+)卷/);
+      const juanHint = juanMatch ? parseInt(juanMatch[1], 10) : null;
+      const quote = extractPrecedingQuote(full.slice(0, offset));
+      const { url, juan } = buildCitation(source, simplifiedTitle, juanHint, quote);
+      // Rewrite the fascicle slot in the visible label to the resolved juan
+      // so the label matches the link target — this also turns a literal
+      // 第N卷 placeholder the LLM left unsubstituted into a real number.
+      // Non-卷 qualifiers (卷上, 第十八愿) carry no 第…卷 slot and are kept.
+      const label = tail.replace(/第[^】卷]*卷/, `第${juan}卷`); // i18n-exempt — rewrites the LLM's Chinese citation marker, must match answer text
+      return `[【《${title}》${label}】](${url})`;
+    },
+  );
+
+  // Pass 2 — bare 《title》 in prose. Split on any markdown links already in
+  // the content (the ones pass 1 just produced, plus any pre-existing links)
+  // so we only process plaintext segments. No quote is bound to a bare
+  // mention, so the chunk stays the top-scored one.
+  const parts = withExplicit.split(/(\[[^\]]*\]\([^)]*\))/g);
+  withExplicit = parts
+    .map((part, i) => {
+      if (i % 2 === 1) return part; // preserved markdown link
+      return part.replace(/《([^》]+)》/g, (bareMatch, rawTitle: string) => {
+        const title = rawTitle.trim();
+        const simplifiedTitle = toSimplified(title);
+        const source = titleMap.get(simplifiedTitle);
+        if (!source) return bareMatch;
+        const { url } = buildCitation(source, simplifiedTitle, null, null);
+        return `[《${title}》](${url})`;
+      });
+    })
+    .join("");
+
+  return withExplicit;
+}

--- a/frontend/src/utils/citationMatch.ts
+++ b/frontend/src/utils/citationMatch.ts
@@ -70,6 +70,11 @@ export function pickSourceForQuote(
   let best: ChatSource | null = null;
   for (const s of candidates) {
     if (s.chunk_index == null) continue;
+    // chunk_text is required by the ChatSource type, but history messages come
+    // back from chat_messages.sources — persisted JSON that no runtime check
+    // validates, and rows written before the field existed simply lack it.
+    // Throwing here would blank the whole message, so skip what we can't match.
+    if (!s.chunk_text) continue;
     if (normalizeForMatch(s.chunk_text).includes(nq)) {
       if (!best || s.score > best.score) best = s;
     }


### PR DESCRIPTION
用户反馈：问「仅限毗昙部，纯白业是否都包含身语业？」，答案引文逐字正确，卷号却错——答案标《俱舍論》第13卷，该段实出卷十六。核查后发现是一条贯穿「索引 → 提示词 → 答案 → 引文链接 → 引文抽屉」的链，本 PR 修两端。

## 根因：`text_embeddings` 的 juan_num 串卷

旧管线把多卷正文当作一卷切块，每块都盖上**第一卷**的卷号。`text 38`（俱舍論）的 `juan_num=13` 存了 109 个 chunk，实际覆盖真实卷 13→17：

| label-13 的 chunk | 实际所属卷 |
|---|---|
| 0–17 | 卷13 ✓ |
| 18–35 | 卷14 ✗ |
| ~40–50 | 卷15 ✗ |
| **58**（本次命中）| **卷16** ✗ |
| ~90–108 | 卷17 ✗ |

`rag_retrieval.py` 的 `[出处: 《X》第N卷]` 表头取自这个 juan_num，模型忠实照抄。**阅读器（`text_contents`）是对的，只有 RAG 索引错**——两者出自不同管线。

三道护栏全数放行，且都不是它们的错：`citation_guard` 的白名单就是从这些错卷号建的；`quote_verifier` 在该 chunk 里确实逐字找得到引文；而这条答案用的是散文体 `(出处: …)`，两者都只认 `【《经名》第N卷】`，一次都没触发。

**为什么长期没修掉**：`generate_embeddings.py` 的 `ON CONFLICT DO NOTHING` 覆盖不掉旧行；`repair_stale_embeddings.py` 只找 `e < 0.9c`（嵌入过少），本缺陷是 `e > c`（过多），谓词恒假。生产上欠嵌入已为 0，过嵌入从未被检测过。

## 改动

**1. `repair_stale_embeddings.py` — 检测器改为双向**

判据落在「**末块是否仍在本卷正文内**」，倍数只作预筛。这一点是实测逼出来的：纯倍数判据（>1.3）在生产选出 1,881 卷，其中 882 卷只是切得更密而并未越界；重嵌它们会打乱 `chunk_index`、作废这些经本来完好的 alignment 引用。加上包含性检验后为 **999 卷 / 550 部**，与独立 SQL 普查（1,020，差额为 `--min-content` 挡掉的残缺正文卷）吻合。

`--min-content 500` 在过量侧是防数据丢失的关键：生产有正文只剩十几字的残缺卷（閑居編 X0949 等），那是 content 坏了不是向量坏了，重嵌会把真向量删掉换成空。

**2. 引文链接的卷号与段号必须同源**（`ChatPage.tsx`）

卷号取自 LLM 写的「第 N 卷」，段号取自检索命中的 chunk——而命中的 chunk 常属于另一卷，拼成 `(卷16, 段58)` 这类不存在的坐标。生产日志实测：近 7 天 119 个去重的引文上下文请求中 33 个落空（27.7%），同一个段号 25 横跨卷 2/4/5/6/7/9/10/11 反复出现。改为只在 `source.juan_num === juan` 时沿用段号，否则发 `-1`，点击退回该卷阅读器。

**3. 引文抽屉不再在空白正文上谎称「前文就在视野外」**（`texts.py` + `CitationDrawer.tsx`）

`has_more_before = low > 0` 是算术捷径，前提是「所请求的 chunk 存在」。它不存在时查询返回空，捷径却仍宣称「前面还有」。改为真去查库。

**4. `check_content_flags.py`** — 巡检 `has_content` 标志与实际内容是否一致。

## 验证

- 生产 `--dry-run` 已跑（**未写入任何数据**，容器内临时文件已清理）：999 卷 / 550 部；`--over-ratio` 1.11/1.3/5.0/50 → 3183/1881/211/1 单调，确认 asyncpg 未截断浮点参数。
- 定点核对：俱舍論卷13（6.8×）、卷22、正法念處經卷22（57.8×）、瑜伽論記卷2（12.8×）全部入选；健康的卷14、卷16 不入选。
- 后端 1412 passed（`test_health_check_probe.py` 3 个失败为预先存在，已在基线上复验）；前端 258 passed；ruff 0.9.7、tsc、i18n ratchet、vite build 全过。

## 合并后仍需人工执行（不在本 PR 内）

本 PR 只修**检测器和消费侧**，不动生产数据。真正让卷号变正确还需要：

1. 分批跑重嵌，建议先 `--over-ratio 5.0` 取最重的 211 卷试点，验过再跑全量 999。
2. 重建这批经的跨藏对齐。这不是修复引入的代价——**126,283 行 `mitra_alignments`（占全部 908,620 行的 13.9%）现在就锚在这些错标 chunk 上**，定位不到，属同源的第二处损坏，一并修掉。

## 已知未覆盖

- `quote_verifier._find_sources` 在引文不在所标卷时会回退到该经任意卷，等于放弃卷号校验。
- 两道护栏都只认 `【《经名》第N卷】`，散文体 `(出处: …)` 不触发。
