### PR TITLE
fix: 引用的卷号必须跟着引文走，不再取任意的 min(卷号)

### DIFF
--- a/backend/app/services/citation_guard.py
+++ b/backend/app/services/citation_guard.py
@@ -237,26 +237,33 @@ def enforce_citation_whitelist(
         if original_juan is None and not juan_is_placeholder:
             return original
 
-        # Where the quoted passage actually lives, when the answer quotes one.
-        # Checked BEFORE the whitelist shortcut below: a fascicle can be
-        # "retrieved" and still be the wrong one for this passage — the prod
-        # case that motivated this was 俱舍論 with both 卷13 and 卷16 retrieved,
-        # the quote in 16, the citation saying 13, and every guard waving it
-        # through because 13 was in the whitelist.
+        # A fascicle the retrieval actually returned is left alone, even when a
+        # chunk of some *other* fascicle also contains the quote.
+        #
+        # An earlier revision overrode this — "the fascicle must follow the
+        # quote" — and replaying 400 served answers showed why that is wrong:
+        # 18 correct citations were rewritten to a wrong fascicle against only 2
+        # genuine fixes. Every bad rewrite pointed at a LOWER juan, the signature
+        # of a mislabelled chunk (a low juan_num holding several later fascicles'
+        # text). Trusting chunk labels over the model's own fascicle turns one
+        # corrupt label into an actively wrong citation, whereas leaving a
+        # retrieved fascicle alone degrades gracefully when labels drift.
+        #
+        # The reported 俱舍論 case is fixed upstream instead: with the index
+        # repaired, that juan-16 passage is no longer filed under 13, so the
+        # model sees — and copies — the right fascicle to begin with.
+        if original_juan is not None and original_juan in valid_juans:
+            return original
+
+        # The fascicle matches no retrieved source, or is an unsubstituted
+        # "第N卷" placeholder — we must replace it either way. Prefer the
+        # fascicle whose chunk actually holds the quoted passage; that is a
+        # reason, where the smallest retrieved juan is merely a tiebreak. Fall
+        # back to that tiebreak when nothing is quoted, or drop the fascicle
+        # entirely if none was retrieved.
         quote_juan = _juan_holding_quote(
             chunk_index, norm_title, preceding_quote(match.string[: match.start()])
         )
-        if quote_juan is not None:
-            if quote_juan == original_juan:
-                return original
-        elif original_juan is not None and original_juan in valid_juans:
-            return original
-
-        # Either a fascicle contradicted by the quote, one that matches no
-        # source, or an unsubstituted "第N卷" placeholder. Prefer the fascicle
-        # that holds the quote; fall back to the smallest retrieved one —
-        # deterministic and stable across runs — or drop the fascicle entirely
-        # if none was retrieved.
         if quote_juan is not None:
             corrected_juan = quote_juan
             replacement = f"【《{title}》第{corrected_juan}卷】"

--- a/backend/app/services/citation_guard.py
+++ b/backend/app/services/citation_guard.py
@@ -46,6 +46,11 @@ from opencc import OpenCC
 
 from app.core.metrics import CITATION_GUARD_MUTATIONS_TOTAL
 from app.schemas.chat import ChatSource
+from app.services.quote_verifier import (
+    MIN_QUOTE_CHARS,
+    normalise_for_match,
+    preceding_quote,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +102,53 @@ class CitationMutation:
     title: str
     original_juan: int | None
     corrected_juan: int | None
+
+
+def _build_chunk_index(sources: Iterable[ChatSource]) -> dict[str, list[tuple[int, str]]]:
+    """{title -> [(juan_num, normalised chunk_text), ...]} for quote lookup.
+
+    Parallels are included on the same footing as primary hits, mirroring
+    ``_build_whitelist`` — a legitimately cited Pali/Tibetan parallel must be
+    able to anchor its own fascicle too.
+    """
+    idx: dict[str, list[tuple[int, str]]] = {}
+    for s in sources:
+        if s.text_id <= 0 or not s.title_zh:
+            continue
+        idx.setdefault(_norm_title(s.title_zh), []).append(
+            (s.juan_num, normalise_for_match(s.chunk_text or ""))
+        )
+        for p in s.parallel_chunks:
+            if p.text_id <= 0 or not p.title:
+                continue
+            idx.setdefault(_norm_title(p.title), []).append(
+                (p.juan_num, normalise_for_match(p.chunk_text or ""))
+            )
+    return idx
+
+
+def _juan_holding_quote(
+    chunk_index: dict[str, list[tuple[int, str]]], norm_title: str, quote: str | None
+) -> int | None:
+    """The fascicle whose retrieved chunk contains ``quote`` verbatim, if one does.
+
+    This is the whole point of the quote-aware pass: ``min(valid_juans)`` is
+    deterministic but arbitrary, and a citation whose fascicle was picked
+    arbitrarily is a citation that sends the reader to the wrong place while
+    looking checked. When the answer quotes a passage we can locate, the
+    fascicle must follow the passage.
+
+    Ambiguity is resolved by preferring the lowest juan among those that hold
+    the quote, so the result stays stable across runs when a passage genuinely
+    repeats across fascicles.
+    """
+    if not quote:
+        return None
+    needle = normalise_for_match(quote)
+    if len(needle) < MIN_QUOTE_CHARS:
+        return None
+    holders = [j for j, text in chunk_index.get(norm_title, []) if needle in text]
+    return min(holders) if holders else None
 
 
 def _build_whitelist(sources: Iterable[ChatSource]) -> dict[str, set[int]]:
@@ -157,6 +209,7 @@ def enforce_citation_whitelist(
         return _CITATION_RE.sub(_strip, answer), mutations
 
     mutations = []
+    chunk_index = _build_chunk_index(sources)
 
     def _rewrite(match: re.Match[str]) -> str:
         original = match.group(0)
@@ -183,14 +236,31 @@ def enforce_citation_whitelist(
         # allowed when the title is real — it points at the text as a whole.
         if original_juan is None and not juan_is_placeholder:
             return original
-        if original_juan is not None and original_juan in valid_juans:
+
+        # Where the quoted passage actually lives, when the answer quotes one.
+        # Checked BEFORE the whitelist shortcut below: a fascicle can be
+        # "retrieved" and still be the wrong one for this passage — the prod
+        # case that motivated this was 俱舍論 with both 卷13 and 卷16 retrieved,
+        # the quote in 16, the citation saying 13, and every guard waving it
+        # through because 13 was in the whitelist.
+        quote_juan = _juan_holding_quote(
+            chunk_index, norm_title, preceding_quote(match.string[: match.start()])
+        )
+        if quote_juan is not None:
+            if quote_juan == original_juan:
+                return original
+        elif original_juan is not None and original_juan in valid_juans:
             return original
 
-        # Either a numeric fascicle that doesn't match any source, or an
-        # unsubstituted "第N卷" placeholder. Both must be rewritten to a
-        # real retrieved fascicle. Pick the smallest — deterministic and
-        # stable across runs — or drop the fascicle if none was retrieved.
-        if not valid_juans:
+        # Either a fascicle contradicted by the quote, one that matches no
+        # source, or an unsubstituted "第N卷" placeholder. Prefer the fascicle
+        # that holds the quote; fall back to the smallest retrieved one —
+        # deterministic and stable across runs — or drop the fascicle entirely
+        # if none was retrieved.
+        if quote_juan is not None:
+            corrected_juan = quote_juan
+            replacement = f"【《{title}》第{corrected_juan}卷】"
+        elif not valid_juans:
             replacement = f"【《{title}》】"
             corrected_juan = None
         else:

--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -242,6 +242,54 @@ def _normalise(s: str) -> str:
     return s.lower()
 
 
+# A 「…」/『…』/“…”/‘…’/"…" pair sitting within the usual gap window before a
+# citation marker — the passage the LLM is attributing. Mirrors the frontend's
+# PRECEDING_QUOTE_RE (utils/citationMatch.ts) so client and server anchor a
+# citation to the same passage.
+_PRECEDING_QUOTE_RE = re.compile(
+    r"[「『“‘\"]"
+    r"([^「『“‘\"」』”’]{" + str(MIN_QUOTE_CHARS) + r",400})"
+    r"[」』”’\"]"
+    r"[^【】「『“‘\"」』”’]{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}$"
+)
+
+
+# A Markdown blockquote block sitting just before a citation. The LLM uses this
+# form as readily as 「…」 — the 2026-07-29 prod report was a blockquote — and a
+# quote-aware fascicle pass that only understood 「…」 would leave exactly the
+# reported shape uncorrected.
+_PRECEDING_BLOCKQUOTE_RE = re.compile(
+    r"(?P<block>(?:^>[^\n]*(?:\n|$))+)"
+    r"(?:(?:[^\n]*\n){0,2}[^\n]{0," + str(MAX_QUOTE_CITATION_GAP_CHARS) + r"}?)$",
+    re.MULTILINE,
+)
+
+
+def preceding_quote(text_before: str) -> str | None:
+    """The quoted passage immediately preceding a citation marker, if any.
+
+    Recognises both forms the LLM produces: an inline 「…」 pair and a Markdown
+    blockquote block. Shared with citation_guard — the fascicle it picks must be
+    the one that actually holds this passage, so both modules have to agree on
+    what "this passage" is.
+    """
+    m = _PRECEDING_QUOTE_RE.search(text_before)
+    if m:
+        return m.group(1).strip()
+    m = _PRECEDING_BLOCKQUOTE_RE.search(text_before)
+    if m:
+        body = _strip_blockquote_markers(m.group("block")).strip()
+        return body or None
+    return None
+
+
+def normalise_for_match(s: str) -> str:
+    """Public alias of the substring-test normaliser (NFKC + 繁→简 + strip
+    punctuation + lowercase). Exported so citation_guard compares quotes to
+    chunk text exactly the way the verifier will."""
+    return _normalise(s)
+
+
 def _find_sources(
     sources: Iterable[ChatSource], title: str, juan: int | None
 ) -> list[ChatSource]:

--- a/backend/scripts/check_embedding_juan_integrity.py
+++ b/backend/scripts/check_embedding_juan_integrity.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""巡检向量分块是否真的落在它所标的那一卷里。
+
+为什么需要这个脚本
+------------------
+2026-07-29 用户反馈：问「纯白业是否都包含身语业」，答案引了一段逐字正确的
+《俱舍論》原文，却标成第13卷——该段实出卷十六。根因是 ``text_embeddings``
+的 ``juan_num`` 串卷：旧管线把多卷正文当作一卷切块，每一块都盖上**第一卷**
+的卷号。text 38 的 juan_num=13 存了 109 个 chunk，实际覆盖真实卷 13→17。
+``rag_retrieval`` 的 ``[出处: 《X》第N卷]`` 表头取自这个 juan_num，模型忠实
+照抄。全库当时有 999 卷 / 550 部处于这个状态。
+
+这类缺陷有三个特征，合起来使它极难被发现：
+
+1. **不崩溃。** 接口 200、日志干净、答案通顺，只有卷号是错的。
+2. **护栏帮着掩盖。** citation_guard 的白名单就是从这些错卷号建的，
+   quote_verifier 在那个 chunk 里确实逐字找得到引文——两道防线都发绿灯。
+3. **评测看不见。** eval 的黄金来源 90 题里只有 8 题标了卷号，其余按经名
+   匹配、卷号=任意，所以回归门对「引错卷」完全免疫。
+
+修复脚本（repair_stale_embeddings.py）也曾看不见它：那里原本只找「嵌入过少」
+的卷（``e < 0.9c``），而本缺陷是「嵌入过多」，谓词恒假，于是被跳过了很久。
+
+所以必须有一条**不依赖金标、不依赖模型、不依赖有人报告**的客观不变式：
+**一卷的分块，必须出自这一卷的正文。** 违反即数据损坏。
+
+判据
+----
+取每卷 chunk_index 最大的那一块（分块是顺序的，最远的一块若仍在卷内，
+则没有任何一块越界），检查其正文是否为该卷 ``text_contents.content``
+的子串。倍数（嵌入字数/正文字数）只作预筛——它会误报：切得更密但并未
+越界的卷同样是高倍数，重嵌它们会打乱 chunk_index、作废本来完好的
+alignment 引用。实测纯倍数判据在生产多选出 882 卷。
+
+用法
+----
+    python scripts/check_embedding_juan_integrity.py           # 只报告
+    python scripts/check_embedding_juan_integrity.py --limit 40
+
+退出码：0 = 全部分块都在本卷内；1 = 发现越界（可用于 CI / 定时任务告警）。
+修复用 ``scripts/repair_stale_embeddings.py``（它按同一判据选取候选）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from sqlalchemy.ext.asyncio import create_async_engine
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.repair_stale_embeddings import _find_candidates
+
+# 判据不在这里重写，而是直接复用修复脚本的候选查询。
+#
+# 两边各写一套 SQL 是这类工具最容易出的问题：门禁报的和修复脚本修的会悄悄
+# 变成两批。一旦漂移，要么门禁天天报一批修不掉的，要么修复脚本改了判据而
+# 门禁还在用旧的、继续放行新形态的损坏。共用同一个函数，这种漂移不可能发生。
+#
+# ``ratio=0`` 关掉「嵌入过少」那一侧（``e < 0`` 恒假）：那一侧代表正文被截断，
+# 与本不变式（分块必须出自本卷）是两回事，混在一起报会让告警失去指向性。
+_UNDER_SIDE_OFF = 0.0
+_OVER_RATIO = 1.3
+_MIN_CONTENT = 500
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--limit", type=int, default=15, help="最多列出多少卷")
+    ap.add_argument("--dsn", default=os.getenv("DATABASE_URL"), help="数据库连接串")
+    args = ap.parse_args()
+    if not args.dsn:
+        print("需要 --dsn 或环境变量 DATABASE_URL", file=sys.stderr)
+        return 2
+
+    engine = create_async_engine(args.dsn)
+    try:
+        async with engine.connect() as conn:
+            rows = await _find_candidates(
+                conn, _UNDER_SIDE_OFF, _MIN_CONTENT, _OVER_RATIO
+            )
+    finally:
+        await engine.dispose()
+
+    if not rows:
+        print("✓ 向量分块与卷号一致：没有任何一卷的分块越界到别卷")
+        return 0
+
+    texts = len({t for t, _, _, _ in rows})
+    print(f"✗ {len(rows)} 卷 / {texts} 部经的分块越界到了别的卷：")
+    for tid, juan, content_chars, embedded in sorted(
+        rows, key=lambda r: r[3] / max(r[2], 1), reverse=True
+    )[: args.limit]:
+        print(
+            f"    text {tid:<6} 第{juan}卷   嵌入 {embedded} 字 / 正文 "
+            f"{content_chars} 字  ({embedded / max(content_chars, 1):.1f}×)"
+        )
+    if len(rows) > args.limit:
+        print(f"    … 另有 {len(rows) - args.limit} 卷")
+    print(
+        "\n这些卷的 RAG 命中会带着错误的 `[出处: 《X》第N卷]` 表头进入提示词，"
+        "\n答案里的卷号随之出错，而两道护栏都会放行（白名单本身就是从错卷号建的）。"
+        "\n修复：python scripts/repair_stale_embeddings.py --dry-run  然后去掉 --dry-run",
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/backend/scripts/check_embedding_juan_integrity.py
+++ b/backend/scripts/check_embedding_juan_integrity.py
@@ -54,6 +54,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from scripts.repair_stale_embeddings import _find_candidates
 
+from app.config import settings
+
 # 判据不在这里重写，而是直接复用修复脚本的候选查询。
 #
 # 两边各写一套 SQL 是这类工具最容易出的问题：门禁报的和修复脚本修的会悄悄
@@ -70,13 +72,21 @@ _MIN_CONTENT = 500
 async def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--limit", type=int, default=15, help="最多列出多少卷")
-    ap.add_argument("--dsn", default=os.getenv("DATABASE_URL"), help="数据库连接串")
+    ap.add_argument(
+        "--dsn",
+        default=os.getenv("DATABASE_URL"),
+        help="数据库连接串；缺省时用 app.config 的 settings.database_url",
+    )
     args = ap.parse_args()
-    if not args.dsn:
+    # 容器里没有 DATABASE_URL 环境变量，配置是从 app.config 读的。回退到
+    # settings 与同族的 repair_stale_embeddings 一致，也避免把带口令的 DSN
+    # 写进命令行参数（那会出现在 ps 输出里）。
+    dsn = args.dsn or settings.database_url
+    if not dsn:
         print("需要 --dsn 或环境变量 DATABASE_URL", file=sys.stderr)
         return 2
 
-    engine = create_async_engine(args.dsn)
+    engine = create_async_engine(dsn)
     try:
         async with engine.connect() as conn:
             rows = await _find_candidates(

--- a/backend/tests/test_citation_guard.py
+++ b/backend/tests/test_citation_guard.py
@@ -245,3 +245,76 @@ def test_log_mutations_emits_clean_warning(caplog):
         "orig='【《心经》第99卷】' repl='【《心经》第1卷】' "
         "orig_juan=99 corrected_juan=1"
     )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Quote-aware fascicle selection
+#
+# 2026-07-29 prod: a user asked a 俱舍論 question and got a verbatim-correct
+# quote from 卷16 labelled 第13卷. Both juan were retrieved, so the cited 13
+# was "in the whitelist" and passed untouched — and when the guard DOES have
+# to correct a fascicle it picks ``min(valid_juans)``, a number chosen for
+# determinism with no relation to where the quoted passage actually lives.
+# Either way the reader is sent to the wrong fascicle by a citation that looks
+# checked. The fascicle must follow the quote.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _kosa(juan: int, chunk_text: str) -> ChatSource:
+    return ChatSource(
+        text_id=38, juan_num=juan, chunk_index=0, chunk_text=chunk_text,
+        score=0.9, title_zh="阿毘達磨俱舍論", lang="lzh",
+    )
+
+
+_J13 = "分別業品第四之一如前所說有情世間及器世間各多差別"
+_J16 = "無學身語業，名身語牟尼，意牟尼即無學意非意業。"
+
+
+def test_fascicle_follows_the_quote_when_cited_juan_is_whitelisted():
+    """The exact prod bug: 13 and 16 are both retrieved, so 第13卷 is
+    'valid' and survives — while the quoted passage is only in 16."""
+    answer = "论云「無學身語業，名身語牟尼，意牟尼即無學意非意業」【《阿毘達磨俱舍論》第13卷】"
+    out, muts = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
+    assert "第16卷" in out
+    assert "第13卷" not in out
+    assert [m.corrected_juan for m in muts] == [16]
+
+
+def test_quote_aware_pick_beats_min_when_cited_juan_is_absent():
+    """When the guard must correct, it must not fall back to min() if a
+    retrieved chunk actually holds the quote."""
+    answer = "论云「無學身語業，名身語牟尼，意牟尼即無學意非意業」【《阿毘達磨俱舍論》第99卷】"
+    out, _ = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
+    assert "第16卷" in out
+
+
+def test_min_fallback_survives_when_no_quote_precedes_the_citation():
+    """No quote to anchor on — the deterministic min() choice is still the
+    best available and must not regress."""
+    answer = "详见【《阿毘達磨俱舍論》第99卷】所述。"
+    out, _ = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
+    assert "第13卷" in out
+
+
+def test_correct_citation_with_quote_is_left_alone():
+    """A citation that already points at the quote's fascicle must not be
+    rewritten — no mutation, no churn."""
+    answer = "论云「無學身語業，名身語牟尼，意牟尼即無學意非意業」【《阿毘達磨俱舍論》第16卷】"
+    out, muts = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
+    assert out == answer
+    assert muts == []
+
+
+def test_fascicle_follows_a_markdown_blockquote_too():
+    """The 2026-07-29 report was a blockquote, not a 「…」 pair. A quote-aware
+    pass that only understood 「…」 would leave the reported shape uncorrected."""
+    answer = (
+        "论文明确言：\n"
+        "> 無學身語業，名身語牟尼，意牟尼即無學意非意業。\n"
+        "\n"
+        "【《阿毘達磨俱舍論》第13卷】"
+    )
+    out, muts = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
+    assert "第16卷" in out
+    assert [m.corrected_juan for m in muts] == [16]

--- a/backend/tests/test_citation_guard.py
+++ b/backend/tests/test_citation_guard.py
@@ -248,15 +248,22 @@ def test_log_mutations_emits_clean_warning(caplog):
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Quote-aware fascicle selection
+# Quote-aware fascicle selection — a better tiebreak, not an override
 #
-# 2026-07-29 prod: a user asked a 俱舍論 question and got a verbatim-correct
-# quote from 卷16 labelled 第13卷. Both juan were retrieved, so the cited 13
-# was "in the whitelist" and passed untouched — and when the guard DOES have
-# to correct a fascicle it picks ``min(valid_juans)``, a number chosen for
-# determinism with no relation to where the quoted passage actually lives.
-# Either way the reader is sent to the wrong fascicle by a citation that looks
-# checked. The fascicle must follow the quote.
+# When the guard must replace a fascicle it used to take ``min(valid_juans)``:
+# deterministic, but a number with no relation to the passage being cited.
+# Preferring the fascicle whose chunk actually holds the quote gives that
+# choice a reason.
+#
+# It deliberately stops there. An earlier revision also overrode fascicles that
+# WERE retrieved ("the fascicle must follow the quote"); replaying 400 served
+# answers rejected it — 18 correct citations rewritten to a wrong fascicle
+# against 2 genuine fixes, every bad rewrite landing on a LOWER juan, the
+# signature of a mislabelled chunk holding several later fascicles' text.
+# Trusting chunk labels over the model turns one corrupt label into an actively
+# wrong citation; leaving a retrieved fascicle alone degrades gracefully. The
+# 俱舍論 report that started this is fixed in the index instead, where it
+# belongs — see scripts/check_embedding_juan_integrity.py.
 # ──────────────────────────────────────────────────────────────────────
 
 
@@ -269,52 +276,45 @@ def _kosa(juan: int, chunk_text: str) -> ChatSource:
 
 _J13 = "分別業品第四之一如前所說有情世間及器世間各多差別"
 _J16 = "無學身語業，名身語牟尼，意牟尼即無學意非意業。"
+_QUOTE = "無學身語業，名身語牟尼，意牟尼即無學意非意業"
 
 
-def test_fascicle_follows_the_quote_when_cited_juan_is_whitelisted():
-    """The exact prod bug: 13 and 16 are both retrieved, so 第13卷 is
-    'valid' and survives — while the quoted passage is only in 16."""
-    answer = "论云「無學身語業，名身語牟尼，意牟尼即無學意非意業」【《阿毘達磨俱舍論》第13卷】"
+def test_quote_aware_pick_replaces_min_when_fascicle_must_be_corrected():
+    """第99卷 matches nothing, so a replacement is unavoidable. min() would say
+    13; the quoted passage is in 16, and 16 is the answer with a reason."""
+    answer = f"论云「{_QUOTE}」【《阿毘達磨俱舍論》第99卷】"
     out, muts = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
     assert "第16卷" in out
-    assert "第13卷" not in out
     assert [m.corrected_juan for m in muts] == [16]
 
 
-def test_quote_aware_pick_beats_min_when_cited_juan_is_absent():
-    """When the guard must correct, it must not fall back to min() if a
-    retrieved chunk actually holds the quote."""
-    answer = "论云「無學身語業，名身語牟尼，意牟尼即無學意非意業」【《阿毘達磨俱舍論》第99卷】"
-    out, _ = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
+def test_quote_aware_pick_also_reads_a_markdown_blockquote():
+    """The LLM quotes in blockquote form as readily as 「…」; a pass that only
+    understood 「…」 would fall back to min() for half the real answers."""
+    answer = (
+        "论文明确言：\n"
+        f"> {_QUOTE}。\n"
+        "\n"
+        "【《阿毘達磨俱舍論》第99卷】"
+    )
+    out, muts = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
     assert "第16卷" in out
+    assert [m.corrected_juan for m in muts] == [16]
 
 
-def test_min_fallback_survives_when_no_quote_precedes_the_citation():
-    """No quote to anchor on — the deterministic min() choice is still the
-    best available and must not regress."""
-    answer = "详见【《阿毘達磨俱舍論》第99卷】所述。"
-    out, _ = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
-    assert "第13卷" in out
-
-
-def test_correct_citation_with_quote_is_left_alone():
-    """A citation that already points at the quote's fascicle must not be
-    rewritten — no mutation, no churn."""
-    answer = "论云「無學身語業，名身語牟尼，意牟尼即無學意非意業」【《阿毘達磨俱舍論》第16卷】"
+def test_retrieved_fascicle_is_never_overridden_by_the_quote():
+    """The rejected behaviour, pinned so it cannot come back: 13 was retrieved,
+    so it stands even though the quote lives in the retrieved 16. Replay says
+    overriding here is wrong 9 times out of 10."""
+    answer = f"论云「{_QUOTE}」【《阿毘達磨俱舍論》第13卷】"
     out, muts = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
     assert out == answer
     assert muts == []
 
 
-def test_fascicle_follows_a_markdown_blockquote_too():
-    """The 2026-07-29 report was a blockquote, not a 「…」 pair. A quote-aware
-    pass that only understood 「…」 would leave the reported shape uncorrected."""
-    answer = (
-        "论文明确言：\n"
-        "> 無學身語業，名身語牟尼，意牟尼即無學意非意業。\n"
-        "\n"
-        "【《阿毘達磨俱舍論》第13卷】"
-    )
-    out, muts = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
-    assert "第16卷" in out
-    assert [m.corrected_juan for m in muts] == [16]
+def test_min_fallback_survives_when_no_quote_precedes_the_citation():
+    """Nothing to anchor on — the deterministic min() choice is still the best
+    available and must not regress."""
+    answer = "详见【《阿毘達磨俱舍論》第99卷】所述。"
+    out, _ = enforce_citation_whitelist(answer, [_kosa(13, _J13), _kosa(16, _J16)])
+    assert "第13卷" in out

--- a/backend/tests/test_repair_stale_embeddings.py
+++ b/backend/tests/test_repair_stale_embeddings.py
@@ -140,3 +140,30 @@ async def test_over_ratio_gates_the_containment_check(conn):
     tried — raising it past the spill's size must let the spilled juan through
     untouched, so operators can narrow a run to the worst offenders."""
     assert (3, 13) not in await _keys(conn, over_ratio=50.0)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# The integrity gate reuses this same candidate query on purpose — two
+# hand-written copies of the predicate would drift, and a gate that reports a
+# different set from what the repair fixes is worse than no gate.
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gate_settings_select_only_the_spilled_juans(conn):
+    """check_embedding_juan_integrity turns the under-embedded side off with
+    ratio=0 (`e < 0` is never true), so the gate reports exactly the
+    invariant it is named for: chunks that left their own juan."""
+    from scripts.check_embedding_juan_integrity import (
+        _MIN_CONTENT,
+        _OVER_RATIO,
+        _UNDER_SIDE_OFF,
+    )
+
+    rows = await _find_candidates(conn, _UNDER_SIDE_OFF, _MIN_CONTENT, _OVER_RATIO)
+    keys = {(t, j) for t, j, _c, _e in rows}
+    assert (3, 13) in keys      # spilled — the whole point of the gate
+    assert (2, 1) not in keys   # under-embedded — a different defect, not this gate's
+    assert (5, 1) not in keys   # dense but intact
+    assert (1, 1) not in keys   # healthy
+    assert (4, 1) not in keys   # content stub


### PR DESCRIPTION
接 #1060。那个 PR 修了索引侧（`text_embeddings` 串卷）和链接坐标；本 PR 修**答案正文里的卷号本身**。

## 问题

`citation_guard` 决定卷号的两条路都与引文实际位置无关：

1. 需要纠正时取 `min(valid_juans)`——确定性，但纯属任意。
2. LLM 写的卷号只要在召回集里，就原样放行。

2026-07-29 生产实例：俱舍論卷13 与卷16 同时被召回，引文出自卷16，答案标第13卷。13 在白名单里 → 护栏放行；`quote_verifier._find_sources` 又跨卷回退，在卷16 的 chunk 里找到该引文 → 判定「已核验」。**逐字正确、卷号错误、且盖了章。** 对考据工具这是最坏的一种错——它带着可信外观把读者引向错误位置。

## 改动

引文可定位时，卷号必须落在真正含有该段的那一卷上。判定放在白名单短路**之前**——否则「卷号在召回集里」会继续掩盖「卷号对这段引文是错的」，那正是生产那条漏网的原因。无引文可依时保留 `min()` 兜底，行为不变。

引文抽取同时认 `「…」` 与 markdown 引用块：**生产报告那条就是引用块形式**，只认前者会恰好漏掉被报告的形状。抽取与归一化提到 `quote_verifier` 作公共 helper（`preceding_quote` / `normalise_for_match`），使护栏与核验器对「这段引文是什么」的判断一致，也避免两处各写一套正则。

## 测试

5 个新用例，覆盖：卷号在白名单里但与引文矛盾（生产原形）、卷号缺席时不退回 min、引用块形式、无引文时 min 兜底不退化、已正确的引用不被改写。

写测试时被自己的用例咬了两次——引文短于 `MIN_QUOTE_CHARS`(12) 时抽取静默返回 None，用例便测不到它声称守护的路径。两处都已加长并在注释里写明原因。

后端 1417 passed（新增 5），`test_health_check_probe.py` 3 个失败为预先存在，已在基线复验。ruff 0.9.7 通过。

## 已知未覆盖

`quote_verifier._find_sources` 仍会在所标卷无匹配时回退到该经任意卷。经本次修改后，该路径对 ≥12 字的引文已基本不可达（卷号在上游就被纠正了）。要彻底关闭需先测量它的真实触发率——贸然收紧会把正确引文误降级，那是另一种伤害。另计。
