### PR TITLE
fix: 补齐其余三处 CBETA 硬换行渲染点

### DIFF
--- a/frontend/src/components/ReaderParallelPanel.tsx
+++ b/frontend/src/components/ReaderParallelPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { unwrapCbetaLines } from "../utils/textReflow";
 import { useTranslation } from "react-i18next";
 import { Empty, Spin, Alert, Collapse, Tag, Progress, Tabs, Button } from "antd";
 import { LinkOutlined, BookOutlined, ExpandAltOutlined } from "@ant-design/icons";
@@ -286,7 +287,7 @@ function ChunkView({ textId, juanNum }: Props) {
                     display: "-webkit-box", WebkitLineClamp: 2,
                     WebkitBoxOrient: "vertical", overflow: "hidden",
                   }}>
-                    {entry.chunk_text}
+                    {unwrapCbetaLines(entry.chunk_text)}
                   </div>
                 </div>
               ),
@@ -298,7 +299,7 @@ function ChunkView({ textId, juanNum }: Props) {
                     padding: "8px 12px", background: "#fafafa",
                     borderRadius: 4, marginBottom: 12,
                   }}>
-                    {entry.chunk_text}
+                    {unwrapCbetaLines(entry.chunk_text)}
                   </div>
                   {entry.parallels.map((p, idx) => {
                     const isMitra = p.source === "mitra-parallel";
@@ -334,7 +335,7 @@ function ChunkView({ textId, juanNum }: Props) {
                         lineHeight: p.lang === "bo" ? 2.1 : 1.85,
                         color: "#333",
                       }}>
-                        …{p.chunk_text}…
+                        …{unwrapCbetaLines(p.chunk_text)}…
                       </div>
                       {p.original_preview && p.original_lang && (
                         <div lang={p.original_lang} style={{

--- a/frontend/src/components/SimilarPassages.tsx
+++ b/frontend/src/components/SimilarPassages.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { List, Typography, Tag, Button, Spin, Empty } from "antd";
 import { ReadOutlined } from "@ant-design/icons";
 import { useNavigate } from "react-router";
+import { unwrapCbetaLines } from "../utils/textReflow";
 import { getSimilarPassages } from "../api/client";
 
 function SimilarPassagesInner({
@@ -92,9 +93,12 @@ function SimilarPassagesInner({
                 margin: "4px 0 0",
                 lineHeight: 1.6,
                 color: "var(--fj-ink-light)",
+                // CBETA 每 ~18 字一个硬换行是版式，不是语义。原样渲染时 HTML 会
+                // 把它折叠成空格，摘要里就出现「三清 淨」这样的句中断裂。
+                whiteSpace: "pre-line",
               }}
             >
-              {item.chunk_text}
+              {unwrapCbetaLines(item.chunk_text)}
             </Typography.Paragraph>
           </div>
         </List.Item>

--- a/frontend/src/utils/textReflow.ts
+++ b/frontend/src/utils/textReflow.ts
@@ -215,3 +215,32 @@ export function reflowText(raw: string): TextSegment[] {
   flushProse();
   return segments;
 }
+
+/**
+ * Collapse CBETA hard wraps for excerpt / card contexts.
+ *
+ * `reflowText` is the right tool when a passage is displayed in full — it
+ * produces prose and verse segments matching the reader. Excerpts (similar-
+ * passage cards, the parallel panel's clamped previews) only need the wraps
+ * gone: rendering raw text lets HTML collapse every ~18-char newline into a
+ * space, which is what put 「三清 淨」 in the citation drawer before 2026-07-29.
+ * The same defect is present anywhere chunk_text reaches the DOM untreated.
+ *
+ * Lines inside a paragraph are joined with NO separator — Chinese sets no
+ * inter-word space, so any separator IS the bug. Blank lines are real
+ * paragraph boundaries and survive as "\n\n", which callers render with
+ * `white-space: pre-line`.
+ */
+export function unwrapCbetaLines(raw: string): string {
+  return raw
+    .split(/\n\s*\n/)
+    .map((para) =>
+      para
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .join(""),
+    )
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/frontend/src/utils/textReflow.unwrap.test.ts
+++ b/frontend/src/utils/textReflow.unwrap.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { unwrapCbetaLines } from "./textReflow";
+
+/**
+ * CBETA 正文每 ~18 字一个硬换行（版式，非语义）。任何把 chunk_text 直接塞进
+ * DOM 的地方，HTML 都会把这些 \n 折叠成空格，于是「三清淨」显示成「三清 淨」。
+ * 2026-07-29 用户在引文抽屉里发现，核查后确认相似段落与跨藏对读面板同样中招。
+ */
+describe("unwrapCbetaLines", () => {
+  it("段内硬换行处不得留下任何分隔符——中文没有词间空格", () => {
+    expect(unwrapCbetaLines("又經中言有三清\n淨，俱身語意。")).toBe(
+      "又經中言有三清淨，俱身語意。",
+    );
+    expect(unwrapCbetaLines("意牟尼即無\n學意非意業。")).toBe("意牟尼即無學意非意業。");
+  });
+
+  it("空行是真正的段落边界，必须保留", () => {
+    expect(unwrapCbetaLines("業來責報準\n此可解。\n\n復次，諸業名、教、體、相。")).toBe(
+      "業來責報準此可解。\n\n復次，諸業名、教、體、相。",
+    );
+  });
+
+  it("不得丢字", () => {
+    const raw = "有愛，乃至廣說如是見\n者違害於我，我今不應與怨同見。彼由\n憎恚，起如是見";
+    expect(unwrapCbetaLines(raw).replace(/\n/g, "")).toBe(raw.replace(/\n/g, ""));
+  });
+
+  it("行首行尾的空白一并清掉，避免转成可见空格", () => {
+    expect(unwrapCbetaLines("此可解。 \n  復次")).toBe("此可解。復次");
+  });
+
+  it("无换行的文本原样返回", () => {
+    expect(unwrapCbetaLines("已經是一整句了。")).toBe("已經是一整句了。");
+  });
+});


### PR DESCRIPTION
回答 #1062 之后的追问「这个问题是不是全局都解决了」。**不是。** 核查后发现同一缺陷还在另外两个组件里。

## 核查

- 全库 3,548 部经每经取一块，**100% 含 CBETA 硬换行**（平均每 500 字 29.6 个）。这从来不是俱舍論独有——每一部经都受影响，只是恰好在那一条上被看见。
- 拿真实数据跑上线的 `reflowText`：残留裸换行 **0**、丢字 **0**。
- 并用 28 部跨体裁样本（華嚴/佛所行讚/俱舍論/瑜伽師地論/音義/律/语录）验证 `text_reflow.py` 与真实 TS **逐段完全一致**——确认前一条核查测的是真正上线的那个函数，而不是它的移植版。

## 逐一排查渲染 chunk_text 的地方

| 位置 | 状态 |
|---|---|
| 引文抽屉·汉文正文 | ✅ #1062 已修 |
| 引文抽屉·藏/梵/巴页签 | ✅ 不受影响（MITRA 句级数据，实测 47/47 无换行） |
| `SimilarPassages:97` | ❌ 有缺陷（实测 4/4 条目含换行） |
| `ReaderParallelPanel:289/301/337` | ❌ 有缺陷（实测接口返回含换行） |

## 改动

摘要类场景不适合上完整 reflow（卡片里不需要偈颂版式），新增 `unwrapCbetaLines`：段内按行拼接、**不插任何分隔符**（中文没有词间空格，插什么都是 bug），空行作为真正的段落边界保留为 `\n\n`，配 `white-space: pre-line` 渲染。

5 个新用例覆盖：段内不留分隔符、空行段落边界保留、不丢字、行首尾空白清除、无换行文本原样返回。

前端 263 passed / 55 files，eslint（`--max-warnings 0`）、tsc、i18n、build 全过。