### PR TITLE
feat(eval): 新增卷号准确率指标——唯一能看见「引错卷」的判据

### DIFF
--- a/backend/app/services/quote_verifier.py
+++ b/backend/app/services/quote_verifier.py
@@ -469,6 +469,46 @@ def verify_quoted_content(
     return corrected, mutations
 
 
+@dataclass(frozen=True)
+class QuoteCitation:
+    """One (quoted passage, cited title, cited fascicle) triple in an answer."""
+
+    quote: str
+    title: str
+    juan: int | None
+
+
+def iter_quote_citations(answer: str) -> list[QuoteCitation]:
+    """Every quoted passage the verifier examines, paired with its citation.
+
+    The candidate predicate (paired marks / blockquote block, ``MIN_QUOTE_CHARS``)
+    is the one both scanners apply before verifying anything. Exposed so callers
+    that need to know *which* passages were checked — the eval's fascicle-accuracy
+    metric, for one — derive them from the same pass that counts them, instead of
+    re-implementing the pairing and drifting away from it.
+    """
+    if not answer or "\u3010\u300a" not in answer:
+        return []
+    out: list[QuoteCitation] = []
+    for m in _QUOTE_CITATION_RE.finditer(answer):
+        quote = _matched_quote(m).strip()
+        if len(quote) >= MIN_QUOTE_CHARS:
+            out.append(QuoteCitation(
+                quote=quote,
+                title=m.group("title"),
+                juan=int(m.group("juan")) if m.group("juan") else None,
+            ))
+    for m in _BLOCKQUOTE_CITATION_RE.finditer(answer):
+        block = _strip_blockquote_markers(m.group("block"))
+        if len(block) >= MIN_QUOTE_CHARS:
+            out.append(QuoteCitation(
+                quote=block.strip(),
+                title=m.group("title"),
+                juan=int(m.group("juan")) if m.group("juan") else None,
+            ))
+    return out
+
+
 def count_checked_quotes(answer: str, sources: list[ChatSource]) -> int:
     """How many quoted passages :func:`verify_quoted_content` actually examines.
 
@@ -479,24 +519,11 @@ def count_checked_quotes(answer: str, sources: list[ChatSource]) -> int:
     "no evidence" scored as "evidence checked out", and the metric rewarded a
     model for quoting the canon *less*.
 
-    Counted here, not returned from ``verify_quoted_content``, so the existing
-    two-tuple contract and its call sites stay untouched. The candidate
-    predicate (paired marks, ``MIN_QUOTE_CHARS``) is the one both scanners
-    apply before they verify anything, and ``test_count_checked_quotes_matches``
-    pins the two together."""
-    if not answer or "【《" not in answer:
-        return 0
-    inline = sum(
-        1
-        for m in _QUOTE_CITATION_RE.finditer(answer)
-        if len(_matched_quote(m).strip()) >= MIN_QUOTE_CHARS
-    )
-    blocks = sum(
-        1
-        for m in _BLOCKQUOTE_CITATION_RE.finditer(answer)
-        if len(_strip_blockquote_markers(m.group("block"))) >= MIN_QUOTE_CHARS
-    )
-    return inline + blocks
+    Delegates to :func:`iter_quote_citations` so the count and the list of what
+    was counted can never disagree; ``test_count_checked_quotes_matches`` pins
+    both to the verifier's own scanners.
+    """
+    return len(iter_quote_citations(answer))
 
 
 def _strip_blockquote_markers(block: str) -> str:

--- a/backend/eval/faithfulness.py
+++ b/backend/eval/faithfulness.py
@@ -26,10 +26,17 @@ remediate at serve time what this metric counts here.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from app.schemas.chat import ChatSource
 from app.services.chat_trust import build_trust_status
 from app.services.citation_guard import enforce_citation_whitelist
-from app.services.quote_verifier import count_checked_quotes, verify_quoted_content
+from app.services.quote_verifier import (
+    count_checked_quotes,
+    iter_quote_citations,
+    normalise_for_match,
+    verify_quoted_content,
+)
 
 # The states build_trust_status can emit, in descending trust order. Kept
 # explicit (rather than imported from the Literal) so the report renders a
@@ -58,6 +65,10 @@ _GATED_RATES = (
     "verified_rate_of_cited",
     "served_trustworthy_rate",
     "verbatim_quote_rate",
+    # Wrong-fascicle citations are invisible to every other gated rate (the
+    # guards resolve quotes against chunks, not against the cited 卷), so this
+    # one has to be watched explicitly or the class regresses unnoticed.
+    "fascicle_accuracy_rate",
 )
 
 
@@ -111,6 +122,37 @@ def compute_faithfulness(answer: str, sources: list[ChatSource]) -> dict:
     }
 
 
+def compute_fascicle_accuracy(
+    answer: str, juan_text: Callable[[str, int], str | None]
+) -> dict:
+    """Is each quoted passage actually in the fascicle the answer cites?
+
+    Deliberately bypasses the retrieved chunks and asks ``text_contents`` — the
+    reader's own source of truth — instead. Everything else in this module
+    replays the runtime guards, and the guards cannot see this class of error:
+    ``quote_verifier._find_sources`` falls back to any fascicle of the cited text
+    when the cited one has no match, so a passage that is verbatim in 卷16 passes
+    while the answer says 第13卷. That is exactly the 2026-07-29 prod report, and
+    every guard waved it through.
+
+    Needs no gold annotation, so it covers every answerable question rather than
+    the handful whose fascicles someone hand-labelled. ``juan_text(title, juan)``
+    returns the fascicle's text, or None when it cannot be resolved — unresolvable
+    citations are left out of the denominator rather than silently scored wrong.
+    """
+    checked = correct = 0
+    for c in iter_quote_citations(answer):
+        if c.juan is None:
+            continue
+        body = juan_text(c.title, c.juan)
+        if not body:
+            continue
+        checked += 1
+        if normalise_for_match(c.quote) in normalise_for_match(body):
+            correct += 1
+    return {"fascicle_checked": checked, "fascicle_correct": correct}
+
+
 def aggregate_faithfulness(rows: list[dict]) -> dict:
     """Aggregate per-answer faithfulness dicts into headline rates + a state
     distribution.
@@ -135,6 +177,8 @@ def aggregate_faithfulness(rows: list[dict]) -> dict:
     served_trustworthy = sum(r.get("served_trustworthy", 0) for r in rows)
     answers_with_quotes = sum(r.get("has_checked_quotes", 0) for r in rows)
     quotes_all_verbatim = sum(r.get("quotes_all_verbatim", 0) for r in rows)
+    fascicle_checked = sum(r.get("fascicle_checked", 0) for r in rows)
+    fascicle_correct = sum(r.get("fascicle_correct", 0) for r in rows)
 
     distribution = dict.fromkeys(TRUST_STATES, 0)
     for r in rows:
@@ -160,6 +204,15 @@ def aggregate_faithfulness(rows: list[dict]) -> dict:
         "verbatim_quote_rate": (
             quotes_all_verbatim / answers_with_quotes if answers_with_quotes else None
         ),
+        # Of the quoted passages whose cited fascicle we could resolve, how many
+        # really are in that fascicle. The only rate here that consults
+        # text_contents rather than the retrieved chunks, and therefore the only
+        # one that can fall when the answer cites the wrong 卷 — see
+        # compute_fascicle_accuracy.
+        "fascicle_accuracy_rate": (
+            fascicle_correct / fascicle_checked if fascicle_checked else None
+        ),
+        "fascicle_checked": fascicle_checked,
         "answers_with_quotes": answers_with_quotes,
         # The brand number: among citing answers, the fraction whose SERVED text
         # misrepresents nothing (post-guard). The deterministic quote-downgrade

--- a/backend/eval/run_eval.py
+++ b/backend/eval/run_eval.py
@@ -25,14 +25,19 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from sqlalchemy import text as sql_text
+
 from app.config import settings
 from app.database import async_session
 from app.services.chat import _build_llm_messages
+from app.services.citation_guard import _norm_title
+from app.services.quote_verifier import iter_quote_citations
 from app.services.rag_retrieval import retrieve_rag_context
 from eval.faithfulness import (
     TRUST_STATES,
     aggregate_faithfulness,
     compute_faithfulness,
+    compute_fascicle_accuracy,
     detect_faithfulness_regressions,
 )
 from eval.retrieval_metrics import (
@@ -55,6 +60,59 @@ REPORTS_DIR = EVAL_DIR / "reports"
 def load_test_set() -> dict:
     with open(TEST_SET_PATH, encoding="utf-8") as f:
         return json.load(f)
+
+
+
+# ── 卷级引文准确率：拿 text_contents 当独立真源 ─────────────────────────
+#
+# 其余忠实度指标重放的是运行时护栏，而护栏看不见「引错卷」——quote_verifier 在
+# 所标卷无匹配时会回退到该经任意卷。所以这里绕开 chunk，直接问该卷正文。
+#
+# 经名 → text_id 沿用护栏的繁简折叠规则，从本题召回的来源里解析：与运行时同源，
+# 也省掉再建一份标题索引。查不到的引用不计入分母（见 compute_fascicle_accuracy）。
+_JUAN_TEXT_CACHE: dict[tuple[int, int], str | None] = {}
+
+
+async def _prefetch_cited_fascicles(session, answer: str, sources: list):
+    """Load the fascicles this answer cites and return a sync lookup over them.
+
+    Prefetched rather than fetched on demand so ``compute_fascicle_accuracy``
+    stays pure and synchronous — the metric is unit-tested in CI, where there is
+    no database, and threading an async callable through it would end that.
+
+    Only the (title, juan) pairs the answer actually cites are loaded, so a run
+    costs a handful of primary-key reads per question, cached across questions.
+    """
+    by_title: dict[str, int] = {}
+    for s in sources:
+        if getattr(s, "title_zh", None) and getattr(s, "text_id", 0) > 0:
+            by_title.setdefault(_norm_title(s.title_zh), s.text_id)
+
+    loaded: dict[tuple[str, int], str | None] = {}
+    for cite in iter_quote_citations(answer):
+        if cite.juan is None or (cite.title, cite.juan) in loaded:
+            continue
+        text_id = by_title.get(_norm_title(cite.title))
+        if text_id is None:
+            # Title outside the retrieved set — citation_guard already strips
+            # those, and we cannot adjudicate a fascicle without knowing which
+            # text it belongs to. Left unresolved → excluded from the denominator.
+            continue
+        key = (text_id, cite.juan)
+        if key not in _JUAN_TEXT_CACHE:
+            row = (
+                await session.execute(
+                    sql_text(
+                        "SELECT content FROM text_contents "
+                        "WHERE text_id = :t AND juan_num = :j AND lang = 'lzh' LIMIT 1"
+                    ),
+                    {"t": text_id, "j": cite.juan},
+                )
+            ).fetchone()
+            _JUAN_TEXT_CACHE[key] = row[0] if row else None
+        loaded[(cite.title, cite.juan)] = _JUAN_TEXT_CACHE[key]
+
+    return lambda title, juan: loaded.get((title, juan))
 
 
 async def run_single_question(
@@ -128,6 +186,11 @@ async def run_single_question(
     # generations (which carry no citations and would drag the rates down).
     if not answer.startswith("[ERROR]"):
         result["faithfulness"] = compute_faithfulness(answer, sources)
+        # 卷级引文准确率：与上面那行不同，它绕开召回的 chunk，直接问 text_contents
+        # 「这段引文在所标的那一卷里吗」——护栏看不见的正是这一类错误。
+        async with async_session() as fascicle_session:
+            juan_text = await _prefetch_cited_fascicles(fascicle_session, answer, sources)
+        result["faithfulness"].update(compute_fascicle_accuracy(answer, juan_text))
 
     # Step 3: Scoring
     if category == "out_of_scope":
@@ -188,12 +251,20 @@ def _faithfulness_section(faith_agg: dict) -> list[str]:
         f"| {faith_agg.get('answers_with_citations', 0)} 条有引用回答 |",
         f"| **逐字引用保真度 (verbatim_quote_rate)** | **{_fmt_rate(faith_agg.get('verbatim_quote_rate'))}** "
         f"| {faith_agg.get('answers_with_quotes', 0)} 条含可核验引文的回答 |",
+        f"| **卷号准确率 (fascicle_accuracy_rate)** | **{_fmt_rate(faith_agg.get('fascicle_accuracy_rate'))}** "
+        f"| {faith_agg.get('fascicle_checked', 0)} 条可判定引文 |",
         f"| 含转述降级引文的回答数 | {faith_agg.get('answers_with_downgraded_quote', 0)} | — |",
         "",
         "> `verified_rate_of_cited` 的分母是**有引用**的回答:引用了来源却一个字都不引原文的",
         "> 回答记 0,不记 1 —— 它什么都没核验。`verbatim_quote_rate` 的分母是**真的引用了",
         "> 原文**的回答,回答「模型把原典放进引号里时,有多少次是逐字的」。两者独立移动,",
         "> 所以一次 run 无法靠少引用来刷分。",
+        "",
+        "> `fascicle_accuracy_rate` 是唯一不查召回 chunk、而是直接问 `text_contents`",
+        "> 「这段引文在所标的那一卷里吗」的指标。其余各项都重放运行时护栏,而护栏看不见",
+        "> 引错卷 —— quote_verifier 在所标卷无匹配时会回退到该经任意卷,于是引文在卷十六",
+        "> 被找到、答案却标第13卷,两道防线一起放行(2026-07-29 线上原形)。分母只计",
+        "> **能判定**的引文:经名不在召回集、或查不到该卷正文的,不计入,不静默记错。",
         "",
         "**可信状态分布**", "",
         "| 状态 | 数量 |", "|------|------|",

--- a/backend/tests/test_fascicle_accuracy.py
+++ b/backend/tests/test_fascicle_accuracy.py
@@ -1,0 +1,89 @@
+"""引文是否真的落在它所标的那一卷里 —— 用 text_contents 做独立真源。
+
+为什么现有指标看不见这件事
+--------------------------
+`compute_faithfulness` 重放的是运行时护栏，而护栏只检验「引文是否逐字出现在
+**召回的 chunk** 里」。2026-07-29 的生产事故正是：引文逐字正确、卷号是错的——
+`quote_verifier._find_sources` 在所标卷无匹配时会回退到该经任意卷，于是引文在
+卷十六的 chunk 里被找到，答案却标第13卷，两道护栏一起发绿灯。
+
+所以这条指标必须绕开 chunk，直接问 text_contents：这段话在第 N 卷里吗？
+不需要金标、不需要人工标注，75 道可答题全覆盖。
+"""
+
+import pytest
+
+from app.services.quote_verifier import iter_quote_citations
+from eval.faithfulness import compute_fascicle_accuracy
+
+_J16 = "無學身語業，名身語牟尼，意牟尼即無學意非意業。所以者何？勝義牟尼唯心為體。"
+_J13 = "分別業品第四之一。如前所說有情世間及器世間各多差別。"
+_QUOTE = "無學身語業，名身語牟尼，意牟尼即無學意非意業"
+
+
+def _lookup(title: str, juan: int) -> str | None:
+    return {("阿毘達磨俱舍論", 13): _J13, ("阿毘達磨俱舍論", 16): _J16}.get((title, juan))
+
+
+class TestIterQuoteCitations:
+    def test_pairs_inline_quote_with_its_citation(self):
+        got = iter_quote_citations(f"论云「{_QUOTE}」【《阿毘達磨俱舍論》第16卷】")
+        assert [(c.title, c.juan) for c in got] == [("阿毘達磨俱舍論", 16)]
+        assert got[0].quote == _QUOTE
+
+    def test_pairs_markdown_blockquote_too(self):
+        answer = f"论文言：\n> {_QUOTE}。\n\n【《阿毘達磨俱舍論》第16卷】"
+        got = iter_quote_citations(answer)
+        assert [(c.title, c.juan) for c in got] == [("阿毘達磨俱舍論", 16)]
+
+    def test_count_checked_quotes_stays_in_sync(self):
+        """两者必须由同一份配对逻辑得出，否则「检查了几条」与「检查了哪几条」
+        会悄悄分叉。"""
+        from app.services.quote_verifier import count_checked_quotes
+
+        answer = (
+            f"甲云「{_QUOTE}」【《阿毘達磨俱舍論》第16卷】。"
+            f"乙云「{_QUOTE}」【《阿毘達磨俱舍論》第13卷】。"
+        )
+        assert len(iter_quote_citations(answer)) == count_checked_quotes(answer, [])
+
+
+class TestFascicleAccuracy:
+    def test_flags_a_quote_that_is_not_in_the_cited_fascicle(self):
+        """生产事故原形：引文逐字正确，卷号指向卷13，而它实出卷十六。"""
+        answer = f"论云「{_QUOTE}」【《阿毘達磨俱舍論》第13卷】"
+        got = compute_fascicle_accuracy(answer, _lookup)
+        assert got["fascicle_checked"] == 1
+        assert got["fascicle_correct"] == 0
+
+    def test_accepts_a_quote_that_is_in_the_cited_fascicle(self):
+        answer = f"论云「{_QUOTE}」【《阿毘達磨俱舍論》第16卷】"
+        got = compute_fascicle_accuracy(answer, _lookup)
+        assert got == {"fascicle_checked": 1, "fascicle_correct": 1}
+
+    def test_tolerates_punctuation_and_script_differences(self):
+        """LLM 常写简体、改标点；判据必须与 quote_verifier 用同一套归一化，
+        否则会把正确的引文误判成错卷。"""
+        answer = "论云「无学身语业名身语牟尼意牟尼即无学意非意业」【《阿毘達磨俱舍論》第16卷】"
+        got = compute_fascicle_accuracy(answer, _lookup)
+        assert got["fascicle_correct"] == 1
+
+    def test_skips_what_it_cannot_adjudicate(self):
+        """查不到该卷正文时不计入分母——沉默地记为「错」会让指标失真。"""
+        answer = f"论云「{_QUOTE}」【《某部未收經》第3卷】"
+        assert compute_fascicle_accuracy(answer, _lookup) == {
+            "fascicle_checked": 0,
+            "fascicle_correct": 0,
+        }
+
+    def test_citation_without_a_fascicle_is_not_checkable(self):
+        answer = f"论云「{_QUOTE}」【《阿毘達磨俱舍論》】"
+        assert compute_fascicle_accuracy(answer, _lookup)["fascicle_checked"] == 0
+
+
+@pytest.mark.parametrize("answer", ["", "没有任何引用的答案。"])
+def test_empty_answers_are_inert(answer):
+    assert compute_fascicle_accuracy(answer, _lookup) == {
+        "fascicle_checked": 0,
+        "fascicle_correct": 0,
+    }


### PR DESCRIPTION
回归门此前在这个维度上**完全不设防**：90 题里只有 8 题标了卷号金标，其余按经名匹配、卷号=任意。而 2026-07-29 用户反馈的正是引错卷——引文逐字正确、卷号是错的。

## 为什么不走「补金标」这条路

原计划是给题库逐题补卷号。放弃了，因为**它对多数题根本不成立**：问「五蕴是什么」，杂阿含 50 卷里好几卷都对，硬指定一卷是在制造错误判据。卷级金标只对 `source_lookup` 一类成立（15 题，8 题已标），补完也只覆盖 17% 的题。

改用不需要金标的客观判据：拿 `text_contents` 当独立真源，问「这段引文在所标的那一卷里吗」。**75 道可答题全覆盖，零人工标注。**

## 为什么现有指标看不见它

`faithfulness.py` 其余各项都重放运行时护栏，而 `quote_verifier._find_sources` 在所标卷无匹配时会**回退到该经任意卷**——引文在卷十六的 chunk 里被找到、答案却标第13卷，两道防线一起发绿灯。所以这条必须绕开 chunk。

## 实现要点

- `iter_quote_citations` 从 `quote_verifier` 抽出，`count_checked_quotes` 改为委托它——「检查了几条」与「检查了哪几条」从此同源，不会各自漂移。
- `compute_fascicle_accuracy` 保持**纯同步**（CI 里没有数据库，异步回调会断掉它的可测性）；卷正文由 `run_eval` 预取后以同步闭包传入，只取答案实际引用的 (经名,卷) 对，跨题缓存。
- **分母只计能判定的引文**：经名不在召回集、或查不到该卷正文的一律不计入，不静默记错——沉默地判错会让指标失真。
- 已加入 `_GATED_RATES`，回归门会盯着它。

## 测试

10 个新用例。并按今天定的规矩实测有效性：把判据架空成「查得到该卷就算对」后，核心用例立刻变红，恢复后转绿。

后端 1427 passed（新增 10），`test_health_check_probe.py` 3 个失败为预先存在；ruff 0.9.7 通过。