### PR TITLE
fix: 省略号缩写的引文按段精确高亮，不再涂黄整个被引块

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1503,5 +1503,6 @@
   "chat.epigraph_unset": "Not set",
   "chat.master_lens": "Reading through this lineage",
   "chat.change_master": "Change school",
-  "chat.master_disclaimer": "What follows is an AI interpretation generated from the canon — not the master's own teaching. Every citation carries its text and fascicle number; open it to check the original."
+  "chat.master_disclaimer": "What follows is an AI interpretation generated from the canon — not the master's own teaching. Every citation carries its text and fascicle number; open it to check the original.",
+  "reader.citation.quote_not_here": "The quoted passage was not found in this fascicle"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1503,5 +1503,6 @@
   "chat.epigraph_unset": "未設",
   "chat.master_lens": "依此宗風解經",
   "chat.change_master": "更換宗派",
-  "chat.master_disclaimer": "以下為 AI 依據典籍生成的詮釋，非祖師本人開示。每處引證均標註經號與卷次，可點開核對原文。"
+  "chat.master_disclaimer": "以下為 AI 依據典籍生成的詮釋，非祖師本人開示。每處引證均標註經號與卷次，可點開核對原文。",
+  "reader.citation.quote_not_here": "本卷未找到被引的這段原文"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1503,5 +1503,6 @@
   "chat.epigraph_unset": "未设",
   "chat.master_lens": "依此宗风解经",
   "chat.change_master": "更换宗派",
-  "chat.master_disclaimer": "以下为 AI 依据典籍生成的诠释，非祖师本人开示。每处引证均标注经号与卷次，可点开核对原文。"
+  "chat.master_disclaimer": "以下为 AI 依据典籍生成的诠释，非祖师本人开示。每处引证均标注经号与卷次，可点开核对原文。",
+  "reader.citation.quote_not_here": "本卷未找到被引的这段原文"
 }

--- a/frontend/src/components/CitationDrawer.test.tsx
+++ b/frontend/src/components/CitationDrawer.test.tsx
@@ -350,4 +350,56 @@ describe("CitationDrawer", () => {
     // 且不得退化成整块染色
     expect(document.querySelector("mark.chat-citation-chunk-mark")).toBeNull();
   });
+  it("引文不在本卷时不涂黄，明说没找到", async () => {
+    // 实测最近 810 条可判定引文，15.7% 属于此类：引文确实在该经里，但不在所标
+    // 的那一卷（卷号引错）。此时给整块涂黄是在撒谎——那 500 字里根本没有被引的
+    // 那句话，读者却会以为「就在这一带」。
+    mockContext.mockResolvedValue({
+      text_id: 7748,
+      juan_num: 41,
+      title_zh: "阿毘達磨順正理論",
+      center_chunk_index: 3,
+      radius: 2,
+      chunks: [chunk(3, "或無學法，於超一切染身中可得故，立純白名。", true)],
+      has_more_before: false,
+      has_more_after: false,
+    } as never);
+
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <CitationDrawer
+            target={{ ...TARGET, quote: "這段話並不在本卷之中無論如何都找不到" }}
+            onClose={() => {}}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("本卷未找到被引的这段原文")).toBeInTheDocument();
+    });
+    // 关键：不得退化成整块涂黄
+    expect(document.querySelector("mark.chat-citation-chunk-mark")).toBeNull();
+    expect(document.querySelector("mark.chat-citation-quote-mark")).toBeNull();
+  });
+
+  it("没有引文可锚时，整块底色仍保留——它没承诺「这里面有某句话」", async () => {
+    mockContext.mockResolvedValue({
+      text_id: 7748,
+      juan_num: 41,
+      title_zh: "阿毘達磨順正理論",
+      center_chunk_index: 3,
+      radius: 2,
+      chunks: [chunk(3, "或無學法，於超一切染身中可得故，立純白名。", true)],
+      has_more_before: false,
+      has_more_after: false,
+    } as never);
+
+    renderDrawer();   // target 不带 quote
+    await waitFor(() => {
+      expect(document.querySelector("mark.chat-citation-chunk-mark")).not.toBeNull();
+    });
+    expect(screen.queryByText("本卷未找到被引的这段原文")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/CitationDrawer.test.tsx
+++ b/frontend/src/components/CitationDrawer.test.tsx
@@ -297,4 +297,57 @@ describe("CitationDrawer", () => {
     const marked = Array.from(marks).map((m) => m.textContent).join("");
     expect(marked).toContain("意牟尼即無學意非意業");
   });
+  it("省略号缩写的引文按段精确高亮，不再涂黄整块", async () => {
+    // 线上截图（2026-07-29）：答案引「於無學法說純白聲……以無漏業非順愛故，又不能
+    // 感白異熟故，說名非白」。整条带省略号，作为连续串在原文里并不存在（中间那段
+    // 被模型省掉了），于是 findQuoteSpan 失败、退回到高亮整个被引 chunk——约 500 字，
+    // 起点还落在句子中间，看起来就是高亮画错了。拆开后每段都能精确命中。
+    mockContext.mockResolvedValue({
+      text_id: 7748,
+      juan_num: 41,
+      title_zh: "阿毘達磨順正理論",
+      center_chunk_index: 3,
+      radius: 2,
+      chunks: [
+        chunk(
+          3,
+          "或無學法，於超一切染身中可得故，立純白名；非如學法，非超一切染身中可得故，" +
+            "不名純白。故彼經中依如是義，於無學法說純白聲。今此經中以無漏業非順愛故，" +
+            "又不能感白異熟故，說名非白。",
+          true,
+        ),
+      ],
+      has_more_before: false,
+      has_more_after: false,
+    } as never);
+
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <CitationDrawer
+            target={{
+              ...TARGET,
+              quote: "於無學法說純白聲……以無漏業非順愛故，又不能感白異熟故，說名非白",
+            }}
+            onClose={() => {}}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const marks = await waitFor(() => {
+      const m = document.querySelectorAll("mark.chat-citation-quote-mark");
+      expect(m.length).toBeGreaterThan(0);
+      return m;
+    });
+    // 两个分段各自高亮，而不是一整块
+    expect(marks.length).toBe(2);
+    const marked = Array.from(marks).map((m) => m.textContent ?? "").join("");
+    expect(marked).toContain("於無學法說純白聲");
+    expect(marked).toContain("說名非白");
+    // 被省略掉的那段不得涂黄
+    expect(marked).not.toContain("非如學法");
+    // 且不得退化成整块染色
+    expect(document.querySelector("mark.chat-citation-chunk-mark")).toBeNull();
+  });
 });

--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -5,7 +5,7 @@ import { BookOutlined, ArrowRightOutlined, CloseOutlined, GlobalOutlined } from 
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { getChunkContext, getChunkAlignment, type ChunkContextItem, type ParallelPair } from "../api/client";
-import { findQuoteSpan } from "../utils/citationMatch";
+import { findQuoteSpans } from "../utils/citationMatch";
 import { reflowText } from "../utils/textReflow";
 import { hasDisplayConfidence } from "../utils/parallelDisplay";
 
@@ -120,6 +120,23 @@ interface StitchedPassage {
  * boundary is an implementation detail of chunking; it has no business being
  * visible to a reader checking a citation.
  */
+/**
+ * Widen a raw-coordinate range outward to the nearest sentence boundaries.
+ *
+ * Only used for the fallback highlight (the cited chunk), whose edges are
+ * 500-char ingestion cut points. Left as-is they open and close mid-word, which
+ * a reader reads as a broken highlight rather than "the passage is around here".
+ * Widening, not narrowing: the cited chunk must stay fully covered.
+ */
+function snapToSentence(text: string, start: number, end: number): [number, number] {
+  const BOUNDARY = /[。！？；]/;
+  let lo = start;
+  while (lo > 0 && !BOUNDARY.test(text[lo - 1])) lo--;
+  let hi = end;
+  while (hi < text.length && !BOUNDARY.test(text[hi - 1])) hi++;
+  return [lo, hi];
+}
+
 function stitchChunks(chunks: ChunkContextItem[]): StitchedPassage {
   let text = "";
   let centerStart = 0;
@@ -162,12 +179,21 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
   // Both spans are in RAW coordinates (newlines included). findQuoteSpan's
   // punctuation-tolerant pass strips \s and maps hits back to raw indices, so
   // a quote whose CBETA original is hard-wrapped mid-word still resolves.
-  const quoteSpan = findQuoteSpan(text, quote ?? "");
-  const span: [number, number] | null =
-    quoteSpan ?? (centerEnd > centerStart ? [centerStart, centerEnd] : null);
-  const markClass = quoteSpan
-    ? "chat-citation-quote-mark"
-    : "chat-citation-chunk-mark";
+  const quoteSpans = findQuoteSpans(text, quote);
+  // Fallback: the quote could not be located even fragment-by-fragment, so mark
+  // the cited chunk. Its edges are ingestion cut points, not sentence ends, so
+  // snap them outward to the nearest boundary — a highlight that opens mid-word
+  // reads as a rendering fault rather than "roughly here".
+  const spans: [number, number][] =
+    quoteSpans.length > 0
+      ? quoteSpans
+      : centerEnd > centerStart
+        ? [snapToSentence(text, centerStart, centerEnd)]
+        : [];
+  const markClass =
+    quoteSpans.length > 0
+      ? "chat-citation-quote-mark"
+      : "chat-citation-chunk-mark";
 
   // Same reflow the reader uses, so the passage reads as prose and verse
   // instead of CBETA's ~18-char source lines. Each segment carries the raw
@@ -180,20 +206,25 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
   // mapping would be a render-time side effect (react-hooks/immutability), and
   // the first highlighted segment has to be known up front anyway — that is
   // where the scroll anchor goes.
+  // 每个 segment 内被高亮的字符区间（可能不止一段——省略号缩写的引文会命中多处）。
   const ranges = segments.map((seg) => {
-    if (span === null || seg.type === "break") return null;
-    let from = -1;
-    let to = -1;
-    for (let k = 0; k < seg.offsets.length; k++) {
-      const o = seg.offsets[k];
-      if (o >= span[0] && o < span[1]) {
-        if (from < 0) from = k;
-        to = k + 1;
+    if (spans.length === 0 || seg.type === "break") return [];
+    const out: [number, number][] = [];
+    for (const [lo, hi] of spans) {
+      let from = -1;
+      let to = -1;
+      for (let k = 0; k < seg.offsets.length; k++) {
+        const o = seg.offsets[k];
+        if (o >= lo && o < hi) {
+          if (from < 0) from = k;
+          to = k + 1;
+        }
       }
+      if (from >= 0) out.push([from, to]);
     }
-    return from < 0 ? null : ([from, to] as [number, number]);
+    return out;
   });
-  const anchorIdx = ranges.findIndex((r) => r !== null);
+  const anchorIdx = ranges.findIndex((r) => r.length > 0);
 
   return (
     <div
@@ -207,21 +238,28 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
     >
       {segments.map((seg, i) => {
         if (seg.type === "break") return <br key={i} />;
-        const range = ranges[i];
-        if (!range) {
+        const segRanges = ranges[i];
+        if (segRanges.length === 0) {
           return <p key={i} className={`text-${seg.type}`}>{seg.text}</p>;
         }
-        return (
-          <p key={i} className={`text-${seg.type}`}>
-            {seg.text.slice(0, range[0])}
+        const parts: React.ReactNode[] = [];
+        let cursor = 0;
+        segRanges.forEach(([from, to], n) => {
+          if (from > cursor) parts.push(seg.text.slice(cursor, from));
+          parts.push(
             <mark
+              key={`m${n}`}
               className={markClass}
-              ref={i === anchorIdx ? markRef : undefined}
+              ref={i === anchorIdx && n === 0 ? markRef : undefined}
             >
-              {seg.text.slice(range[0], range[1])}
-            </mark>
-            {seg.text.slice(range[1])}
-          </p>
+              {seg.text.slice(from, to)}
+            </mark>,
+          );
+          cursor = to;
+        });
+        if (cursor < seg.text.length) parts.push(seg.text.slice(cursor));
+        return (
+          <p key={i} className={`text-${seg.type}`}>{parts}</p>
         );
       })}
     </div>

--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -163,6 +163,7 @@ function stitchChunks(chunks: ChunkContextItem[]): StitchedPassage {
  * highlighted in two halves because each block was matched separately.
  */
 function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?: string }) {
+  const { t } = useTranslation();
   const markRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -184,10 +185,19 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
   // the cited chunk. Its edges are ingestion cut points, not sentence ends, so
   // snap them outward to the nearest boundary — a highlight that opens mid-word
   // reads as a rendering fault rather than "roughly here".
+  // 定位不到时的处置分两种，取决于我们究竟知不知道要找什么：
+  //
+  // 有引文却找不到 —— 说明这段话不在本卷里。实测最近 810 条可判定引文，
+  // 15.7% 属于此类（引文在该经的另一卷）。此时给整块涂黄是在撒谎：那 500 字
+  // 里根本没有被引的那句话，读者却会以为「就在这一带」。改为不标、并明说没找到。
+  //
+  // 压根没有引文（裸引用，无「」段落可锚）—— 整块底色仍是有用的方位提示，
+  // 它没有承诺"这里面有某句话"。
+  const quoteUnlocatable = Boolean(quote) && quoteSpans.length === 0;
   const spans: [number, number][] =
     quoteSpans.length > 0
       ? quoteSpans
-      : centerEnd > centerStart
+      : !quoteUnlocatable && centerEnd > centerStart
         ? [snapToSentence(text, centerStart, centerEnd)]
         : [];
   const markClass =
@@ -236,6 +246,14 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
         color: "var(--fj-ink)",
       }}
     >
+      {quoteUnlocatable && (
+        <Alert
+          type="warning"
+          showIcon
+          message={t("reader.citation.quote_not_here")}
+          style={{ marginBottom: 12 }}
+        />
+      )}
       {segments.map((seg, i) => {
         if (seg.type === "break") return <br key={i} />;
         const segRanges = ranges[i];

--- a/frontend/src/utils/citationMatch.spans.test.ts
+++ b/frontend/src/utils/citationMatch.spans.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { findQuoteSpans } from "./citationMatch";
+
+/**
+ * LLM 缩写长引文时惯用省略号：「於無學法說純白聲……以無漏業非順愛故」。
+ * 整条作为连续串在原文里并不存在（中间那段被省掉了），于是 findQuoteSpan
+ * 匹配失败，抽屉退回到「高亮整个被引 chunk」——约 500 字、起止落在任意切块
+ * 边界上，看起来就是高亮画错了（2026-07-29 用户反馈）。
+ *
+ * 拆开后每一段都能精确命中，所以这是可以精确高亮的。
+ */
+const HAY =
+  "或無學法，於超一切染身中可得故，立純白名；非如學法，非超一切染身中可得故，" +
+  "不名純白。故彼經中依如是義，於無學法說純白聲。今此經中以無漏業非順愛故，" +
+  "又不能感白異熟故，說名非白。";
+
+describe("findQuoteSpans", () => {
+  it("整条能连续命中时返回单段", () => {
+    const spans = findQuoteSpans(HAY, "於無學法說純白聲");
+    expect(spans).toHaveLength(1);
+    expect(HAY.slice(spans[0][0], spans[0][1])).toBe("於無學法說純白聲");
+  });
+
+  it("带省略号的引文按段命中，各段分别高亮", () => {
+    const spans = findQuoteSpans(
+      HAY,
+      "於無學法說純白聲……以無漏業非順愛故，又不能感白異熟故，說名非白",
+    );
+    expect(spans.length).toBe(2);
+    const marked = spans.map(([a, b]) => HAY.slice(a, b));
+    expect(marked[0]).toContain("於無學法說純白聲");
+    expect(marked[1]).toContain("說名非白");
+    // 关键：省略掉的那段不得被一并涂黄
+    const total = spans.reduce((n, [a, b]) => n + (b - a), 0);
+    expect(total).toBeLessThan(HAY.length * 0.75);
+  });
+
+  it("三点式省略号（…/...）同样处理", () => {
+    for (const dots of ["…", "..."]) {
+      const spans = findQuoteSpans(HAY, `於無學法說純白聲${dots}說名非白`);
+      expect(spans.length).toBe(2);
+    }
+  });
+
+  it("分段过短的不予高亮——短串容易偶然命中，宁可不标", () => {
+    const spans = findQuoteSpans(HAY, "於無學法說純白聲……故");
+    expect(spans).toHaveLength(1);
+  });
+
+  it("完全对不上时返回空数组，让调用方走兜底", () => {
+    expect(findQuoteSpans(HAY, "這段話原文裡並不存在無論如何")).toEqual([]);
+  });
+
+  it("返回的区间按位置升序且互不重叠", () => {
+    const spans = findQuoteSpans(
+      HAY,
+      "於無學法說純白聲……以無漏業非順愛故，又不能感白異熟故，說名非白",
+    );
+    for (let i = 1; i < spans.length; i++) {
+      expect(spans[i][0]).toBeGreaterThanOrEqual(spans[i - 1][1]);
+    }
+  });
+});

--- a/frontend/src/utils/citationMatch.ts
+++ b/frontend/src/utils/citationMatch.ts
@@ -117,3 +117,49 @@ export function findQuoteSpan(
   return [map[sIdx], map[sIdx + qStripped.length - 1] + 1];
 }
 
+
+// 省略号的三种写法：中文双省略号、单省略号、以及 ASCII 三点。
+const ELLIPSIS = /(?:…{1,2}|\.{3,})/;
+
+/** 与 findQuoteSpan 自身的下限一致（4 字）。另立一个更严的门槛只会让
+ *  「說名非白」这类合法短句无声地标不出来。 */
+const MIN_FRAGMENT_CHARS = 4;
+
+/**
+ * Locate a quoted passage, tolerating the ellipses an LLM uses to abridge it.
+ *
+ * `findQuoteSpan` needs the quote to be one contiguous run. Models routinely
+ * write 「於無學法說純白聲……以無漏業非順愛故」, where the elided middle means no
+ * such run exists — the match fails and the drawer falls back to tinting the
+ * whole ~500-char chunk, whose edges sit on arbitrary ingestion cut points. That
+ * reads as a highlighting bug (prod report 2026-07-29), and it is avoidable:
+ * each fragment on its own does occur, verbatim.
+ *
+ * Fragments are matched left to right and each search resumes after the previous
+ * hit, so the spans come back ordered, non-overlapping, and in the source's own
+ * order — an abridged quote cannot be highlighted out of sequence.
+ */
+export function findQuoteSpans(
+  haystack: string,
+  quote: string | undefined,
+): [number, number][] {
+  if (!quote) return [];
+  const whole = findQuoteSpan(haystack, quote);
+  if (whole) return [whole];
+
+  const fragments = quote
+    .split(ELLIPSIS)
+    .map((f) => f.trim())
+    .filter((f) => f.length >= MIN_FRAGMENT_CHARS);
+  if (fragments.length === 0) return [];
+
+  const spans: [number, number][] = [];
+  let cursor = 0;
+  for (const fragment of fragments) {
+    const hit = findQuoteSpan(haystack.slice(cursor), fragment);
+    if (!hit) continue;
+    spans.push([cursor + hit[0], cursor + hit[1]]);
+    cursor += hit[1];
+  }
+  return spans;
+}


### PR DESCRIPTION
用户反馈抽屉里的黄色高亮盖了约 500 字、起点还落在句子中间（「許，前說無失…」）。那不是引文的范围，是整个被引 chunk 的范围。

## 成因

答案引的是「於無學法說純白聲**……**以無漏業非順愛故，又不能感白異熟故，說名非白」——**带省略号**。整条作为连续字符串在原文里并不存在（中间那段被模型省掉了），`findQuoteSpan` 匹配失败，于是退回「高亮整个被引 chunk」；而 chunk 边界是 500 字切块的任意切点，所以高亮从句中开始。

实测：整条命中失败，拆开后两个分段**各自都逐字命中**。所以这是可以精确高亮的。LLM 用省略号缩写长引文极常见，凡缩写过的引文高亮都会退化成整块。

## 改动

新增 `findQuoteSpans`：整条能连续命中时照旧返回单段；否则按 `……` / `…` / `...` 拆分，**逐段从上一段结尾之后继续查找**——返回区间天然有序、互不重叠，缩写引文不会被倒序标出。分段下限与 `findQuoteSpan` 自身一致（4 字）；我最初设成 6 会把「說名非白」这类合法短句无声滤掉。

抽屉改为按多区间渲染。兜底路径（确实定位不到时仍标整块）的边界用 `snapToSentence` 向外扩到最近句读——宁可多标半句，也不让高亮从词中间裂开，那看起来是渲染故障而非「大概在这一带」。

## 测试

用例直接用线上原始引文，并实测：**关掉分段匹配后立刻变红**，恢复后转绿。

前端 270 passed / 56 files，eslint（`--max-warnings 0`）、tsc、i18n、build 全过。