### PR TITLE
feat: 引用健康度回放监测——先装眼睛，不设阈值

### DIFF
--- a/backend/scripts/citation_health_report.py
+++ b/backend/scripts/citation_health_report.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""回放最近已服务的答案，报告引用健康度三项指标。
+
+为什么是回放，不是 eval
+----------------------
+`eval/run_eval.py` 能算 `fascicle_accuracy_rate`，但夜间回归门跑的是 `--no-llm`
+——它在生成答案前就返回了，所以**忠实度指标在定时任务里从不被计算**。带 LLM 的
+全量 eval 要烧 75 次生成 + 75 次评判，且题库是固定的 90 题。
+
+回放已经服务出去的答案没有这些问题：成本为零，样本是真实用户提问，而且随时间
+持续积累。2026-07-29 首测就拿到 1,672 条可判定引用，比一次 eval 多 6–8 倍。
+
+报告什么
+--------
+1. **卷号准确率** —— 带引号的引文，是否真的在所标的那一卷里。
+   拿 ``text_contents`` 做独立真源，绕开召回的 chunk：护栏会跨卷回退，
+   结构性看不见「引错卷」（详见 eval/faithfulness.compute_fascicle_accuracy）。
+
+2. **引号覆盖率** —— 多少引用带「」或引用块。没有引号的引用，quote_verifier
+   查不了、引文抽屉锚不了、卷号准确率也量不到它——它完全游离在核验体系之外。
+   2026-07-29 实测这一类占 51.6%，是当前最大的盲区。
+
+3. **引文定位与所标卷号的一致率** —— 引文能在该经的哪一卷逐字找到，那一卷与
+   答案所标的卷号是否相同。
+   这一项是为一个**尚未裁决的问题**攒证据：能否让运行时护栏按引文所在位置自动
+   纠正卷号。此前实测该做法 18 错 2 对而被否决，但那次用的是索引修复前的答案，
+   18 处误改全部由错标 chunk 驱动。索引现已干净（受损面归零），结论可能不同。
+   若这一项长期高位，自动纠正就是可行的；若不然，就该老实走提示词那条路。
+
+刻意不设阈值
+-----------
+修复前基线 0.722，修复后样本只有 25 条引文——数据不足时定红线，要么天天误报、
+要么永不触发。先纯报告积累两周，阈值连同 cron 的告警一起补。所以本脚本**总是
+退出 0**，除非自身出错。
+
+用法（在 fojin-backend 容器内，cwd /app）：
+    python scripts/citation_health_report.py
+    python scripts/citation_health_report.py --days 7 --limit 2000
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import text as sql_text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.config import settings
+from app.services.citation_guard import _norm_title
+from app.services.quote_verifier import (
+    _BLOCKQUOTE_CITATION_RE,
+    _QUOTE_CITATION_RE,
+    iter_quote_citations,
+    normalise_for_match,
+)
+
+# 所有 【《经名》第N卷】 引用，无论前面有没有引号 —— 引号覆盖率的分母。
+_ANY_CITATION_RE = re.compile(r"【《(?P<title>[^》]+)》(?:第(?P<juan>\d+)卷)?】")
+
+_ANSWERS = sql_text(
+    """
+    -- CAST 而非 ::text —— SQLAlchemy 的 text() 会把 `::text` 里的冒号当成
+    -- 绑定参数名，语句直接送不到数据库；CAST 两种方言都认，测试也才跑得起来。
+    SELECT id, content, CAST(sources AS TEXT)
+    FROM chat_messages
+    WHERE role = 'assistant'
+      AND content LIKE '%【《%'
+      AND sources IS NOT NULL
+      AND created_at > :since
+    ORDER BY id DESC
+    LIMIT :limit
+    """
+)
+
+
+def _title_index(raw_sources: str) -> dict[str, int]:
+    """{繁简折叠后的经名 -> text_id}，与护栏的解析规则同源。"""
+    try:
+        payload = json.loads(raw_sources)
+    except (TypeError, ValueError):
+        return {}
+    items = payload if isinstance(payload, list) else payload.get("sources") or []
+    out: dict[str, int] = {}
+    for s in items:
+        if s.get("title_zh") and (s.get("text_id") or 0) > 0:
+            out.setdefault(_norm_title(s["title_zh"]), s["text_id"])
+    return out
+
+
+class _Corpus:
+    """按 (text_id, juan) 和 text_id 缓存归一化后的正文，全程只读。"""
+
+    def __init__(self, conn):
+        self._conn = conn
+        self._juan: dict[tuple[int, int], str | None] = {}
+        self._whole: dict[int, list[tuple[int, str]]] = {}
+
+    async def juan(self, text_id: int, juan_num: int) -> str | None:
+        key = (text_id, juan_num)
+        if key not in self._juan:
+            row = (
+                await self._conn.execute(
+                    sql_text(
+                        "SELECT content FROM text_contents "
+                        "WHERE text_id = :t AND juan_num = :j AND lang = 'lzh' LIMIT 1"
+                    ),
+                    {"t": text_id, "j": juan_num},
+                )
+            ).fetchone()
+            self._juan[key] = normalise_for_match(row[0]) if row else None
+        return self._juan[key]
+
+    async def juans_of(self, text_id: int) -> list[tuple[int, str]]:
+        if text_id not in self._whole:
+            rows = (
+                await self._conn.execute(
+                    sql_text(
+                        "SELECT juan_num, content FROM text_contents "
+                        "WHERE text_id = :t AND lang = 'lzh' ORDER BY juan_num"
+                    ),
+                    {"t": text_id},
+                )
+            ).fetchall()
+            self._whole[text_id] = [(r[0], normalise_for_match(r[1])) for r in rows]
+        return self._whole[text_id]
+
+
+async def _report(conn, days: int, limit: int) -> dict:
+    since = datetime.now(UTC) - timedelta(days=days)
+    rows = (await conn.execute(_ANSWERS, {"since": since, "limit": limit})).fetchall()
+    corpus = _Corpus(conn)
+
+    citations = anchored = 0            # 引号覆盖率
+    fascicle_checked = fascicle_ok = 0  # 卷号准确率
+    located = located_agrees = 0        # 引文定位 vs 所标卷号
+
+    for _id, content, raw_sources in rows:
+        by_title = _title_index(raw_sources)
+        if not by_title:
+            continue
+
+        # 引号覆盖率：带引号的引用位置（含引用块）对全部引用取比。
+        anchored_ends = {m.end() for m in _QUOTE_CITATION_RE.finditer(content)}
+        anchored_ends |= {m.end() for m in _BLOCKQUOTE_CITATION_RE.finditer(content)}
+        for m in _ANY_CITATION_RE.finditer(content):
+            if not m.group("juan"):
+                continue
+            if _norm_title(m.group("title")) not in by_title:
+                continue
+            citations += 1
+            if m.end() in anchored_ends:
+                anchored += 1
+
+        for cite in iter_quote_citations(content):
+            if cite.juan is None:
+                continue
+            text_id = by_title.get(_norm_title(cite.title))
+            if text_id is None:
+                continue
+            body = await corpus.juan(text_id, cite.juan)
+            if body is None:
+                # 查不到该卷正文 —— 判不了就不判，绝不静默记错。
+                continue
+            needle = normalise_for_match(cite.quote)
+            fascicle_checked += 1
+            if needle in body:
+                fascicle_ok += 1
+                located += 1
+                located_agrees += 1
+                continue
+            # 所标卷没有 —— 看看它到底在哪一卷。命中多卷时取最小，与
+            # citation_guard._juan_holding_quote 的决胜规则保持一致。
+            holders = [j for j, text in await corpus.juans_of(text_id) if needle in text]
+            if holders:
+                located += 1
+                if min(holders) == cite.juan:
+                    located_agrees += 1
+
+    return {
+        "answers": len(rows),
+        "days": days,
+        "citations": citations,
+        "anchored": anchored,
+        "fascicle_checked": fascicle_checked,
+        "fascicle_ok": fascicle_ok,
+        "located": located,
+        "located_agrees": located_agrees,
+    }
+
+
+def _pct(num: int, den: int) -> str:
+    return f"{num / den * 100:5.1f}%  ({num}/{den})" if den else "     —  (0/0)"
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--days", type=int, default=7, help="回放最近几天的答案")
+    ap.add_argument("--limit", type=int, default=2000, help="最多回放多少条答案")
+    ap.add_argument("--json", action="store_true", help="输出 JSON，便于入库/画图")
+    args = ap.parse_args()
+
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            r = await _report(conn, args.days, args.limit)
+    finally:
+        await engine.dispose()
+
+    if args.json:
+        print(json.dumps(r, ensure_ascii=False))
+        return 0
+
+    print(f"引用健康度 · 最近 {r['days']} 天 · {r['answers']} 条含引用答案\n")
+    print(f"  卷号准确率        {_pct(r['fascicle_ok'], r['fascicle_checked'])}")
+    print("     带引号的引文，是否真的在所标的那一卷里（真源：text_contents）")
+    print()
+    print(f"  引号覆盖率        {_pct(r['anchored'], r['citations'])}")
+    print("     无引号的引用完全游离在核验体系之外：查不了、锚不了、也量不到")
+    print()
+    print(f"  定位与标注一致率  {_pct(r['located_agrees'], r['located'])}")
+    print("     引文能逐字定位的前提下，它所在的卷是否就是答案标的那一卷。")
+    print("     长期高位 → 运行时按引文自动纠正卷号可行；反之应走提示词约束。")
+    print()
+    print("  * 刻意不设阈值：修复后样本尚不足以定红线，先积累两周。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/backend/tests/test_citation_health_report.py
+++ b/backend/tests/test_citation_health_report.py
@@ -1,0 +1,111 @@
+"""引用健康度回放的三项计数口径。
+
+这三个数各自回答一个具体问题，口径错了就会把决策带偏，所以每一项的分子分母
+都在这里钉住：
+
+* 卷号准确率 —— 带引号的引文是否真的在所标的那一卷里。
+* 引号覆盖率 —— 多少引用带「」；不带的完全无法核验（2026-07-29 实测占 51.6%）。
+* 定位与标注一致率 —— 为「能否让护栏按引文自动纠正卷号」攒证据。此前该做法
+  实测 18 错 2 对被否决，但那次数据是索引修复前的；现在索引干净了，需要新证据。
+"""
+
+import json
+
+import pytest
+import pytest_asyncio
+from scripts.citation_health_report import _report
+from sqlalchemy import text as sql_text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.models.chat import ChatMessage, ChatSession
+from app.models.text import BuddhistText, TextContent
+
+_J13 = "分別業品第四之一。如前所說有情世間及器世間各多差別。"
+_J16 = "無學身語業，名身語牟尼，意牟尼即無學意非意業。所以者何？勝義牟尼唯心為體。"
+_QUOTE = "無學身語業，名身語牟尼，意牟尼即無學意非意業"
+
+_SOURCES = json.dumps(
+    [{"text_id": 38, "juan_num": 16, "chunk_index": 0, "chunk_text": _J16,
+      "score": 0.9, "title_zh": "阿毘達磨俱舍論"}]
+)
+
+
+@pytest_asyncio.fixture
+async def conn():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as c:
+        for model in (BuddhistText, TextContent, ChatSession, ChatMessage):
+            await c.run_sync(model.__table__.create)
+        await c.execute(sql_text(
+            "INSERT INTO buddhist_texts (id, cbeta_id, title_zh, lang) "
+            "VALUES (38, 'T1558', '阿毘達磨俱舍論', 'lzh')"))
+        for juan, body in ((13, _J13), (16, _J16)):
+            await c.execute(sql_text(
+                "INSERT INTO text_contents (text_id, juan_num, content, lang, char_count) "
+                "VALUES (38, :j, :b, 'lzh', :n)"), {"j": juan, "b": body, "n": len(body)})
+        await c.execute(sql_text(
+            "INSERT INTO chat_sessions (id, title) VALUES (1, 't')"))
+    async with engine.connect() as c:
+        yield c
+    await engine.dispose()
+
+
+async def _add(conn, answer: str, mid: int = 1):
+    # created_at 走 server_default(now())，天然落在 --days 窗口内。
+    await conn.execute(sql_text(
+        "INSERT INTO chat_messages (id, session_id, role, content, sources, created_at) "
+        "VALUES (:i, 1, 'assistant', :c, :s, CURRENT_TIMESTAMP)"),
+        {"i": mid, "c": answer, "s": _SOURCES})
+
+
+@pytest.mark.asyncio
+async def test_quote_in_the_cited_fascicle_counts_as_correct(conn):
+    await _add(conn, f"论云「{_QUOTE}」【《阿毘達磨俱舍論》第16卷】")
+    r = await _report(conn, days=7, limit=100)
+    assert (r["fascicle_checked"], r["fascicle_ok"]) == (1, 1)
+
+
+@pytest.mark.asyncio
+async def test_quote_in_another_fascicle_counts_as_wrong(conn):
+    """生产原形：引文逐字正确、卷号指向卷13，而它实出卷十六。"""
+    await _add(conn, f"论云「{_QUOTE}」【《阿毘達磨俱舍論》第13卷】")
+    r = await _report(conn, days=7, limit=100)
+    assert (r["fascicle_checked"], r["fascicle_ok"]) == (1, 0)
+    # 但它能被定位到 —— 只是定位结果与标注不一致，这正是第三项要量的。
+    assert (r["located"], r["located_agrees"]) == (1, 0)
+
+
+@pytest.mark.asyncio
+async def test_quoteless_citation_counts_against_anchor_coverage(conn):
+    """无引号的引用进不了卷号准确率的分母，只会拉低引号覆盖率 —— 两个口径
+    必须分开，否则「没引号」会被误读成「引对了」。"""
+    await _add(conn, f"经论指出：{_QUOTE}【《阿毘達磨俱舍論》第16卷】")
+    r = await _report(conn, days=7, limit=100)
+    assert (r["citations"], r["anchored"]) == (1, 0)
+    assert r["fascicle_checked"] == 0
+
+
+@pytest.mark.asyncio
+async def test_anchored_citation_counts_toward_coverage(conn):
+    await _add(conn, f"论云「{_QUOTE}」【《阿毘達磨俱舍論》第16卷】")
+    r = await _report(conn, days=7, limit=100)
+    assert (r["citations"], r["anchored"]) == (1, 1)
+
+
+@pytest.mark.asyncio
+async def test_unlocatable_quote_is_excluded_from_the_agreement_rate(conn):
+    """全经都找不到（模型转述）的引文，计入卷号准确率的分母（它确实没在所标
+    卷里），但不能计入定位一致率 —— 那一项问的是「定位得到时准不准」。"""
+    await _add(conn, "论云「這段話原文裡並不存在無論如何都找不到」【《阿毘達磨俱舍論》第16卷】")
+    r = await _report(conn, days=7, limit=100)
+    assert (r["fascicle_checked"], r["fascicle_ok"]) == (1, 0)
+    assert (r["located"], r["located_agrees"]) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_citation_outside_the_retrieved_sources_is_ignored(conn):
+    """经名不在召回集时无法解析 text_id，判不了就不判 —— 不进任何分母。"""
+    await _add(conn, "论云「某段引文長度足夠參與匹配」【《某部未收經》第3卷】")
+    r = await _report(conn, days=7, limit=100)
+    assert r["citations"] == 0
+    assert r["fascicle_checked"] == 0


### PR DESCRIPTION
`fascicle_accuracy_rate` 虽已进 `_GATED_RATES`，但**夜间回归门跑 `--no-llm`，在生成答案前就返回**，所以忠实度指标在定时任务里从不被计算——指标有了，自动化的消费者没有。

## 为什么是回放，不是跑 eval

| | LLM eval | 生产回放 |
|---|---|---|
| 成本 | 75 次生成 + 75 次评判 | **零** |
| 样本 | ~150–200 条引文 | **1,672 条**，且持续积累 |
| 提问来源 | 固定 90 题 | **真实用户** |
| 覆盖的模型 | 仅默认模型 | 用户各自配的 key —— **真实供给** |

## 三个数，各回答一个具体问题

1. **卷号准确率**——带引号的引文是否真在所标那一卷。真源用 `text_contents`，绕开召回的 chunk：护栏会跨卷回退，结构性看不见「引错卷」。
2. **引号覆盖率**——多少引用带「」。不带引号的引用 `quote_verifier` 查不了、抽屉锚不了、卷号准确率也量不到，**完全游离在核验体系之外**，实测占一半以上。
3. **定位与标注一致率**——引文能逐字定位时，它所在的卷是否就是答案标的那一卷。

第 3 项是为一个**尚未裁决的问题**攒证据：能否让运行时护栏按引文位置自动纠正卷号。此前实测该做法 **18 错 2 对**被否决，但那次数据是**索引修复前**的，18 处误改全由错标 chunk 驱动。索引现已干净（受损面归零），结论可能不同——需要新证据才能重新裁决。

## 刻意不设阈值

修复前基线 0.722、修复后样本仅 25 条引文。数据不足时定红线，要么天天误报、要么永不触发——那不是门禁，是摆设。**先纯报告积累两周**，阈值连同 cron 告警一起补。脚本总是退出 0（除非自身出错）。

## 生产首跑（最近 7 天 / 211 条含引用答案）

| 指标 | 数值 |
|---|---|
| 卷号准确率 | 79.2% (206/260) |
| 引号覆盖率 | 45.9% (272/592) |
| 定位与标注一致率 | **80.8% (206/255)** |

## 测试

6 个用例，并**逐项实测有效性**：把「卷号包含性判定」和「引号区分」分别架空后，各有用例变红。

一个只有实跑才撞得出的坑：SQL 用 `CAST` 而非 `::text`——SQLAlchemy 的 `text()` 会把 `::text` 的冒号当成绑定参数名，语句根本送不到数据库。

后端 1433 passed（新增 6），`test_health_check_probe.py` 3 个失败为预先存在；ruff 0.9.7 通过。