### PR TITLE
feat(chat): 会话列表补上「⋯」菜单——重命名 / 置顶 / 删除

### DIFF
--- a/backend/alembic/versions/0174_add_chat_sessions_pinned.py
+++ b/backend/alembic/versions/0174_add_chat_sessions_pinned.py
@@ -1,0 +1,40 @@
+"""Add chat_sessions.pinned.
+
+The sidebar lists a user's conversations newest-first, which is the wrong order
+for the few a reader actually returns to: a long-running study thread on a
+single sutra sinks below a week of one-off questions. Pinning is the standard
+answer and needs exactly one bit per session.
+
+Boolean rather than a `pinned_at` timestamp: ordering *within* the pinned group
+only matters once a user has pinned enough conversations to need it, and the
+group is rendered as its own section at the top of the list. Falling back to
+`created_at desc` inside it keeps the ordering rule identical to the rest of
+the list, which is the less surprising behaviour.
+
+Defaults to false, so every existing row keeps its current position.
+
+Revision ID: 0174
+Revises: 0173
+Create Date: 2026-07-31
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0174"
+down_revision: str | None = "0173"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_sessions",
+        sa.Column("pinned", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_sessions", "pinned")

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -33,6 +33,7 @@ from app.schemas.chat import (
     HotQuestionCard,
     HotQuestionCardsResponse,
     SessionListItem,
+    SessionUpdateRequest,
 )
 from app.services.chat import (
     FREE_DAILY_LIMIT_ANONYMOUS,
@@ -48,6 +49,7 @@ from app.services.chat import (
     send_message,
     send_message_stream,
     update_message_feedback,
+    update_session,
 )
 from app.services.chat_trust import trust_status_from_diagnostic
 from app.services.master_profiles import list_masters
@@ -462,6 +464,21 @@ async def set_message_feedback(
         trust_status=trust_by_message.get(msg.id),
         feedback=msg.feedback,
         created_at=msg.created_at,
+    )
+
+
+@router.patch("/sessions/{session_id}", response_model=SessionListItem)
+async def patch_session(
+    session_id: int,
+    payload: SessionUpdateRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Rename and/or (un)pin a chat session.
+
+    重命名 / 置顶会话。需要登录，且只能改自己的会话。"""
+    return await update_session(
+        db, session_id, user.id, title=payload.title, pinned=payload.pinned
     )
 
 

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -1,6 +1,18 @@
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    false,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -31,6 +43,10 @@ class ChatSession(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"), nullable=True)
     title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # Sorts ahead of everything else in the sidebar (migration 0174).
+    pinned: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=false(), default=False
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ChatRequest(BaseModel):
@@ -166,9 +166,29 @@ class ChatSessionResponse(BaseModel):
 class SessionListItem(BaseModel):
     id: int
     title: str | None
+    pinned: bool = False
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class SessionUpdateRequest(BaseModel):
+    """Rename and/or (un)pin a session. Omitted fields are left untouched."""
+
+    # 500 is the column width; a sidebar row shows ~20 chars, so anything past
+    # 200 is already unreadable there and only serves to bloat the list payload.
+    title: str | None = Field(None, min_length=1, max_length=200)
+    pinned: bool | None = None
+
+    @field_validator("title")
+    @classmethod
+    def _strip_title(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        cleaned = v.strip()
+        if not cleaned:
+            raise ValueError("会话名称不能为空")
+        return cleaned
 
 
 class ShareQARequest(BaseModel):

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -42,6 +42,7 @@ from app.services.chat_sessions import (  # noqa: F401
     get_session_for_user,
     list_sessions,
     update_message_feedback,
+    update_session,
 )
 from app.services.chat_trust import build_trust_status, persist_answer_diagnostic
 from app.services.citation_guard import enforce_citation_whitelist, log_mutations

--- a/backend/app/services/chat_sessions.py
+++ b/backend/app/services/chat_sessions.py
@@ -42,9 +42,42 @@ async def list_sessions(session: AsyncSession, user_id: int) -> list[ChatSession
     result = await session.execute(
         select(ChatSession)
         .where(ChatSession.user_id == user_id)
-        .order_by(ChatSession.created_at.desc())
+        .order_by(ChatSession.pinned.desc(), ChatSession.created_at.desc())
     )
     return list(result.scalars().all())
+
+
+async def update_session(
+    db: AsyncSession,
+    session_id: int,
+    user_id: int,
+    title: str | None = None,
+    pinned: bool | None = None,
+) -> ChatSession:
+    """Rename and/or (un)pin a session the user owns.
+
+    Both fields are optional so one endpoint serves both menu actions, but a
+    request carrying neither is rejected rather than silently succeeding — a
+    caller that sends an empty patch has a bug, and a 200 would hide it.
+    """
+    if title is None and pinned is None:
+        raise ValidationError("没有要更新的内容")
+
+    cs = await get_session_for_user(db, session_id, user_id)
+
+    if title is not None:
+        # The schema already strips and length-checks; this is the last line of
+        # defence for any other caller.
+        cleaned = title.strip()
+        if not cleaned:
+            raise ValidationError("会话名称不能为空")
+        cs.title = cleaned
+    if pinned is not None:
+        cs.pinned = pinned
+
+    await db.commit()
+    await db.refresh(cs)
+    return cs
 
 
 async def get_history(session: AsyncSession, session_id: int) -> list[ChatMessage]:

--- a/backend/tests/test_chat_session_update.py
+++ b/backend/tests/test_chat_session_update.py
@@ -1,0 +1,160 @@
+"""Rename / pin a chat session (PATCH /chat/sessions/{id}).
+
+Covers the service and the request schema. The sidebar's "..." menu is the only
+caller today, but the endpoint is ownership-scoped and therefore worth pinning
+down independently of the UI that drives it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.core.exceptions import AccessDeniedError, NotFoundError, ValidationError
+from app.schemas.chat import SessionUpdateRequest
+from app.services.chat_sessions import update_session
+
+
+def _make_session(**overrides):
+    cs = MagicMock()
+    cs.id = overrides.get("id", 7)
+    cs.user_id = overrides.get("user_id", 1)
+    cs.title = overrides.get("title", "旧标题")
+    cs.pinned = overrides.get("pinned", False)
+    return cs
+
+
+def _db_returning(cs):
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = cs
+    db.execute.return_value = result
+    return db
+
+
+# ── service ──────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_rename_sets_title_and_commits():
+    cs = _make_session()
+    db = _db_returning(cs)
+    out = await update_session(db, 7, user_id=1, title="《心经》逐句读")
+    assert out.title == "《心经》逐句读"
+    assert cs.pinned is False  # untouched field stays put
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_pin_sets_flag_without_touching_title():
+    cs = _make_session(title="原名")
+    db = _db_returning(cs)
+    await update_session(db, 7, user_id=1, pinned=True)
+    assert cs.pinned is True
+    assert cs.title == "原名"
+
+
+@pytest.mark.anyio
+async def test_unpin_is_not_swallowed_by_the_none_check():
+    """`pinned=False` is falsy — an `if pinned:` implementation would silently
+    no-op here and the user's un-pin click would do nothing."""
+    cs = _make_session(pinned=True)
+    db = _db_returning(cs)
+    await update_session(db, 7, user_id=1, pinned=False)
+    assert cs.pinned is False
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_empty_patch_is_rejected_rather_than_a_silent_ok():
+    db = _db_returning(_make_session())
+    with pytest.raises(ValidationError):
+        await update_session(db, 7, user_id=1)
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_whitespace_title_rejected_at_the_service_too():
+    cs = _make_session(title="原名")
+    db = _db_returning(cs)
+    with pytest.raises(ValidationError):
+        await update_session(db, 7, user_id=1, title="   ")
+    assert cs.title == "原名"
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_other_users_session_is_denied():
+    db = _db_returning(_make_session(user_id=2))
+    with pytest.raises(AccessDeniedError):
+        await update_session(db, 7, user_id=1, pinned=True)
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_missing_session_is_404_not_500():
+    db = _db_returning(None)
+    with pytest.raises(NotFoundError):
+        await update_session(db, 7, user_id=1, title="x")
+
+
+@pytest.mark.anyio
+async def test_ownership_is_checked_before_any_write():
+    """Order matters: a title assigned before the ownership check would be
+    flushed by any later commit in the same session."""
+    cs = _make_session(user_id=2, title="别人的会话")
+    db = _db_returning(cs)
+    with pytest.raises(AccessDeniedError):
+        await update_session(db, 7, user_id=1, title="改名")
+    assert cs.title == "别人的会话"
+
+
+# ── request schema ───────────────────────────────────────────────────────
+
+def test_schema_strips_surrounding_whitespace():
+    assert SessionUpdateRequest(title="  《法华经》  ").title == "《法华经》"
+
+
+def test_schema_rejects_whitespace_only_title():
+    with pytest.raises(PydanticValidationError):
+        SessionUpdateRequest(title="　 ")
+
+
+def test_schema_rejects_empty_title():
+    with pytest.raises(PydanticValidationError):
+        SessionUpdateRequest(title="")
+
+
+def test_schema_rejects_overlong_title():
+    with pytest.raises(PydanticValidationError):
+        SessionUpdateRequest(title="经" * 201)
+
+
+def test_schema_allows_pin_only_patch():
+    payload = SessionUpdateRequest(pinned=True)
+    assert payload.title is None
+    assert payload.pinned is True
+
+
+# ── 迁移与 ORM 的一致性 ──────────────────────────────────────────────────
+
+def test_migration_0174_and_the_orm_agree_on_the_column():
+    """整个 backend/tests 没有真库往返（conftest 里 PG/ES/Redis 全是 mock），
+    而 alembic-dry-run 只跑 upgrade/downgrade、从不 SELECT。两边合起来的后果是：
+    迁移里写 "pinned"、ORM 里写成别的名字，全套测试照样绿，直到生产上第一次
+    查会话列表才炸。这条把两个字面量钉在一起。"""
+    import re
+    from pathlib import Path
+
+    from app.models.chat import ChatSession
+
+    src = Path(__file__).resolve().parents[1] / "alembic" / "versions" / "0174_add_chat_sessions_pinned.py"
+    body = src.read_text(encoding="utf-8")
+    m = re.search(r'op\.add_column\(\s*"([^"]+)",\s*sa\.Column\(\s*"([^"]+)"', body)
+    assert m, "迁移 0174 的 add_column 形态变了，这条检查已失效——请同步更新"
+    table, column = m.group(1), m.group(2)
+
+    assert table == ChatSession.__tablename__
+    assert column in ChatSession.__table__.columns
+    # 迁移建的是 NOT NULL DEFAULT false；ORM 若声明成可空，读回来会是 None
+    # 而不是 False，前端 `!!s.pinned` 虽兜得住，排序 `pinned.desc()` 却会错乱。
+    assert ChatSession.__table__.columns[column].nullable is False

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1510,5 +1510,15 @@
   "chat.master_lens": "Reading through this lineage",
   "chat.change_master": "Change school",
   "chat.master_disclaimer": "What follows is an AI interpretation generated from the canon — not the master's own teaching. Every citation carries its text and fascicle number; open it to check the original.",
-  "reader.citation.quote_not_here": "The quoted passage was not found in this fascicle"
+  "reader.citation.quote_not_here": "The quoted passage was not found in this fascicle",
+  "chat.rename": "Rename",
+  "chat.rename_session_title": "Rename conversation",
+  "chat.rename_placeholder": "Enter a new name",
+  "chat.rename_failed": "Rename failed",
+  "chat.pin": "Pin conversation",
+  "chat.unpin": "Unpin",
+  "chat.pin_failed": "Action failed",
+  "chat.session_group_pinned": "Pinned",
+  "chat.session_actions": "More actions",
+  "chat.save": "Save"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1510,5 +1510,15 @@
   "chat.master_lens": "依此宗風解經",
   "chat.change_master": "更換宗派",
   "chat.master_disclaimer": "以下為 AI 依據典籍生成的詮釋，非祖師本人開示。每處引證均標註經號與卷次，可點開核對原文。",
-  "reader.citation.quote_not_here": "本卷未找到被引的這段原文"
+  "reader.citation.quote_not_here": "本卷未找到被引的這段原文",
+  "chat.rename": "重新命名",
+  "chat.rename_session_title": "重新命名對話",
+  "chat.rename_placeholder": "輸入新的對話名稱",
+  "chat.rename_failed": "重新命名失敗",
+  "chat.pin": "置頂聊天",
+  "chat.unpin": "取消置頂",
+  "chat.pin_failed": "操作失敗",
+  "chat.session_group_pinned": "已置頂",
+  "chat.session_actions": "更多操作",
+  "chat.save": "儲存"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1510,5 +1510,15 @@
   "chat.master_lens": "依此宗风解经",
   "chat.change_master": "更换宗派",
   "chat.master_disclaimer": "以下为 AI 依据典籍生成的诠释，非祖师本人开示。每处引证均标注经号与卷次，可点开核对原文。",
-  "reader.citation.quote_not_here": "本卷未找到被引的这段原文"
+  "reader.citation.quote_not_here": "本卷未找到被引的这段原文",
+  "chat.rename": "重命名",
+  "chat.rename_session_title": "重命名对话",
+  "chat.rename_placeholder": "输入新的对话名称",
+  "chat.rename_failed": "重命名失败",
+  "chat.pin": "置顶聊天",
+  "chat.unpin": "取消置顶",
+  "chat.pin_failed": "操作失败",
+  "chat.session_group_pinned": "已置顶",
+  "chat.session_actions": "更多操作",
+  "chat.save": "保存"
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1672,6 +1672,10 @@ export interface ChatResponse {
 export interface ChatSessionItem {
   id: ChatSessionId;
   title: string | null;
+  // Optional, not `boolean`: during a rolling backend deploy a replica running
+  // the pre-0174 code answers /chat/sessions without this field, and the new
+  // bundle is already being served. Undefined must read as "not pinned".
+  pinned?: boolean;
   created_at: string;
 }
 
@@ -1841,6 +1845,15 @@ export async function getChatSessionMessages(
 
 export async function deleteChatSession(sessionId: number): Promise<void> {
   await api.delete(`/chat/sessions/${sessionId}`);
+}
+
+/** Rename and/or (un)pin a session. Omitted fields are left untouched. */
+export async function updateChatSession(
+  sessionId: number,
+  patch: { title?: string; pinned?: boolean },
+): Promise<ChatSessionItem> {
+  const { data } = await api.patch<ChatSessionItem>(`/chat/sessions/${sessionId}`, patch);
+  return data;
 }
 
 export async function updateChatMessageFeedback(

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -12,8 +12,13 @@ import {
   getHotQuestions,
   getMasters,
   getRandomHotQuestions,
+  getChatSessionMessages,
   sendChatMessageStream,
+  updateChatSession,
+  deleteChatSession,
+  type ChatSessionItem,
 } from "../api/client";
+import type { ChatSessionId } from "../types/branded";
 
 vi.mock("../api/client", async () => {
   const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
@@ -28,6 +33,7 @@ vi.mock("../api/client", async () => {
     getRandomHotQuestions: vi.fn(),
     sendChatMessageStream: vi.fn(),
     deleteChatSession: vi.fn(),
+    updateChatSession: vi.fn(),
     updateChatMessageFeedback: vi.fn(),
     getChunkContext: vi.fn(),
   };
@@ -310,5 +316,181 @@ describe("ChatPage 首屏结构", () => {
     await waitFor(() => {
       expect(container.querySelector(".chat-jump-bottom")).toBeNull();
     });
+  });
+});
+
+// ── 会话行的 ⋯ 菜单（重命名 / 置顶 / 删除）──────────────────────────────
+
+const SESSIONS: ChatSessionItem[] = [
+  { id: 11 as ChatSessionId, title: "《心经》色空怎么讲", pinned: false, created_at: new Date().toISOString() },
+  { id: 12 as ChatSessionId, title: "四圣谛是哪四谛", pinned: true, created_at: new Date().toISOString() },
+];
+
+/** 渲染出会话列表，并把 ⋯ 菜单打开在第 index 行上。 */
+async function openRowMenu(index: number) {
+  const title = SESSIONS[index].title!;
+  const r = renderPage();
+  await waitFor(() => {
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
+  const rows = r.container.querySelectorAll<HTMLElement>(".chat-session-row");
+  const row = [...rows].find((el) => el.textContent?.includes(title))!;
+  fireEvent.click(row.querySelector(".chat-session-more")!);
+  await waitFor(() => {
+    expect(screen.getByText("重命名")).toBeInTheDocument();
+  });
+  return { ...r, row };
+}
+
+describe("会话行 ⋯ 菜单", () => {
+  beforeEach(() => {
+    vi.mocked(getChatSessions).mockResolvedValue(SESSIONS);
+    vi.mocked(updateChatSession).mockResolvedValue(SESSIONS[0]);
+    vi.mocked(getChatSessionMessages).mockResolvedValue({
+      total: 0, page: 1, size: 50, messages: [],
+    });
+    vi.mocked(deleteChatSession).mockResolvedValue(undefined);
+  });
+
+  it("菜单开出三项：重命名 / 置顶 / 删除", async () => {
+    await openRowMenu(0);
+    expect(screen.getByText("重命名")).toBeInTheDocument();
+    expect(screen.getByText("置顶聊天")).toBeInTheDocument();
+    expect(screen.getByText("删除")).toBeInTheDocument();
+  });
+
+  // antd 的 Dropdown 一个 aria 都不加（实测 role/aria-haspopup/aria-expanded 全为
+  // null）。读屏软件只会念「更多操作，按钮」，既不知道它开菜单，也不知道开没开。
+  it("a11y: 触发器声明自己是菜单按钮，并如实反映展开状态", async () => {
+    const { row } = await openRowMenu(0);
+    const btn = row.querySelector(".chat-session-more")!;
+    expect(btn.tagName).toBe("BUTTON");     // span[role=button] 上 Enter 不会合成 click
+    expect(btn.getAttribute("aria-haspopup")).toBe("menu");
+    expect(btn.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  // 鼠标点开时 antd 不把焦点移进菜单，Esc 因此没有接收者 —— 得自己在
+  // document 上接。
+  it("a11y: 鼠标点开的菜单，Esc 能关掉", async () => {
+    const { row } = await openRowMenu(0);
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(row.querySelector(".chat-session-more")!.getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
+  // 承重点。antd 的菜单渲染进 portal，但 React 合成事件仍沿**组件树**冒泡，
+  // 而 Dropdown 在组件树里就挂在会话行内部 —— 不 stopPropagation 的话，点
+  // 「重命名」会同时触发整行的 onClick，把用户甩进另一个会话。DOM 上看不出来，
+  // 只有断言 getChatSessionMessages 没被调用才能证伪。
+  it("承重点: 点菜单项不会顺带切换会话", async () => {
+    await openRowMenu(0);
+    fireEvent.click(screen.getByText("重命名"));
+    await screen.findByPlaceholderText("输入新的对话名称");
+    expect(vi.mocked(getChatSessionMessages)).not.toHaveBeenCalled();
+  });
+
+  it("已置顶的行菜单显示「取消置顶」，且发出的是 pinned:false", async () => {
+    await openRowMenu(1);
+    expect(screen.queryByText("置顶聊天")).toBeNull();
+    fireEvent.click(screen.getByText("取消置顶"));
+    await waitFor(() => {
+      expect(vi.mocked(updateChatSession)).toHaveBeenCalledWith(12, { pinned: false });
+    });
+  });
+
+  it("未置顶的行发出的是 pinned:true", async () => {
+    await openRowMenu(0);
+    fireEvent.click(screen.getByText("置顶聊天"));
+    await waitFor(() => {
+      expect(vi.mocked(updateChatSession)).toHaveBeenCalledWith(11, { pinned: true });
+    });
+  });
+
+  // 注意 /保\s*存/：antd 的 Button 会在恰好两个汉字之间插一个空格，
+  // 无线的 /保存/ 匹配不到 —— 这是把断言写成恒假、而非恒真的那一类。
+  it("重命名弹窗预填当前标题，提交时去掉首尾空白", async () => {
+    await openRowMenu(0);
+    fireEvent.click(screen.getByText("重命名"));
+    const input = await screen.findByPlaceholderText("输入新的对话名称");
+    expect((input as HTMLInputElement).value).toBe("《心经》色空怎么讲");
+    fireEvent.change(input, { target: { value: "  色空章逐句读  " } });
+    fireEvent.click(screen.getByRole("button", { name: /保\s*存/ }));
+    await waitFor(() => {
+      expect(vi.mocked(updateChatSession)).toHaveBeenCalledWith(11, { title: "色空章逐句读" });
+    });
+  });
+
+  it("标题没改动就提交不发请求（省掉一次无谓写库）", async () => {
+    await openRowMenu(0);
+    fireEvent.click(screen.getByText("重命名"));
+    await screen.findByPlaceholderText("输入新的对话名称");
+    fireEvent.click(screen.getByRole("button", { name: /保\s*存/ }));
+    // 用输入框消失（destroyOnHidden 会销毁弹窗内容）判定「已关闭」——
+    // 标题节点在 antd 关闭后仍留在 DOM 里，用它判定会恒假。
+    // 判定「弹窗已关闭」不能等 DOM 消失：jsdom 不派发 transitionend，rc-motion
+    // 的离场动画永远走不完，destroyOnHidden 也就永远不销毁内容。退场类是弹窗
+    // 由开变关的第一手证据，也让下面那条 not.toHaveBeenCalled 不至于恒真
+    // （若这一次点击根本没落到 onOk 上，这里就先红了）。
+    await waitFor(() => {
+      expect(document.querySelector(".ant-modal")?.className).toContain("ant-zoom-leave");
+    });
+    expect(vi.mocked(updateChatSession)).not.toHaveBeenCalled();
+  });
+
+  // 删除「正在生成回答」的那个会话，必须先中断流。不中断的话流会跑到天然结束，
+  // 这期间 sending 一直为真，输入框被 `if (!msg || sending) return` 锁死 6-18 秒，
+  // 而画面上什么都没有 —— 用户只会以为站坏了。
+  // （这是 ⋯ 菜单之前就有的老问题，删除入口本来就挂在同一行上。）
+  it("承重点: 删除正在流式生成的当前会话，会中断请求", async () => {
+    let signal: AbortSignal | undefined;
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks, options) => {
+        cb = callbacks;
+        signal = options?.signal;      // 流不结束，模拟"正在生成"
+      },
+    );
+    const { container } = renderPage();
+    await waitFor(() => expect(screen.getByText(SESSIONS[0].title!)).toBeInTheDocument());
+
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+    cb!.onSessionId(SESSIONS[0].id);   // 后端回传：当前活动会话 = 11
+    await waitFor(() => expect(signal).toBeDefined());
+    expect(signal!.aborted).toBe(false);
+
+    const row = [...container.querySelectorAll<HTMLElement>(".chat-session-row")]
+      .find((el) => el.textContent?.includes(SESSIONS[0].title!))!;
+    fireEvent.click(row.querySelector(".chat-session-more")!);
+    await waitFor(() => expect(screen.getByText("删除")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("删除"));
+    // Modal.confirm 的确认键；antd 会在两个汉字间插空格
+    const ok = await screen.findByRole("button", { name: /删\s*除/ });
+    fireEvent.click(ok);
+
+    await waitFor(() => {
+      expect(signal!.aborted).toBe(true);
+    });
+  });
+
+  // 置顶的会话必须从日期分组里**移走**，不是同时出现在两处 —— 后者会让同一个
+  // 会话渲染两次并撞 React key。
+  it("置顶会话只出现一次，且在「已置顶」组里", async () => {
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("四圣谛是哪四谛")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("四圣谛是哪四谛")).toHaveLength(1);
+
+    const list = container.querySelector(".chat-session-list")!;
+    const labels = [...list.querySelectorAll("div")]
+      .filter((d) => ["已置顶", "今天"].includes(d.textContent?.trim() ?? ""))
+      .map((d) => d.textContent!.trim());
+    expect(labels[0]).toBe("已置顶");
+
+    const pinnedRow = [...container.querySelectorAll(".chat-session-row")]
+      .find((el) => el.textContent?.includes("四圣谛是哪四谛"))!;
+    expect(pinnedRow.querySelector(".chat-session-pin-mark")).not.toBeNull();
   });
 });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback, useMemo, useEffect, lazy, Suspense, memo
 import { useNavigate, useSearchParams, Link } from "react-router";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
-import { Input, Button, message, Alert, Tooltip, Modal, Tag, Spin } from "antd";
+import { Input, Button, message, Alert, Tooltip, Modal, Tag, Spin, Dropdown } from "antd";
 import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
@@ -29,6 +29,10 @@ import {
   DislikeFilled,
   ShareAltOutlined,
   DownOutlined,
+  MoreOutlined,
+  EditOutlined,
+  PushpinOutlined,
+  PushpinFilled,
 } from "@ant-design/icons";
 const ShareCard = lazy(() => import("../components/ShareCard"));
 const CitationDrawer = lazy(() => import("../components/CitationDrawer"));
@@ -43,6 +47,7 @@ import {
   getChatSessions,
   getChatSessionMessages,
   deleteChatSession,
+  updateChatSession,
   getApiKeyStatus,
   getChatQuota,
   getChunkContext,
@@ -176,14 +181,21 @@ function parseCitationHref(href: string): ParsedCitation | null {
   return { textId, juanNum, chunkIndex, titleZh, quote };
 }
 
-function groupSessionsByDate(sessions: ChatSessionItem[]): { label: string; items: ChatSessionItem[] }[] {
+// Pinned sessions leave the date groups entirely and form their own section at
+// the top — that is the whole point of pinning. Leaving them ALSO in 今天/更早
+// would show the same conversation twice and give two rows the same React key.
+function groupSessions(sessions: ChatSessionItem[]): { label: string; items: ChatSessionItem[] }[] {
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const yesterday = new Date(today.getTime() - 86400000);
   const weekAgo = new Date(today.getTime() - 7 * 86400000);
 
-  const groups: Record<string, ChatSessionItem[]> = { today: [], yesterday: [], week: [], older: [] };
+  const groups: Record<string, ChatSessionItem[]> = { pinned: [], today: [], yesterday: [], week: [], older: [] };
   for (const s of sessions) {
+    if (s.pinned) {
+      groups.pinned.push(s);
+      continue;
+    }
     const d = new Date(s.created_at);
     if (d >= today) groups.today.push(s);
     else if (d >= yesterday) groups.yesterday.push(s);
@@ -193,11 +205,113 @@ function groupSessionsByDate(sessions: ChatSessionItem[]): { label: string; item
 
   // label is an i18n key — render with t(group.label)
   const result: { label: string; items: ChatSessionItem[] }[] = [];
+  if (groups.pinned.length) result.push({ label: "chat.session_group_pinned", items: groups.pinned });
   if (groups.today.length) result.push({ label: "chat.session_group_today", items: groups.today });
   if (groups.yesterday.length) result.push({ label: "chat.session_group_yesterday", items: groups.yesterday });
   if (groups.week.length) result.push({ label: "chat.session_group_week", items: groups.week });
   if (groups.older.length) result.push({ label: "chat.session_group_older", items: groups.older });
   return result;
+}
+
+interface SessionRowProps {
+  s: ChatSessionItem;
+  active: boolean;
+  onSelect: (id: number) => void;
+  onRename: (s: ChatSessionItem) => void;
+  onTogglePin: (s: ChatSessionItem) => void;
+  onDelete: (id: number) => void;
+}
+
+/** One conversation in the sidebar, with its ⋯ menu (重命名 / 置顶 / 删除).
+ *
+ * Shared by the desktop sidebar and the mobile drawer, which render the same
+ * list twice. Before this existed the two copies had already drifted apart in
+ * their click handlers; a three-item menu duplicated by hand would drift again.
+ */
+function SessionRow({ s, active, onSelect, onRename, onTogglePin, onDelete }: SessionRowProps) {
+  const { t } = useTranslation();
+  const pinned = !!s.pinned;
+  // 受控 open 有两个理由，都不是为了好看：
+  // ① antd 的 Dropdown 不给触发器加任何 aria —— 读屏软件只会念「更多操作，按钮」，
+  //    不会说这是个菜单、也不会说它已展开。aria-expanded 需要我们自己知道状态。
+  // ② 鼠标点开时 antd 不把焦点移进菜单（实测 activeElement 仍是 body），Esc 因此
+  //    没有接收者。挂一个 document 级监听补上。
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+  return (
+    <div
+      className="chat-session-row"
+      data-active={active || undefined}
+      // 选中/悬停的配色全部交给 CSS（见 .chat-session-row[data-active]）——
+      // 行内 style 的优先级压过类选择器，留在这里会让 :hover 规则永远不生效。
+      style={{
+        padding: "8px 6px 8px 12px",
+        borderRadius: 6,
+        cursor: "pointer",
+        fontSize: 13,
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        gap: 4,
+      }}
+      onClick={() => onSelect(s.id)}
+    >
+      <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
+        {pinned && (
+          <PushpinFilled
+            className="chat-session-pin-mark"
+            style={{ fontSize: 10, marginRight: 4, opacity: 0.55 }}
+          />
+        )}
+        {s.title || t("chat.new_chat")}
+      </span>
+      <Dropdown
+        trigger={["click"]}
+        placement="bottomRight"
+        open={open}
+        onOpenChange={setOpen}
+        menu={{
+          items: [
+            { key: "rename", icon: <EditOutlined />, label: t("chat.rename") },
+            { key: "pin", icon: <PushpinOutlined />, label: pinned ? t("chat.unpin") : t("chat.pin") },
+            { type: "divider" },
+            { key: "delete", icon: <DeleteOutlined />, label: t("chat.delete"), danger: true },
+          ],
+          onClick: ({ key, domEvent }) => {
+            // 承重。菜单虽然渲染进 portal，但 React 合成事件沿**组件树**冒泡，
+            // 而 Dropdown 在组件树里就挂在这一行内部 —— 不拦住的话，点「重命名」
+            // 会同时触发整行的 onClick 把用户甩进这个会话。实测过：去掉这一行，
+            // ChatPage.test.tsx 的「点菜单项不会顺带切换会话」立刻变红。
+            domEvent.stopPropagation();
+            if (key === "rename") onRename(s);
+            else if (key === "pin") onTogglePin(s);
+            else if (key === "delete") onDelete(s.id);
+          },
+        }}
+      >
+        {/* 必须是原生 <button>：Dropdown 的 click 触发器只听 click 事件，而浏览器
+            只为真正的可交互元素把 Enter/空格合成成 click。span[role=button] 看着
+            一样，键盘用户却永远打不开这个菜单。 */}
+        <button
+          type="button"
+          className="chat-session-more"
+          aria-label={t("chat.session_actions")}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <MoreOutlined style={{ fontSize: 13 }} />
+        </button>
+      </Dropdown>
+    </div>
+  );
 }
 
 interface MessageBubbleProps {
@@ -691,7 +805,7 @@ export default function ChatPage() {
     [sessions, sessionFilter],
   );
   const groupedSessions = useMemo(
-    () => groupSessionsByDate(filteredSessions ?? []),
+    () => groupSessions(filteredSessions ?? []),
     [filteredSessions],
   );
 
@@ -841,6 +955,17 @@ export default function ChatPage() {
     setShowJumpToBottom(false);
   };
 
+  // 声明在 handleDeleteSession 之前是必需的，不是排版偏好：删除当前会话要中断
+  // 流，而 React Compiler 对「引用了声明在自己之后的绑定」会整支放弃编译，连带
+  // 把同组件里其它 useCallback 的手写依赖数组判成不可保留（实测 4 个 error）。
+  const [streamingId, setStreamingId] = useState(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const handleCancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
   const handleDeleteSession = (sid: number) => {
     Modal.confirm({
       title: t("chat.delete_session_title"),
@@ -851,7 +976,15 @@ export default function ChatPage() {
       onOk: async () => {
         try {
           await deleteChatSession(sid);
-          if (sessionId === sid) handleNewChat();
+          if (sessionId === sid) {
+            // 删掉正在生成的那个会话时必须先中断流。handleNewChat 只清 messages，
+            // 而解锁 `sending` 的唯一出口是 onDone —— 不 abort 的话流会继续跑到
+            // 天然结束（首字就要 6-18s，长答案更久），这期间 onToken 在空数组上
+            // map（无声无息），输入框却因 `if (!msg || sending) return` 一直发不出
+            // 东西。abort 会走 onError→onDone，把 sending/streamingId 一并复位。
+            handleCancel();
+            handleNewChat();
+          }
           refetchSessions();
         } catch {
           message.error(t("chat.delete_failed"));
@@ -860,13 +993,45 @@ export default function ChatPage() {
     });
   };
 
-  const [streamingId, setStreamingId] = useState(0);
-  const abortRef = useRef<AbortController | null>(null);
+  // Rename runs through a real Modal rather than Modal.confirm: confirm()'s
+  // content is rendered once and never re-rendered, so a controlled <Input>
+  // inside it can't show what the user types.
+  const [renameTarget, setRenameTarget] = useState<ChatSessionItem | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [renameSaving, setRenameSaving] = useState(false);
 
-  const handleCancel = useCallback(() => {
-    abortRef.current?.abort();
-    abortRef.current = null;
+  const handleOpenRename = useCallback((s: ChatSessionItem) => {
+    setRenameTarget(s);
+    setRenameValue(s.title || "");
   }, []);
+
+  const handleSubmitRename = useCallback(async () => {
+    if (!renameTarget) return;
+    const title = renameValue.trim();
+    if (!title || title === renameTarget.title) {
+      setRenameTarget(null);
+      return;
+    }
+    setRenameSaving(true);
+    try {
+      await updateChatSession(renameTarget.id, { title });
+      setRenameTarget(null);
+      refetchSessions();
+    } catch {
+      message.error(t("chat.rename_failed"));
+    } finally {
+      setRenameSaving(false);
+    }
+  }, [renameTarget, renameValue, refetchSessions, t]);
+
+  const handleTogglePin = useCallback(async (s: ChatSessionItem) => {
+    try {
+      await updateChatSession(s.id, { pinned: !s.pinned });
+      refetchSessions();
+    } catch {
+      message.error(t("chat.pin_failed"));
+    }
+  }, [refetchSessions, t]);
 
   const handleFileChange = useCallback(async (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -1265,23 +1430,15 @@ export default function ChatPage() {
                       {t(group.label)}
                     </div>
                     {group.items.map((s) => (
-                      <div key={s.id}
-                        style={{
-                          padding: "8px 12px", borderRadius: 6, cursor: "pointer", fontSize: 13,
-                          color: sessionId === s.id ? "var(--fj-accent)" : "var(--fj-ink-muted)",
-                          background: sessionId === s.id ? "rgba(217,208,193,0.3)" : "transparent",
-                          display: "flex", justifyContent: "space-between", alignItems: "center",
-                        }}
-                        onClick={() => { loadSession(s.id); setSidebarOpen(false); }}
-                      >
-                        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
-                          {s.title || t("chat.new_chat")}
-                        </span>
-                        <DeleteOutlined
-                          style={{ fontSize: 11, color: "var(--fj-ink-muted)", marginLeft: 4 }}
-                          onClick={(e) => { e.stopPropagation(); handleDeleteSession(s.id); }}
-                        />
-                      </div>
+                      <SessionRow
+                        key={s.id}
+                        s={s}
+                        active={sessionId === s.id}
+                        onSelect={(id) => { loadSession(id); setSidebarOpen(false); }}
+                        onRename={handleOpenRename}
+                        onTogglePin={handleTogglePin}
+                        onDelete={handleDeleteSession}
+                      />
                     ))}
                   </div>
                 ))}
@@ -1333,28 +1490,15 @@ export default function ChatPage() {
                   {t(group.label)}
                 </div>
                 {group.items.map((s) => (
-                  <div key={s.id}
-                    style={{
-                      padding: "8px 12px",
-                      borderRadius: 6,
-                      cursor: "pointer",
-                      fontSize: 13,
-                      color: sessionId === s.id ? "var(--fj-accent)" : "var(--fj-ink-muted)",
-                      background: sessionId === s.id ? "rgba(217,208,193,0.3)" : "transparent",
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                    }}
-                    onClick={() => loadSession(s.id)}
-                  >
-                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
-                      {s.title || t("chat.new_chat")}
-                    </span>
-                    <DeleteOutlined
-                      style={{ fontSize: 11, color: "var(--fj-ink-muted)", marginLeft: 4 }}
-                      onClick={(e) => { e.stopPropagation(); handleDeleteSession(s.id); }}
-                    />
-                  </div>
+                  <SessionRow
+                    key={s.id}
+                    s={s}
+                    active={sessionId === s.id}
+                    onSelect={loadSession}
+                    onRename={handleOpenRename}
+                    onTogglePin={handleTogglePin}
+                    onDelete={handleDeleteSession}
+                  />
                 ))}
               </div>
             ))}
@@ -1688,6 +1832,26 @@ export default function ChatPage() {
           />
         </Suspense>
       )}
+      <Modal
+        open={renameTarget !== null}
+        title={t("chat.rename_session_title")}
+        okText={t("chat.save")}
+        cancelText={t("chat.cancel")}
+        confirmLoading={renameSaving}
+        onOk={handleSubmitRename}
+        onCancel={() => setRenameTarget(null)}
+        destroyOnHidden
+        width={400}
+      >
+        <Input
+          value={renameValue}
+          onChange={(e) => setRenameValue(e.target.value)}
+          onPressEnter={handleSubmitRename}
+          placeholder={t("chat.rename_placeholder")}
+          maxLength={200}
+          autoFocus
+        />
+      </Modal>
     </>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -378,6 +378,58 @@ em {
   outline-offset: 1px;
 }
 
+/* 会话行的 ⋯ 菜单。默认隐藏、悬停/聚焦/菜单展开时现身 —— 侧栏只有 220px，
+   常驻一个图标会挤掉本就不够的标题宽度。 */
+.chat-session-more {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 4px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  color: var(--fj-ink-muted);
+  transition: opacity 0.12s ease, background 0.12s ease;
+}
+/* :focus 与 :focus-within 都写上，不只写 :focus-visible —— 后者的命中规则由
+   浏览器启发式决定（编程式聚焦、部分自动化环境下并不匹配），而"键盘 Tab 到了
+   一个 opacity:0 的按钮上"是这里最糟的失败态。 */
+.chat-session-row:hover .chat-session-more,
+.chat-session-row:focus-within .chat-session-more,
+.chat-session-more:focus,
+.chat-session-more.ant-dropdown-open {
+  opacity: 1;
+}
+/* 触屏没有 hover：那里必须常驻，否则菜单永远打不开。 */
+@media (hover: none) {
+  .chat-session-more {
+    opacity: 0.65;
+  }
+}
+.chat-session-more:hover {
+  background: rgba(217, 208, 193, 0.45);
+  color: var(--fj-ink);
+}
+.chat-session-more:focus-visible {
+  outline: 2px solid var(--fj-accent);
+  outline-offset: 1px;
+  opacity: 1;
+}
+.chat-session-row {
+  color: var(--fj-ink-muted);
+  background: transparent;
+}
+.chat-session-row:hover {
+  background: rgba(217, 208, 193, 0.18);
+}
+.chat-session-row[data-active] {
+  color: var(--fj-accent);
+  background: rgba(217, 208, 193, 0.3);
+}
+
 /* Key 状态行沉到侧栏底部（会话列表是 flex:1，排它后面即到底） */
 .chat-sidebar-foot {
   flex-shrink: 0;


### PR DESCRIPTION
侧栏此前每行只挂一个常驻的垃圾桶：**唯一能做的操作恰好是最危险的那个**，而最想做的两件——给长期研读的那条起个名字、把它钉在顶上——都做不到。一周的零散提问就能把正在追的一部经论压到列表底部。

后端本来一样都没有（`ChatSession` 只有 id/user_id/title/created_at，路由只有 GET/DELETE），所以这是完整实现而非接线。

## 改了什么

- **迁移 0174**：`chat_sessions` 新增 `pinned`（默认 false，现有行位置不变）
- **`PATCH /chat/sessions/{id}`**：一个端点同时服务改名与置顶。空 patch 直接 422 而不是静默 200——发空 patch 的调用方是有 bug 的，200 会把它藏起来
- 归属校验在**任何写入之前**完成：先赋值再校验的话，同一 session 里任何后续 commit 都会把改动刷进别人的会话
- 置顶的会话移入独立的「已置顶」组并**从日期组移除**——同时出现在两处会让同一会话渲染两次并撞 React key
- 桌面侧栏与移动抽屉此前各自复制了一份会话行（**且已在点击处理上出现分叉**），抽成 `SessionRow` 一处实现

## 两处承重实现

**菜单项的 onClick 必须 `stopPropagation`。** antd 的菜单渲染进 portal，但 React 合成事件沿*组件树*冒泡，而 Dropdown 就挂在会话行内部——不拦住的话，点「重命名」会同时把用户甩进那个会话。

**触发器必须是原生 `<button>` 而非 `span[role=button]`。** Dropdown 只听 click，而浏览器只为真正的可交互元素把 Enter/空格合成成 click——用 span 的话键盘用户永远打不开这个菜单。

## 终审另修四处

前两处是评审发现的**既有**缺陷/疏漏，非本 PR 引入：

- **删除「正在生成回答」的当前会话时没有中断流。** `handleNewChat` 只清 messages，而解锁 `sending` 的唯一出口是 `onDone`——不 abort 的话输入框会被锁死到这次生成自然结束（首字就 6-18s），期间画面全空，用户只会以为站坏了
- **⋯ 缺无障碍语义**：antd 的 Dropdown 一个 aria 都不加。补 `aria-haspopup` 与受控的 `aria-expanded`；并自己在 document 上接 Esc（鼠标点开时 antd 不移焦点，Esc 原本没有接收者）
- `streamingId/abortRef/handleCancel` 上移。不是排版偏好：引用声明在自己之后的绑定会让 React Compiler 整支放弃编译，连带把同组件里其它 useCallback 的手写依赖判成不可保留（实测 4 个 lint error）
- 补一条**迁移↔ORM 列名一致性检查**。`backend/tests` 全是 mock 会话、没有真库往返，而 `alembic-dry-run` 只跑 upgrade/downgrade 从不 SELECT——两边合起来的后果是列名写错也能全绿到生产

## 验证

后端 14 个新单测、前端 23 个（新增 10 个）。**九次变异测试**逐条确认无修复时会红：`if pinned` 吞掉取消置顶 / 归属校验后置 / 去掉 stopPropagation / 置顶不移出日期组 / 去掉 trim / 去掉 abort / 去掉 aria / 去掉 Esc 监听 / ORM 列名改错。

全量：前端 58 文件 301 用例、后端 1454 通过（3 个 `test_health_check_probe.py` 失败为既有，干净树上同样失败）；ruff / eslint / tsc / i18n ratchet / build 全绿。

**真浏览器实测**（桩后端）：桌面侧栏与移动抽屉两条路径——⋯ 悬停现身、菜单三项、置顶后移入「已置顶」组、重命名弹窗预填并 trim、删除弹确认框、点行本体仍能加载会话；桩收到的 PATCH 载荷正确。

## 三项未验证，如实记录

1. **键盘按 Enter 打开菜单没能实测**——自动化浏览器不把按键送进页面（探针连 keydown 都没记录到）。依据是 HTML 规范里 `<button>` 的 activation behavior
2. `@media (hover: none)` 的触屏常驻显示在桌面 Chrome 里触发不了
3. **滚动部署窗口**：`deploy.sh` 先重建 frontend、再滚动重启两个 backend 副本。这几十秒内新 bundle 会轮询到旧副本——PATCH 落到旧副本会 405，或置顶成功后 refetch 命中旧副本导致刚置顶的会话弹回原组。自愈、无数据丢失。schema 侧是安全的：`server_default=sa.false()` 让旧代码的 INSERT 仍然有效