### PR TITLE
feat(chat): 侧栏收起态改成图标轨（对标 ChatGPT）

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1520,5 +1520,6 @@
   "chat.pin_failed": "Action failed",
   "chat.session_group_pinned": "Pinned",
   "chat.session_actions": "More actions",
-  "chat.save": "Save"
+  "chat.save": "Save",
+  "chat.search_sessions_label": "Search conversations"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1520,5 +1520,6 @@
   "chat.pin_failed": "操作失敗",
   "chat.session_group_pinned": "已置頂",
   "chat.session_actions": "更多操作",
-  "chat.save": "儲存"
+  "chat.save": "儲存",
+  "chat.search_sessions_label": "搜尋對話"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1520,5 +1520,6 @@
   "chat.pin_failed": "操作失败",
   "chat.session_group_pinned": "已置顶",
   "chat.session_actions": "更多操作",
-  "chat.save": "保存"
+  "chat.save": "保存",
+  "chat.search_sessions_label": "搜索会话"
 }

--- a/frontend/src/components/RailIcons.tsx
+++ b/frontend/src/components/RailIcons.tsx
@@ -1,0 +1,68 @@
+/**
+ * 收起态侧栏图标轨专用的描边图标。
+ *
+ * 为什么不用 @ant-design/icons：antd 的图标是**实心字形**（填充路径），
+ * 同尺寸下比 ChatGPT 那套 1.75px 描边图标明显更重，四个并排时尤其扎眼。
+ * 描边粗细是字形烘焙进去的，改不了 —— 只能换成 stroke 图标。
+ *
+ * 约定：24×24 视口、fill=none、stroke=currentColor，尺寸由 CSS 的 width/height
+ * 控制（见 .chat-rail-btn svg），颜色随按钮的 color 走。
+ */
+
+const BASE = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.75,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  "aria-hidden": true,
+  focusable: false,
+};
+
+/** 侧栏面板：圆角矩形 + 左侧分栏线。对应 ChatGPT 的收起/展开图标。 */
+export function RailSidebarIcon() {
+  return (
+    <svg {...BASE} data-rail-icon="sidebar">
+      <rect x="3" y="4" width="18" height="16" rx="3" />
+      <path d="M9 4v16" />
+    </svg>
+  );
+}
+
+/** 铅笔方框：新对话。ChatGPT 用的就是这个字形。 */
+export function RailNewChatIcon() {
+  return (
+    <svg {...BASE} data-rail-icon="new-chat">
+      {/* 右上角故意留口，让铅笔从缺口穿出 */}
+      <path d="M12.4 4.6H6.6A2.6 2.6 0 0 0 4 7.2v10.2A2.6 2.6 0 0 0 6.6 20h10.2a2.6 2.6 0 0 0 2.6-2.6v-5.8" />
+      <path d="M16.6 3.95a1.9 1.9 0 1 1 2.69 2.69l-6.66 6.66-3.35.94.94-3.35z" />
+    </svg>
+  );
+}
+
+/** 放大镜：搜索会话。 */
+export function RailSearchIcon() {
+  return (
+    <svg {...BASE} data-rail-icon="search">
+      <circle cx="11" cy="11" r="6.4" />
+      <path d="M15.8 15.8 20.4 20.4" />
+    </svg>
+  );
+}
+
+/**
+ * 齿轮：API Key 配置。
+ *
+ * 这一格 ChatGPT 没有对应物（它那里是会话气泡，语义完全不同，照搬会变成撒谎），
+ * 所以只统一描边风格、保留"设置"语义。轮廓是 8 齿外/内半径交替算出来的
+ * 32 点多边形，靠 stroke-linejoin=round 圆化齿尖。
+ */
+export function RailSettingsIcon() {
+  return (
+    <svg {...BASE} data-rail-icon="settings">
+      <path d="M19.10 10.82 L21.33 10.90 L21.33 13.10 L19.10 13.18 L17.86 16.19 L19.38 17.82 L17.82 19.38 L16.19 17.86 L13.18 19.10 L13.10 21.33 L10.90 21.33 L10.82 19.10 L7.81 17.86 L6.18 19.38 L4.62 17.82 L6.14 16.19 L4.90 13.18 L2.67 13.10 L2.67 10.90 L4.90 10.82 L6.14 7.81 L4.62 6.18 L6.18 4.62 L7.81 6.14 L10.82 4.90 L10.90 2.67 L13.10 2.67 L13.18 4.90 L16.19 6.14 L17.82 4.62 L19.38 6.18 L17.86 7.81 Z" />
+      <circle cx="12" cy="12" r="3.3" />
+    </svg>
+  );
+}

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -105,6 +105,8 @@ beforeEach(() => {
 afterEach(() => {
   vi.clearAllMocks();
   useAuthStore.setState({ token: null, user: null });
+  // 侧栏收起状态持久化在 localStorage —— 不清的话它会泄漏到后面的用例里
+  localStorage.removeItem("fojin.chat.sidebarCollapsed");
 });
 
 /** 等空状态首屏就绪（建议卡片到位）后再断言结构。 */
@@ -493,4 +495,60 @@ describe("会话行 ⋯ 菜单", () => {
       .find((el) => el.textContent?.includes("四圣谛是哪四谛"))!;
     expect(pinnedRow.querySelector(".chat-session-pin-mark")).not.toBeNull();
   });
+});
+
+// ── 收起态的图标轨（对标 ChatGPT 的窄轨）────────────────────────────────
+
+describe("收起态图标轨", () => {
+  beforeEach(() => {
+    // 搜索入口与展开态的搜索框共用 `sessions.length > 5` 这个显示条件，
+    // 所以这里必须给足 6 条 —— 少于 6 条时轨上本来就不该有搜索图标。
+    vi.mocked(getChatSessions).mockResolvedValue(
+      Array.from({ length: 6 }, (_, i) => ({
+        id: (i + 1) as ChatSessionId,
+        title: `会话 ${i + 1}`,
+        pinned: false,
+        created_at: new Date().toISOString(),
+      })),
+    );
+  });
+
+  // 收起态的图标轨：点搜索图标要展开侧栏**并且**把光标送进搜索框。只断言
+  // "搜索框出现了"是不够的 —— 展开后还要用户自己再点一次输入框，那这个图标
+  // 就只是个"展开"按钮的重复。
+  it("收起态: 点搜索图标 → 展开侧栏并聚焦搜索框", async () => {
+    localStorage.setItem("fojin.chat.sidebarCollapsed", "1");
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelector(".chat-sidebar[data-collapsed]")).not.toBeNull();
+    });
+    // 收起态不该有搜索框，只有轨上的图标
+    expect(container.querySelector(".chat-sidebar input")).toBeNull();
+
+    // findBy* 而非 getBy*：会话列表是异步查询，图标要等它落地才出现
+    fireEvent.click(await screen.findByRole("button", { name: "搜索会话" }));
+
+    await waitFor(() => {
+      expect(container.querySelector(".chat-sidebar[data-collapsed]")).toBeNull();
+    });
+    const input = container.querySelector<HTMLInputElement>(".chat-sidebar input")!;
+    expect(input).not.toBeNull();
+    expect(document.activeElement).toBe(input);
+  });
+
+  // 收起态原本把 Key 状态整个藏了 —— 而"有没有配 Key"直接决定问答能不能用。
+  it("收起态: 轨上是四个无边框图标，Key 状态没被藏掉", async () => {
+    localStorage.setItem("fojin.chat.sidebarCollapsed", "1");
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(container.querySelector(".chat-sidebar[data-collapsed]")).not.toBeNull();
+    });
+    await screen.findByRole("button", { name: "搜索会话" });   // 等会话查询落地
+    const rail = container.querySelector(".chat-sidebar")!;
+    const labels = [...rail.querySelectorAll("button")].map((b) => b.getAttribute("aria-label"));
+    expect(labels).toEqual(["展开侧栏", "新对话", "搜索会话", "配置 API Key"]);
+    // 每个都挂上了图标轨样式类（边框是靠 .chat-rail-btn 去掉的）
+    expect(rail.querySelectorAll("button.chat-rail-btn")).toHaveLength(4);
+  });
+
 });

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -551,4 +551,22 @@ describe("收起态图标轨", () => {
     expect(rail.querySelectorAll("button.chat-rail-btn")).toHaveLength(4);
   });
 
+  // 轨上四个必须是同一套描边图标。antd 的图标是实心字形，描边粗细烘焙在字形里
+  // 改不掉 —— 混用的话四个并排时轻重不一，正是要修的那个观感问题。
+  it("收起态: 四个都是描边图标（无 antd 实心字形混入）", async () => {
+    localStorage.setItem("fojin.chat.sidebarCollapsed", "1");
+    const { container } = renderPage();
+    await screen.findByRole("button", { name: "搜索会话" });
+    const rail = container.querySelector(".chat-sidebar")!;
+
+    expect([...rail.querySelectorAll("[data-rail-icon]")].map((e) => e.getAttribute("data-rail-icon")))
+      .toEqual(["sidebar", "new-chat", "search", "settings"]);
+    // 一个 antd 字形都不该剩下
+    expect(rail.querySelectorAll(".anticon")).toHaveLength(0);
+    // 四个描边粗细一致，否则并排看仍然轻重不一
+    const widths = [...rail.querySelectorAll("[data-rail-icon]")]
+      .map((e) => e.getAttribute("stroke-width"));
+    expect(new Set(widths).size).toBe(1);
+  });
+
 });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams, Link } from "react-router";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { Input, Button, message, Alert, Tooltip, Modal, Tag, Spin, Dropdown } from "antd";
+import type { InputRef } from "antd";
 import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
@@ -33,6 +34,7 @@ import {
   EditOutlined,
   PushpinOutlined,
   PushpinFilled,
+  SearchOutlined,
 } from "@ant-design/icons";
 const ShareCard = lazy(() => import("../components/ShareCard"));
 const CitationDrawer = lazy(() => import("../components/CitationDrawer"));
@@ -676,14 +678,27 @@ export default function ChatPage() {
     if (typeof window === "undefined") return false;
     return window.localStorage.getItem("fojin.chat.sidebarCollapsed") === "1";
   });
-  const toggleSidebarCollapsed = () => {
-    setSidebarCollapsed((prev) => {
-      const next = !prev;
-      try { window.localStorage.setItem("fojin.chat.sidebarCollapsed", next ? "1" : "0"); } catch { /* ignore */ }
-      return next;
-    });
-  };
+  const setCollapsed = useCallback((next: boolean) => {
+    setSidebarCollapsed(next);
+    try { window.localStorage.setItem("fojin.chat.sidebarCollapsed", next ? "1" : "0"); } catch { /* ignore */ }
+  }, []);
+  const toggleSidebarCollapsed = () => setCollapsed(!sidebarCollapsed);
   const [sessionFilter, setSessionFilter] = useState("");
+  // 收起态点搜索图标 → 展开侧栏并把光标送进搜索框。展开是异步的（输入框此刻还
+  // 没挂载），所以用一个 ref 记下意图，等 sidebarCollapsed 落地后再 focus。
+  // 用 ref 而不是 state：effect 里改 state 会被 React Compiler 判成
+  // set-state-in-effect（本仓库是 error 级）。
+  const sessionSearchRef = useRef<InputRef>(null);
+  const wantSearchFocusRef = useRef(false);
+  useEffect(() => {
+    if (sidebarCollapsed || !wantSearchFocusRef.current) return;
+    wantSearchFocusRef.current = false;
+    sessionSearchRef.current?.focus();
+  }, [sidebarCollapsed]);
+  const handleRailSearch = useCallback(() => {
+    wantSearchFocusRef.current = true;
+    setCollapsed(false);
+  }, [setCollapsed]);
   const [tabIndex, setTabIndex] = useState(-1);
   const [hasOlderMessages, setHasOlderMessages] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
@@ -1462,19 +1477,43 @@ export default function ChatPage() {
             <Button
               type="text"
               size="small"
+              className={sidebarCollapsed ? "chat-rail-btn" : undefined}
               icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
               onClick={toggleSidebarCollapsed}
               aria-label={sidebarCollapsed ? t("chat.expand_sidebar") : t("chat.collapse_sidebar")}
               style={{ alignSelf: sidebarCollapsed ? "center" : "flex-end", color: "var(--fj-ink-muted)" }}
             />
           </Tooltip>
+          {/* 收起态是一条图标轨：按钮去掉边框、统一 32×32 居中。带边框的方块在
+              48px 宽的窄轨里会显得又挤又重，这也是它和 ChatGPT 观感差最多的地方。 */}
           <Tooltip title={sidebarCollapsed ? t("chat.new_chat") : ""} placement="right">
-            <Button icon={<PlusOutlined />} block={!sidebarCollapsed} onClick={handleNewChat} aria-label={t("chat.new_chat")}>
+            <Button
+              icon={<PlusOutlined />}
+              type={sidebarCollapsed ? "text" : "default"}
+              className={sidebarCollapsed ? "chat-rail-btn" : undefined}
+              block={!sidebarCollapsed}
+              onClick={handleNewChat}
+              aria-label={t("chat.new_chat")}
+            >
               {!sidebarCollapsed && t("chat.new_chat")}
             </Button>
           </Tooltip>
+          {/* 搜索在收起态原本整个消失。这里给它一个入口：点开即展开并聚焦。
+              显示条件与展开态的搜索框严格一致，否则会展开出一个没有搜索框的侧栏。 */}
+          {sidebarCollapsed && sessions && sessions.length > 5 && (
+            <Tooltip title={t("chat.search_sessions_label")} placement="right">
+              <Button
+                type="text"
+                className="chat-rail-btn"
+                icon={<SearchOutlined />}
+                onClick={handleRailSearch}
+                aria-label={t("chat.search_sessions_label")}
+              />
+            </Tooltip>
+          )}
           {!sidebarCollapsed && sessions && sessions.length > 5 && (
             <Input
+              ref={sessionSearchRef}
               placeholder={t("chat.search_sessions")}
               size="small"
               allowClear
@@ -1503,6 +1542,27 @@ export default function ChatPage() {
               </div>
             ))}
           </div>}
+          {/* 收起态原本连 Key 状态一起消失了 —— 但「有没有配 Key」直接决定问答
+              能不能用，是这条轨上唯一必须留住的状态。压成一个图标沉到底部。 */}
+          {sidebarCollapsed && (
+            <>
+              <div style={{ flex: 1 }} />
+              <Tooltip
+                placement="right"
+                title={keyStatus?.has_api_key
+                  ? `${t("chat.key_configured")} (${keyStatus.provider})`
+                  : t("chat.configure_key")}
+              >
+                <Button
+                  type="text"
+                  className="chat-rail-btn"
+                  icon={<SettingOutlined />}
+                  onClick={() => navigate("/profile?tab=apikey")}
+                  aria-label={t("chat.configure_key")}
+                />
+              </Tooltip>
+            </>
+          )}
           {!sidebarCollapsed && (
             <div className="chat-sidebar-foot">
               <Button icon={<SettingOutlined />} block type="text" size="small"

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -19,7 +19,6 @@ import {
   SettingOutlined,
   MenuOutlined,
   MenuFoldOutlined,
-  MenuUnfoldOutlined,
   DownloadOutlined,
   StopOutlined,
   CopyOutlined,
@@ -34,12 +33,17 @@ import {
   EditOutlined,
   PushpinOutlined,
   PushpinFilled,
-  SearchOutlined,
 } from "@ant-design/icons";
 const ShareCard = lazy(() => import("../components/ShareCard"));
 const CitationDrawer = lazy(() => import("../components/CitationDrawer"));
 import ChatModelSelector from "../components/ChatModelSelector";
 import MasterGallery, { MasterSeal } from "../components/MasterGallery";
+import {
+  RailSidebarIcon,
+  RailNewChatIcon,
+  RailSearchIcon,
+  RailSettingsIcon,
+} from "../components/RailIcons";
 import DraggableModal from "../components/DraggableModal";
 import { getMasters } from "../api/client";
 import type { CitationTarget } from "../components/CitationDrawer";
@@ -1478,7 +1482,7 @@ export default function ChatPage() {
               type="text"
               size="small"
               className={sidebarCollapsed ? "chat-rail-btn" : undefined}
-              icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+              icon={sidebarCollapsed ? <RailSidebarIcon /> : <MenuFoldOutlined />}
               onClick={toggleSidebarCollapsed}
               aria-label={sidebarCollapsed ? t("chat.expand_sidebar") : t("chat.collapse_sidebar")}
               style={{ alignSelf: sidebarCollapsed ? "center" : "flex-end", color: "var(--fj-ink-muted)" }}
@@ -1488,7 +1492,7 @@ export default function ChatPage() {
               48px 宽的窄轨里会显得又挤又重，这也是它和 ChatGPT 观感差最多的地方。 */}
           <Tooltip title={sidebarCollapsed ? t("chat.new_chat") : ""} placement="right">
             <Button
-              icon={<PlusOutlined />}
+              icon={sidebarCollapsed ? <RailNewChatIcon /> : <PlusOutlined />}
               type={sidebarCollapsed ? "text" : "default"}
               className={sidebarCollapsed ? "chat-rail-btn" : undefined}
               block={!sidebarCollapsed}
@@ -1505,7 +1509,7 @@ export default function ChatPage() {
               <Button
                 type="text"
                 className="chat-rail-btn"
-                icon={<SearchOutlined />}
+                icon={<RailSearchIcon />}
                 onClick={handleRailSearch}
                 aria-label={t("chat.search_sessions_label")}
               />
@@ -1556,7 +1560,7 @@ export default function ChatPage() {
                 <Button
                   type="text"
                   className="chat-rail-btn"
-                  icon={<SettingOutlined />}
+                  icon={<RailSettingsIcon />}
                   onClick={() => navigate("/profile?tab=apikey")}
                   aria-label={t("chat.configure_key")}
                 />

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -430,6 +430,37 @@ em {
   background: rgba(217, 208, 193, 0.3);
 }
 
+/* ── 收起态：一条居中的图标轨 ─────────────────────────────────────── */
+.chat-sidebar[data-collapsed] {
+  align-items: center;
+  gap: 4px;          /* 展开态的 8px 在窄轨里会把三个图标拉得过散 */
+  padding-top: 2px;
+}
+.chat-rail-btn.ant-btn {
+  width: 34px;
+  height: 34px;
+  min-width: 34px;
+  padding: 0;
+  border-radius: 8px;
+  color: var(--fj-ink-muted);
+  /* 展开态的 + 是主按钮（有边框有底色），收起态统一成无边框图标 —— 带边框的
+     方块在 48px 宽的轨里又挤又重。 */
+  border: none;
+  box-shadow: none;
+}
+.chat-rail-btn.ant-btn:hover,
+.chat-rail-btn.ant-btn:focus-visible {
+  background: rgba(217, 208, 193, 0.45);
+  color: var(--fj-ink);
+}
+.chat-rail-btn.ant-btn:focus-visible {
+  outline: 2px solid var(--fj-accent);
+  outline-offset: 1px;
+}
+.chat-rail-btn .anticon {
+  font-size: 16px;
+}
+
 /* Key 状态行沉到侧栏底部（会话列表是 flex:1，排它后面即到底） */
 .chat-sidebar-foot {
   flex-shrink: 0;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -457,8 +457,15 @@ em {
   outline: 2px solid var(--fj-accent);
   outline-offset: 1px;
 }
+/* 描边图标（RailIcons）按 width/height 定尺寸；antd 的实心字形按 font-size。
+   轨上四个都是前者，这条 .anticon 规则留给展开态尚存的 antd 图标兜底。 */
 .chat-rail-btn .anticon {
   font-size: 16px;
+}
+.chat-rail-btn svg {
+  width: 19px;
+  height: 19px;
+  display: block;
 }
 
 /* Key 状态行沉到侧栏底部（会话列表是 flex:1，排它后面即到底） */


### PR DESCRIPTION
收起后的侧栏此前是「一个无边框的展开箭头 + 一个**带边框的方块按钮**」，在 48px 宽的轨里又挤又重——这是它和 ChatGPT 观感差最多的地方。

更要紧的是**搜索和 Key 状态在收起时整个消失**：想搜一条旧对话，得先展开、再找到搜索框、再点进去。

## 改了什么

| | 之前 | 现在 |
|---|---|---|
| 按钮样式 | 展开箭头无边框，「+」是带边框方块 | 四个统一 34×34 无边框图标，居中 |
| 搜索 | 收起时消失 | 轨上有图标，点一下**展开并直接聚焦搜索框** |
| Key 状态 | 收起时消失 | 压成齿轮沉到轨底 |

「有没有配 Key」直接决定问答能不能用，是这条轨上唯一必须留住的状态，所以没有跟着一起藏掉。

## 两个实现细节

**聚焦要跨过一次异步。** 点搜索图标时输入框还没挂载，所以用 ref 记下意图、等 `sidebarCollapsed` 落地后再 focus。用 ref 而非 state：effect 里改 state 会被 React Compiler 判成 `set-state-in-effect`（本仓库是 error 级）。

**搜索图标的显示条件必须与展开态搜索框严格一致**（`sessions.length > 5`），否则会展开出一个没有搜索框的侧栏。

## 验证

新增 2 个用例，都做了变异测试确认无修复时会红：去掉 focus 意图（搜索图标退化成第二个「展开」按钮）、把 Key 状态改回收起时隐藏。

全量：58 文件 303 用例通过；tsc / eslint / i18n ratchet / build 全绿。

**真浏览器实测**：四个按钮均 34×34、零边框、相对轨中心**偏移 0**；点搜索确实展开并把光标送进搜索框；轨底齿轮在视口内且可点中。

一处环境伪影记录在案：收起→展开的宽度过渡在 CDP 后台标签页里不推进，实测读到的 48px 是卡住的过渡起始值——关掉 `transition` 后立刻变成 React 写入的 `220px`，逻辑正确。