### PR TITLE
style(chat): 侧栏右缘补一条很浅的分隔线

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -430,6 +430,27 @@ em {
   background: rgba(217, 208, 193, 0.3);
 }
 
+/* 侧栏右缘的分隔线。
+   用 ::after 而不是 border-right：全局是 border-box，加边框会把内容盒挤掉
+   1px，48px 轨里 34px 的按钮就不再正中（实测偏移会从 0 变成 -0.5）。绝对定位
+   的伪元素完全不参与布局。
+   颜色走 --fj-border，深浅两套主题各自有定义；再压低透明度到「很浅」，让它只
+   划出边界而不抢注意力。 */
+.chat-sidebar {
+  position: relative;
+}
+.chat-sidebar::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--fj-border);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 /* ── 收起态：一条居中的图标轨 ─────────────────────────────────────── */
 .chat-sidebar[data-collapsed] {
   align-items: center;


### PR DESCRIPTION
侧栏与对话区此前只靠 16px 空白隔开，边界是隐含的；ChatGPT 在同一位置有一条很浅的竖线。

## 一个实现选择

用 `::after` 绝对定位，**不用 `border-right`**：全局是 `box-sizing: border-box`，加边框会把内容盒挤掉 1px，48px 图标轨里 34px 的按钮就不再正中——实测居中偏移会从 `0` 变成 `-0.5`。伪元素完全不参与布局。

颜色走 `--fj-border`（浅色 `#d9d0c1` / 深色 `#60553f` 各有定义），再压到 `0.45` 透明度：只划出边界，不抢注意力。

## 一处我替你做的判断

**收起态和展开态都加。** 只在收起态加的话，切换侧栏时这条线会忽隐忽现。如果你只想要收起态有，把选择器改成 `.chat-sidebar[data-collapsed]::after` 即可。

## 验证

真浏览器实测：
- 伪元素落位正确（1px、绝对定位、`rgb(217,208,193)` @ 0.45）
- **按钮居中偏移仍是 0**（这正是不用 border 的原因）
- 深色主题下线也在，颜色随变量切到 `rgb(96,85,63)`
- 展开态（220px）同样有线

全量 304 用例通过；tsc / eslint / i18n ratchet / build 全绿。

纯 CSS 视觉改动，没有可写的行为断言——jsdom 不解析样式表、也算不出伪元素样式，所以这条只能靠眼睛验，截图已附在对话里。