### PR TITLE
feat(chat): 收起轨补第四个按钮「最近聊天」

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1521,5 +1521,6 @@
   "chat.session_group_pinned": "Pinned",
   "chat.session_actions": "More actions",
   "chat.save": "Save",
-  "chat.search_sessions_label": "Search conversations"
+  "chat.search_sessions_label": "Search conversations",
+  "chat.recent_chats": "Recent chats"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1521,5 +1521,6 @@
   "chat.session_group_pinned": "已置頂",
   "chat.session_actions": "更多操作",
   "chat.save": "儲存",
-  "chat.search_sessions_label": "搜尋對話"
+  "chat.search_sessions_label": "搜尋對話",
+  "chat.recent_chats": "最近聊天"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1521,5 +1521,6 @@
   "chat.session_group_pinned": "已置顶",
   "chat.session_actions": "更多操作",
   "chat.save": "保存",
-  "chat.search_sessions_label": "搜索会话"
+  "chat.search_sessions_label": "搜索会话",
+  "chat.recent_chats": "最近聊天"
 }

--- a/frontend/src/components/RailIcons.tsx
+++ b/frontend/src/components/RailIcons.tsx
@@ -51,6 +51,16 @@ export function RailSearchIcon() {
   );
 }
 
+/** 对话气泡：最近聊天。ChatGPT 收起轨上的第四个就是它。 */
+export function RailChatsIcon() {
+  return (
+    <svg {...BASE} data-rail-icon="chats">
+      {/* 近圆形泡身 + 左下角小尾巴 */}
+      <path d="M20 11.6c0 4.09-3.58 7.4-8 7.4a9 9 0 0 1-2.63-.38L5 20.2l1.32-3.4A7.1 7.1 0 0 1 4 11.6C4 7.51 7.58 4.2 12 4.2s8 3.31 8 7.4z" />
+    </svg>
+  );
+}
+
 /**
  * 齿轮：API Key 配置。
  *

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -536,8 +536,29 @@ describe("收起态图标轨", () => {
     expect(document.activeElement).toBe(input);
   });
 
+  // 最近聊天：与"展开侧栏"动作相同、意图不同。断言必须落在"会话列表真的露出来了"
+  // 上 —— 只断言侧栏展开的话，这个按钮就算什么也不做（沿用 Tooltip 的默认行为）
+  // 也可能碰巧通过。
+  it("收起态: 点最近聊天 → 展开侧栏并露出会话列表", async () => {
+    localStorage.setItem("fojin.chat.sidebarCollapsed", "1");
+    const { container } = renderPage();
+    await screen.findByRole("button", { name: "最近聊天" });
+    expect(container.querySelector(".chat-session-list")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "最近聊天" }));
+
+    await waitFor(() => {
+      expect(container.querySelector(".chat-sidebar[data-collapsed]")).toBeNull();
+    });
+    const list = container.querySelector(".chat-session-list")!;
+    expect(list).not.toBeNull();
+    expect(list.querySelectorAll(".chat-session-row").length).toBe(6);
+    // 收起状态要落盘，否则刷新后又缩回去
+    expect(localStorage.getItem("fojin.chat.sidebarCollapsed")).toBe("0");
+  });
+
   // 收起态原本把 Key 状态整个藏了 —— 而"有没有配 Key"直接决定问答能不能用。
-  it("收起态: 轨上是四个无边框图标，Key 状态没被藏掉", async () => {
+  it("收起态: 轨上是五个无边框图标，Key 状态没被藏掉", async () => {
     localStorage.setItem("fojin.chat.sidebarCollapsed", "1");
     const { container } = renderPage();
     await waitFor(() => {
@@ -546,24 +567,24 @@ describe("收起态图标轨", () => {
     await screen.findByRole("button", { name: "搜索会话" });   // 等会话查询落地
     const rail = container.querySelector(".chat-sidebar")!;
     const labels = [...rail.querySelectorAll("button")].map((b) => b.getAttribute("aria-label"));
-    expect(labels).toEqual(["展开侧栏", "新对话", "搜索会话", "配置 API Key"]);
+    expect(labels).toEqual(["展开侧栏", "新对话", "搜索会话", "最近聊天", "配置 API Key"]);
     // 每个都挂上了图标轨样式类（边框是靠 .chat-rail-btn 去掉的）
-    expect(rail.querySelectorAll("button.chat-rail-btn")).toHaveLength(4);
+    expect(rail.querySelectorAll("button.chat-rail-btn")).toHaveLength(5);
   });
 
-  // 轨上四个必须是同一套描边图标。antd 的图标是实心字形，描边粗细烘焙在字形里
+  // 轨上五个必须是同一套描边图标。antd 的图标是实心字形，描边粗细烘焙在字形里
   // 改不掉 —— 混用的话四个并排时轻重不一，正是要修的那个观感问题。
-  it("收起态: 四个都是描边图标（无 antd 实心字形混入）", async () => {
+  it("收起态: 五个都是描边图标（无 antd 实心字形混入）", async () => {
     localStorage.setItem("fojin.chat.sidebarCollapsed", "1");
     const { container } = renderPage();
     await screen.findByRole("button", { name: "搜索会话" });
     const rail = container.querySelector(".chat-sidebar")!;
 
     expect([...rail.querySelectorAll("[data-rail-icon]")].map((e) => e.getAttribute("data-rail-icon")))
-      .toEqual(["sidebar", "new-chat", "search", "settings"]);
+      .toEqual(["sidebar", "new-chat", "search", "chats", "settings"]);
     // 一个 antd 字形都不该剩下
     expect(rail.querySelectorAll(".anticon")).toHaveLength(0);
-    // 四个描边粗细一致，否则并排看仍然轻重不一
+    // 描边粗细必须一致，否则并排看轻重不一
     const widths = [...rail.querySelectorAll("[data-rail-icon]")]
       .map((e) => e.getAttribute("stroke-width"));
     expect(new Set(widths).size).toBe(1);

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -42,6 +42,7 @@ import {
   RailSidebarIcon,
   RailNewChatIcon,
   RailSearchIcon,
+  RailChatsIcon,
   RailSettingsIcon,
 } from "../components/RailIcons";
 import DraggableModal from "../components/DraggableModal";
@@ -1512,6 +1513,21 @@ export default function ChatPage() {
                 icon={<RailSearchIcon />}
                 onClick={handleRailSearch}
                 aria-label={t("chat.search_sessions_label")}
+              />
+            </Tooltip>
+          )}
+          {/* 最近聊天：展开侧栏露出会话列表。与"展开侧栏"按钮动作相同、意图不同 ——
+              一个是"开合面板"，一个是"我的旧对话在哪"。ChatGPT 同样两个都给。
+              不设显示条件：一个会话都没有时展开出空列表，正好告诉新用户以后
+              会话会出现在这里。 */}
+          {sidebarCollapsed && (
+            <Tooltip title={t("chat.recent_chats")} placement="right">
+              <Button
+                type="text"
+                className="chat-rail-btn"
+                icon={<RailChatsIcon />}
+                onClick={() => setCollapsed(false)}
+                aria-label={t("chat.recent_chats")}
               />
             </Tooltip>
           )}


### PR DESCRIPTION
对齐 ChatGPT 收起轨的四件套：**侧栏面板 / 新对话 / 搜索 / 最近聊天**。气泡是同一套 1.75px 描边手写图标（近圆泡身 + 左下小尾巴），不是 antd 的实心字形。

## 它做什么

展开侧栏、露出会话列表 —— 与「展开侧栏」按钮**动作相同、意图不同**：一个是"开合面板"，一个是"我的旧对话在哪"。ChatGPT 同样两个都给。

**不设显示条件**（搜索按钮有 `sessions > 5` 的门槛，它没有）：一个会话都没有时展开出空列表，正好告诉新用户以后会话会出现在这里。

## 两处变异测试

- 把 `setCollapsed(false)` 换成 `setSidebarCollapsed(false)`（绕过落盘）→ 刷新后又缩回去，用例红在 `localStorage` 断言上
- 气泡换成 antd 的 `MessageOutlined` →「五个都是描边图标」用例立刻抓到实心字形混入

新用例的断言特意落在**"会话列表真的露出来了"**，而不是"侧栏展开了" —— 后者就算按钮什么都不做也可能碰巧通过。

## 验证

真浏览器实测：五个图标描边均 **1.75**、尺寸均 **19×19**、**居中偏移全为 0**、轨上**零个** antd 字形；点「最近聊天」展开并列出 6 条会话，收起状态落盘为 `"0"`。

全量 305 用例通过；tsc / eslint / i18n ratchet / build 全绿。