### PR TITLE
feat(chat): 会话进 URL，配 Key 页给出能真正返回原会话的按钮

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1522,5 +1522,6 @@
   "chat.session_actions": "More actions",
   "chat.save": "Save",
   "chat.search_sessions_label": "Search conversations",
-  "chat.recent_chats": "Recent chats"
+  "chat.recent_chats": "Recent chats",
+  "profile.back_to_chat": "Back to AI Q&A"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1522,5 +1522,6 @@
   "chat.session_actions": "更多操作",
   "chat.save": "儲存",
   "chat.search_sessions_label": "搜尋對話",
-  "chat.recent_chats": "最近聊天"
+  "chat.recent_chats": "最近聊天",
+  "profile.back_to_chat": "返回 AI 問答"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1522,5 +1522,6 @@
   "chat.session_actions": "更多操作",
   "chat.save": "保存",
   "chat.search_sessions_label": "搜索会话",
-  "chat.recent_chats": "最近聊天"
+  "chat.recent_chats": "最近聊天",
+  "profile.back_to_chat": "返回 AI 问答"
 }

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -2,7 +2,8 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
+import { message } from "antd";
 import ChatPage from "./ChatPage";
 import { useAuthStore } from "../stores/authStore";
 import {
@@ -19,6 +20,18 @@ import {
   type ChatSessionItem,
 } from "../api/client";
 import type { ChatSessionId } from "../types/branded";
+
+// 只替换 message，其余 antd 组件保持真实。
+// 为什么不能靠"页面上有没有出现错误文案"来断言：antd v5 的静态 message 在
+// React 19 下要靠入口处那个 v5-patch 才生效，而测试不走入口 —— 于是 message.error
+// 在 jsdom 里是无声的，用 queryByText 断言会永远为真（实测变异打不红）。
+vi.mock("antd", async () => {
+  const actual = await vi.importActual<typeof import("antd")>("antd");
+  return {
+    ...actual,
+    message: { ...actual.message, error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() },
+  };
+});
 
 vi.mock("../api/client", async () => {
   const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
@@ -69,13 +82,20 @@ const MASTERS = [
   },
 ];
 
-function renderPage() {
+/** 把当前 URL 渲染出来，好断言跳转目标 —— 比 mock useNavigate 更接近真实。 */
+function LocationProbe() {
+  const loc = useLocation();
+  return <span data-testid="loc">{loc.pathname + loc.search}</span>;
+}
+
+function renderPage(entry = "/chat") {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <HelmetProvider>
       <QueryClientProvider client={client}>
-        <MemoryRouter initialEntries={["/chat"]}>
+        <MemoryRouter initialEntries={[entry]}>
           <ChatPage />
+          <LocationProbe />
         </MemoryRouter>
       </QueryClientProvider>
     </HelmetProvider>,
@@ -590,4 +610,90 @@ describe("收起态图标轨", () => {
     expect(new Set(widths).size).toBe(1);
   });
 
+});
+
+// ── 会话与 URL 的往返（去配 Key 再回来不丢会话）────────────────────────
+
+describe("会话与 URL", () => {
+  const SIX = Array.from({ length: 6 }, (_, i) => ({
+    id: (i + 1) as ChatSessionId,
+    title: `会话 ${i + 1}`,
+    pinned: false,
+    created_at: new Date().toISOString(),
+  }));
+
+  beforeEach(() => {
+    vi.mocked(getChatSessions).mockResolvedValue(SIX);
+    vi.mocked(getChatSessionMessages).mockResolvedValue({
+      total: 1, page: 1, size: 50,
+      messages: [{ id: 99, role: "user" as const, content: "色即是空怎么讲", sources: null, created_at: new Date().toISOString() }],
+    });
+  });
+
+  // 承重点。sessionId 此前只是组件 state，一离开 /chat 就没了 —— 这条断言的是
+  // 「带 ?s= 进来能把那个会话读回来」，也就是返回按钮真正依赖的能力。
+  it("带 ?s= 进入时恢复该会话", async () => {
+    renderPage("/chat?s=3");
+    await waitFor(() => {
+      expect(vi.mocked(getChatSessionMessages)).toHaveBeenCalledWith(3, 1, 50);
+    });
+    expect(await screen.findByText("色即是空怎么讲")).toBeInTheDocument();
+  });
+
+  // 旧链接（会话已删 / 本就不属于自己，后端 403/404）不该在进页面时糊一脸报错。
+  it("?s= 指向打不开的会话时静默退回空白首屏", async () => {
+    vi.mocked(getChatSessionMessages).mockRejectedValue(new Error("404"));
+    renderPage("/chat?s=999");
+    await waitFor(() => {
+      expect(vi.mocked(getChatSessionMessages)).toHaveBeenCalledWith(999, 1, 50);
+    });
+    // 首屏建议卡片还在 = 退回了空白态
+    expect(await screen.findByText("「三毒」指的是哪三种毒？")).toBeInTheDocument();
+    // 打不开的 id 不该留在地址栏里
+    await waitFor(() => {
+      expect(screen.getByTestId("loc").textContent).not.toContain("s=999");
+    });
+    // 「静默」必须单独断言：只查"退回了空白态"的话，实现照样弹一个错误提示也能过
+    // ——这条最初就是这么写的，变异测试（忽略 silent 参数）没能打红才发现。
+    expect(vi.mocked(message.error)).not.toHaveBeenCalled();
+  });
+
+  it("点开会话后 ?s= 跟着写进 URL（可收藏）", async () => {
+    const { container } = renderPage();
+    await waitFor(() => expect(screen.getByText("会话 2")).toBeInTheDocument());
+    const row = [...container.querySelectorAll<HTMLElement>(".chat-session-row")]
+      .find((el) => el.textContent?.includes("会话 2"))!;
+    fireEvent.click(row.querySelector("span")!);
+    await waitFor(() => {
+      expect(screen.getByTestId("loc").textContent).toBe("/chat?s=2");
+    });
+  });
+
+  it("点新对话清掉 ?s=", async () => {
+    renderPage("/chat?s=3");
+    await waitFor(() => {
+      expect(screen.getByTestId("loc").textContent).toBe("/chat?s=3");
+    });
+    fireEvent.click(screen.getByRole("button", { name: /新对话/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId("loc").textContent).toBe("/chat");
+    });
+  });
+
+  // 「配置 Key」必须把来源和会话一起带过去，否则 /profile 那边既不知道该不该显示
+  // 返回按钮，也不知道该返回到哪个会话。
+  it("配置 Key 跳转带上 from=chat 与当前会话", async () => {
+    renderPage("/chat?s=3");
+    await waitFor(() => {
+      expect(screen.getByTestId("loc").textContent).toBe("/chat?s=3");
+    });
+    fireEvent.click(screen.getByRole("button", { name: /已配置 Key|配置 API Key/ }));
+    await waitFor(() => {
+      const loc = screen.getByTestId("loc").textContent!;
+      expect(loc).toContain("/profile?");
+      expect(loc).toContain("tab=apikey");
+      expect(loc).toContain("from=chat");
+      expect(loc).toContain("s=3");
+    });
+  });
 });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -611,6 +611,10 @@ export const MessageBubble = memo(
 
 export default function ChatPage() {
   const navigate = useNavigate();
+  // 必须声明在 loadSession / handleNewChat 之前：引用声明在自己之后的绑定会让
+  // React Compiler 对整个组件放弃编译，并把同组件里其它 useCallback 的手写依赖
+  // 判成不可保留（见 PR #1077 里踩过的 4 个 lint error）。
+  const [searchParams, setSearchParams] = useSearchParams();
   const { t } = useTranslation();
   const { user } = useAuthStore();
   const [input, setInput] = useState("");
@@ -924,10 +928,27 @@ export default function ChatPage() {
     setShowJumpToBottom((prev) => (prev === !near ? prev : !near));
   }, [setShowJumpToBottom]);
 
-  const loadSession = async (sid: number) => {
+  /** 把「当前在读哪个会话」写进 URL（?s=）。
+   *
+   * 两个用处：① 去 /profile 配 Key 再返回时能落回原会话 —— 此前 sessionId 只是
+   * 组件 state，一离开 /chat 就没了；② 顺带让单条对话可收藏。
+   * 一律 replace：不然每切一次会话就往浏览历史塞一条，后退键会变得很难用。 */
+  const syncSessionParam = useCallback((sid: number | undefined) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (sid === undefined) next.delete("s");
+      else next.set("s", String(sid));
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
+  /** silent：按 URL 恢复时用。链接可能是旧的（会话已删、或本就不属于自己，
+   *  后端会 403/404），一进页面就弹错误提示只是噪音，退回空白首屏即可。 */
+  const loadSession = useCallback(async (sid: number, silent = false) => {
     try {
       const data = await getChatSessionMessages(sid, 1, 50);
       setSessionId(sid);
+      syncSessionParam(sid);
       setMessages(data.messages);
       setCurrentPage(1);
       setHasOlderMessages(data.total > data.messages.length);
@@ -942,9 +963,27 @@ export default function ChatPage() {
         handleMessagesScroll();
       }, 100);
     } catch {
-      message.error(t("chat.load_session_failed"));
+      syncSessionParam(undefined);   // 别把打不开的 id 留在地址栏里
+      if (!silent) message.error(t("chat.load_session_failed"));
     }
-  };
+  }, [syncSessionParam, handleMessagesScroll, t]);
+
+  // 挂载时按 ?s= 恢复会话。ref 守卫是必需的：syncSessionParam 会改 searchParams，
+  // 不守就会自我触发成循环；loadSession 每次渲染都是新引用（exhaustive-deps 要求
+  // 列进依赖），也靠这个守卫兜住重复执行。
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (restoredRef.current) return;
+    const raw = searchParams.get("s");
+    if (!raw) return;
+    const sid = Number(raw);
+    if (!Number.isInteger(sid) || sid <= 0) return;
+    restoredRef.current = true;
+    // 放进微任务里调：loadSession 第一句就是 await，实际不会同步 setState，但
+    // React Compiler 只看调用点、不看 await，会判成 set-state-in-effect（error 级）。
+    // 挪进回调既符合规则本意（"外部状态变化时在回调里 setState"），也不改变时序。
+    queueMicrotask(() => { loadSession(sid, true); });
+  }, [searchParams, loadSession]);
 
   const loadOlderMessages = async () => {
     if (!sessionId || loadingOlder) return;
@@ -964,6 +1003,7 @@ export default function ChatPage() {
 
   const handleNewChat = () => {
     setSessionId(undefined);
+    syncSessionParam(undefined);
     setMessages([]);
     setHasOlderMessages(false);
     setCurrentPage(1);
@@ -1223,6 +1263,7 @@ export default function ChatPage() {
       onSessionId: (newSessionId: number) => {
         if (!sessionId) {
           setSessionId(newSessionId);
+          syncSessionParam(newSessionId);
           if (user) refetchSessions();
         }
       },
@@ -1273,7 +1314,7 @@ export default function ChatPage() {
       modelId: modelId === "deepseek:v4-pro" ? null : modelId,
       attachmentIds: attachmentIdsForSend.length ? attachmentIdsForSend : null,
     });
-  }, [sending, sessionId, masterId, modelId, user, attachments, refetchSessions, refetchQuota, queryClient, scrollToBottom, setShowJumpToBottom]);
+  }, [sending, sessionId, masterId, modelId, user, attachments, refetchSessions, refetchQuota, queryClient, scrollToBottom, setShowJumpToBottom, syncSessionParam]);
 
   const handleSend = useCallback(async () => {
     await handleSendMessage(input);
@@ -1376,7 +1417,6 @@ export default function ChatPage() {
   }, [tabSuggestions, tabIndex]);
 
   // Handle pre-filled message from URL params (e.g. from "Ask XiaoJin" button on reader page)
-  const [searchParams, setSearchParams] = useSearchParams();
   const autoSentRef = useRef(false);
   useEffect(() => {
     const q = searchParams.get("q");
@@ -1392,6 +1432,14 @@ export default function ChatPage() {
       : `关于这段经文：\n\n> ${context}\n\n${q}`; // i18n-exempt — chat message payload sent to the zh RAG pipeline
     handleSendMessage(msg);
   }, [searchParams, setSearchParams, handleSendMessage]);
+
+  /** 去配 Key。带上来源与当前会话，好让 /profile 给出一个能真正返回原会话的按钮 ——
+   *  sessionId 只是组件 state，离开 /chat 就没了，光有「返回」会落在空白新对话上。 */
+  const goConfigureKey = useCallback(() => {
+    const q = new URLSearchParams({ tab: "apikey", from: "chat" });
+    if (sessionId !== undefined) q.set("s", String(sessionId));
+    navigate(`/profile?${q.toString()}`);
+  }, [navigate, sessionId]);
 
   const handleExport = useCallback(() => {
     if (messages.length === 0) {
@@ -1466,7 +1514,7 @@ export default function ChatPage() {
               <div className="chat-sidebar-foot">
                 <Button icon={<SettingOutlined />} block type="text" size="small"
                   style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
-                  onClick={() => { navigate("/profile?tab=apikey"); setSidebarOpen(false); }}>
+                  onClick={() => { goConfigureKey(); setSidebarOpen(false); }}>
                   {keyStatus?.has_api_key ? `${t("chat.key_configured")} (${keyStatus.provider})` : t("chat.configure_key")}
                 </Button>
               </div>
@@ -1577,7 +1625,7 @@ export default function ChatPage() {
                   type="text"
                   className="chat-rail-btn"
                   icon={<RailSettingsIcon />}
-                  onClick={() => navigate("/profile?tab=apikey")}
+                  onClick={goConfigureKey}
                   aria-label={t("chat.configure_key")}
                 />
               </Tooltip>
@@ -1587,7 +1635,7 @@ export default function ChatPage() {
             <div className="chat-sidebar-foot">
               <Button icon={<SettingOutlined />} block type="text" size="small"
                 style={{ color: "var(--fj-ink-muted)", fontSize: 12 }}
-                onClick={() => navigate("/profile?tab=apikey")}>
+                onClick={goConfigureKey}>
                 {keyStatus?.has_api_key ? `${t("chat.key_configured")} (${keyStatus.provider})` : t("chat.configure_key")}
               </Button>
             </div>

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import type { ReactNode } from "react";
 import i18n from "../i18n";
 import enTranslation from "../../public/locales/en/translation.json";
@@ -22,6 +22,12 @@ vi.mock("../api/client", () => ({
   changePassword: vi.fn(),
 }));
 
+/** 把当前 URL 渲染出来，好断言返回按钮跳去了哪。 */
+function LocationProbe() {
+  const loc = useLocation();
+  return <span data-testid="loc">{loc.pathname + loc.search}</span>;
+}
+
 function renderPage(ui: ReactNode, initialPath = "/profile") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -30,6 +36,7 @@ function renderPage(ui: ReactNode, initialPath = "/profile") {
     <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={[initialPath]}>
         {ui}
+        <LocationProbe />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -101,5 +108,47 @@ describe("ProfilePage", () => {
     expect(screen.getByText("Display name")).toBeInTheDocument();
     expect(screen.getByText("Email")).toBeInTheDocument();
     expect(screen.getByText("Joined")).toBeInTheDocument();
+  });
+
+  // ── 从 /chat 来的返回入口 ──────────────────────────────────────────
+  //
+  // API Key 面板全站只有 /chat 的三个「配置 Key」按钮进得来，所以从那儿来的人
+  // 需要一条回头路。但从头像菜单进个人中心的人不该看到它，所以判据是 from=chat。
+
+  function loginAndRender(path: string) {
+    useAuthStore.setState({
+      token: "token",
+      user: {
+        id: 1, username: "reader", email: "reader@example.com", display_name: null,
+        role: "user", is_active: true, created_at: "2026-01-10T00:00:00Z",
+      },
+    });
+    return renderPage(<ProfilePage />, path);
+  }
+
+  it("不是从 /chat 来时，不出现返回按钮", () => {
+    loginAndRender("/profile?tab=apikey");
+    expect(screen.queryByRole("button", { name: /Back to AI Q&A/ })).toBeNull();
+  });
+
+  // 承重点：必须带回原来那个会话。只跳 /chat 的话会落在空白新对话上 ——
+  // 和点顶部导航没有任何区别，这个按钮也就白加了。
+  it("从 /chat 带会话来时，返回按钮回到那个会话", () => {
+    loginAndRender("/profile?tab=apikey&from=chat&s=42");
+    fireEvent.click(screen.getByRole("button", { name: /Back to AI Q&A/ }));
+    expect(screen.getByTestId("loc").textContent).toBe("/chat?s=42");
+  });
+
+  it("从 /chat 来但没有会话（新对话未发言）时，回到 /chat", () => {
+    loginAndRender("/profile?tab=apikey&from=chat");
+    fireEvent.click(screen.getByRole("button", { name: /Back to AI Q&A/ }));
+    expect(screen.getByTestId("loc").textContent).toBe("/chat");
+  });
+
+  // s 来自地址栏，是可被随意编辑的输入。非数字不该被原样拼进跳转目标。
+  it("?s= 不是数字时退回 /chat，不把脏值拼进 URL", () => {
+    loginAndRender("/profile?tab=apikey&from=chat&s=../../evil");
+    fireEvent.click(screen.getByRole("button", { name: /Back to AI Q&A/ }));
+    expect(screen.getByTestId("loc").textContent).toBe("/chat");
   });
 });

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { Typography, Card, Tabs, List, Tag, Empty, Spin, Descriptions, Button, Space, Pagination, Input, Select, message, Alert, Form } from "antd";
-import { BookOutlined, HistoryOutlined, UserOutlined, ReadOutlined, KeyOutlined, DeleteOutlined, CheckCircleOutlined, LockOutlined } from "@ant-design/icons";
+import { BookOutlined, HistoryOutlined, UserOutlined, ReadOutlined, KeyOutlined, DeleteOutlined, CheckCircleOutlined, LockOutlined, ArrowLeftOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../stores/authStore";
 import { getBookmarks, getHistory, getApiKeyStatus, saveApiKey, deleteApiKey, changePassword } from "../api/client";
@@ -204,9 +204,28 @@ export default function ProfilePage() {
     );
   }
 
+  // 这一页的 API Key 面板全站只有 /chat 的三个「配置 Key」入口进得来，所以从那里
+  // 来的人需要一条回头路。判据用 from=chat 而不是无条件显示：从头像菜单点进个人
+  // 中心的人，看到一个「返回 AI 问答」只会莫名其妙。
+  // 带上 ?s= 一起回去，才是真的"返回"——否则落在空白新对话上，和点顶部导航没区别
+  // （sessionId 只是 ChatPage 的组件 state，离开就没了）。
+  const cameFromChat = searchParams.get("from") === "chat";
+  const backSid = searchParams.get("s");
+  const backToChat = backSid && /^\d+$/.test(backSid) ? `/chat?s=${backSid}` : "/chat";
+
   return (
     <div style={{ maxWidth: 800, margin: "24px auto" }}>
       <Space direction="vertical" size="large" style={{ width: "100%" }}>
+        {cameFromChat && (
+          <Button
+            type="link"
+            icon={<ArrowLeftOutlined />}
+            onClick={() => navigate(backToChat)}
+            style={{ paddingLeft: 0, alignSelf: "flex-start" }}
+          >
+            {t("profile.back_to_chat")}
+          </Button>
+        )}
         <Title level={3}>{t("auth.profile")}</Title>
 
         <Tabs


### PR DESCRIPTION
`/profile?tab=apikey` 全站只有 /chat 的三个「配置 Key」入口进得来，却没有回头路。

**但光加一个「返回 AI 问答」解决不了问题**：`sessionId` 此前只是 ChatPage 的组件 state（`ChatPage.tsx` 里一个裸 `useState`，没有任何 URL/存储恢复），一离开 /chat 就没了 —— 返回后会落在**空白新对话**上，和点顶部导航没有区别。

## 先让会话可寻址

- `?s=<id>` 与当前会话双向同步：点开会话、后端回传新会话 id 时写入；点新对话时清除。一律 `replace`，不然每切一次会话就往浏览历史塞一条，后退键会变得很难用。
- 挂载时按 `?s=` 恢复。链接可能是旧的（会话已删、或本就不属于自己，后端 403/404），这条路径**静默失败**并把坏 id 从地址栏清掉 —— 一进页面就弹错误提示只是噪音。
- **顺带副产品**：单条对话现在可收藏。

## 再让返回真的是"返回"

- 「配置 Key」跳转带上 `from=chat` 与当前会话；`/profile` **只在 from=chat 时**显示返回按钮（从头像菜单进个人中心的人看到它只会莫名其妙），并带 `?s=` 回去。
- `?s=` 来自地址栏、可被任意编辑，**非数字一律退回 /chat**，不原样拼进跳转目标。

## 两处避坑

- `useSearchParams` 的声明**上移到 loadSession 之前**。引用声明在自己之后的绑定会让 React Compiler 对整个组件放弃编译（#1077 里踩过 4 个 lint error，报错还落在无辜函数上）。
- 恢复调用放进 `queueMicrotask`：`loadSession` 第一句就是 `await`、实际不会同步 setState，但编译器只看调用点，会判成 `set-state-in-effect`（error 级）。

## 一条我自己没写对的断言

八条变异逐条验过会红。**其中一条最初没打红**：「静默退回」用例只查了"退回空白态"、没查"静默"，实现照样弹提示也能过。

改成 spy `message.error` 才抓得住 —— 因为 antd v5 的静态 message 在 React 19 下要靠入口那个 v5-patch 才生效，而测试不走入口，**用 DOM 文案断言恒真**。

## 验证

前端 314 用例通过（新增 9 条）；tsc / eslint / i18n ratchet / build 全绿。

**浏览器实测完整往返**：点开会话 → URL 写上 `?s=2` → 点「已配置 Key」→ 跳转带 `from=chat&s=2` → 页面出现返回按钮 → 点它回到 `/chat?s=2`，会话「什么是四圣谛？」恢复并高亮为选中行。

## 顺带查证：截图里那个自动填充不是我们的 bug

你截图里「服务商」被浏览器填成了人名。查下来 rc-select 内部输入框**本来就带 `autocomplete="off"`**（`node_modules/rc-select/lib/Selector/Input.js:42`），是 Chrome 的密码管理器主动忽略了它。antd 的 `Select` 也不接受 `autoComplete` prop（TS 直接拒）。**我们这边没有可改的地方**，所以没动。选项是固定的，填错也存不进去。