### PR TITLE
feat(chat): 模型目录加入 DeepSeek V4 Flash（可选，默认仍是 Pro）

### DIFF
--- a/backend/app/services/llm_catalog.py
+++ b/backend/app/services/llm_catalog.py
@@ -23,9 +23,17 @@ class ModelOption:
 
 # Order matters — first entry is the default when no localStorage value exists.
 # 每个模型商只保留最新的一个旗舰模型。
+#
+# DeepSeek 是这条规则唯一的例外，且是有意的：flash 不是第二个旗舰，而是同一代
+# 模型的轻快档 —— 上下文（1M）与最大输出（384K）和 pro 完全相同，价格是 1/3
+# （输入 1 vs 3、输出 2 vs 6 元/百万 token），并发上限 2500 vs 500，两者都支持
+# 思考模式。放进目录是让人能自己选着比，默认仍是 pro：换默认要先用
+# backend/eval 的 90 题量出引用准确性与幻觉率的差，没数据之前不动。
 CATALOG: list[ModelOption] = [
     ModelOption("deepseek:v4-pro", "deepseek", "deepseek-v4-pro",
                 "DeepSeek V4 Pro", "旗舰模型，复杂推理", False),
+    ModelOption("deepseek:v4-flash", "deepseek", "deepseek-v4-flash",
+                "DeepSeek V4 Flash", "同代轻快档，上下文同为 1M，价格约 1/3", False),
     ModelOption("dashscope:qwen3.6-plus", "dashscope", "qwen3.6-plus",
                 "通义千问 Qwen3.6 Plus", "阿里最新文本旗舰", False),
     ModelOption("moonshot:kimi-k2.6", "moonshot", "kimi-k2.6",

--- a/backend/tests/test_llm_catalog.py
+++ b/backend/tests/test_llm_catalog.py
@@ -124,3 +124,44 @@ def test_resolve_byok_provider_mismatch_falls_to_platform(monkeypatch):
     assert model == "deepseek-v4-pro"
     assert is_byok is False
     assert provider == "deepseek"
+
+
+# ── DeepSeek V4 Flash（可选档，默认仍是 pro）─────────────────────────────
+
+def test_flash_is_in_catalog_but_not_the_default():
+    """加 flash 的整个前提就是"默认不变"——默认路径的答案质量要等 backend/eval
+    的 90 题量出引用准确性与幻觉率的差之后再说。这条断言把这个前提钉住：
+    有人手滑把 flash 挪到第一位、或改了 DEFAULT_MODEL_ID，这里立刻红。"""
+    assert "deepseek:v4-flash" in CATALOG_BY_ID
+    assert DEFAULT_MODEL_ID == "deepseek:v4-pro"
+    assert CATALOG[0].id == "deepseek:v4-pro", "首项即默认（前端无 localStorage 时取它）"
+
+
+def test_resolve_platform_deepseek_flash(monkeypatch):
+    """flash 与 pro 同属 deepseek，平台已有的 Key 直接覆盖它 —— 加进目录就是
+    所有人立刻可用，不需要任何人配 Key。"""
+    monkeypatch.setattr(llm_module.settings, "llm_api_url", "https://api.deepseek.com/v1")
+    monkeypatch.setattr(llm_module.settings, "llm_api_key", "platform-key")
+
+    url, key, model, is_byok, provider = _resolve_with_model_override(None, "deepseek:v4-flash")
+    assert url == PROVIDER_URLS["deepseek"]
+    assert key == "platform-key"
+    assert model == "deepseek-v4-flash"   # 上游真实模型名，不是目录 id
+    assert is_byok is False
+    assert provider == "deepseek"
+
+
+def test_flash_counts_as_a_reasoning_model():
+    """两个模型都支持思考模式。_REASONING_MODEL_MARKERS 里的 "deepseek-v4" 是
+    子串匹配，所以 flash 自动落进推理分支 —— 推理额度与前端那条「正在推敲经文」
+    的进度提示都靠它。若有人把标记收窄成精确匹配，这条会红。"""
+    assert llm_module._is_reasoning_model("deepseek-v4-flash") is True
+    assert llm_module._is_reasoning_model("deepseek-v4-pro") is True
+
+
+def test_flash_gets_the_same_reasoning_headroom_as_pro():
+    """推理模型会额外拿一份 headroom，免得隐藏推理把可见答案的额度吃光。
+    flash 必须和 pro 拿到一样的待遇，否则长答案会被截断。"""
+    assert llm_module._with_reasoning_headroom("deepseek-v4-flash", 2000) == \
+           llm_module._with_reasoning_headroom("deepseek-v4-pro", 2000)
+    assert llm_module._with_reasoning_headroom("deepseek-v4-flash", 2000) > 2000


### PR DESCRIPTION
## flash 是什么

**不是第二个旗舰，是同代模型的轻快档**（官方价格页数据）：

| | flash | pro |
|---|---|---|
| 上下文 | 1M | 1M |
| 最大输出 | 384K | 384K |
| 输入（未命中缓存） | **1 元/M** | 3 元/M |
| 输出 | **2 元/M** | 6 元/M |
| 并发上限 | **2500** | 500 |
| 思考模式 | 支持 | 支持 |

能力维度（上下文、最大输出）完全相同，价格是 1/3。所以它是 `llm_catalog.py` 里"每个模型商只保留最新的一个旗舰模型"这条约定的一个**有意例外**，注释里写明了理由。

## 默认不动，这是加它的整个前提

换默认会改变模型看到什么、想多久 —— 必须先用 `backend/eval` 的 90 题（6 分类，LLM 裁判打**引用准确性 / 无幻觉 / 检索相关性 / 答案完整性**四维）量出差距。目录里放一个可选项，让人自己选着比，是零风险拿到这份数据的第一步。

有一条测试专门钉住这个前提：`test_flash_is_in_catalog_but_not_the_default` —— 有人手滑把 flash 挪到第一位或改了 `DEFAULT_MODEL_ID`，立刻红。

## 代码无需其他改动（已逐条查证）

- `_REASONING_MODEL_MARKERS` 里的 `"deepseek-v4"` 是**子串匹配**，flash 自动落进推理分支 —— 推理额度与前端「正在推敲经文」的进度提示照常工作
- `available = byok_ok or platform_ok`（`chat.py:284`）—— flash 与 pro 同属 deepseek，**平台已有的 Key 直接覆盖它**，加进目录就是所有人立刻可用
- 前端模型选择器完全数据驱动，同 provider 自动归组、共用 logo

## 验证

**四条变异测试逐条验过会红**：把 flash 挪到首位、改 `DEFAULT_MODEL_ID`、目录里误填目录 id 而非上游模型名、把推理标记收窄成精确匹配。

后端 1458 通过（3 个失败是 `test_health_check_probe.py` 的既有证书解析问题，干净树上同样失败）；前端 314 通过；ruff / tsc / eslint 全绿。

**浏览器实测**：清掉 localStorage 后默认仍是 **Pro**；下拉里 Flash 与 Pro 同组且**可选**，Kimi 仍标「需配置 Key」不可选；选中 Flash 后落盘且刷新后记住。

## 下一步（不在本 PR）

上线后你实际用几轮 flash 感受一下。要把它扶正成默认，需要 90 题的 A/B 数据 —— 目前有两个障碍：`run_eval.py` 没有 `--model` 开关（模型从 `settings.llm_model` 读），且我本地 `DEEPSEEK_API_KEY` 是空的。