### PR TITLE
style(chat): 模型下拉去掉 provider 分组，收紧行高并放开弹层宽度

### DIFF
--- a/frontend/src/components/ChatModelSelector.tsx
+++ b/frontend/src/components/ChatModelSelector.tsx
@@ -43,12 +43,6 @@ interface SelectOption {
   disabled?: boolean;
 }
 
-interface SelectGroup {
-  label: string;
-  title: string;
-  options: SelectOption[];
-}
-
 function buildLabel(model: ChatModelOption, t: TFunction): React.ReactNode {
   const suffix = model.available ? "" : t("chat.model_requires_key");
   const text = `${model.label}${suffix}`;
@@ -73,27 +67,19 @@ function buildLabel(model: ChatModelOption, t: TFunction): React.ReactNode {
   );
 }
 
-function groupByProvider(models: ChatModelOption[], t: TFunction): SelectGroup[] {
-  const groups = new Map<string, ChatModelOption[]>();
-  for (const m of models) {
-    const arr = groups.get(m.provider) ?? [];
-    arr.push(m);
-    groups.set(m.provider, arr);
-  }
-  const result: SelectGroup[] = [];
-  for (const [provider, items] of groups) {
-    result.push({
-      label: provider,
-      title: provider,
-      options: items.map((m) => ({
-        value: m.id,
-        label: buildLabel(m, t),
-        title: m.description,
-        disabled: !m.available,
-      })),
-    });
-  }
-  return result;
+/** 扁平列表，不按 provider 分组。
+ *
+ * 原先分组的两个代价都不小：分组标题直接显示的是原始 provider id（deepseek /
+ * dashscope 这种机器名），5 个模型要占 9 行；而 antd 会给分组内的选项额外加一段
+ * 左缩进（.ant-select-item-option-grouped），那正是下拉左侧那条空白。
+ * 每个选项前面已经有厂商 logo，provider 这一层信息并没有丢。 */
+function buildOptions(models: ChatModelOption[], t: TFunction): SelectOption[] {
+  return models.map((m) => ({
+    value: m.id,
+    label: buildLabel(m, t),
+    title: m.description,
+    disabled: !m.available,
+  }));
 }
 
 export default function ChatModelSelector({ value, onChange }: ChatModelSelectorProps) {
@@ -131,20 +117,24 @@ export default function ChatModelSelector({ value, onChange }: ChatModelSelector
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const groupedOptions = useMemo<SelectGroup[]>(() => {
+  const options = useMemo<SelectOption[]>(() => {
     if (!models) return [];
-    return groupByProvider(models, t);
+    return buildOptions(models, t);
   }, [models, t]);
 
   return (
     <Select
       size="small"
       style={{ minWidth: 180 }}
+      // 弹层不跟随触发器宽度：触发器只有 180px，跟随会把「通义千问 Qwen3.6 Plus」
+      // 「Kimi K2.6（需配置 Key）」这类较长的标签截断。
+      popupMatchSelectWidth={false}
+      classNames={{ popup: { root: "chat-model-popup" } }}
       loading={loading}
       disabled={loading}
       value={value}
       onChange={onChange}
-      options={groupedOptions}
+      options={options}
     />
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -430,6 +430,17 @@ em {
   background: rgba(217, 208, 193, 0.3);
 }
 
+/* 模型选择下拉：收紧行高与左右内边距。antd 默认的 5px/12px 是给正文尺寸的列表
+   准备的，而这里是 size="small" 的工具栏控件，跟着输入框走更协调。 */
+.chat-model-popup .ant-select-item {
+  min-height: 0;
+  padding: 5px 10px;
+  line-height: 1.35;
+}
+.chat-model-popup {
+  min-width: 210px;
+}
+
 /* 侧栏右缘的分隔线。
    用 ::after 而不是 border-right：全局是 border-box，加边框会把内容盒挤掉
    1px，48px 轨里 34px 的按钮就不再正中（实测偏移会从 0 变成 -0.5）。绝对定位


### PR DESCRIPTION
下拉里 **5 个模型占了 9 行**，其中 4 行是分组标题 —— 而标题直接显示的是**原始 provider id**（`deepseek` / `dashscope` / `moonshot` / `zhipu` 这种机器名），对读者没有意义。

## 左侧那段空白的成因（查证过，不是猜的）

来自分组：antd 给分组内的选项加了 `paddingInlineStart = controlPaddingHorizontal × 2`（12 → **24px**），见 `antd/es/select/style/dropdown.js:115`。去掉分组后回到 10px。

## 改了什么

| | 之前 | 现在 |
|---|---|---|
| 行数 | 9（含 4 行机器名标题） | **5** |
| 首项左内边距 | 24px | **10px** |
| 弹层宽度 | 跟随触发器 180px，长标签被截断 | **289px**，零截断 |
| 是否滚动 | 是 | 否 |

每个选项前面本来就有厂商 logo，**provider 这一层信息并没有随分组一起丢**。

两个实现细节：
- `popupMatchSelectWidth={false}` 解开宽度 —— 触发器只有 180px，跟随它会把「通义千问 Qwen3.6 Plus（需配置 Key）」「Kimi K2.6（需配置 Key）」截断
- 用 `classNames={{ popup: { root } }}` 而不是 `popupClassName`：后者在 antd 5.29 已标 deprecated（`select/index.d.ts:50`）

## 验证

浏览器实测（桩目录与生产的 5 个模型完全一致）：分组标题 **0** 个、9 行降到 **5** 行不再滚动、首项左内边距 **24→10px**、弹层 **289px** 宽（触发器仍 180px），**五个标签全部不再截断**（含之前被切掉的「通义千问 Qwen3.6 Plus（需配置 Key）」）。

前端 314 用例通过；tsc / eslint / build 全绿。

这是纯视觉改动，没有可写的行为断言 —— jsdom 不解析样式表、也算不出弹层布局，所以靠实测数字与截图，没假装拿测试盖章。

## 取舍说明

模型只有 5 个时扁平列表更好读；若将来目录涨到十几个，分组会重新变得有价值 —— 到那时应该恢复分组，但要把 provider id 映射成可读名称（DeepSeek / 阿里云 / Moonshot / 智谱），而不是直接显示机器名。