### PR TITLE
fix(chat): 额度说法与实际对齐——注册用户是 200 次，不是文案写的 10 次

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -324,7 +324,7 @@
   "profile.password_changed": "Password changed. Other devices have been signed out.",
   "profile.password_too_frequent": "Too many attempts. Please try again later.",
   "profile.password_change_failed": "The current password is incorrect or the new password does not meet requirements",
-  "profile.byok_description": "Add your own AI API key for unlimited AI Buddhist Q&A. Without a key, the platform free quota applies (10 requests per day). Keys are stored with AES encryption and used only for AI API calls.",
+  "profile.byok_description": "Signed-in accounts get {{limit}} free questions a day — plenty for regular study. Adding your own AI API key lifts that limit, but the usage is billed to your key. Keys are stored with AES encryption and used only for AI API calls.",
   "profile.api_key_configured": "Configured: {{provider}} · {{preview}}",
   "profile.delete": "Delete",
   "profile.provider": "Provider",
@@ -1523,5 +1523,8 @@
   "chat.save": "Save",
   "chat.search_sessions_label": "Search conversations",
   "chat.recent_chats": "Recent chats",
-  "profile.back_to_chat": "Back to AI Q&A"
+  "profile.back_to_chat": "Back to AI Q&A",
+  "profile.byok_description_generic": "Adding your own AI API key lifts the platform's free daily limit, but the usage is billed to your key. Keys are stored with AES encryption and used only for AI API calls.",
+  "chat.quota_low": "Your free daily quota is running low — {{remaining}} left.",
+  "chat.quota_low_action": "Add your own API key to lift the limit"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -324,7 +324,7 @@
   "profile.password_changed": "密碼已修改，其他裝置上的登入已失效",
   "profile.password_too_frequent": "操作過於頻繁，請稍後再試",
   "profile.password_change_failed": "目前密碼不正確或新密碼不合要求",
-  "profile.byok_description": "配置自己的 AI API Key，即可無限使用 AI 佛典問答功能。不配置則使用平臺免費額度（每日 10 次）。Key 經 AES 加密儲存，僅用於呼叫 AI 介面。",
+  "profile.byok_description": "登入後每日可免費問答 {{limit}} 次，日常研讀足夠用。設定自己的 AI API Key 後不再受此限制，但呼叫費用由你的 Key 承擔。Key 經 AES 加密儲存，僅用於呼叫 AI 介面。",
   "profile.api_key_configured": "已配置: {{provider}} · {{preview}}",
   "profile.delete": "刪除",
   "profile.provider": "服務商",
@@ -1523,5 +1523,8 @@
   "chat.save": "儲存",
   "chat.search_sessions_label": "搜尋對話",
   "chat.recent_chats": "最近聊天",
-  "profile.back_to_chat": "返回 AI 問答"
+  "profile.back_to_chat": "返回 AI 問答",
+  "profile.byok_description_generic": "設定自己的 AI API Key 後，問答次數不再受平台免費額度限制，但呼叫費用由你的 Key 承擔。Key 經 AES 加密儲存，僅用於呼叫 AI 介面。",
+  "chat.quota_low": "今日免費額度快用完了，剩餘 {{remaining}} 次。",
+  "chat.quota_low_action": "設定自己的 API Key 可不受此限制"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -324,7 +324,7 @@
   "profile.password_changed": "密码已修改，其他设备上的登录已失效",
   "profile.password_too_frequent": "操作过于频繁，请稍后再试",
   "profile.password_change_failed": "当前密码不正确或新密码不合要求",
-  "profile.byok_description": "配置自己的 AI API Key，即可无限使用 AI 佛典问答功能。不配置则使用平台免费额度（每日 10 次）。Key 经 AES 加密存储，仅用于调用 AI 接口。",
+  "profile.byok_description": "登录后每日可免费问答 {{limit}} 次，日常研读足够用。配置自己的 AI API Key 后不再受此限制，但调用费用由你的 Key 承担。Key 经 AES 加密存储，仅用于调用 AI 接口。",
   "profile.api_key_configured": "已配置: {{provider}} · {{preview}}",
   "profile.delete": "删除",
   "profile.provider": "服务商",
@@ -1523,5 +1523,8 @@
   "chat.save": "保存",
   "chat.search_sessions_label": "搜索会话",
   "chat.recent_chats": "最近聊天",
-  "profile.back_to_chat": "返回 AI 问答"
+  "profile.back_to_chat": "返回 AI 问答",
+  "profile.byok_description_generic": "配置自己的 AI API Key 后，问答次数不再受平台免费额度限制，但调用费用由你的 Key 承担。Key 经 AES 加密存储，仅用于调用 AI 接口。",
+  "chat.quota_low": "今日免费额度快用完了，剩余 {{remaining}} 次。",
+  "chat.quota_low_action": "配置自己的 API Key 可不受此限制"
 }

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -697,3 +697,39 @@ describe("会话与 URL", () => {
     });
   });
 });
+
+// ── 额度将尽提醒（登录用户此前什么都看不到）────────────────────────────
+
+describe("额度提醒", () => {
+  function loggedIn(quota: { limit: number; used: number; remaining: number; has_byok: boolean }) {
+    vi.mocked(getChatQuota).mockResolvedValue(quota);
+    return renderPage();
+  }
+
+  // 承重点：阈值以上不该出现。常驻一个「今日剩余 197 次」是纯噪音，
+  // 只断言"快用完时会显示"的话，一个无条件常显的实现照样能过。
+  it("额度充足时不打扰（197/200 不提示）", async () => {
+    loggedIn({ limit: 200, used: 3, remaining: 197, has_byok: false });
+    await screen.findByText("「三毒」指的是哪三种毒？");
+    expect(screen.queryByText(/额度快用完/)).toBeNull();
+  });
+
+  it("剩余降到阈值内时提醒（15 次）", async () => {
+    loggedIn({ limit: 200, used: 185, remaining: 15, has_byok: false });
+    expect(await screen.findByText(/今日免费额度快用完了，剩余 15 次/)).toBeInTheDocument();
+  });
+
+  it("剩余极少时升级为 error 级", async () => {
+    const { container } = loggedIn({ limit: 200, used: 198, remaining: 2, has_byok: false });
+    await screen.findByText(/剩余 2 次/);
+    expect(container.querySelector(".ant-alert-error")).not.toBeNull();
+  });
+
+  // 自带 Key 的用户后端返回 remaining = -1（不限次）。若实现用 `remaining <= 20`
+  // 判定，-1 会满足条件 —— 给一个根本没有限额的人弹「额度快用完」。
+  it("承重点: 自带 Key（remaining 为 -1）不弹额度提醒", async () => {
+    loggedIn({ limit: 200, used: 500, remaining: -1, has_byok: true });
+    await screen.findByText("「三毒」指的是哪三种毒？");
+    expect(screen.queryByText(/额度快用完/)).toBeNull();
+  });
+});

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -74,6 +74,10 @@ import {
 } from "../api/chatAttachments";
 import { useAuthStore, type UserProfile } from "../stores/authStore";
 
+// 登录用户的额度提示只在快用完时出现。常驻一个「今日剩余 198 次」是纯噪音 ——
+// 而毫无预警地撞上上限、直接吃一个错误，才是真正会让人懵的那种体验。
+const LOW_QUOTA_THRESHOLD = 20;
+
 const MAX_ATTACHMENTS = 5;
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 const ATTACHMENT_ACCEPT = ".pdf,.txt,.md,.docx,.csv,.html,.htm";
@@ -1805,6 +1809,20 @@ export default function ChatPage() {
               <Alert
                 message={<span>{t("chat.quota_info", { limit: quota.limit, remaining: quota.remaining })}<a onClick={() => navigate("/login")}>{t("chat.login")}</a>{t("chat.login_quota_hint")}</span>}
                 type={quota.remaining <= 2 ? "warning" : "info"} showIcon closable
+                style={{ marginBottom: 8, fontSize: 12 }}
+              />
+            )}
+            {/* 登录用户此前在这里什么都看不到 —— 撞到上限是毫无预警的。
+                remaining 对自带 Key 的用户是 -1，所以 >= 0 已经把他们排除掉了。 */}
+            {user && quota && quota.remaining >= 0 && quota.remaining <= LOW_QUOTA_THRESHOLD && (
+              <Alert
+                message={
+                  <span>
+                    {t("chat.quota_low", { remaining: quota.remaining })}
+                    <a onClick={goConfigureKey}>{t("chat.quota_low_action")}</a>
+                  </span>
+                }
+                type={quota.remaining <= 3 ? "error" : "warning"} showIcon closable
                 style={{ marginBottom: 8, fontSize: 12 }}
               />
             )}

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -10,11 +10,13 @@ import { useAuthStore } from "../stores/authStore";
 import {
   getApiKeyStatus,
   getBookmarks,
+  getChatQuota,
   getHistory,
 } from "../api/client";
 
 vi.mock("../api/client", () => ({
   getApiKeyStatus: vi.fn(),
+  getChatQuota: vi.fn(),
   getBookmarks: vi.fn(),
   getHistory: vi.fn(),
   saveApiKey: vi.fn(),
@@ -67,6 +69,9 @@ describe("ProfilePage", () => {
       model: null,
       key_preview: null,
     });
+    vi.mocked(getChatQuota).mockResolvedValue({
+      limit: 200, used: 3, remaining: 197, has_byok: false,
+    });
     vi.mocked(getBookmarks).mockResolvedValue({ total: 0, page: 1, size: 20, items: [] });
     vi.mocked(getHistory).mockResolvedValue({ total: 0, page: 1, size: 20, items: [] });
     useAuthStore.setState({ token: null, user: null });
@@ -108,6 +113,44 @@ describe("ProfilePage", () => {
     expect(screen.getByText("Display name")).toBeInTheDocument();
     expect(screen.getByText("Email")).toBeInTheDocument();
     expect(screen.getByText("Joined")).toBeInTheDocument();
+  });
+
+  // ── BYOK 说明里的额度数字 ─────────────────────────────────────────
+  //
+  // 这段文案原先硬编码「每日 10 次」——那是**匿名**用户的限额，而这个页面只有
+  // 登录用户看得到（他们的实际上限是 200）。少说了 20 倍，还是注册用户唯一能
+  // 看到额度的地方。根因是数字在翻译文件和后端常量里各写了一处。
+
+  it("额度数字来自接口，不是翻译文件里的写死值", async () => {
+    useAuthStore.setState({
+      token: "token",
+      user: {
+        id: 1, username: "reader", email: "reader@example.com", display_name: null,
+        role: "user", is_active: true, created_at: "2026-01-10T00:00:00Z",
+      },
+    });
+    vi.mocked(getChatQuota).mockResolvedValue({
+      limit: 999, used: 0, remaining: 999, has_byok: false,   // 故意取一个不可能写死的值
+    });
+    renderPage(<ProfilePage />, "/profile?tab=apikey");
+
+    expect(await screen.findByText(/999 free questions a day/)).toBeInTheDocument();
+  });
+
+  it("拿不到额度时退回不带数字的说法，而不是显示错的数字", async () => {
+    useAuthStore.setState({
+      token: "token",
+      user: {
+        id: 1, username: "reader", email: "reader@example.com", display_name: null,
+        role: "user", is_active: true, created_at: "2026-01-10T00:00:00Z",
+      },
+    });
+    vi.mocked(getChatQuota).mockRejectedValue(new Error("boom"));
+    const { container } = renderPage(<ProfilePage />, "/profile?tab=apikey");
+
+    await screen.findByText(/Adding your own AI API key lifts the platform/);
+    // 兜底文案里一个具体次数都不该出现
+    expect(container.textContent).not.toMatch(/\d+\s*(free questions|次)/);
   });
 
   // ── 从 /chat 来的返回入口 ──────────────────────────────────────────

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -6,7 +6,7 @@ import { Typography, Card, Tabs, List, Tag, Empty, Spin, Descriptions, Button, S
 import { BookOutlined, HistoryOutlined, UserOutlined, ReadOutlined, KeyOutlined, DeleteOutlined, CheckCircleOutlined, LockOutlined, ArrowLeftOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../stores/authStore";
-import { getBookmarks, getHistory, getApiKeyStatus, saveApiKey, deleteApiKey, changePassword } from "../api/client";
+import { getBookmarks, getHistory, getApiKeyStatus, getChatQuota, saveApiKey, deleteApiKey, changePassword } from "../api/client";
 
 const { Title } = Typography;
 
@@ -111,6 +111,15 @@ export default function ProfilePage() {
     value: p.value,
     label: t(p.labelKey),
   }));
+
+  // 额度上限从接口取，不写死在翻译文件里。此前 profile.byok_description 里硬编码
+  // 的「每日 10 次」是匿名用户的限额，而这个页面只有登录用户看得到（他们的实际
+  // 上限是 200）—— 数字与 FREE_DAILY_LIMIT_USER 各写一处，迟早再次漂移。
+  const { data: quota } = useQuery({
+    queryKey: ["chat-quota"],
+    queryFn: getChatQuota,
+    enabled: !!token,
+  });
 
   const { data: keyStatus, refetch: refetchKey } = useQuery({
     queryKey: ["apiKeyStatus"],
@@ -356,7 +365,9 @@ export default function ProfilePage() {
                   <Space direction="vertical" size="middle" style={{ width: "100%" }}>
                     <Alert
                       message="Bring Your Own Key (BYOK)"
-                      description={t("profile.byok_description")}
+                      description={quota
+                        ? t("profile.byok_description", { limit: quota.limit })
+                        : t("profile.byok_description_generic")}
                       type="info"
                       showIcon
                     />


### PR DESCRIPTION
个人中心 BYOK 面板告诉用户「不配置则使用平台免费额度（**每日 10 次**）」，但**这个页面只有登录用户看得到**，而他们的实际上限是 `FREE_DAILY_LIMIT_USER = 200`。10 是**匿名**用户的限额。

**少说了 20 倍**，还可能推着人去配一把根本不需要的 Key。

更糟的是：这句错话是注册用户**唯一**能看到额度的地方 —— `/chat` 里那条额度提示的条件是 `!user`，只对游客显示。

## 三处一起改

**① 额度数字改从 `/chat/quota` 取，不再写死在翻译文件里。**

根因就是同一个数字在后端常量和翻译文件里各写了一处 —— 只改文案的话，下次改常量还会再漂移一遍。接口拿不到时退回一句**不带数字**的说法，而不是显示一个可能错的数字。

**② 登录用户在剩余 ≤ 20 时才出现「额度将尽」提醒。**

不做常驻计数器：「今日剩余 197 次」是纯噪音，而毫无预警撞上上限、直接吃一个错误，才是真正会让人懵的体验。

自带 Key 的用户后端返回 `remaining = -1`，靠 `remaining >= 0` 排除 —— **只写 `<= 20` 的话会给一个根本没有限额的人弹「额度快用完」**。这条有专门的承重测试。

**③「无限使用」改成「不再受此限制，但调用费用由你的 Key 承担」** —— 自带 Key 确实不限平台次数，但那不是白送的。

## 现在三档说法是准确的

| 身份 | 每日上限 | 依据 |
|---|---|---|
| 未登录 | 10 | IP，Redis 24h TTL |
| 已登录（用平台 Key） | 200 | user_id，Postgres |
| 已登录 + 自带 Key | 不限（费用自付） | 跳过检查 |

## 验证

**三条变异测试逐条验过会红**：提醒条改成无条件常显、判定去掉 `remaining >= 0`（把 -1 也算进阈值）、文案退回写死数字。

前端 320 用例通过（新增 6 条）；tsc / eslint / i18n ratchet / build 全绿。

**浏览器实测**：登录 + 剩余 12 → 出现 warning 级「今日免费额度快用完了，剩余 12 次」；个人中心显示「每日可免费问答 **200** 次」，页面上再无「10 次」字样；上一轮的返回按钮未受影响。

## 数字本身没动

200 和 10 我认为都合理，且没有数据支持调整（我读不到生产使用分布）。粗算 Pro 单轮约 0.036 元，一个用户用满 200 次约 7 元/天 —— 以当前真实流量不成问题，但**注册用户涨起来时这个数字要重新算**。刚上线的 Flash 是现成缓冲：同样 200 次，成本 1/3。