### PR TITLE
style(chat): 模型描述只讲特点，不提价格

### DIFF
--- a/backend/app/services/llm_catalog.py
+++ b/backend/app/services/llm_catalog.py
@@ -32,8 +32,11 @@ class ModelOption:
 CATALOG: list[ModelOption] = [
     ModelOption("deepseek:v4-pro", "deepseek", "deepseek-v4-pro",
                 "DeepSeek V4 Pro", "旗舰模型，复杂推理", False),
+    # 描述里不提价格：这是给读者选模型用的提示，价格是运营侧的事，摆在选择器里
+    # 只会让人以为便宜的那个"缩水"了。实际上两者规格相同，所以说明这一点最有用。
+    # 也不写"更快"——名字里的 Flash 已经是厂商的定位，而我们没有实测数据支撑。
     ModelOption("deepseek:v4-flash", "deepseek", "deepseek-v4-flash",
-                "DeepSeek V4 Flash", "同代轻快档，上下文同为 1M，价格约 1/3", False),
+                "DeepSeek V4 Flash", "同代轻量档，上下文同为 1M", False),
     ModelOption("dashscope:qwen3.6-plus", "dashscope", "qwen3.6-plus",
                 "通义千问 Qwen3.6 Plus", "阿里最新文本旗舰", False),
     ModelOption("moonshot:kimi-k2.6", "moonshot", "kimi-k2.6",

--- a/backend/tests/test_llm_catalog.py
+++ b/backend/tests/test_llm_catalog.py
@@ -165,3 +165,12 @@ def test_flash_gets_the_same_reasoning_headroom_as_pro():
     assert llm_module._with_reasoning_headroom("deepseek-v4-flash", 2000) == \
            llm_module._with_reasoning_headroom("deepseek-v4-pro", 2000)
     assert llm_module._with_reasoning_headroom("deepseek-v4-flash", 2000) > 2000
+
+
+def test_model_descriptions_carry_no_pricing():
+    """描述是给读者选模型用的提示，不是价目表。摆价格在选择器里只会让人以为
+    便宜的那个"缩水"了 —— 而两者规格其实相同。"""
+    import re
+    for opt in CATALOG:
+        assert not re.search(r"价格|费用|元|/\s*3|便宜|免费", opt.description), \
+            f"{opt.id} 的描述里出现了价格字样: {opt.description!r}"


### PR DESCRIPTION
Flash 的描述原本写着「同代轻快档，上下文同为 1M，**价格约 1/3**」。

价格是运营侧的事，摆在模型选择器里只会让人**以为便宜的那个「缩水」了** —— 而两者规格其实完全相同（上下文 1M、最大输出 384K、都支持思考模式）。说明这一点，才是选模型时真正有用的信息。

也**没写「更快」**：名字里的 Flash 已经是厂商的定位，而我们没有实测数据支撑这个说法 —— 这一轮我在延迟推测上已经被数据推翻过两次。

改成：**「同代轻量档，上下文同为 1M」**

价格依据留在代码注释里，那是给维护者看的。

## 加了一条守卫

`test_model_descriptions_carry_no_pricing` —— 任何模型描述里出现「价格/费用/元/便宜/免费」等字样即失败。变异测试验过：把「价格约 1/3」塞回去立刻红。

## 验证

后端 1459 通过（3 个失败是 `test_health_check_probe.py` 的既有证书解析问题，干净树上同样失败）；ruff 干净。

纯文案改动，只动一个字符串加一条测试。