### PR TITLE
feat(models): 目录扩到国际三家，下拉只列当前真能用的

### DIFF
--- a/backend/app/services/llm_catalog.py
+++ b/backend/app/services/llm_catalog.py
@@ -50,6 +50,16 @@ CATALOG: list[ModelOption] = [
                 "Kimi K3", "Moonshot 最新旗舰，上下文 1M", False),
     ModelOption("zhipu:glm-5.2", "zhipu", "glm-5.2",
                 "智谱 GLM-5.2", "智谱最新旗舰，上下文 1M", False),
+    # 国际三家。同样只对自带 Key 的用户可选。
+    # 名单能放开加，是因为选择器只列当前真能用的模型 —— 加一个厂商不会让下拉变长。
+    ModelOption("openai:gpt-5.6-sol", "openai", "gpt-5.6-sol",
+                "GPT-5.6 Sol", "OpenAI 旗舰，复杂推理", False),
+    ModelOption("anthropic:claude-opus-5", "anthropic", "claude-opus-5",
+                "Claude Opus 5", "Anthropic 旗舰", False),
+    # Gemini 3 系列没有 Pro 档（官方文档确认），最新的稳定版就是 3.6 Flash；
+    # 3.1 Pro 尚是 preview，不进目录。
+    ModelOption("gemini:gemini-3.6-flash", "gemini", "gemini-3.6-flash",
+                "Gemini 3.6 Flash", "Google 最新稳定版", False),
 ]
 
 CATALOG_BY_ID = {opt.id: opt for opt in CATALOG}

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -61,7 +61,8 @@ PROVIDER_DEFAULT_MODELS = {
     "siliconflow": "Qwen/Qwen2.5-7B-Instruct",
     # 国际
     "openai": "gpt-5.6-luna",
-    "gemini": "gemini-2.0-flash",
+    # gemini-2.0 系列 2026-06 已停服（官方文档标 Shut down）
+    "gemini": "gemini-3.6-flash",
     "groq": "llama-3.3-70b-versatile",
     "mistral": "mistral-small-latest",
     "xai": "grok-2-latest",

--- a/backend/tests/test_llm_catalog.py
+++ b/backend/tests/test_llm_catalog.py
@@ -176,14 +176,23 @@ def test_model_descriptions_carry_no_pricing():
             f"{opt.id} 的描述里出现了价格字样: {opt.description!r}"
 
 
-def test_catalog_and_provider_defaults_agree_on_generation():
-    """同一个厂商的型号在三处各写一份：CATALOG（/chat 的选择器）、
-    PROVIDER_DEFAULT_MODELS（自带 Key 未指定模型时的默认）、以及前端个人中心的
-    建议列表。前两处在同一个仓、同一门语言里，没有理由不一致 —— 只更新其中一处，
-    自带 Key 的用户会拿到和界面上写的完全不同的模型。
+# 目录与默认值可以不同档，但必须在这里登记理由 —— 空着的分歧一律视为"改了一处
+# 忘了另一处"。登记项本身也会被校验：写了但实际相等，说明理由已过期。
+INTENTIONAL_TIER_DIFFERENCES = {
+    # 目录是"用户主动挑"的清单，给旗舰；默认值是"没挑时替他决定"，钱是用户自己
+    # 出的，给经济档更稳妥。BYOK 用户没在选择器里指定模型时走的就是默认值。
+    "openai": ("gpt-5.6-sol", "gpt-5.6-luna"),
+    # 同理：Opus 是旗舰，Sonnet 是主力档。没主动挑模型的人不该被默认送进最贵的那档。
+    "anthropic": ("claude-opus-5", "claude-sonnet-5"),
+}
 
-    只比对非 deepseek 的三家：deepseek 在 CATALOG 里刻意有 pro/flash 两档，而默认
-    值只能是一个，本来就不该相等。
+
+def test_catalog_and_provider_defaults_agree_on_generation():
+    """同一个厂商的型号在 CATALOG（/chat 的选择器）与 PROVIDER_DEFAULT_MODELS
+    （自带 Key 未指定模型时的默认）里各写一份。两处都在同一个仓、同一门语言里，
+    只更新其中一处，自带 Key 的用户会拿到和界面上写的完全不同的模型。
+
+    deepseek 不比：它在 CATALOG 里刻意有 pro/flash 两档，而默认值只能是一个。
     """
     from app.services.llm_client import PROVIDER_DEFAULT_MODELS
 
@@ -191,10 +200,27 @@ def test_catalog_and_provider_defaults_agree_on_generation():
         if opt.provider == "deepseek":
             continue
         default = PROVIDER_DEFAULT_MODELS.get(opt.provider)
+        expected = INTENTIONAL_TIER_DIFFERENCES.get(opt.provider)
+        if expected:
+            assert (opt.model, default) == expected, (
+                f"{opt.provider} 登记了有意的档位差异 {expected}，但实际是 "
+                f"({opt.model!r}, {default!r}) —— 版本变了就把登记项一起更新"
+            )
+            continue
         assert default == opt.model, (
             f"{opt.provider}: 选择器写的是 {opt.model!r}，"
-            f"而 PROVIDER_DEFAULT_MODELS 写的是 {default!r}"
+            f"而 PROVIDER_DEFAULT_MODELS 写的是 {default!r}。"
+            f"若这是有意的档位差异，请登记进 INTENTIONAL_TIER_DIFFERENCES 并写明理由"
         )
+
+
+def test_registered_tier_differences_are_still_differences():
+    """登记表里的项若已变成相等，说明那条理由过期了 —— 及时删掉，别让豁免长草。"""
+    from app.services.llm_client import PROVIDER_DEFAULT_MODELS
+
+    for provider, (cat, default) in INTENTIONAL_TIER_DIFFERENCES.items():
+        assert cat != default, f"{provider} 的登记项两边相同，已无差异可豁免"
+        assert PROVIDER_DEFAULT_MODELS.get(provider) == default
 
 
 def test_one_entry_per_provider_except_deepseek():

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1526,5 +1526,6 @@
   "profile.back_to_chat": "Back to AI Q&A",
   "profile.byok_description_generic": "Adding your own AI API key lifts the platform's free daily limit, but the usage is billed to your key. Keys are stored with AES encryption and used only for AI API calls.",
   "chat.quota_low": "Your free daily quota is running low — {{remaining}} left.",
-  "chat.quota_low_action": "Add your own API key to lift the limit"
+  "chat.quota_low_action": "Add your own API key to lift the limit",
+  "chat.configure_other_models": "Use another provider…"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1526,5 +1526,6 @@
   "profile.back_to_chat": "返回 AI 問答",
   "profile.byok_description_generic": "設定自己的 AI API Key 後，問答次數不再受平台免費額度限制，但呼叫費用由你的 Key 承擔。Key 經 AES 加密儲存，僅用於呼叫 AI 介面。",
   "chat.quota_low": "今日免費額度快用完了，剩餘 {{remaining}} 次。",
-  "chat.quota_low_action": "設定自己的 API Key 可不受此限制"
+  "chat.quota_low_action": "設定自己的 API Key 可不受此限制",
+  "chat.configure_other_models": "設定其他廠商模型…"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1526,5 +1526,6 @@
   "profile.back_to_chat": "返回 AI 问答",
   "profile.byok_description_generic": "配置自己的 AI API Key 后，问答次数不再受平台免费额度限制，但调用费用由你的 Key 承担。Key 经 AES 加密存储，仅用于调用 AI 接口。",
   "chat.quota_low": "今日免费额度快用完了，剩余 {{remaining}} 次。",
-  "chat.quota_low_action": "配置自己的 API Key 可不受此限制"
+  "chat.quota_low_action": "配置自己的 API Key 可不受此限制",
+  "chat.configure_other_models": "配置其他厂商模型…"
 }

--- a/frontend/src/components/ChatModelSelector.test.tsx
+++ b/frontend/src/components/ChatModelSelector.test.tsx
@@ -1,0 +1,119 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ChatModelSelector from "./ChatModelSelector";
+import { fetchChatModels, type ChatModelOption } from "../api/chatModels";
+
+vi.mock("../api/chatModels", async () => {
+  const actual = await vi.importActual<typeof import("../api/chatModels")>("../api/chatModels");
+  return { ...actual, fetchChatModels: vi.fn() };
+});
+
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false, media: query, onchange: null,
+      addListener: () => {}, removeListener: () => {},
+      addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+});
+
+function model(over: Partial<ChatModelOption> & { id: string }): ChatModelOption {
+  return {
+    provider: "deepseek", label: over.id, description: "", vision: false,
+    available: true, requires_byok: false, ...over,
+  };
+}
+
+/** 目录里多数厂商没有平台 Key，所以 available 为假的是常态而非例外。 */
+const CATALOG: ChatModelOption[] = [
+  model({ id: "deepseek:v4-pro", label: "DeepSeek V4 Pro" }),
+  model({ id: "deepseek:v4-flash", label: "DeepSeek V4 Flash" }),
+  model({ id: "moonshot:kimi-k3", label: "Kimi K3", provider: "moonshot", available: false, requires_byok: true }),
+  model({ id: "openai:gpt-5.6-sol", label: "GPT-5.6 Sol", provider: "openai", available: false, requires_byok: true }),
+  model({ id: "gemini:gemini-3.6-flash", label: "Gemini 3.6 Flash", provider: "gemini", available: false, requires_byok: true }),
+];
+
+async function openDropdown() {
+  const { container } = render(
+    <ChatModelSelector value="deepseek:v4-pro" onChange={onChange} onConfigureKey={onConfigureKey} />,
+  );
+  await waitFor(() => {
+    expect(container.querySelector(".ant-select-selector")).not.toBeNull();
+  });
+  fireEvent.mouseDown(container.querySelector(".ant-select-selector")!);
+  await waitFor(() => {
+    expect(document.querySelectorAll(".ant-select-item-option").length).toBeGreaterThan(0);
+  });
+  return container;
+}
+
+/** 下拉里实际列出的文案。已选项也印着同样的文字，所以断言必须限定在下拉内。 */
+function optionTexts(): string[] {
+  return [...document.querySelectorAll(".ant-select-item-option-content")]
+    .map((e) => e.textContent?.trim() ?? "");
+}
+
+const onChange = vi.fn();
+const onConfigureKey = vi.fn();
+
+beforeEach(() => {
+  onChange.mockClear();
+  onConfigureKey.mockClear();
+  vi.mocked(fetchChatModels).mockResolvedValue(CATALOG);
+});
+
+describe("ChatModelSelector", () => {
+  // 承重点。改之前 5 项里只有 2 项能点；目录还要继续加厂商，全列出来会变成
+  // 「10 项里 2 项能点」——那不是"能力更全"，是把下拉变成一排点不动的灰条。
+  it("只列当前真能用的模型，不可用的不出现在列表里", async () => {
+    await openDropdown();
+    // 断言必须限定在下拉内：已选项 .ant-select-selection-item 上也印着同样的文案，
+    // 用 screen.getByText 会撞上两个节点。
+    const listed = optionTexts();
+    expect(listed).toEqual([
+      "DeepSeek V4 Pro",
+      "DeepSeek V4 Flash",
+      "配置其他厂商模型…",
+    ]);
+  });
+
+  it("入口排在所有模型之后", async () => {
+    await openDropdown();
+    const listed = optionTexts();
+    expect(listed[listed.length - 1]).toContain("配置其他厂商模型");
+  });
+
+  // 承重点。末项不是模型：若不拦，它的哨兵值会被当成 modelId 写进 localStorage
+  // 并发给后端 —— 后端查不到这个 id，会静默退回默认模型，用户看到的选择器却显示
+  // 「配置其他厂商模型…」。
+  it("承重点: 点末项只跳转，不当作模型选中", async () => {
+    await openDropdown();
+    fireEvent.click(screen.getByText("配置其他厂商模型…"));
+    await waitFor(() => {
+      expect(onConfigureKey).toHaveBeenCalledTimes(1);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("点真模型正常回传 id", async () => {
+    await openDropdown();
+    fireEvent.click(screen.getByText("DeepSeek V4 Flash"));
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("deepseek:v4-flash");
+    });
+    expect(onConfigureKey).not.toHaveBeenCalled();
+  });
+
+  // 用户配了 Kimi 的 Key 之后，后端把 available 翻成真 —— 它就该出现在列表里。
+  // 这条是"只列可用"这个策略成立的前提：可用集合是随用户变化的，不是写死的。
+  it("配了某厂商 Key 后，该厂商模型出现在列表里", async () => {
+    vi.mocked(fetchChatModels).mockResolvedValue(
+      CATALOG.map((m) => (m.id === "moonshot:kimi-k3" ? { ...m, available: true } : m)),
+    );
+    await openDropdown();
+    const listed = optionTexts();
+    expect(listed).toContain("Kimi K3");
+    expect(listed.some((x) => x.includes("GPT-5.6 Sol"))).toBe(false);
+  });
+});

--- a/frontend/src/components/ChatModelSelector.tsx
+++ b/frontend/src/components/ChatModelSelector.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Select, Tooltip } from "antd";
-import { PictureOutlined } from "@ant-design/icons";
+import { PictureOutlined, SettingOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { fetchChatModels, type ChatModelOption } from "../api/chatModels";
@@ -22,7 +22,12 @@ const PROVIDER_LOGO: Record<string, string> = {
 interface ChatModelSelectorProps {
   value: string;
   onChange: (modelId: string) => void;
+  /** 点「配置其他厂商模型」时调用（跳到个人中心的 API Key 面板）。 */
+  onConfigureKey: () => void;
 }
+
+/** 末项的哨兵值。它不是一个模型 —— 选中它只跳转，不改变当前所选模型。 */
+const CONFIGURE_KEY_VALUE = "__configure_key__";
 
 const FALLBACK_OPTIONS: ChatModelOption[] = [
   {
@@ -67,22 +72,37 @@ function buildLabel(model: ChatModelOption, t: TFunction): React.ReactNode {
   );
 }
 
-/** 扁平列表，不按 provider 分组。
+/** 只列当前**真能用**的模型，末尾放一个通往 Key 配置页的入口。
  *
- * 原先分组的两个代价都不小：分组标题直接显示的是原始 provider id（deepseek /
- * dashscope 这种机器名），5 个模型要占 9 行；而 antd 会给分组内的选项额外加一段
- * 左缩进（.ant-select-item-option-grouped），那正是下拉左侧那条空白。
- * 每个选项前面已经有厂商 logo，provider 这一层信息并没有丢。 */
+ * 不列不可用的，是因为它们占位却点不动：目录里多数厂商没有平台 Key，全列出来会
+ * 变成「10 项里 2 项能点」。收进一个入口后，目录随便加厂商都不会撑长这个下拉，
+ * 而「还能用别的」这件事仍然说得出来 —— 只是从一排灰条变成一句话。
+ *
+ * 也不按 provider 分组：分组标题显示的是原始 provider id（deepseek / dashscope
+ * 这种机器名），且 antd 会给分组内的选项额外加一段左缩进
+ * （.ant-select-item-option-grouped）。每个选项前面已有厂商 logo。 */
 function buildOptions(models: ChatModelOption[], t: TFunction): SelectOption[] {
-  return models.map((m) => ({
-    value: m.id,
-    label: buildLabel(m, t),
-    title: m.description,
-    disabled: !m.available,
-  }));
+  const usable = models.filter((m) => m.available);
+  return [
+    ...usable.map((m) => ({
+      value: m.id,
+      label: buildLabel(m, t),
+      title: m.description,
+    })),
+    {
+      value: CONFIGURE_KEY_VALUE,
+      label: (
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+          <SettingOutlined />
+          {t("chat.configure_other_models")}
+        </span>
+      ),
+      title: t("chat.configure_other_models"),
+    },
+  ];
 }
 
-export default function ChatModelSelector({ value, onChange }: ChatModelSelectorProps) {
+export default function ChatModelSelector({ value, onChange, onConfigureKey }: ChatModelSelectorProps) {
   const { t } = useTranslation();
   const [models, setModels] = useState<ChatModelOption[] | null>(null);
   const [loading, setLoading] = useState(true);
@@ -133,7 +153,14 @@ export default function ChatModelSelector({ value, onChange }: ChatModelSelector
       loading={loading}
       disabled={loading}
       value={value}
-      onChange={onChange}
+      // 末项不是模型：拦下来只跳转，不写进 value，也不落 localStorage。
+      onChange={(next) => {
+        if (next === CONFIGURE_KEY_VALUE) {
+          onConfigureKey();
+          return;
+        }
+        onChange(next);
+      }}
       options={options}
     />
   );

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1889,7 +1889,7 @@ export default function ChatPage() {
                     <DownOutlined style={{ fontSize: 10 }} />
                   </Button>
                 </Tooltip>
-                <ChatModelSelector value={modelId} onChange={handleModelChange} />
+                <ChatModelSelector value={modelId} onChange={handleModelChange} onConfigureKey={goConfigureKey} />
                 <span className="chat-input-spacer" />
                 {sending ? (
                   <Button


### PR DESCRIPTION
「加模型」和「下拉要紧凑」本来是**反方向**的：目录里多数厂商没有平台 Key，全列出来会从「5 项 2 项能点」变成「10 项 2 项能点」—— 那不是能力更全，是一排点不动的灰条。

所以先改选择器，再加模型。

## 选择器：只列当前真能用的

| | 之前 | 现在（未配任何第三方 Key） |
|---|---|---|
| 后端返回 | 8 个模型 | 8 个模型 |
| 下拉列出 | 8 项（**6 项灰掉**） | **3 项，零灰条** |
| 弹层高 | 会滚动 | 104px |

末尾一项「配置其他厂商模型…」通往 Key 配置页，**复用上一轮那条 `from=chat&s=` 的链路**，配完能原路返回原会话。

**名单从此可以随便加** —— 下拉长度只跟"你能用几个"有关。配了 Kimi Key 后，Kimi K3 自己出现在列表里（实测过）。

### 一个承重点

末项**不是模型**：选中它只跳转，不写进 `value`、不落 localStorage。若不拦，哨兵值会被当成 `modelId` 发给后端 —— 后端查不到便**静默退回默认模型**，而界面上却显示着「配置其他厂商模型…」。有专门的测试，变异验过会红。

## 目录新增（均按官方文档核对 API id）

- `openai:gpt-5.6-sol` — GPT-5.6 Sol
- `anthropic:claude-opus-5` — Claude Opus 5
- `gemini:gemini-3.6-flash` — Gemini 3.6 Flash（**Gemini 3 系列没有 Pro 档**，3.1 Pro 尚是 preview）

## 顺带修一个已经坏掉的默认值

`PROVIDER_DEFAULT_MODELS` 里 gemini 写的是 `gemini-2.0-flash`，而**官方文档已标 Shut down**（2026-06 停服）—— 自带 Gemini Key 的用户今天就是坏的。

## 豆包这次没加，理由

官方模型列表页两次都取不到内容，手上只有二手文章上的 `doubao-seed-2-0-pro-260215`。这类字符串写错的后果是那位用户**直接 model not found**，按既定规矩只认官方来源。你有官方链接的话我随时补上。

## 守卫改成「允许分歧但必须登记理由」

| 厂商 | 目录（用户主动挑→旗舰） | 默认值（没挑时→经济档） |
|---|---|---|
| openai | `gpt-5.6-sol` | `gpt-5.6-luna` |
| anthropic | `claude-opus-5` | `claude-sonnet-5` |

默认值是"没挑时替他决定"，而**钱是用户自己出的** —— 给经济档更稳妥。登记项本身也被校验：写了但实际相等即判为理由过期。

**这条守卫本轮又当场抓到我两次**（先 openai，再 anthropic）。

## 验证

**五条变异逐条验过会红**：前端三条（不过滤 available / 不拦末项 / 入口排到最前）、后端两条（登记项过期 / 新厂商忘了同步默认值）。

后端 1464 通过（3 个既有证书失败）；前端 325 通过（新增 5 条）；ruff（CI 范围 `app/ eval/`）/ tsc / eslint / i18n ratchet / build 全绿。

**浏览器实测**两种身份：未配 Key → 3 项零灰条；配了 Kimi Key → Kimi K3 自动出现；点末项跳到 `/profile?tab=apikey&from=chat` 且 localStorage 里的模型仍是 `null`。

⚠️ 一次全量测试出现过 1 条间歇性失败，随后三轮 325 全过，但**我没抓到失败的用例名**，所以不能断言它不是我新加的那 5 条之一。本仓已知有一条偶发红（`CollectionsPage.test.tsx` 的 i18n 语言态竞态）。