### PR TITLE
fix(chat): 修「重新进入后问第一个问题，对话生成到一半整个消失」

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -733,3 +733,45 @@ describe("额度提醒", () => {
     expect(screen.queryByText(/额度快用完/)).toBeNull();
   });
 });
+
+  // ── 用户实拍录屏复现（2026-08-01）────────────────────────────────────
+  //
+  // 症状：重新登录后问第一个问题，回答生成到一半，整个对话突然消失、退回空白首屏，
+  // 而输入区的「停止」按钮还在（说明流仍在跑）。之后的问题都正常。
+  //
+  // 机制：恢复 effect 的 `if (!raw) return` 早退时没有置位守卫。干净进 /chat 时
+  // 守卫保持 false；等流回传 session_id、syncSessionParam 把 ?s= 写进 URL，
+  // searchParams 一变，这个 effect 就把**刚写进去的那个 id** 当成"要恢复的历史
+  // 会话"去拉消息 —— 而此刻助手回答还没落库，拿回空数组，setMessages 把正在流式
+  // 的对话整个替换掉。
+  it("回归: 流式中途写入 ?s= 不得把正在进行的对话清空", async () => {
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks) => { cb = callbacks; },
+    );
+    // 新会话此刻在后端还没有任何已落库的消息
+    vi.mocked(getChatSessionMessages).mockResolvedValue({
+      total: 0, page: 1, size: 50, messages: [],
+    });
+
+    const { container } = renderPage();          // 干净进入，URL 里没有 ?s=
+    await waitFor(() => expect(screen.getByText("「三毒」指的是哪三种毒？")).toBeInTheDocument());
+
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+
+    cb!.onSessionId(4242 as unknown as number);  // 后端回传新会话 id → 写入 ?s=
+    await waitFor(() => {
+      expect(screen.getByTestId("loc").textContent).toBe("/chat?s=4242");
+    });
+    cb!.onToken("色即是空");
+
+    // 给"错误的恢复"足够的时间发生（微任务 + 一次 HTTP 往返）
+    await new Promise((r) => setTimeout(r, 120));
+
+    // 对话必须还在：空白首屏的建议卡片不该回来
+    expect(container.querySelector(".chat-hero-cards")).toBeNull();
+    expect(container.textContent).toContain("色即是空");
+    // 而且根本不该去拉这个会话的历史消息
+    expect(vi.mocked(getChatSessionMessages)).not.toHaveBeenCalled();
+  });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -972,17 +972,24 @@ export default function ChatPage() {
     }
   }, [syncSessionParam, handleMessagesScroll, t]);
 
-  // 挂载时按 ?s= 恢复会话。ref 守卫是必需的：syncSessionParam 会改 searchParams，
-  // 不守就会自我触发成循环；loadSession 每次渲染都是新引用（exhaustive-deps 要求
-  // 列进依赖），也靠这个守卫兜住重复执行。
+  // 按 ?s= 恢复会话。**只在挂载后判这一次**，之后 URL 里的 s 一律视为本页面自己
+  // 写进去的，不再回头去"恢复"。
+  //
+  // 守卫必须在读 s 之前就置位。此前它只在真的拿到 s 之后才置位，于是干净进入
+  // /chat（没有 s）时守卫一直是 false；等流回传 session_id、syncSessionParam 把
+  // ?s= 写进 URL，searchParams 一变这个 effect 就重跑，把**刚写进去的那个 id**
+  // 当成历史会话去拉消息 —— 而此刻助手回答还没落库，拿回空数组，setMessages 把
+  // 正在流式的对话整个替换掉：页面退回空白首屏，而「停止」按钮还在（sending 没
+  // 人动）。用户看到的就是"问第一个问题问到一半，整个对话没了"。
+  // 只发生在每次页面加载后的第一问 —— 此后守卫为真。
   const restoredRef = useRef(false);
   useEffect(() => {
     if (restoredRef.current) return;
+    restoredRef.current = true;
     const raw = searchParams.get("s");
     if (!raw) return;
     const sid = Number(raw);
     if (!Number.isInteger(sid) || sid <= 0) return;
-    restoredRef.current = true;
     // 放进微任务里调：loadSession 第一句就是 await，实际不会同步 setState，但
     // React Compiler 只看调用点、不看 await，会判成 set-state-in-effect（error 级）。
     // 挪进回调既符合规则本意（"外部状态变化时在回调里 setState"），也不改变时序。


### PR DESCRIPTION
用户实拍录屏（`每天第一次使用AI问答的bug.mp4`）：重新登录后问第一个问题，回答生成到一半，**整个对话突然不见、退回空白首屏**，而输入区的「停止」按钮还在 —— 流其实还在跑，只是 messages 被清空了。之后的问题都正常。

逐帧看：

| 帧 | 画面 |
|---|---|
| t=13s | 「已检索 5 部经典《華嚴經文義要決問答》…·正在生成回答」，停止按钮 |
| t=14s | **空白首屏（标题+建议卡片）**，停止按钮**仍在** |

「停止」还在 = `sending` 仍为真 = **不是组件重挂载**（重挂载会让它变回「发送」）。所以是 messages 被单独清空了。

## 这是我 #1081（会话进 URL）引入的回归

恢复 effect 里 `if (!raw) return` 这条早退**没有置位守卫**：

1. 干净进 `/chat`（URL 无 `?s=`）→ 守卫保持 `false`
2. 提问 → 后端回传 `session_id` → `syncSessionParam` 把 `?s=<新id>` 写进 URL
3. `searchParams` 一变，effect 重跑，守卫仍是 `false`
4. 它把**刚写进去的那个 id** 当成"要恢复的历史会话"去拉消息 —— 而此刻助手回答还没落库，**拿回空数组**，`setMessages` 整体替换掉正在流式的对话

**「只有第一次」也由此解释**：守卫此后为真，同一页面内不再复发；重新登录 = 重新加载页面 = 守卫复位。用户说的"重新登录之后"，实质是"重新加载页面之后"。

## 修法

守卫**在读 `s` 之前**就置位 —— 恢复只是挂载那一刻的事，之后 URL 里的 `s` 一律视为本页面自己写进去的。

## 验证：前后对照，不只是"改完测试绿了"

**jsdom 回归用例**确定性复现；变异（守卫退回原位）立刻打红。

**真浏览器**（桩后端发真 SSE，每 100ms 采样一次）：

| | 采样序列 | 多余的历史拉取 |
|---|---|---|
| bug 版 | 前 300ms 有对话，**第 400ms 起变空白并一直保持** | **1 次** |
| 修复版 | 全程有对话，答案完整落地 | **0 次** |

原有的「带 `?s=` 进入时恢复该会话」功能未被改坏（37 用例全绿）。

## 一处过程记录

第一次在浏览器里验 bug 版时我**没能复现**，差点误判。原因是我用 `.chat-hero-cards` 选择器判定空白态，它不可靠；换成判文案（"可以问我关于佛经内容"）才看见。这也是为什么我没有停在"jsdom 测试红了就算复现"。

## 验证

前端 337 用例通过；tsc / eslint / build 全绿。