### PR TITLE
feat(models): 补上豆包（Seed 2.1 Pro），并修掉它落后两代的默认值

### DIFF
--- a/backend/app/services/llm_catalog.py
+++ b/backend/app/services/llm_catalog.py
@@ -50,6 +50,12 @@ CATALOG: list[ModelOption] = [
                 "Kimi K3", "Moonshot 最新旗舰，上下文 1M", False),
     ModelOption("zhipu:glm-5.2", "zhipu", "glm-5.2",
                 "智谱 GLM-5.2", "智谱最新旗舰，上下文 1M", False),
+    # 2026-08-01 从火山方舟官方模型列表页核对（该站是 JS 渲染，WebFetch 只能拿到
+    # 导航骨架，必须用浏览器打开才读得到表格）。"推荐模型"一栏里的旗舰就是它。
+    # 没取 doubao-seed-evolving：它上下文更大（1024k）但是**滚动别名**，模型会在
+    # 用户脚下悄悄更换——对一个把答案真实性当最高准则的项目，钉死版本更稳妥。
+    ModelOption("doubao:seed-2-1-pro", "doubao", "doubao-seed-2-1-pro-260628",
+                "豆包 Seed 2.1 Pro", "字节最新旗舰，上下文 256k", False),
     # 国际三家。同样只对自带 Key 的用户可选。
     # 名单能放开加，是因为选择器只列当前真能用的模型 —— 加一个厂商不会让下拉变长。
     ModelOption("openai:gpt-5.6-sol", "openai", "gpt-5.6-sol",

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -53,7 +53,7 @@ PROVIDER_DEFAULT_MODELS = {
     "dashscope": "qwen3.7-plus",
     "zhipu": "glm-5.2",
     "moonshot": "kimi-k3",
-    "doubao": "doubao-1.5-pro-32k",
+    "doubao": "doubao-seed-2-1-pro-260628",   # 1.5 已落后两代
     "minimax": "MiniMax-Text-01",
     "stepfun": "step-1-8k",
     "baichuan": "Baichuan4-Air",

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -49,8 +49,8 @@ const PROVIDER_MODELS: Record<string, Array<{ value: string; label: string; hint
     { value: "gemini-2.5-pro", label: "2.5 Pro", hintKey: "profile.modelHint.flagship" },
   ],
   doubao: [
-    { value: "doubao-1.5-lite-32k", label: "1.5 Lite", hintKey: "profile.modelHint.economy" },
-    { value: "doubao-1.5-pro-32k", label: "1.5 Pro", hintKey: "profile.modelHint.main" },
+    { value: "doubao-seed-2-1-turbo-260628", label: "Seed 2.1 Turbo", hintKey: "profile.modelHint.economy_fast" },
+    { value: "doubao-seed-2-1-pro-260628", label: "Seed 2.1 Pro", hintKey: "profile.modelHint.flagship" },
   ],
   siliconflow: [
     { value: "deepseek-ai/DeepSeek-V3", label: "DeepSeek V3", hintKey: "profile.modelHint.deepseek_mirror" },


### PR DESCRIPTION
上一轮同步各家型号时**豆包是唯一没敢动的**：火山方舟的文档站是 JS 渲染，WebFetch 只能拿到导航骨架，手上只有二手文章上的 `doubao-seed-2-0-pro-260215`。

这次改用**浏览器打开官方模型列表页**，读到了真正的表格 —— 而二手文章又一次不可靠：

| Model ID | 定位 | 上下文 |
|---|---|---|
| **`doubao-seed-2-1-pro-260628`** | 官方「推荐模型」· 旗舰 | 256k |
| `doubao-seed-2-1-turbo-260628` | 推荐模型 · 快档 | — |
| `doubao-seed-evolving` | 快速迭代（滚动别名） | 1024k |
| `doubao-seed-2-0-pro-260215` | **上一代**（二手文章说的那个） | 256k |

## 三处一起改

- `llm_catalog` — 新增 `doubao:seed-2-1-pro`
- **`PROVIDER_DEFAULT_MODELS`** — `doubao-1.5-pro-32k` → `doubao-seed-2-1-pro-260628`。**这处比目录更要紧**：1.5 已落后两代，自带豆包 Key 又没指定模型的用户走的就是它
- `ProfilePage` 建议值 — 1.5 Lite/Pro → Seed 2.1 Turbo/Pro

沿用 **pro 档、不改档位**（与 Qwen 那次同一原则：换档会悄悄抬高自带 Key 用户的花费）。沿用既有 hintKey，**没新增 i18n 键**。

## 没取 `doubao-seed-evolving`，理由

它上下文更大（1024k），但那是个**滚动别名** —— 模型会在用户脚下悄悄更换。对一个把答案真实性当最高准则的项目，钉死版本更稳妥。

## 估价表仍不补豆包

那个价格页反复把标签页弹到 `about:blank`，抓不到稳定数字。理由与上一轮一致：**没有可靠来源时，退回一个有据可查的默认估价，好过填猜测值。**

## 验证

跨文件一致性守卫**自动覆盖了这个新厂商**（目录与默认值必须指向同一上游模型），19 条目录用例全绿。

后端 1464 通过（3 个既有证书失败）；前端 337 通过；ruff / tsc / eslint / build 全绿。