### PR TITLE
fix(chat): 经名字形跟随界面语言，并补上追问/抽屉/⋯ 三处够不着的交互

### DIFF
--- a/frontend/src/components/CitationDrawer.test.tsx
+++ b/frontend/src/components/CitationDrawer.test.tsx
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import i18n from "../i18n";
+import zhHantTranslation from "../../public/locales/zh-Hant/translation.json";
 import CitationDrawer, { type CitationTarget } from "./CitationDrawer";
 import {
   getChunkContext,
@@ -13,6 +15,9 @@ let originalScrollIntoView: typeof Element.prototype.scrollIntoView | undefined;
 
 // jsdom 不实现 matchMedia / scrollIntoView，而 antd Tabs 与 CitationBlocks 用到它们。
 beforeAll(() => {
+  // 只有 zh 内联在 i18n 实例里，其余走 HttpBackend——jsdom 下永不 resolve。
+  // 切 zh-Hant 的用例必须先预置资源包，否则 changeLanguage() 挂到超时。
+  i18n.addResourceBundle("zh-Hant", "translation", zhHantTranslation, true, true);
   if (!window.matchMedia) {
     window.matchMedia = (query: string) =>
       ({
@@ -59,14 +64,14 @@ function chunk(i: number, text: string, isCenter = false): ChunkContextItem {
   return { chunk_index: i, chunk_text: text, is_center: isCenter };
 }
 
-function renderDrawer() {
+function renderDrawer(overrides: Partial<React.ComponentProps<typeof CitationDrawer>> = {}) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>
-        <CitationDrawer target={TARGET} onClose={() => {}} />
+        <CitationDrawer target={TARGET} onClose={() => {}} {...overrides} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -75,6 +80,12 @@ function renderDrawer() {
 beforeEach(() => {
   vi.clearAllMocks();
   mockAlignment.mockResolvedValue({ parallels: [] } as never);
+});
+
+// 语言是 i18n 单例上的全局状态：切过 zh-Hant 的用例必须还原，否则会漏进同一
+// worker 里后续的用例与后续的测试文件。
+afterEach(async () => {
+  if (i18n.language !== "zh") await i18n.changeLanguage("zh");
 });
 
 describe("CitationDrawer", () => {
@@ -401,5 +412,85 @@ describe("CitationDrawer", () => {
       expect(document.querySelector("mark.chat-citation-chunk-mark")).not.toBeNull();
     });
     expect(screen.queryByText("本卷未找到被引的这段原文")).not.toBeInTheDocument();
+  });
+});
+
+describe("CitationDrawer — 面板标题的字形跟随界面语言", () => {
+  beforeEach(() => {
+    mockContext.mockResolvedValue({
+      text_id: 1558, juan_num: 16, title_zh: "阿毘達磨俱舍論",
+      center_chunk_index: 7, radius: 2,
+      chunks: [chunk(7, "無學身語業，即意三牟尼", true)],
+      has_more_before: false, has_more_after: false,
+    } as never);
+  });
+
+  it("简体界面：从 chip 传进来的 CBETA 繁体经名折成简体", async () => {
+    renderDrawer({ target: { ...TARGET, titleZh: "阿毘達磨俱舍論" } });
+    expect(await screen.findByText("《阿毘达磨俱舍论》· 第 16 卷")).toBeInTheDocument();
+  });
+
+  it("繁體界面：简体经名还原成繁体", async () => {
+    // 这才是生产上真正发生的那一半：内联引文的 titleZh 走 parseCitationHref，
+    // 而 URL 里存的是 toSimplified 过的键，于是繁體读者点开抽屉看到简体标题。
+    await i18n.changeLanguage("zh-Hant");
+    renderDrawer({ target: { ...TARGET, titleZh: "阿毘达磨俱舍论" } });
+    expect(await screen.findByText("《阿毘達磨俱舍論》· 第 16 卷")).toBeInTheDocument();
+  });
+});
+
+describe("CitationDrawer — Esc 关闭", () => {
+  beforeEach(() => {
+    mockContext.mockResolvedValue({
+      text_id: 1558, juan_num: 16, title_zh: "阿毘達磨俱舍論",
+      center_chunk_index: 7, radius: 2,
+      chunks: [chunk(7, "無學身語業，即意三牟尼", true)],
+      has_more_before: false, has_more_after: false,
+    } as never);
+  });
+
+  it("按 Esc 关闭面板", async () => {
+    // 侧栏面板按 Esc 关闭是所有人的普遍预期，不只是键盘用户——鼠标用户也会按。
+    // 此前整个组件没有任何 keydown 监听，Esc 完全没有接收者（真机实测按了没反应）。
+    const onClose = vi.fn();
+    renderDrawer({ onClose });
+    await screen.findByText(/阿毘/);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("有 antd 弹窗开着时，Esc 归弹窗，不连带关掉面板", async () => {
+    // 重命名会话 / 分享卡片都是 Modal。两者都监听 Esc，若面板也照单全收，
+    // 用户按一次 Esc 会同时失去弹窗和正在对照的原文。
+    const onClose = vi.fn();
+    renderDrawer({ onClose });
+    await screen.findByText(/阿毘/);
+    const wrap = document.createElement("div");
+    wrap.className = "ant-modal-wrap";
+    document.body.appendChild(wrap);
+    try {
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+    } finally {
+      wrap.remove();
+    }
+  });
+
+  it("Modal 关闭后残留的隐藏 .ant-modal-wrap 不该把 Esc 永久锁死", async () => {
+    // antd 关掉 Modal 后并不移除 .ant-modal-wrap，只是 display:none。
+    // 按「存在性」判断的话，用户重命名过一次会话之后，面板的 Esc 就再也不响应了。
+    const onClose = vi.fn();
+    renderDrawer({ onClose });
+    await screen.findByText(/阿毘/);
+    const wrap = document.createElement("div");
+    wrap.className = "ant-modal-wrap";
+    wrap.style.display = "none";
+    document.body.appendChild(wrap);
+    try {
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      wrap.remove();
+    }
   });
 });

--- a/frontend/src/components/CitationDrawer.tsx
+++ b/frontend/src/components/CitationDrawer.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { getChunkContext, getChunkAlignment, type ChunkContextItem, type ParallelPair } from "../api/client";
 import { findQuoteSpans } from "../utils/citationMatch";
+import { localizeHan } from "../utils/hanScript";
 import { reflowText } from "../utils/textReflow";
 import { hasDisplayConfidence } from "../utils/parallelDisplay";
 
@@ -292,8 +293,28 @@ function CitationBlocks({ chunks, quote }: { chunks: ChunkContextItem[]; quote?:
  * with the chat on the left while verifying the cited passage.
  */
 export default function CitationDrawer({ target, onClose }: Props) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [activeLang, setActiveLang] = useState<string>("lzh");
+
+  // Esc 关闭。此前整个组件没有任何 keydown 监听 —— 面板是个非模态侧栏，浏览器
+  // 不会替它处理 Esc，真机实测按了完全没反应。
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      // 别抢 antd Modal 的 Esc：重命名会话 / 分享卡片开着时，这一下属于它们，
+      // 否则用户按一次会同时失去弹窗和正在对照的原文。
+      //
+      // 判**可见性**而不是存在性：antd 关掉 Modal 后并不移除 .ant-modal-wrap，
+      // 只是把它 display:none 留在 DOM 里。按存在性判断的话，用户重命名过一次
+      // 会话之后，面板的 Esc 就再也不响应了。
+      const modalOpen = Array.from(document.querySelectorAll<HTMLElement>(".ant-modal-wrap"))
+        .some((el) => el.style.display !== "none");
+      if (modalOpen) return;
+      onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["citation-context", target?.textId, target?.juanNum, target?.chunkIndex],
@@ -386,9 +407,12 @@ export default function CitationDrawer({ target, onClose }: Props) {
     ? `/texts/${target.textId}/read?juan=${target.juanNum}&highlight_chunk=${target.chunkIndex}`
     : "#";
 
+  // 经名的字形跟随读者的界面语言，不跟随语料。两个来源都会走错方向：chip 传来
+  // 的是 CBETA 原始繁体，内联引文传来的是 URL 里那个 toSimplified 过的键 —— 前者
+  // 让简体读者看到繁体，后者让繁體讀者看到简体。localizeHan 把两边收敛到同一处。
   const titleText = target
     ? t("reader.citation.title_with_juan", {
-        title: target.titleZh || data?.title_zh || "",
+        title: localizeHan(target.titleZh || data?.title_zh || "", i18n.language),
         n: target.juanNum,
       })
     : t("reader.citation.title");

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -775,3 +775,51 @@ describe("额度提醒", () => {
     // 而且根本不该去拉这个会话的历史消息
     expect(vi.mocked(getChatSessionMessages)).not.toHaveBeenCalled();
   });
+
+describe("导出 Markdown", () => {
+  /** 抓住 handleExport 生成的那个 Blob —— jsdom 没有 createObjectURL。 */
+  function captureExport() {
+    const blobs: Blob[] = [];
+    const createURL = vi.fn((b: Blob) => { blobs.push(b); return "blob:x"; });
+    (URL as unknown as { createObjectURL: unknown }).createObjectURL = createURL;
+    (URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn();
+    // a.click() 在 jsdom 里会尝试导航，噪声很大且无意义。
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    return { blobs, clickSpy };
+  }
+
+  it("导出的参考经文按界面语言折字，不直出 CBETA 繁体", async () => {
+    // 导出的是给人读的 .md：界面是简体，文件里却写《雜阿含經》，
+    // 与用户屏幕上刚看到的 chip 对不上号。
+    vi.mocked(getChatSessions).mockResolvedValue([
+      { id: 7 as ChatSessionId, title: "心经问答", created_at: "2026-08-01T00:00:00Z", pinned: false },
+    ] as unknown as ChatSessionItem[]);
+    vi.mocked(getChatSessionMessages).mockResolvedValue({
+      total: 2, page: 1, size: 50,
+      messages: [
+        { id: 1, role: "user", content: "色是什么", sources: null, created_at: "2026-08-01T00:00:00Z" },
+        {
+          id: 2, role: "assistant", content: "色是 rūpa。", created_at: "2026-08-01T00:00:01Z",
+          sources: [{ text_id: 5, title_zh: "雜阿含經", juan_num: 16, chunk_index: 0, chunk_text: "…", score: 0.9 }],
+        },
+      ],
+    } as never);
+
+    const { blobs, clickSpy } = captureExport();
+    try {
+      renderPage("/chat?s=7");
+      await waitFor(() => expect(screen.getByText(/色是 rūpa/)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole("button", { name: "download" }));
+      await waitFor(() => expect(blobs).toHaveLength(1));
+
+      const md = await blobs[0].text();
+      expect(md).toContain("《杂阿含经》第16卷");
+      expect(md).not.toContain("《雜阿含經》第16卷");
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+});

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -8,6 +8,7 @@ import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { CITATION_URL_SCHEME, injectCitationLinks } from "../utils/citationLinks";
+import { localizeHan } from "../utils/hanScript";
 import { quoteCheckDetail } from "../utils/trustDetail";
 import { isNearBottom } from "../utils/scrollBottom";
 import {
@@ -353,7 +354,10 @@ function MessageBubbleInner({
   // only short-circuits parent-driven, prop-equal re-renders — so tooltips/toasts
   // update immediately, without `t` having to enter the comparator (and without
   // risking the per-token memo skip if t's identity weren't stable).
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  // CBETA 的 title_zh 恒为繁体；经名该用哪种字形由读者的界面语言决定，不由语料决定。
+  // 只作用于**经名**——答案正文（尤其是通过了逐字核验的引文）一个字都不改写。
+  const lang = i18n.language;
   const isAssistantText =
     m.role === "assistant" && m.content !== THINKING_SENTINEL && m.content !== REQUEST_FAILED_SENTINEL;
 
@@ -366,8 +370,8 @@ function MessageBubbleInner({
   }, [isAssistantText, isStreaming, m.content]);
 
   const rendered = useMemo(
-    () => (isAssistantText ? tightenLists(injectCitationLinks(cleanContent, m.sources)) + (isStreaming ? " ▌" : "") : ""),
-    [isAssistantText, cleanContent, m.sources, isStreaming],
+    () => (isAssistantText ? tightenLists(injectCitationLinks(cleanContent, m.sources, lang)) + (isStreaming ? " ▌" : "") : ""),
+    [isAssistantText, cleanContent, m.sources, isStreaming, lang],
   );
 
   // Distinct retrieved sources (deduped by text + fascicle) shown as a
@@ -507,7 +511,7 @@ function MessageBubbleInner({
                         onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.16)"; e.currentTarget.style.color = "var(--fj-accent)"; }}
                         onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.06)"; e.currentTarget.style.color = "var(--fj-ink-muted)"; }}
                       >
-                        {t("reader.citation.title_with_juan", { title: s.title_zh, n: s.juan_num })}
+                        {t("reader.citation.title_with_juan", { title: localizeHan(s.title_zh ?? "", lang), n: s.juan_num })}
                       </button>
                     ))}
                   </div>
@@ -515,19 +519,30 @@ function MessageBubbleInner({
                 {suggestions.length > 0 && !sending && (
                   <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
                     {suggestions.map((q, i) => (
-                      <span
+                      // 必须是原生 <button>：浏览器只为真正的可交互元素把 Enter/空格
+                      // 合成成 click。span[role=button] 看着一模一样，键盘用户和读屏
+                      // 用户却永远触发不了这些追问 —— 而它们是继续对话的主要入口。
+                      // fontFamily 要显式 inherit：button 不继承字体族，去掉这行会在
+                      // 一堆 Noto Serif 里冒出一颗系统默认字体的胶囊。用长属性而不是
+                      // font 简写——简写会连带重置 fontSize，得靠对象键序才能救回来。
+                      <button
                         key={i}
+                        type="button"
                         onClick={() => onSuggestionClick(q)}
                         style={{
                           display: "inline-block", padding: "4px 12px", borderRadius: 14,
                           border: "1px solid var(--fj-gold, #b08d57)", color: "var(--fj-gold, #b08d57)",
+                          fontFamily: "inherit",
+                          // button 的 UA 默认是 text-align:center。单行时看不出来，
+                          // 长追问换行后每一行都会居中——和改动前的 span 不一样。
+                          textAlign: "start",
                           fontSize: 12, cursor: "pointer", background: "transparent", transition: "all 0.2s", lineHeight: 1.6,
                         }}
                         onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.1)"; e.currentTarget.style.color = "var(--fj-accent)"; e.currentTarget.style.borderColor = "var(--fj-accent)"; }}
                         onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--fj-gold, #b08d57)"; e.currentTarget.style.borderColor = "var(--fj-gold, #b08d57)"; }}
                       >
                         {q}
-                      </span>
+                      </button>
                     ))}
                   </div>
                 )}
@@ -619,7 +634,7 @@ export default function ChatPage() {
   // React Compiler 对整个组件放弃编译，并把同组件里其它 useCallback 的手写依赖
   // 判成不可保留（见 PR #1077 里踩过的 4 个 lint error）。
   const [searchParams, setSearchParams] = useSearchParams();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user } = useAuthStore();
   const [input, setInput] = useState("");
   const [masterId, setMasterId] = useState<string | null>(null);
@@ -1470,7 +1485,9 @@ export default function ChatPage() {
           md += `**${t("chat.export_sources_label")}**\n`;
           for (const s of m.sources) {
             const title = s.title_zh
-              ? t("chat.export_source_titled", { title: s.title_zh, n: s.juan_num })
+              // 导出的 .md 是给人读的：经名跟随导出时的界面语言，与用户屏幕上
+              // 刚看到的 chip 一致，否则文件里的《雜阿含經》对不上页面的《杂阿含经》。
+              ? t("chat.export_source_titled", { title: localizeHan(s.title_zh, i18n.language), n: s.juan_num })
               : t("chat.export_source_untitled", { id: s.text_id, n: s.juan_num });
             md += `- 📖 ${title} (${Math.round(s.score * 100)}%)\n`;
           }
@@ -1485,7 +1502,7 @@ export default function ChatPage() {
     a.download = `${sessionTitle}-${new Date().toISOString().slice(0, 10)}.md`;
     a.click();
     URL.revokeObjectURL(url);
-  }, [messages, sessions, sessionId, t]);
+  }, [messages, sessions, sessionId, t, i18n.language]);
 
   return (
     <>
@@ -1963,7 +1980,16 @@ export default function ChatPage() {
         {citationTarget !== null && (
           <>
             <div className="chat-citation-divider" onMouseDown={handleCitationDragStart} />
-            <div className="chat-citation-panel" style={{ width: citationPanelWidth }}>
+            {/* complementary 而不是 dialog：这是个**非模态**侧栏，左边的对话仍可读可点
+                （见 global.css 里 .chat-citation-panel 的说明）。标成 dialog 会让读屏
+                以为进入了模态上下文。整页此前只有一个 <main>，补上这个 landmark 后，
+                读屏用户才能直接跳到原文对照区，而不必从对话里一路 Tab 过来。 */}
+            <div
+              className="chat-citation-panel"
+              role="complementary"
+              aria-label={t("reader.citation.title")}
+              style={{ width: citationPanelWidth }}
+            >
               <Suspense fallback={<div style={{ padding: 40, textAlign: "center" }}>…</div>}>
                 <CitationDrawer
                   target={citationTarget}

--- a/frontend/src/pages/MessageBubble.test.tsx
+++ b/frontend/src/pages/MessageBubble.test.tsx
@@ -1,12 +1,17 @@
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { Components } from "react-markdown";
+import i18n from "../i18n";
+import zhHantTranslation from "../../public/locales/zh-Hant/translation.json";
 import { MessageBubble } from "./ChatPage";
 import type { ChatMessageItem, ChatSource } from "../api/client";
 import type { TextId } from "../types/branded";
 
 // antd (Button/Tooltip) reads matchMedia via useBreakpoint under jsdom.
 beforeAll(() => {
+  // 只有 zh 被内联进 i18n 实例，其余走 HttpBackend——在 jsdom 里永远不 resolve。
+  // 切到 zh-Hant 的用例必须先把包预置进去，否则 changeLanguage() 挂到超时。
+  i18n.addResourceBundle("zh-Hant", "translation", zhHantTranslation, true, true);
   if (!window.matchMedia) {
     window.matchMedia = ((query: string) => ({
       matches: false, media: query, onchange: null,
@@ -14,6 +19,12 @@ beforeAll(() => {
       addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
     })) as unknown as typeof window.matchMedia;
   }
+});
+
+// 语言是 i18n 单例上的全局状态：切过 zh-Hant 的用例必须还原，否则会漏进同
+// 一 worker 里后续的用例（和后续的测试文件）。
+afterEach(async () => {
+  if (i18n.language !== "zh") await i18n.changeLanguage("zh");
 });
 
 const markdownComponents = {} as Components;
@@ -146,7 +157,8 @@ describe("MessageBubble", () => {
     // Label + a clickable chip for the retrieved source, even though the answer
     // text never named it inline.
     expect(screen.getByText("参考经文")).toBeInTheDocument();
-    const chip = screen.getByText("《雜阿含經》· 第 16 卷");
+    // 经名折成简体：界面语言是 zh（见 src/test/setup.ts），而 title_zh 恒为 CBETA 繁体。
+    const chip = screen.getByText("《杂阿含经》· 第 16 卷");
     fireEvent.click(chip);
     expect(onSourceClick).toHaveBeenCalledWith(expect.objectContaining({ text_id: 5, juan_num: 16 }));
   });
@@ -161,8 +173,8 @@ describe("MessageBubble", () => {
         ],
       }),
     });
-    expect(screen.getAllByText("《心經》· 第 1 卷")).toHaveLength(1);
-    expect(screen.getByText("《金剛經》· 第 1 卷")).toBeInTheDocument();
+    expect(screen.getAllByText("《心经》· 第 1 卷")).toHaveLength(1);
+    expect(screen.getByText("《金刚经》· 第 1 卷")).toBeInTheDocument();
   });
 
   it("shows no source list when the answer has no retrieved sources", () => {
@@ -173,5 +185,62 @@ describe("MessageBubble", () => {
   it("skips sources without a title (nothing to label the chip with)", () => {
     renderBubble({ m: msg({ sources: [src({ title_zh: undefined })] }) });
     expect(screen.queryByText("参考经文")).toBeNull();
+  });
+
+  // ——— 繁简：CBETA 的 title_zh 恒为繁体，界面语言说了算 ———
+  // 生产实测（简体界面）：答案正文写「色不异空」，紧跟的引文标记却是
+  // 【《般若波羅蜜多心經》第1卷】，chip 也是繁体，而点开抽屉标题又变回简体。
+  // 同一部经一屏三种字形，直接削弱「这是同一段原文」的可信度。
+
+  it("内联引文标记的经名跟随界面语言，不直出 CBETA 繁体", () => {
+    renderBubble({
+      m: msg({
+        content: "如【《般若波羅蜜多心經》第1卷】所说。",
+        sources: [src({ text_id: 9 as TextId, juan_num: 1, chunk_index: 0, title_zh: "般若波羅蜜多心經" })],
+      }),
+    });
+    expect(document.body.textContent).toContain("《般若波罗蜜多心经》第1卷");
+    expect(document.body.textContent).not.toContain("《般若波羅蜜多心經》第1卷");
+  });
+
+  it("繁體界面：经名保持繁体，不被折成简体", async () => {
+    // 这条才真正证明 i18n.language 被接进了 injectCitationLinks / chip。
+    // 只测简体是恒真的——injectCitationLinks 的 language 默认就是 "zh"，
+    // 组件哪怕一个参数都不传，简体断言照样绿。
+    await i18n.changeLanguage("zh-Hant");
+    renderBubble({
+      m: msg({
+        content: "如【《般若波羅蜜多心經》第1卷】所说。",
+        sources: [src({ text_id: 9 as TextId, juan_num: 1, chunk_index: 0, title_zh: "般若波羅蜜多心經" })],
+      }),
+    });
+    expect(document.body.textContent).toContain("《般若波羅蜜多心經》第1卷");
+    expect(document.body.textContent).not.toContain("《般若波罗蜜多心经》第1卷");
+  });
+
+  it("折字只作用于经名，答案正文里被逐字核验过的引文一字不动", () => {
+    // 承重。「已逐字核验」这个徽章的全部价值就在于引文与藏经原文逐字相同；
+    // 若界面语言能改写引文本身，徽章当场变成假话。
+    renderBubble({
+      m: msg({
+        content: "论云「無學身語業，即意三牟尼」者。【《雜阿含經》第16卷】",
+        sources: [src({ text_id: 5 as TextId, juan_num: 16, chunk_index: 0, title_zh: "雜阿含經" })],
+      }),
+    });
+    expect(document.body.textContent).toContain("「無學身語業，即意三牟尼」");
+    expect(document.body.textContent).toContain("《杂阿含经》第16卷");
+  });
+
+  it("追问建议是原生 button —— span 上挂 onClick，键盘和读屏永远够不到", () => {
+    const { onSuggestionClick } = renderBubble({
+      m: msg({ content: "答案正文\n[追问] 什么是阿赖耶识" }),
+    });
+    const chip = screen.getByRole("button", { name: "什么是阿赖耶识" });
+    // 断言标签名而不只是 role：span[role=button] 也能被 getByRole 找到，但浏览器
+    // 只为真正的可交互元素把 Enter/空格合成成 click。这里守的正是那一点。
+    expect(chip.tagName).toBe("BUTTON");
+    expect(chip.tabIndex).toBeGreaterThanOrEqual(0);
+    fireEvent.click(chip);
+    expect(onSuggestionClick).toHaveBeenCalledWith("什么是阿赖耶识");
   });
 });

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -403,10 +403,17 @@ em {
 .chat-session-more.ant-dropdown-open {
   opacity: 1;
 }
-/* 触屏没有 hover：那里必须常驻，否则菜单永远打不开。 */
+/* 触屏没有 hover：那里必须常驻，否则菜单永远打不开。
+   同时把命中区撑到 24×24 —— 实测桌面下它只有 21×17，低于 WCAG 2.2 AA 的
+   最小目标尺寸（2.5.8）。桌面用鼠标勉强能点，手指点不准，而这恰恰是它唯一
+   常驻可见的场合。用 min-width/height 而不是加 padding：padding 会把图标
+   在 220px 的窄栏里往外顶，挤掉本就不够的标题宽度。 */
 @media (hover: none) {
   .chat-session-more {
     opacity: 0.65;
+    min-width: 24px;
+    min-height: 24px;
+    justify-content: center;
   }
 }
 .chat-session-more:hover {

--- a/frontend/src/utils/citationLinks.test.ts
+++ b/frontend/src/utils/citationLinks.test.ts
@@ -81,3 +81,47 @@ describe("injectCitationLinks — 卷号与段号必须同源", () => {
     expect(chunk).toBe("7");
   });
 });
+
+/**
+ * CBETA 的 title_zh 恒为繁体，而答案正文是 LLM 写的简体。两者并排出现在同一句话里
+ * ——生产实测：简体界面下答案写「色不异空」，紧跟的引文标记却是
+ * 【《般若波羅蜜多心經》第1卷】，而点开后抽屉标题又是简体的《般若波罗蜜多心经》。
+ * 同一部经在一屏内出现两种字形，直接削弱「这是同一段原文」的可信度，而可核对引用
+ * 正是这个产品唯一在转的护城河。
+ *
+ * 修法与 CollectionsPage / CrossCanonPage 一致：localizeHan(text, language)。
+ * 只动**经名**，绝不动答案正文——被逐字核验过的引文一个字都不能改写。
+ */
+describe("injectCitationLinks — 可见经名跟随界面语言", () => {
+  it("简体界面：把 CBETA 繁体经名折成简体", () => {
+    const out = injectCitationLinks("见【《阿毘達磨俱舍論》第9卷】所说。", [src()], "zh");
+    expect(out).toContain("【《阿毘达磨俱舍论》第9卷】");
+  });
+
+  it("繁体界面：保持繁体，不被折成简体", () => {
+    const out = injectCitationLinks("见【《阿毘達磨俱舍論》第9卷】所说。", [src()], "zh-Hant");
+    expect(out).toContain("【《阿毘達磨俱舍論》第9卷】");
+  });
+
+  it("裸经名（无【】标记的第二遍扫描）同样跟随界面语言", () => {
+    const out = injectCitationLinks("《阿毘達磨俱舍論》里说。", [src()], "zh");
+    expect(out).toContain("[《阿毘达磨俱舍论》]");
+  });
+
+  it("只折经名，不碰答案正文里被引的经句", () => {
+    // 承重。「無學身語業，即意三牟尼」是通过了逐字核验的引文，界面语言不是
+    // 改写它的理由——一旦这里也转字，「已逐字核验」这个徽章当场就变成假话。
+    const out = injectCitationLinks(
+      "论云「無學身語業，即意三牟尼」者。【《阿毘達磨俱舍論》第9卷】",
+      [src()],
+      "zh",
+    );
+    expect(out).toContain("「無學身語業，即意三牟尼」");
+    expect(out).toContain("《阿毘达磨俱舍论》");
+  });
+
+  it("URL 里的标题仍是简体，与界面语言无关（抽屉靠它做键匹配）", () => {
+    const out = injectCitationLinks("见【《阿毘達磨俱舍論》第9卷】所说。", [src()], "zh-Hant");
+    expect(urlOf(out)).toContain(encodeURIComponent("阿毘达磨俱舍论"));
+  });
+});

--- a/frontend/src/utils/citationLinks.ts
+++ b/frontend/src/utils/citationLinks.ts
@@ -4,6 +4,7 @@ import {
   extractPrecedingQuote,
   pickSourceForQuote,
 } from "./citationMatch";
+import { localizeHan } from "./hanScript";
 
 /**
  * Custom URL scheme for citation links. Lives here rather than in ChatPage so
@@ -30,8 +31,20 @@ export const CITATION_URL_SCHEME = "fojin-citation";
  * When a matched source lacks chunk_index (legacy chat history from before
  * the chunk_index field was wired through) we emit chunk_index=-1; the click
  * handler in the renderer falls back to reader-page navigation in that case.
+ *
+ * `language` decides the script of the **visible** sutra name only. CBETA's
+ * title_zh is always traditional, so a simplified reader would otherwise read
+ * 「色不异空」 and see 【《般若波羅蜜多心經》…】 in the same sentence. Everything
+ * else is left byte-for-byte alone — above all the quoted passage, which has
+ * been verbatim-checked against the canon; re-scripting it would make the
+ * 「已逐字核验」 badge a lie. Defaults to simplified, matching
+ * scriptForLanguage's own fallback for any non-Hant locale.
  */
-export function injectCitationLinks(content: string, sources: ChatSource[] | null): string {
+export function injectCitationLinks(
+  content: string,
+  sources: ChatSource[] | null,
+  language: string = "zh",
+): string {
   if (!sources || sources.length === 0) return content;
 
   // Two indexes over the RAG sources, both keyed on the simplified title so
@@ -102,7 +115,7 @@ export function injectCitationLinks(content: string, sources: ChatSource[] | nul
       // 第N卷 placeholder the LLM left unsubstituted into a real number.
       // Non-卷 qualifiers (卷上, 第十八愿) carry no 第…卷 slot and are kept.
       const label = tail.replace(/第[^】卷]*卷/, `第${juan}卷`); // i18n-exempt — rewrites the LLM's Chinese citation marker, must match answer text
-      return `[【《${title}》${label}】](${url})`;
+      return `[【《${localizeHan(title, language)}》${label}】](${url})`;
     },
   );
 
@@ -120,7 +133,7 @@ export function injectCitationLinks(content: string, sources: ChatSource[] | nul
         const source = titleMap.get(simplifiedTitle);
         if (!source) return bareMatch;
         const { url } = buildCitation(source, simplifiedTitle, null, null);
-        return `[《${title}》](${url})`;
+        return `[《${localizeHan(title, language)}》](${url})`;
       });
     })
     .join("");


### PR DESCRIPTION
一次真机排查（生产 /chat 实测 + 全量读 ChatPage）后，按 ROI 挑出的四项：
曝光面最大、成本最低、不需要产品决策、共用同一遍验证面。

## 1. 繁简：同一部经在一屏里出现两种字形

实测（简体界面）：答案正文写「色不异空」，紧跟的引文标记却是
【《般若波羅蜜多心經》第1卷】，参考经文 chip 也是繁体，而点开抽屉标题又
变回简体的《般若波罗蜜多心经》。三处规范化各行其是：

  · 内联引文标记 —— injectCitationLinks 原样保留 LLM 抄自语料的繁体
  · 参考经文 chip —— 直出 CBETA 的 title_zh（恒为繁体）
  · 抽屉标题     —— citationLinks 把 toSimplified 过的键塞进 URL，
                    parseCitationHref 再取出来，于是恒为简体

繁體界面下则整个反过来：chip 繁、抽屉简。

修法与 CollectionsPage / CrossCanonPage 一致，接现成的 localizeHan：
内联标记、chip、抽屉标题、导出 .md 四处收敛到「读者的界面语言说了算」。

承重约束：只折**经名**。答案正文一个字都不改写 —— 尤其是通过了逐字核验的
引文，一旦跟着转字，「已逐字核验」这个徽章当场变成假话。为此单独留了一条
用例，断言 「無學身語業，即意三牟尼」 在简体界面下原样保留。

## 2. 追问建议：span 上挂 onClick，键盘和读屏永远够不到

tabIndex=-1、无 role、无键盘处理。而追问是继续对话的主要入口。改成原生
<button> —— 只有真正的可交互元素，浏览器才会把 Enter/空格合成成 click。

真机 A/B 量过，与原 span 逐项等同：355.4×29.2 完全一致、字体族一致、
padding/border/color 一致；差别只有 tabIndex −1→0（正是要的）。补了两条
UA 默认样式：fontFamily:inherit（漏了会掉回 Arial，实测宽度也差 1.3px）、
textAlign:start（button 默认 center，长追问换行后每行都会居中）。

## 3. 引用抽屉：Esc 关不掉，且不在无障碍树上

整个组件没有任何 keydown 监听，真机按 Esc 毫无反应 —— 而按 Esc 关侧栏面板
是所有人的普遍预期，不只是键盘用户。

判**可见性**而非存在性：antd 关掉 Modal 后并不移除 .ant-modal-wrap，只是
display:none 留在 DOM 里。按存在性判断的话，用户重命名过一次会话之后，面板
的 Esc 就再也不响应了。这一点单独留了用例，变异（退回存在性判断）实测打红。

同时给面板补 role=complementary + aria-label：整页此前只有一个 <main>，
读屏用户没有任何 landmark 可以跳到原文对照区。用 complementary 而不是
dialog —— 它是非模态的，左边对话仍可读可点，标成 dialog 是撒谎。

## 4. 会话行的 ⋯ 按钮只有 21×17

低于 WCAG 2.2 AA 的最小目标尺寸（2.5.8, 24×24）。桌面用鼠标勉强能点，
手指点不准 —— 而 @media (hover:none) 恰恰是它唯一常驻可见的场合。
真机套用后实测：21×17 → 24×24，标题宽度只从 162px 缩到 159px，行不溢出。

## 验证

· 每条新用例都先实测无修复时会红，且失败原因正确（不是拼写/类型错）
· 「繁體界面」那条是关键：只测简体是恒真的 —— injectCitationLinks 的
  language 默认就是 "zh"，组件哪怕一个参数不传，简体断言照样绿
· OpenCC 的实际输出先算过再写断言（阿毘達磨俱舍論 → 阿毘达磨俱舍论，
  毘/斲 都不变），否则会因错误原因而红
· 三条既有用例断言的是旧的繁体 chip 标签，已按新规格改写
· 真机隔离验证了单测覆盖不到的两点：button 的视觉等价、⋯ 的命中区放大
· 全套门禁：tsc / eslint --max-warnings 0 / i18n ratchet / vitest 352 全绿