### PR TITLE
fix(chat): 手机上原文对照堆到对话下方，并给断流补上能算失败率的埋点

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -823,3 +823,84 @@ describe("导出 Markdown", () => {
     }
   });
 });
+
+describe("断流埋点 chat_stream_error", () => {
+  /** 为什么要这个埋点：中途断流在今天完全量不出来。
+   *  · docker logs 里那行 "LLM stream broke mid-stream" 随每次部署重建容器而清空
+   *  · 「孤儿 user 消息」查不到 —— _save_messages 把 user+assistant 两行一起写，
+   *    断流时一行都不落
+   *  · 「Umami chat 事件 − DB user 行」也不行 —— 游客根本不建 session、完全不落库，
+   *    而游客是大多数，差值会被游客淹没
+   *  只剩前端知道真相：它手里有「这一条流吐没吐过 token」。 */
+  function withUmami() {
+    const track = vi.fn();
+    (window as Window & { umami?: { track: typeof track } }).umami = { track };
+    (globalThis as unknown as { umami: unknown }).umami = { track };
+    return track;
+  }
+
+  async function startSend() {
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, cbs) => { cb = cbs; },
+    );
+    vi.mocked(getChatSessionMessages).mockResolvedValue({
+      total: 0, page: 1, size: 50, messages: [],
+    } as never);
+    const { container } = renderPage();
+    await waitFor(() => expect(screen.getByText("「三毒」指的是哪三种毒？")).toBeInTheDocument());
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+    return cb!;
+  }
+
+  afterEach(() => {
+    delete (window as Window & { umami?: unknown }).umami;
+    delete (globalThis as unknown as { umami?: unknown }).umami;
+  });
+
+  /** 只数 chat_stream_error 这一类事件 —— 同一次发送还会打 "chat" 等其它点。 */
+  const errEvents = (track: ReturnType<typeof vi.fn>) =>
+    track.mock.calls.filter((c) => c[0] === "chat_stream_error").map((c) => c[1]);
+
+  it("吐过 token 后才失败 → 记为 mid_stream，且只记一次", async () => {
+    // 这一种最危险：气泡里留着一段看似完整的半截答案，没有失败标记也没有重试按钮，
+    // 而分享/复制按钮照常可用 —— 截断的内容能被做成分享卡片送出去。
+    //
+    // onDone 必须跟着调：client.ts 里**每一处** onError 后面都紧跟 onDone()，
+    // 不调就是在测一个production里不存在的时序（第一版就是这么漏掉重复计数的）。
+    const track = withUmami();
+    const cb = await startSend();
+    cb.onToken!("「色」是梵语 rūpa 的意译，在《心经》的语境中");
+    cb.onError!("上游中断");
+    cb.onDone!();
+    expect(errEvents(track)).toEqual([{ stage: "mid_stream" }]);
+  });
+
+  it("一个 token 都没到就失败 → 记为 no_token，且不被 onDone 重复计一次", async () => {
+    // 承重：onError 之后 onDone 必定到达，而此时 tokenCount 仍是 0 —— 少了
+    // sawError 守卫，同一次失败会同时记 no_token 和 empty_done，
+    // 直接把失败率的分子灌成两倍。
+    const track = withUmami();
+    const cb = await startSend();
+    cb.onError!("上游 503");
+    cb.onDone!();
+    expect(errEvents(track)).toEqual([{ stage: "no_token" }]);
+  });
+
+  it("流悄无声息地结束（没有 error 帧、也没有 token）→ 记为 empty_done", async () => {
+    const track = withUmami();
+    const cb = await startSend();
+    cb.onDone!();
+    expect(errEvents(track)).toEqual([{ stage: "empty_done" }]);
+  });
+
+  it("正常完成不记任何错误事件", async () => {
+    // 承重：这个埋点是要拿来算失败率的分子，成功路径漏进去就直接把分子污染了。
+    const track = withUmami();
+    const cb = await startSend();
+    cb.onToken!("完整答案");
+    cb.onDone!();
+    expect(errEvents(track)).toEqual([]);
+  });
+});

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1206,8 +1206,19 @@ export default function ChatPage() {
     // abort mid-stream and surface as "请求失败，请重试".
     const timeoutId = setTimeout(() => abortController.abort(), 300_000);
 
+    // 断流埋点的两个本地计数。放在闭包里而不是 state / ref：每次发送都要一份
+    // 全新的，且绝不能在 setMessages 的 updater 里做统计（StrictMode 会跑两遍）。
+    //
+    // 为什么非要前端来记：中途断流在服务端量不出来。docker logs 里那行
+    // "LLM stream broke mid-stream" 随每次部署重建容器而清空；DB 侧也查不到 ——
+    // _save_messages 把 user+assistant 两行一起写，断流时一行都不落，而游客
+    // 根本不建 session、完全不落库。只有前端知道「这一条流吐没吐过 token」。
+    let tokenCount = 0;
+    let sawError = false;
+
     await sendChatMessageStream(msg, sessionId, masterId, {
       onToken: (content: string) => {
+        tokenCount += 1;
         setMessages((prev) =>
           prev.map((m) => {
             if (m.id !== assistantId) return m;
@@ -1294,6 +1305,13 @@ export default function ChatPage() {
         }
       },
       onError: (errMsg: string) => {
+        sawError = true;
+        // mid_stream 与 no_token 必须分开：后者前端已能自愈（转失败哨兵 + 给出
+        // 重试按钮），前者留下的是一段看似完整的半截答案 —— 没有失败标记、没有
+        // 重试按钮，而分享/复制照常可用。分开记才知道真正要修的那部分占多少。
+        if (typeof umami !== "undefined") {
+          umami.track("chat_stream_error", { stage: tokenCount > 0 ? "mid_stream" : "no_token" });
+        }
         message.error(errMsg);
         setMessages((prev) =>
           prev.map((m) =>
@@ -1308,6 +1326,12 @@ export default function ChatPage() {
         abortRef.current = null;
         setStreamingId(0);
         setSending(false);
+        // 流结束了，却既没有 error 帧也没有任何 token —— 后端发了个光秃秃的 done。
+        // 下面那段兜底会把气泡转成失败哨兵，但服务端不会为此留下任何痕迹，
+        // 所以这里单独记一档。sawError 拦住重复计数。
+        if (!sawError && tokenCount === 0 && typeof umami !== "undefined") {
+          umami.track("chat_stream_error", { stage: "empty_done" });
+        }
         // Empty completion: the stream ended without ever delivering a token
         // (and without an error frame — e.g. a bare `done`). If the bubble is
         // still the thinking placeholder, nothing will ever replace it and it
@@ -1507,7 +1531,12 @@ export default function ChatPage() {
   return (
     <>
       <Helmet><title>{t("chat.page_title")}</title></Helmet>
-      <div style={{
+      {/* className 是必需的，不是装饰：这个外壳的 display:flex 写在行内样式里，
+          而行内样式没有任何 CSS 选择器够得到 —— 于是 global.css 里那条
+          「移动端把引用面板铺满宽度」的规则结构上不可能生效为「堆叠」，面板
+          只会在同一行里把对话列挤成 0 宽。给它一个类名，断点才改得动
+          flex-direction。 */}
+      <div className="chat-shell" style={{
         display: "flex",
         height: "calc(100vh - 120px)",
         gap: 16,
@@ -1671,7 +1700,7 @@ export default function ChatPage() {
         </div>}
 
         {/* Chat area */}
-        <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <div className="chat-main-column" style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
           {/* Chat header: mobile toggle + export */}
           <div style={{ display: "flex", marginBottom: 4 }}>
             <div className="chat-column-inner" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -824,9 +824,28 @@ em {
    column via an additional class applied when the panel is open (handled
    in ChatPage inline style). */
 @media (max-width: 768px) {
+  /* 手机上把原文对照堆到对话下方，而不是并排。
+     .chat-shell 的 flex-direction 必须在这里翻成 column —— 光给面板
+     width:100% 是不够的：外壳仍是 row/nowrap，面板 flex-shrink:0 占满整行宽，
+     对话列被压成 0 宽，容器还横向溢出。真机 390px 复现过：对话整个消失，
+     输入框缩成一条竖线，工具栏溢出屏幕。 */
+  .chat-shell {
+    flex-direction: column;
+  }
+  /* 行内样式只给了 minWidth:0；换成纵向后要限制的是高度，否则对话列会按内容
+     撑开，把面板顶出视口。 */
+  .chat-main-column {
+    min-height: 0;
+  }
   .chat-citation-panel {
     width: 100% !important;
-    height: 60vh;
+    /* 60vh → 50vh。这个 60vh 从来没被真正执行过：面板此前根本堆叠不起来，
+       所以它只是给一个并排面板设了个高度，没人验过纵向分配。真机 390px 量过：
+       60vh 时对话列 228px，扣掉页头与输入区后消息可视区只剩 32px（约一行），
+       等于对话仍然看不见 —— 而用户点开原文正是为了「两边对着看」。
+       50vh 给到消息 104px（约四行），原文仍有 354px（约十四行）。 */
+    height: 50vh;
+    flex-shrink: 0;
     border-top: 1px solid var(--fj-border, #e8e0d4);
   }
   .chat-citation-divider {


### PR DESCRIPTION
## 1. 移动端引用面板：那条规则结构上从来就不可能生效

global.css 的 768px 断点里给 .chat-citation-panel 写了 width:100%，意图是
在手机上把原文对照堆到对话下方。这个意图无法实现 —— 外壳的 display:flex 写在
ChatPage 的**行内样式**上，那个 div 没有 class，没有任何 CSS 选择器够得到它的
flex-direction。于是外壳始终是 row/nowrap，面板 flex-shrink:0 占满整行宽度。

真机 390px 几何复现（外壳压到 390px + 手工套用断点声明）：
  修复前  对话列宽度 0，容器横向溢出 21px，输入框被压成一条竖线，工具栏溢出屏幕
  修复后  stacked=true，对话列 390×228，面板 390 宽在其下方，零溢出

修法：给外壳 .chat-shell、对话列 .chat-main-column，断点里翻 flex-direction:
column 并补 min-height:0（行内样式只给了 minWidth:0，纵向排布要限制的是高度）。

顺带把面板高度从 60vh 调到 50vh。这个 60vh 不是「已调好的既有值」—— 面板此前
根本堆叠不起来，纵向分配从没被执行过。真机量过：
  60vh → 对话列 228px，扣掉页头与输入区后消息可视区只剩 32px（约一行）
  50vh → 消息 104px（约四行），原文仍有 354px（约十四行）
用户点开原文正是为了两边对着看，32px 只比 0 好一点。

影响面：Umami 30 天，/chat 会话里 mobile 22.9% + tablet 2.6% = 25.5%；
触屏用户每月约 97 次 source_click 会打开这个面板。

## 2. 断流埋点：这个数今天在服务端量不出来

想给「中途断流」定优先级，却发现三条路都不通：
  · docker logs 里那行 "LLM stream broke mid-stream" 随每次部署重建容器而清空
    （json-file 驱动），只剩 3 小时窗口，样本 n=7
  · 「孤儿 user 消息」查不到 —— _save_messages 把 user+assistant 两行一起写，
    且落库在整段生成完之后，断流时一行都不落
  · 「Umami chat 事件 − DB user 行」也不行 —— 游客根本不建 session、完全不落库
    （services/chat.py 第 388-390 行），而游客是大多数，差值会被游客淹没

只有前端知道「这一条流吐没吐过 token」。onError / onDone 里按三档打点：
  mid_stream  吐过 token 后失败 —— 最危险的一种：气泡里留着一段看似完整的
              半截答案，无失败标记、无重试按钮，而分享/复制照常可用
  no_token    一个 token 都没到 —— 前端已能自愈（转失败哨兵 + 重试按钮）
  empty_done  流悄无声息地结束，连 error 帧都没有

计数用闭包局部量，不用 state/ref：每次发送要一份全新的，且绝不能在 setMessages
的 updater 里做统计（StrictMode 会跑两遍）。

## 验证

· 每条新用例都先实测无修复时会红
· 变异检验救回一个真问题：第一版把 onError 之后不调 onDone 当成了合法时序，
  拿掉 sawError 守卫竟然打不红。查 client.ts 才发现**每一处** onError 后面都
  紧跟 onDone() —— 少了守卫，同一次失败会同时记 no_token 和 empty_done，
  把失败率的分子直接灌成两倍。改成按真实时序断言后，变异立刻打红
· 移动端布局是 CSS，单测覆盖不到，用真机 390px 几何复现前后对照（含截图）
· 全套门禁：tsc / eslint --max-warnings 0 / i18n ratchet / vitest 356 全绿

## 本轮明确没做的一项

上一轮我根据 Umami 数据（laptop 内联引文:chip = 1.2:1，mobile = 23:1，384 次
移动端提问里只有 4 次点开内联引文）推测「内联引文在手机上太小点不中」。
实测把这个推测证伪了：内联引文是 194.6×24.1px 的 inline-block，已达 24×24，
且 .chat-markdown 在移动端没有任何缩字号规则。原因未知，不修一个已被证伪的
成因。等本 PR 上线后重新观察 citation_click 的设备分布 —— 面板此前在手机上
一点就把对话弄没，本身就是个可能的成因，修好它正好是一次自然实验。