### PR TITLE
fix(chat): 推理额度不足会饿死答案——Flash 上等 60-69 秒只拿到一句报错

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -1073,12 +1073,20 @@ async def send_message_stream(
         yield f"data: {json.dumps({'type': 'error', 'message': error_msg}, ensure_ascii=False)}\n\n"
         full_answer = full_answer or error_msg
 
+    # reasoning 与 model 是这条日志里最贵的两个字段，别删：
+    # 隐藏推理和可见答案共用同一个 max_tokens，所以「0 chars」的成因几乎总是
+    # 「reasoning 把预算吃光了」—— 没有这两个数就分不清是模型选得不对、上游抽风、
+    # 还是预算不够。而 provider 分不出 pro 和 flash（两者都是 deepseek），
+    # 2026-08-01 那次排查因此得先去翻 Prometheus 的 model 标签才知道用的是哪个。
     logger.info(
-        "chat/stream phase-2 LLM done in %.2fs (%d chars, session_id=%s, provider=%s)",
+        "chat/stream phase-2 LLM done in %.2fs (%d chars, reasoning=%d chars, "
+        "session_id=%s, provider=%s, model=%s)",
         _time.monotonic() - phase2_start,
         len(full_answer),
+        reasoning_chars,
         chat_session_id,
         provider,
+        model,
     )
 
     # Empty-completion guard: the stream finished without ever producing an

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -115,13 +115,27 @@ def _is_reasoning_model(model: str | None) -> bool:
     return any(k in m for k in _REASONING_MODEL_MARKERS)
 
 
+# 隐藏推理与可见答案共用同一个 max_tokens。这个额度必须大到「推理再长也饿不死
+# 答案」——它是天花板不是目标，推理少的模型（pro 实测只用约 1k）一分钱都不多花。
+#
+# 曾经是 4000，那是 2026-06-23 针对**标题**（30 token 上限）定的，从没在「重推理
+# 模型 + 完整 RAG 答案」上验证过。2026-08-01 生产实测把它打穿：同一问题、同一把
+# BYOK Key、同一端点，只换模型 ——
+#   deepseek-v4-pro    8 个推理事件、首字 11.2s、1,515 字、38s 完成
+#   deepseek-v4-flash  57–66 个推理事件、11,826 字符推理（≈7,884 token）、正文 0 字
+# 而当时整个上限只有 2000+4000=6000：推理独自顶穿天花板，模型被 length 截断，
+# 正文一个 token 都没轮到，用户等 60–69 秒只拿到「未能生成任何回答内容」。
+# 24000 ≈ 实测推理量的 3 倍，相对该档 384K 的最大输出仍是很小的一块。
+_REASONING_HEADROOM_TOKENS = 24000
+
+
 def _with_reasoning_headroom(model: str | None, max_tokens: int) -> int:
     """Add budget for hidden reasoning_content on reasoning models so the
     visible answer isn't starved. max_tokens is a ceiling, not a target, so
     this is ~free for responses that don't hit the old cap — it only prevents
     reasoning from eating the entire short cap (empty titles) or truncating
     long answers."""
-    return max_tokens + 4000 if _is_reasoning_model(model) else max_tokens
+    return max_tokens + _REASONING_HEADROOM_TOKENS if _is_reasoning_model(model) else max_tokens
 
 
 def _build_anthropic_body(model: str, messages: list[dict], *, temperature: float = 0.7,

--- a/backend/tests/test_chat_stream_reasoning_event.py
+++ b/backend/tests/test_chat_stream_reasoning_event.py
@@ -166,3 +166,25 @@ async def test_reasoning_events_are_throttled():
     # 载荷是累计字符数，必须单调递增
     chars = [e["chars"] for e in reasoning_events]
     assert chars == sorted(chars), f"累计字符数应单调递增；实际: {chars}"
+
+
+@pytest.mark.anyio
+async def test_phase2_log_records_reasoning_volume_and_model(caplog):
+    """phase-2 日志必须带上推理字符数与模型名。
+
+    2026-08-01 的排查里，日志只说「96.75s, 0 chars, provider=deepseek」——
+    看不出这 96 秒花在哪，也看不出是 pro 还是 flash（provider 两者都是 deepseek）。
+    定位因此绕了很远：先翻 Prometheus 的 model 标签才知道是 flash，再从 SSE 流里
+    数 reasoning 事件才知道推理吃掉了全部预算。
+
+    这两个字段一旦在日志里，同一个故障一眼就能断：
+      "0 chars, reasoning=11826 chars, model=deepseek-v4-flash" —— 推理顶穿上限。
+    """
+    import logging
+    with caplog.at_level(logging.INFO, logger="app.services.chat"):
+        await _run([{"reasoning_content": "先看《地藏經》怎麼說"}, {"content": "答案正文"}])
+
+    line = next((r.getMessage() for r in caplog.records if "phase-2 LLM done" in r.getMessage()), None)
+    assert line is not None, "phase-2 计时日志没打出来"
+    assert "reasoning=10 chars" in line, f"日志缺少推理字符数: {line}"
+    assert "model=deepseek-v4-pro" in line, f"日志缺少模型名: {line}"

--- a/backend/tests/test_reasoning_token_budget.py
+++ b/backend/tests/test_reasoning_token_budget.py
@@ -21,8 +21,38 @@ def test_non_reasoning_models_not_detected():
 
 def test_headroom_added_only_for_reasoning_models():
     # The title cap is the worst case: 30 tokens, fully eaten by reasoning.
-    assert _with_reasoning_headroom("deepseek-v4-flash", 30) == 30 + 4000
-    assert _with_reasoning_headroom("deepseek-v4-pro", 2000) == 2000 + 4000
+    from app.services.llm_client import _REASONING_HEADROOM_TOKENS as H
+    assert _with_reasoning_headroom("deepseek-v4-flash", 30) == 30 + H
+    assert _with_reasoning_headroom("deepseek-v4-pro", 2000) == 2000 + H
     # Non-reasoning models keep the tight, cheap cap unchanged.
     assert _with_reasoning_headroom("deepseek-chat", 30) == 30
     assert _with_reasoning_headroom("glm-5.1", 2000) == 2000
+
+
+def test_headroom_covers_a_reasoning_trace_actually_seen_in_production():
+    """+4000 是 2026-06-23 针对**标题**（30 token 上限）定的，从没在「重推理模型
+    + 完整 RAG 答案」上验证过。2026-08-01 生产实测把它打穿了：
+
+    同一个问题（《地藏经》的孝道观与儒家有何不同？）、同一把 BYOK Key、同一端点，
+    只换模型 ——
+      deepseek-v4-pro    8 个推理事件、首字 11.2s、1,515 字、38s 完成
+      deepseek-v4-flash  57–66 个推理事件、**11,826 字符的推理**、正文 0 字、
+                         60–69s 后报「未能生成任何回答内容」
+
+    11,826 字符按 _estimate_tokens 的 2/3 口径 ≈ 7,884 token，而当时的整个上限是
+    2000+4000=6000 —— 推理独自就顶穿了天花板，模型被 length 截断，正文一个 token
+    都没轮到。生产日志里另有一条 96.75s / 0 字符（session 2618）是同一回事。
+
+    max_tokens 是天花板不是目标：调高它对推理少的模型（pro 只用约 1k）完全免费。
+    """
+    # 用实测到的那条推理轨迹作为下限，而不是拍一个好看的数字。
+    observed_reasoning_tokens = 11826 * 2 // 3   # ≈ 7884
+    answer_budget = 2000
+
+    budget = _with_reasoning_headroom("deepseek-v4-flash", answer_budget)
+
+    # 光够装下推理还不行 —— 装完推理必须还剩得下整段答案。
+    assert budget >= observed_reasoning_tokens + answer_budget, (
+        f"预算 {budget} 装不下实测的 {observed_reasoning_tokens} token 推理 + "
+        f"{answer_budget} token 答案；这正是生产上 0 字回答的成因"
+    )


### PR DESCRIPTION
用户报「响应变慢」。实测下来不是慢，是**必然失败**：他选的 deepseek-v4-flash
在这类问题上一个正文 token 都吐不出来。

## 定位

同一问题（《地藏经》的孝道观与儒家有何不同？）、同一把 BYOK Key、同一端点，
只换模型，走显式 model_id 让两边都进 BYOK 分支：

  检索完成      pro 1,978ms   flash 1,979ms   ← 检索不是瓶颈，几乎一模一样
  首字          pro 11.2s     flash 从未到达
  总耗时        pro 38.2s     flash 69.1s
  正文字符      pro 1,515     flash 0
  reasoning 事件 pro 8        flash 66
  结果          pro 成功       flash「未能生成任何回答内容」

复跑 flash 取推理字符数：11,826 字符、57 个事件、正文 0 字、60.1s。

算术就此闭合：11,826 字符按 _estimate_tokens 的 2/3 口径 ≈ 7,884 token，而整个
max_tokens 只有 2000 + 4000 = 6000。**推理独自顶穿了天花板**，模型被 length
截断，正文一个 token 都没轮到。生产日志里另有一条 96.75s / 0 字符
（session 2618）是同一回事，后端当时也打了 "produced no tokens and no error"。

那个 +4000 是 2026-06-23 针对**标题**（30 token 上限）定的，从没在「重推理模型
+ 完整 RAG 答案」上验证过。pro 只用约 1k 推理，所以一直没暴露。

不是前端回归：#1093 / #1094 全是渲染层改动，且 01:48–02:32 的慢样本（56s / 64s）
早于这两次部署。

## 改动

1. 推理额度 4000 → 24000（≈实测推理量的 3 倍；该档最大输出 384K，这仍是很小
   一块）。max_tokens 是天花板不是目标，推理少的模型一分钱都不多花。
2. phase-2 日志补上 reasoning 字符数与 model。这次排查绕了很远正是因为日志只有
   「96.75s, 0 chars, provider=deepseek」—— 看不出时间花在哪，也分不清 pro 还是
   flash（两者 provider 都是 deepseek），得先去翻 Prometheus 的 model 标签。
   补上之后同类故障一眼可断。

## 验证

· 额度用例拿实测那条推理轨迹当下限，不拍好看的数字；无修复时报
  「预算 6000 装不下实测的 7884 token 推理 + 2000 token 答案」
· 日志用例先红在「日志缺少推理字符数」，改完转绿
· 两处既有用例把 +4000 写死，改为引用同一个常量
· ruff（改动文件）+ pytest 1466 通过；test_health_check_probe 的 3 个失败在
  master 上同样红，与本改动无关

## 未解决

调高额度让 flash 有机会答完，但它在这类问题上要推理 60 秒以上仍是事实。
「flash 是否值得留在目录里」是产品判断，需要 backend/eval 的 90 题跑一轮
延迟与引用准确性再定，本 PR 不动目录。