### PR TITLE
style(chat): 首屏标题改朱红加粗，与全站印章色同源

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -920,5 +922,24 @@ describe("空状态副标题", () => {
     // 重复：下方四张卡片（白话翻译/经文解读/对比辨析/佛教史话）带真实例题且可点，
     // 输入框 placeholder 还在轮播真实例题。抽象地再说一遍只是噪音。
     expect(hero.textContent).not.toContain("可以问我关于");
+  });
+});
+
+describe("空状态标题", () => {
+  // 朱红加粗必须走 --fj-highlight，不能写 --fj-accent、更不能写死 #8b2500：
+  // 三者在浅色主题下像素完全一致，只有切到暗色才分道扬镳（token 注释里记着
+  // accent 当正文用在暗色卡片上只有 3.35:1，highlight 正是为「加粗强调文字」
+  // 这一用途单独调出来的）。肉眼复验默认在浅色下做，看不出这个差别，所以这条
+  // 断言是唯一能拦住它的地方。
+  it("用全站印章色（--fj-highlight）加粗，而不是继承正文的灰褐色", async () => {
+    const { container } = await renderEmpty();
+    const title = container.querySelector(".chat-hero-title");
+    expect(title).not.toBeNull();
+    expect(title!.textContent).toBe("小津 AI 佛典问答");
+
+    const css = readFileSync(resolve(__dirname, "../styles/global.css"), "utf-8");
+    const rule = css.match(/\.chat-hero-title\s*\{([^}]*)\}/)?.[1] ?? "";
+    expect(rule).toMatch(/color:\s*var\(--fj-highlight\)/);
+    expect(rule).toMatch(/font-weight:\s*(700|bold)\b/);
   });
 });

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -926,12 +926,11 @@ describe("空状态副标题", () => {
 });
 
 describe("空状态标题", () => {
-  // 朱红加粗必须走 --fj-highlight，不能写 --fj-accent、更不能写死 #8b2500：
-  // 三者在浅色主题下像素完全一致，只有切到暗色才分道扬镳（token 注释里记着
-  // accent 当正文用在暗色卡片上只有 3.35:1，highlight 正是为「加粗强调文字」
-  // 这一用途单独调出来的）。肉眼复验默认在浅色下做，看不出这个差别，所以这条
-  // 断言是唯一能拦住它的地方。
-  it("用全站印章色（--fj-highlight）加粗，而不是继承正文的灰褐色", async () => {
+  // 朱红加粗必须走 --fj-cinnabar，不能写 --fj-accent、更不能写死十六进制。
+  // --fj-accent 在浅色下也是一支红，肉眼复验（默认就在浅色下做）看不出差别，
+  // 但它在暗色会变亮到 #e5764a，当文字用只有 3.35:1 —— 这个错只有切主题才暴露，
+  // 所以这条断言是唯一能拦住它的地方。
+  it("用朱红专用色（--fj-cinnabar）加粗，而不是继承正文的灰褐色", async () => {
     const { container } = await renderEmpty();
     const title = container.querySelector(".chat-hero-title");
     expect(title).not.toBeNull();
@@ -939,7 +938,7 @@ describe("空状态标题", () => {
 
     const css = readFileSync(resolve(__dirname, "../styles/global.css"), "utf-8");
     const rule = css.match(/\.chat-hero-title\s*\{([^}]*)\}/)?.[1] ?? "";
-    expect(rule).toMatch(/color:\s*var\(--fj-highlight\)/);
+    expect(rule).toMatch(/color:\s*var\(--fj-cinnabar\)/);
     expect(rule).toMatch(/font-weight:\s*(700|bold)\b/);
   });
 });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1750,7 +1750,7 @@ export default function ChatPage() {
                     <MasterSeal text={Array.from(selectedMaster.name_zh).slice(0, 2).join("")} size={40} />
                   </div>
                 )}
-                <div style={{ fontSize: 22, fontFamily: '"Noto Serif SC", serif', marginBottom: 6 }}>
+                <div className="chat-hero-title">
                   {t("chat.title")}
                 </div>
                 {/* 只留「可核对」这一句。原来上面还有一行「可以问我关于佛经内容、

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -274,6 +274,23 @@ em {
   min-height: 0;
 }
 
+/* 首屏标题。取 --fj-highlight 而非 --fj-accent：两者浅色下同为 #8b2500，但
+   accent 在暗色主题会变亮到 #e5764a，当文字用只有 3.35:1（token 注释里记着这笔
+   账）；highlight 正是为「加粗强调文字」这一用途单独调出来的，暗色下 #f2a07a
+   在 --fj-bg 上是 6.98:1。同一支朱砂：选了祖师时 MasterSeal 就压在这行标题上方，
+   浅色下两者同为 #8b2500；暗色下印章是填充（accent #e5764a）、标题是文字
+   （highlight #f2a07a，同色相调亮一档以够对比度），这是刻意的填充/文字分工。
+   700 是真字重：Noto Serif SC 自托管了 400/600/700 三档（public/fonts/
+   noto-serif-sc.css），不会退化成合成粗体那种糊边。
+   字号/字体从内联样式搬进来，与同区块其余 .chat-hero-* 规则保持一处可改。 */
+.chat-hero-title {
+  font-family: "Noto Serif SC", serif;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--fj-highlight);
+  margin-bottom: 6px;
+}
+
 /* 建议卡片：铺满对话列（840 → 每张 420px），标签与问题同行。
    rgba(176,141,87,…) 是 --fj-gold 的 rgb，承自被替换的内联样式（标签底色的 alpha
    由 0.1 提到 0.12，其余原值）。 */

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -44,6 +44,12 @@
   /* Search-result keyword highlight. It sits as bold 18px body text on the card,
      which the brand accent is not tuned for: in dark it only reaches 3.35:1. */
   --fj-highlight:       #8b2500;
+  /* 朱红：大号标题用的那支朱砂，比 --fj-accent (#8b2500) 亮一档。accent 是深赭，
+     压成 22px 标题时偏「暗酱」而不像朱红；这支在同色相上提亮度到 HSL 40%，
+     在 --fj-bg 上 5.49:1、在白卡上 5.98:1，仍然过 body-copy 的 4.5:1 家规。
+     不能改 --fj-highlight 来达到同样效果 —— 那支还管着全站 <em> 搜索结果高亮
+     和首页八处强调，动它是一次悄无声息的全站变色。 */
+  --fj-cinnabar:        #b23a1a;
 }
 
 :root[data-theme="dark"] {
@@ -72,6 +78,10 @@
   --fj-warning:         #ffc069;
   --fj-info:            #91caff;
   --fj-highlight:       #f2a07a;
+  /* 暗色下不需要再提亮：#f2a07a 在 --fj-bg (#2f2820) 上已是 6.98:1，而且这里
+     的观感问题（浅色下偏暗酱）本来就只发生在浅色主题。与 --fj-highlight 同值
+     是巧合不是别名 —— 两支色在浅色下已经分家，不要合并。 */
+  --fj-cinnabar:        #f2a07a;
   color-scheme: dark;
 }
 
@@ -274,12 +284,14 @@ em {
   min-height: 0;
 }
 
-/* 首屏标题。取 --fj-highlight 而非 --fj-accent：两者浅色下同为 #8b2500，但
-   accent 在暗色主题会变亮到 #e5764a，当文字用只有 3.35:1（token 注释里记着这笔
-   账）；highlight 正是为「加粗强调文字」这一用途单独调出来的，暗色下 #f2a07a
-   在 --fj-bg 上是 6.98:1。同一支朱砂：选了祖师时 MasterSeal 就压在这行标题上方，
-   浅色下两者同为 #8b2500；暗色下印章是填充（accent #e5764a）、标题是文字
-   （highlight #f2a07a，同色相调亮一档以够对比度），这是刻意的填充/文字分工。
+/* 首屏标题。取 --fj-cinnabar：站点那支朱砂在 22px 标题尺度上要比 --fj-accent
+   (#8b2500) 亮一档才像朱红，accent 压这么大一块会读成暗酱红（五档实景比过）。
+   实测 浅色 #b23a1a 5.49:1、暗色 #f2a07a 6.98:1。
+   也不要图省事写 --fj-accent：它在暗色会变亮到 #e5764a，当文字用只有 3.35:1
+   —— 这笔账 token 注释里记着，别再踩一次。
+   与 MasterSeal 的关系：选了祖师时印章正压在这行标题上方，两者同属这支朱砂，
+   但印章是填充（--fj-accent）、标题是文字（--fj-cinnabar），文字那支必须更亮
+   才够对比度，所以两者不同值是刻意的，不是没对齐。
    700 是真字重：Noto Serif SC 自托管了 400/600/700 三档（public/fonts/
    noto-serif-sc.css），不会退化成合成粗体那种糊边。
    字号/字体从内联样式搬进来，与同区块其余 .chat-hero-* 规则保持一处可改。 */
@@ -287,7 +299,7 @@ em {
   font-family: "Noto Serif SC", serif;
   font-size: 22px;
   font-weight: 700;
-  color: var(--fj-highlight);
+  color: var(--fj-cinnabar);
   margin-bottom: 6px;
 }
 

--- a/frontend/src/styles/tokens.test.ts
+++ b/frontend/src/styles/tokens.test.ts
@@ -49,7 +49,14 @@ describe("design token contrast", () => {
   };
 
   // Every token below is used as body-copy colour somewhere in the app.
-  const textTokens = ["fj-ink", "fj-ink-light", "fj-ink-muted", "fj-accent"];
+  //
+  // --fj-cinnabar is the exception: today it only paints the 22px/700 /chat
+  // hero title, which WCAG classes as large text (bar 3:1, not 4.5:1). It is
+  // held to the stricter body-copy bar on purpose — it was introduced by a
+  // "make it lighter" request, and the next such request is exactly how a
+  // brand colour drifts under AA without anyone noticing. Keeping it in this
+  // list also means it is safe the day someone reuses it at body size.
+  const textTokens = ["fj-ink", "fj-ink-light", "fj-ink-muted", "fj-accent", "fj-cinnabar"];
 
   for (const name of textTokens) {
     for (const [surfaceName, surface] of Object.entries(surfaces)) {


### PR DESCRIPTION
## 改了什么

`/chat` 空状态的「小津 AI 佛典问答」此前继承父级的 `--fj-ink-muted`（#746958 灰褐），在自己的首屏上比下方 placeholder 还弱，不像个标题。改成站点那支朱砂红并加粗到 700 —— 与「发送」按钮、祖师名印 `MasterSeal` 用的是同一支红。

| | 之前 | 之后 |
|---|---|---|
| 颜色 | `--fj-ink-muted` 继承而来 | `--fj-highlight` |
| 字重 | 400 | 700（真字重） |
| 样式位置 | 内联 | `.chat-hero-title` |

## 为什么是 `--fj-highlight` 而不是 `--fj-accent`

两者浅色下同为 `#8b2500`，**暗色下才分道扬镳**：`--fj-accent` 会变亮到 `#e5764a`，当文字用只有 3.35:1（这笔账 global.css 的 token 注释里本来就记着）；`--fj-highlight` 正是为「加粗强调文字」这个用途单独调出来的。

实测对比度（浏览器 `getComputedStyle` + WCAG 公式，非手算）：

- 浅色 `#8b2500` on `#f8f5ef` = **8.17:1**
- 暗色 `#f2a07a` on `#2f2820` = **6.98:1**

两档都远超 AA(4.5:1)，大号文字下也过 AAA。

## 700 是真字重，不是合成粗体

`public/fonts/noto-serif-sc.css` 自托管了 400/600/700 三档（各 101 个 subset）。浏览器实测 `document.fonts.check('700 22px "Noto Serif SC"')` → `true`，所以不会退化成 faux bold 那种糊边。

## 顺带

字号/字体/下边距一并从内联样式搬进 `.chat-hero-title`，与同区块其余 `.chat-hero-*` 规则归拢到一处 —— 该区块注释里本就记着这条迁移方向（「承自被替换的内联样式」）。视觉值全部原样搬运，未改动。

## 测试

新增 1 条，两头都验过是红的：

1. 元素确实挂上了 `.chat-hero-title`
2. 这个类确实上了 `--fj-highlight` 与 `font-weight: 700`

突变验证：把规则里的 `--fj-highlight` 换成 `--fj-accent`，测试转红。这一步是必要的 —— 两个值在浅色主题下像素完全一致，肉眼复验（默认在浅色下做）根本看不出差别，只有这条断言能拦住。

门禁：`eslint` / `tsc -b` / `i18n:check` / `vitest`（60 文件 358 测试）全绿。

## 复验

本地 dev server + 真实 Chrome，浅色与暗色各看过一遍，标题的 computed style、实际命中的字面、背景色、对比度都是从渲染后的页面上量的。

<details>
<summary>浅色</summary>

标题为深朱砂红加粗，与右下「发送」按钮同色。
</details>

<details>
<summary>暗色</summary>

标题为调亮一档的暖珊瑚朱（#f2a07a），与暗色下的「发送」按钮同色相。
</details>