### PR TITLE
fix(seo): og:url 与 JSON-LD 用 http，与 canonical 自相矛盾

### DIFF
--- a/backend/app/api/seo.py
+++ b/backend/app/api/seo.py
@@ -90,6 +90,31 @@ def _escape_meta_value(value: str) -> str:
     )
 
 
+def public_base_url(request: Request) -> str:
+    """Base URL as the *outside world* sees it, i.e. with the real scheme.
+
+    ``request.base_url`` reports the scheme of the connection uvicorn actually
+    accepted. Behind our nginx hop that is always ``http``, so every URL built
+    from it went out as ``http://`` — og:url, the JSON-LD ``url``, and every
+    breadcrumb item. Cloudflare's Automatic HTTPS Rewrites then silently
+    patched only the ``href``-bearing ``<link rel="canonical">``, leaving the
+    page self-contradictory: canonical said https, og:url said http, and the
+    sitemap (which hardcodes https) disagreed with both.
+
+    nginx sets ``X-Forwarded-Proto`` with ``proxy_set_header``, which
+    OVERWRITES any client-supplied value, so unlike ``X-Forwarded-For`` (which
+    is *appended* to — see backend/entrypoint.sh for why we deliberately do not
+    run uvicorn with ``--proxy-headers``) this header cannot be spoofed through
+    the proxy and is safe to trust. Values other than http/https are ignored.
+    """
+    base = str(request.base_url).rstrip("/")
+    forwarded = request.headers.get("x-forwarded-proto", "")
+    scheme = forwarded.split(",")[0].strip().lower()
+    if scheme in ("http", "https"):
+        base = re.sub(r"^https?://", f"{scheme}://", base, count=1)
+    return base
+
+
 def _sub_literal(pattern: re.Pattern[str], replacement: str, html: str, *, count: int = 1) -> str:
     """``pattern.sub`` that treats ``replacement`` as a literal string.
 
@@ -195,7 +220,7 @@ def _build_text_meta(text, request: Request, *, route: str) -> tuple[str, str, s
     )
     description = "".join(desc_parts)
 
-    base = str(request.base_url).rstrip("/")
+    base = public_base_url(request)
     # base_url comes from the inbound request — under cloudflare/nginx the
     # forwarded scheme/host should already be set on the request.
     if route == "read":
@@ -241,7 +266,7 @@ async def _serve_text_seo_html(
     # Detail route is the indexable surface — give Googlebot a real body.
     # Reader route stays a SPA shell (it's noindex anyway).
     if route == "detail":
-        base_url = str(request.base_url).rstrip("/")
+        base_url = public_base_url(request)
         patched = _inject_text_jsonld(
             patched, _build_breadcrumb_jsonld(text, canonical_url=canonical, base_url=base_url)
         )
@@ -489,7 +514,7 @@ def _build_share_qa_meta(record: SharedQA, request: Request) -> dict[str, str]:
     answer_plain = _strip_markdown(record.answer or "")
     description = _truncate_for_meta(answer_plain or question, limit=150)
 
-    base = str(request.base_url).rstrip("/")
+    base = public_base_url(request)
     canonical = f"{base}/share/qa/{record.id}"
     og_image = f"{base}/api/og/share/qa/{record.id}"
     return {

--- a/backend/app/api/seo_dict.py
+++ b/backend/app/api/seo_dict.py
@@ -35,7 +35,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from app.api.seo import _escape_meta_value
+from app.api.seo import _escape_meta_value, public_base_url
 from app.database import get_db
 from app.models.dictionary import DictionaryEntry
 from app.models.text import BuddhistText, TextContent
@@ -353,7 +353,7 @@ async def dict_seo_html(headword: str, request: Request, db: AsyncSession = Depe
         for e in entries
     ]
 
-    base_url = str(request.base_url).rstrip("/")
+    base_url = public_base_url(request)
     canonical = f"{base_url}/dict/{canonical_headword}"
     headword = canonical_headword
 

--- a/backend/app/api/seo_persons.py
+++ b/backend/app/api/seo_persons.py
@@ -22,7 +22,7 @@ from fastapi.responses import HTMLResponse
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.seo import _escape_meta_value
+from app.api.seo import _escape_meta_value, public_base_url
 from app.database import get_db
 from app.models.knowledge_graph import KGEntity, KGRelation
 from app.models.text import BuddhistText
@@ -380,7 +380,7 @@ async def person_seo_html(
     if entity is None or entity.entity_type != "person":
         raise HTTPException(status_code=404, detail="person not found")
 
-    base_url = str(request.base_url).rstrip("/")
+    base_url = public_base_url(request)
 
     try:
         canonical_id = await _find_canonical_person_id(db, entity)

--- a/backend/tests/test_seo_base_url_scheme.py
+++ b/backend/tests/test_seo_base_url_scheme.py
@@ -1,0 +1,121 @@
+"""Regression tests for the public base URL scheme used by SEO routes.
+
+Behind nginx, ``request.base_url`` always reports ``http`` (uvicorn runs
+without ``--proxy-headers`` on purpose — see backend/entrypoint.sh). Every URL
+built from it therefore went out as ``http://``: og:url, the JSON-LD ``url``,
+and every breadcrumb item. Cloudflare's Automatic HTTPS Rewrites patched only
+the ``href``-bearing ``<link rel="canonical">``, so production served pages
+whose canonical said https while og:url and the structured data said http —
+and the sitemap (hardcoded https) disagreed with both.
+"""
+
+import re
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from app.api.seo import public_base_url
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/probe")
+    async def probe(request: Request):  # pragma: no cover - trivial
+        return {"base": public_base_url(request)}
+
+    return app
+
+
+async def _probe(headers: dict[str, str] | None = None) -> str:
+    transport = ASGITransport(app=_app())
+    async with AsyncClient(transport=transport, base_url="http://fojin.app") as client:
+        resp = await client.get("/probe", headers=headers or {})
+    return resp.json()["base"]
+
+
+@pytest.mark.asyncio
+async def test_forwarded_proto_https_upgrades_scheme():
+    assert await _probe({"X-Forwarded-Proto": "https"}) == "https://fojin.app"
+
+
+@pytest.mark.asyncio
+async def test_without_header_scheme_is_left_alone():
+    """Self-hosters running plain HTTP must not be handed https URLs."""
+    assert await _probe() == "http://fojin.app"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_proto_http_stays_http():
+    assert await _probe({"X-Forwarded-Proto": "http"}) == "http://fojin.app"
+
+
+@pytest.mark.asyncio
+async def test_multi_value_header_takes_first_hop():
+    assert await _probe({"X-Forwarded-Proto": "https, http"}) == "https://fojin.app"
+
+
+@pytest.mark.asyncio
+async def test_uppercase_value_is_normalised():
+    assert await _probe({"X-Forwarded-Proto": "HTTPS"}) == "https://fojin.app"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bogus", ["javascript", "ftp", "", "  ", "https://evil.com"])
+async def test_bogus_scheme_is_ignored(bogus: str):
+    """Anything that is not exactly http/https must not reach the URL."""
+    assert await _probe({"X-Forwarded-Proto": bogus}) == "http://fojin.app"
+
+
+@pytest.mark.asyncio
+async def test_host_beginning_with_http_survives_the_rewrite():
+    """A host whose name starts with "http" must come back intact.
+
+    Note on what this does NOT prove: mutating the implementation's
+    ``re.sub(..., count=1)`` into a blanket ``str.replace`` leaves this test
+    green. That is not a gap in the case — a base URL is always ``scheme://host``
+    and a host can never contain a second ``://``, so the two forms are
+    genuinely equivalent here. ``count=1`` is kept as defence in depth for the
+    day this helper is handed something with a path, not because a test pins it.
+    """
+    transport = ASGITransport(app=_app())
+    async with AsyncClient(transport=transport, base_url="http://http-archive.example") as client:
+        resp = await client.get("/probe", headers={"X-Forwarded-Proto": "https"})
+    assert resp.json()["base"] == "https://http-archive.example"
+
+
+@pytest.mark.asyncio
+async def test_person_page_canonical_and_og_url_agree(monkeypatch):
+    """End-to-end: the two signals that contradicted each other in production.
+
+    This is the assertion that actually mattered — a page whose canonical and
+    og:url disagree on scheme is a self-contradictory signal to crawlers.
+    """
+    from app.api import seo_persons
+
+    class _Entity:
+        id = 42
+        name_zh = "法藏"
+        name_en = name_sa = name_pi = name_bo = None
+        entity_type = "person"
+        description = "华严宗祖师"
+        properties: dict = {}
+        external_ids: dict = {}
+
+    html = seo_persons._render_person_html(
+        _Entity(),
+        related_texts=[],
+        related_persons=[],
+        canonical="https://fojin.app/persons/42",
+        base_url="https://fojin.app",
+    )
+
+    canonical = re.search(r'<link rel="canonical" href="([^"]+)"', html)
+    og_url = re.search(r'<meta property="og:url" content="([^"]+)"', html)
+    assert canonical and og_url
+    assert canonical.group(1) == og_url.group(1)
+    assert canonical.group(1).startswith("https://")
+
+    # The structured data must agree too — Cloudflare never rewrites <script>.
+    assert "http://fojin.app" not in html


### PR DESCRIPTION
## 问题（生产实测）

`curl -H "User-Agent: Googlebot" https://fojin.app/persons/173759`：

```
<link rel="canonical" href="https://fojin.app/persons/164224" />
<meta property="og:url" content="http://fojin.app/persons/164224" />
JSON-LD  Person.url      = http://fojin.app/persons/164224
JSON-LD  breadcrumb item = http://fojin.app , http://fojin.app/kg , …
```

canonical 与 og:url 在代码里**取自同一个变量**，输出却不同。

## 根因

`request.base_url` 报告的是 uvicorn 实际接受的连接协议——在 nginx 后面**永远是 http**，所以源头全部是 `http://`。

Cloudflare 的 Automatic HTTPS Rewrites 只改写带 `href`/`src` 的属性，于是单单把 `<link rel="canonical">` 补成了 https，`<meta content="">` 和 `<script>` 里的 JSON-LD 原样放行。结果：

- 页面自相矛盾（canonical 说 https，og:url 与结构化数据说 http）
- 与 `sitemap.py` / `rss.py` 里硬编码的 `https://fojin.app` 也对不上

这个 bug 一直存在，被 CF 掩盖了一半，所以此前没人发现。

## 修法：刻意不动 uvicorn

`backend/entrypoint.sh` 有明确注释说明**故意不加 `--proxy-headers`**：nginx 用 `$proxy_add_x_forwarded_for` 把真实 IP **追加到 XFF 最右**，而 `--proxy-headers` 取**最左**——正是可伪造的那一项。加它会引入 IP 伪造漏洞，因此绝不能碰。

改用一个只管协议的 helper `public_base_url()`：

- 读 `X-Forwarded-Proto`。该头由 nginx 以 `proxy_set_header` **覆盖**写入（不是追加），因此经代理不可伪造，与 XFF 的情况本质不同
- 白名单只认 `http` / `https`，其余值（`ftp`、`javascript`、`https://evil.com`…）一律忽略
- **无该头时保持原样**，自部署在纯 HTTP 下不会被硬塞 https URL

`seo.py` / `seo_dict.py` / `seo_persons.py` 共 5 处调用点统一。

## 验证

12 个测试，并做了变异测试确认有效性：

| 变异 | 结果 |
|---|---|
| 移除协议重写（回到 bug 状态） | 打红 4 个 ✅ |
| 去掉 http/https 白名单 | 打红 3 个 ✅ |
| `count=1` 改为全局 `replace` | **12 个全绿** ⚠️ |

第三个变异没被抓住。已确认**那不是用例缺口**：base URL 形如 `scheme://host`，host 不可能含第二个 `://`，两种写法在此场景真的等价。已在该用例的 docstring 里写明它证明不了什么，避免留下虚假的安全感；`count=1` 作为防御保留。

其余门禁：`ruff check app/ eval/` 对 CI 的 0.9.7 干净；`pytest tests/ -q` → **1,505 passed**（另 3 个 `test_health_check_probe` 失败为本机 `cryptography` 版本所致，在未触碰 backend 的分支上同样复现）。