### PR TITLE
fix(nginx): 前端这一跳别覆盖 X-Forwarded-Proto，否则后端永远看到 http

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,24 @@
+# Carry the ORIGINAL client protocol through this hop instead of overwriting it.
+#
+# The chain is: Cloudflare (https) → host nginx → this container → backend.
+# The host nginx already sets `X-Forwarded-Proto $scheme`, which on its :443
+# server is "https". But every proxy_set_header below used *this* container's
+# own $scheme — and the host→container hop is plain http — so the correct value
+# was thrown away and the backend always saw "http". Consequence: every URL the
+# backend built from request.base_url went out as http:// (og:url, JSON-LD url,
+# breadcrumbs), while Cloudflare's Automatic HTTPS Rewrites patched only the
+# href-bearing <link rel="canonical"> — leaving pages self-contradictory.
+#
+# Trusting the inbound header is safe *here specifically*: this container is
+# published on 127.0.0.1 only (see FRONTEND_BIND in docker-compose.yml), so the
+# header can only have come from the host nginx, which overwrites whatever the
+# client sent. $scheme remains the fallback for direct/local access and for
+# self-hosters running without a second proxy in front.
+map $http_x_forwarded_proto $fwd_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -89,7 +110,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
         proxy_buffering off;
         proxy_cache off;
         proxy_read_timeout 120s;
@@ -108,7 +129,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
     }
 
     # SEO HTML for individual sutra pages — backend injects per-text
@@ -122,7 +143,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
         # Don't cache so a frontend redeploy is visible immediately
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         include /etc/nginx/security-headers.conf;
@@ -137,7 +158,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
         add_header Cache-Control "public, max-age=3600";
         include /etc/nginx/security-headers.conf;
     }
@@ -150,7 +171,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
         add_header Cache-Control "public, max-age=3600";
         include /etc/nginx/security-headers.conf;
     }
@@ -164,7 +185,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         include /etc/nginx/security-headers.conf;
     }
@@ -210,7 +231,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
     }
 
     # Research assistant: one request fans out into a plan + several retrievals
@@ -223,7 +244,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
         proxy_read_timeout 180s;
         proxy_send_timeout 180s;
     }
@@ -233,7 +254,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
     }
 
     # OpenAPI docs — publicly accessible as the API documentation portal
@@ -242,21 +263,21 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
     }
     location /redoc {
         proxy_pass $upstream_backend/redoc;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
     }
     location /openapi.json {
         proxy_pass $upstream_backend/openapi.json;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $fwd_proto;
     }
 
     # Service worker must not be cached — ensures PWA picks up new versions


### PR DESCRIPTION
## 背景：#1107 上线后没生效

#1107 让后端改读 `X-Forwarded-Proto` 决定协议，合并部署后（`last-backend-restart` 已是该 commit、两个 backend 容器均已重启）生产的 og:url **依然是 http**。

先排除了「后端代码写错」——直接给 backend 容器发请求：

| 请求 | og:url |
|---|---|
| 带 `X-Forwarded-Proto: https` | **https**://…/persons/164224 ✅ |
| 不带该头 | http://…/persons/164224 ✅（符合设计） |

后端逻辑正确。问题在这一跳。

## 根因

链路：**Cloudflare (https) → 宿主 nginx → 本容器 → backend**

宿主 nginx 已经设了 `X-Forwarded-Proto $scheme`，在它的 `:443` server 上即 `https`。但本容器的 **12 处** `proxy_set_header` 用的是**自己的** `$scheme`，而宿主→容器那一跳是明文 http——于是把上游已经算对的值**覆盖**成了 http。

后端拿到 http，所有由 `request.base_url` 构造的 URL 随之全是 http（og:url、JSON-LD `url`、整条面包屑）。Cloudflare 的 Automatic HTTPS Rewrites 只补带 `href` 的 `<link rel="canonical">`，页面因此自相矛盾——这也是为什么这个 bug 长期没被发现。

## 改动

新增 `map`，转发上游值，`$scheme` 仅作回退；12 处 `proxy_set_header` 统一改用它。

### 为什么信任入站头在这里是安全的

本容器只发布在 **127.0.0.1**（`docker-compose.yml` 的 `FRONTEND_BIND`，配置里还专门注释了 docker iptables 会绕过 ufw 的坑），外部无法直连，因此该头只可能来自宿主 nginx，而宿主 nginx 会**覆盖**客户端传来的任何值。

这与 `X-Forwarded-For` 的情形**本质不同**：XFF 是**追加**的，所以后端另有 `core/client_ip.py` 取最右项，且 `entrypoint.sh` 明确不开 uvicorn 的 `--proxy-headers`（它取最左，是可伪造的那一项）。本 PR 不触碰那条链路。

回退保留 `$scheme`，直连访问与没有二级代理的自部署不受影响。

## 验证

一次性 nginx 容器实测（生产宿主，独立端口，未触碰 `fojin-frontend`）：

```
真实 nginx.conf + security-headers.conf
  nginx -t  →  syntax is ok / test is successful

map 行为
  不带头                    →  http     （回退 $scheme）
  X-Forwarded-Proto: https  →  https
  X-Forwarded-Proto: http   →  http
```

合并部署后应做的确认：`/persons/173759` 的 canonical、og:url、JSON-LD `url`、breadcrumb **四者全部为 https 且一致**。