### PR TITLE
fix(seo): 经文页分享出去是首页的卡片——og:* 从未被注入

### DIFF
--- a/backend/app/api/seo.py
+++ b/backend/app/api/seo.py
@@ -60,6 +60,16 @@ _ROBOTS_RE = re.compile(
 _HEAD_CLOSE_RE = re.compile(r"</head>", re.IGNORECASE)
 _ROOT_DIV_RE = re.compile(r'<div\s+id="root"\s*></div>', re.IGNORECASE)
 
+# Open Graph / Twitter equivalents of the three tags above. Without these the
+# injected page keeps the SPA template's homepage og:* values, so *sharing any
+# text or shared-QA link posts a card advertising the homepage* — wrong title,
+# and an og:url that sends the reader to `/` instead of the thing being shared.
+_OG_TITLE_RE = re.compile(r'<meta\s+property="og:title"\s+content="[^"]*"\s*/?>', re.IGNORECASE)
+_OG_DESCRIPTION_RE = re.compile(r'<meta\s+property="og:description"\s+content="[^"]*"\s*/?>', re.IGNORECASE)
+_OG_URL_RE = re.compile(r'<meta\s+property="og:url"\s+content="[^"]*"\s*/?>', re.IGNORECASE)
+_TW_TITLE_RE = re.compile(r'<meta\s+name="twitter:title"\s+content="[^"]*"\s*/?>', re.IGNORECASE)
+_TW_DESCRIPTION_RE = re.compile(r'<meta\s+name="twitter:description"\s+content="[^"]*"\s*/?>', re.IGNORECASE)
+
 # Cap on how much text we inject into the SEO HTML body. Googlebot weighs the
 # *first* ~2000 chars heaviest; injecting much more than this hits diminishing
 # returns and inflates page weight for real users (the SEO block is rendered
@@ -153,7 +163,16 @@ def _inject_meta(
     canonical_url: str,
     robots: str = "index, follow",
 ) -> str:
-    """Replace <title>, <meta name="description">, <link rel="canonical">, and <meta name="robots">.
+    """Replace title / description / canonical / robots **and the og:* + twitter:* mirrors**.
+
+    The Open Graph tags matter as much as ``<title>`` here: they are what a
+    WeChat or Twitter share card renders. Leaving the template's values in
+    place meant every shared text — and every shared QA, which is the entire
+    point of ``/share/qa/{id}`` — posted a card titled after the homepage,
+    with an ``og:url`` pointing at ``/`` rather than the thing being shared.
+
+    ``og:image`` is deliberately NOT touched: there is no per-text image, so
+    the site-wide share card is the correct asset.
 
     If a canonical link is missing entirely (the default for the React SPA
     template), we add it just before the closing </head> tag.
@@ -174,6 +193,14 @@ def _inject_meta(
         f'<meta name="robots" content="{safe_robots}" />',
         new_html,
     )
+    for pattern, replacement in (
+        (_OG_TITLE_RE, f'<meta property="og:title" content="{safe_title}" />'),
+        (_OG_DESCRIPTION_RE, f'<meta property="og:description" content="{safe_desc}" />'),
+        (_OG_URL_RE, f'<meta property="og:url" content="{safe_canonical}" />'),
+        (_TW_TITLE_RE, f'<meta name="twitter:title" content="{safe_title}" />'),
+        (_TW_DESCRIPTION_RE, f'<meta name="twitter:description" content="{safe_desc}" />'),
+    ):
+        new_html = _sub_literal(pattern, replacement, new_html)
     canonical_tag = f'<link rel="canonical" href="{safe_canonical}" />'
     if _CANONICAL_RE.search(new_html):
         new_html = _sub_literal(_CANONICAL_RE, canonical_tag, new_html)
@@ -528,13 +555,16 @@ def _build_share_qa_meta(record: SharedQA, request: Request) -> dict[str, str]:
 
 
 _OG_TAG_PATTERNS = (
-    re.compile(r'<meta\s+property="og:title"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
-    re.compile(r'<meta\s+property="og:description"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    # First three reuse the named patterns defined near the top — the share-QA
+    # path strips exactly the tags the text path rewrites, and two copies of
+    # these regexes would drift apart the first time one side is edited.
+    _OG_TITLE_RE,
+    _OG_DESCRIPTION_RE,
     re.compile(r'<meta\s+property="og:image"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
     re.compile(r'<meta\s+property="og:image:width"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
     re.compile(r'<meta\s+property="og:image:height"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
     re.compile(r'<meta\s+property="og:type"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
-    re.compile(r'<meta\s+property="og:url"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
+    _OG_URL_RE,
     re.compile(r'<meta\s+name="twitter:card"\s+content="[^"]*"\s*/?>', re.IGNORECASE),
 )
 

--- a/backend/tests/test_seo_og_per_page.py
+++ b/backend/tests/test_seo_og_per_page.py
@@ -1,0 +1,104 @@
+"""``_inject_meta`` must rewrite og:* / twitter:* too, not just <title>.
+
+Production regression: `/texts/13` served the correct `<title>` and canonical
+but kept the SPA template's homepage Open Graph tags — so sharing any sutra to
+WeChat/Twitter posted a card titled "佛津 FoJin — 问佛经，得到能核对原文的答案"
+whose og:url was `https://fojin.app/`. Every share pointed readers at the
+homepage instead of the thing being shared.
+
+Why the existing suite missed it: `tests/test_seo_meta_injection.py` uses a
+hand-written SHELL with no og:* tags at all, so there was nothing to leave
+stale. These tests deliberately mirror the REAL `frontend/index.html` head.
+"""
+
+import re
+
+from app.api.seo import _inject_meta
+
+# Mirrors the real frontend/index.html head — the homepage values are exactly
+# what leaked onto every text page before the fix.
+SHELL = (
+    "<!doctype html><html><head>"
+    "<title>佛津 FoJin — 佛经 AI 问答，每句引用可点开核对原文</title>"
+    '<meta name="description" content="向大藏经提问，小津用原文回答……" />'
+    '<meta name="robots" content="index, follow" />'
+    '<link rel="canonical" href="https://fojin.app/" />'
+    '<meta property="og:type" content="website" />'
+    '<meta property="og:title" content="佛津 FoJin — 问佛经，得到能核对原文的答案" />'
+    '<meta property="og:description" content="AI 从大藏经原文作答……" />'
+    '<meta property="og:url" content="https://fojin.app/" />'
+    '<meta property="og:image" content="https://fojin.app/og-image.png" />'
+    '<meta name="twitter:title" content="佛津 FoJin — 问佛经，得到能核对原文的答案" />'
+    '<meta name="twitter:description" content="AI 从大藏经原文作答……" />'
+    "</head><body></body></html>"
+)
+
+TITLE = "《大方廣佛華嚴經》 般若译 — 佛津 FoJin"
+DESC = "《大方廣佛華嚴經》全文在线阅读，般若译。"
+CANONICAL = "https://fojin.app/texts/13"
+
+
+def _meta(html: str, prop: str) -> str | None:
+    m = re.search(r'<meta\s+(?:property|name)="' + re.escape(prop) + r'"\s+content="([^"]*)"', html)
+    return m.group(1) if m else None
+
+
+def _patched() -> str:
+    return _inject_meta(SHELL, title=TITLE, description=DESC, canonical_url=CANONICAL)
+
+
+def test_og_url_points_at_this_page_not_the_homepage():
+    """The regression that mattered: a shared sutra must not link to `/`."""
+    assert _meta(_patched(), "og:url") == CANONICAL
+
+
+def test_og_title_and_description_are_page_specific():
+    html = _patched()
+    assert _meta(html, "og:title") == TITLE
+    assert _meta(html, "og:description") == DESC
+
+
+def test_twitter_card_fields_follow_too():
+    html = _patched()
+    assert _meta(html, "twitter:title") == TITLE
+    assert _meta(html, "twitter:description") == DESC
+
+
+def test_og_image_is_left_alone():
+    """There is no per-text image; the site-wide share card is correct here."""
+    assert _meta(_patched(), "og:image") == "https://fojin.app/og-image.png"
+
+
+def test_no_homepage_leftovers_anywhere_in_head():
+    """Nothing may still advertise the homepage URL or its tagline."""
+    html = _patched()
+    head = html[: html.index("</head>")]
+    assert 'content="https://fojin.app/"' not in head
+    assert "问佛经，得到能核对原文的答案" not in head
+
+
+def test_each_og_tag_appears_exactly_once():
+    """Rewrite-in-place, not append — duplicated og:url is undefined behaviour."""
+    html = _patched()
+    for prop in ("og:title", "og:description", "og:url"):
+        assert html.count(f'"{prop}"') == 1, prop
+
+
+def test_values_are_escaped_in_og_tags_too():
+    """og:* splices the same user-controlled strings; escaping must apply there."""
+    html = _inject_meta(
+        SHELL,
+        title='evil" onload="x',
+        description="a<b>c",
+        canonical_url="https://fojin.app/texts/1",
+    )
+    assert 'onload="x' not in html
+    assert "&quot;" in _meta(html, "og:title")
+    assert "&lt;b&gt;" in _meta(html, "og:description")
+
+
+def test_title_and_canonical_still_work():
+    """Guard the pre-existing behaviour this change sits on top of."""
+    html = _patched()
+    assert f"<title>{TITLE}</title>" in html
+    assert f'<link rel="canonical" href="{CANONICAL}" />' in html


### PR DESCRIPTION
## 问题（生产实测 `/texts/13`）

| 标签 | 值 | |
|---|---|---|
| `<title>` | 《大方廣佛華嚴經》 般若译 — 佛津 FoJin | ✅ |
| `canonical` | `https://fojin.app/texts/13` | ✅ |
| **`og:title`** | 佛津 FoJin — 问佛经，得到能核对原文的答案 | ❌ 首页的 |
| **`og:description`** | AI 从大藏经原文作答…… | ❌ 首页的 |
| **`og:url`** | `https://fojin.app/` | ❌ 首页的 |

**任何人把一部经分享到微信/Twitter，卡片标题是首页标语，点进去落到首页**，而不是被分享的那部经。这是直接作用在口碑传播上的损耗——每传一次削一次。

根因：`_inject_meta` 只改 `title` / `description` / `canonical` / `robots`，**从不碰 `og:*`**，于是页面继承 SPA 模板里的首页值。

## 改动

补上 `og:title` / `og:description` / `og:url` 与 `twitter:title` / `twitter:description`。

**`og:image` 刻意不动**——没有 per-text 图，站点级分享卡片就是这里的正确资产。

### `/share/qa/{id}` 不受影响

它走 `_inject_share_qa_meta`：内部先调 `_inject_meta`，再 `_strip_existing_og_tags` 剥净，然后追加自己那一套（含指向 `/api/og/share/qa/{id}` 的**动态** og:image）。已由既有测试与本 PR 同跑验证。

顺带把 `_OG_TAG_PATTERNS` 的前三条改为复用新提取的具名正则——strip 掉的正是 rewrite 的那几个标签，留两份同义正则早晚会漂移。

## 为什么既有测试没抓住

`tests/test_seo_meta_injection.py` 用的 `SHELL` 是手写的，**里面压根没有 `og:*` 标签**，自然不存在"陈旧值残留"可言。新测试的 SHELL **刻意照抄真实 `frontend/index.html` 的 head**，homepage 的值原样放进去。

## 验证

8 个用例，含转义（og 同样拼接用户可控字符串）与「每个 og 标签只出现一次」（重写而非追加，重复 og:url 是未定义行为）。

**变异验证**：撤掉 og 替换循环 → 打红 5 个。

`ruff check app/ eval/` 对 CI 的 0.9.7 干净；`pytest tests/ -q` → **1,513 passed**（3 个 `test_health_check_probe` 失败为本机 `cryptography` 版本所致，未触碰 backend 的分支上同样复现）。