### PR TITLE
revert(i18n): 首页副标题回到「全球佛教古籍数字资源聚合平台」

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2,7 +2,7 @@
   "app.name": "佛津 FoJin",
   "home.title_accent": "Fo",
   "home.title_rest": "Jin",
-  "app.tagline": "Ask the canon — get answers you can check against the source",
+  "app.tagline": "Global Buddhist Classics Digital Resource Platform",
   "app.title": "FoJin — Buddhist canon Q&A, every citation opens to its source",
   "nav.home": "Home",
   "nav.search": "Search",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -2,7 +2,7 @@
   "app.name": "佛津",
   "home.title_accent": "佛",
   "home.title_rest": "津",
-  "app.tagline": "問佛經，得到能核對原文的答案",
+  "app.tagline": "全球佛教古籍數字資源聚合平臺",
   "app.title": "佛津 FoJin — 佛經 AI 問答，每句引用可點開核對原文",
   "nav.home": "首頁",
   "nav.search": "搜尋",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -2,7 +2,7 @@
   "app.name": "佛津",
   "home.title_accent": "佛",
   "home.title_rest": "津",
-  "app.tagline": "问佛经，得到能核对原文的答案",
+  "app.tagline": "全球佛教古籍数字资源聚合平台",
   "app.title": "佛津 FoJin — 佛经 AI 问答，每句引用可点开核对原文",
   "nav.home": "首页",
   "nav.search": "搜索",


### PR DESCRIPTION
## 改什么

首页 logo 下那一行可见副标题，从 #1106 引入的

> 问佛经，得到能核对原文的答案

还原为

> 全球佛教古籍数字资源聚合平台

zh / en / zh-Hant 三语同步还原为 #1106 之前的值。

## 影响面

`app.tagline` 在整个前端**只有一个使用点**：

```
frontend/src/pages/HomePage.tsx:167
  <div className="home-subtitle">{t("app.tagline")}</div>
```

所以本 PR 只动首页那一行，不触及任何其他页面。

## 刻意没动的

`app.title`（首页 `<title>`，即浏览器标签页与 Google 搜索结果的标题）保持
「佛津 FoJin — 佛经 AI 问答，每句引用可点开核对原文」。它不在用户指的那一行里，
承担的是搜索结果里的价值主张，与页面上的品牌标语可以各司其职。

同理未动：`frontend/index.html` 的 meta / og、`og-image.png` 分享卡、
`staticPages.json` 的 SEO 文案。若需一并还原，另开 PR。

## 验证

- `npm run i18n:check` ✅ / `tsc -b --noEmit` ✅ / `npm run lint` ✅
- `npm test` ✅ 60 files / 360 tests 全绿（无用例断言过这行文案）
- `npm run build` ✅
- 在 `vite preview` 中**实际加载首页**，三语逐一确认 `.home-subtitle` 渲染值：
  - zh → 全球佛教古籍数字资源聚合平台
  - en → Global Buddhist Classics Digital Resource Platform
  - zh-Hant → 全球佛教古籍數字資源聚合平臺