### PR TITLE
fix(chat): 10MB 附件上限从未生效——nginx 默认 1MiB 先把请求挡了

### DIFF
--- a/deploy/host-nginx/fojin.conf
+++ b/deploy/host-nginx/fojin.conf
@@ -59,6 +59,15 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 60s;
+        # nginx 默认只放行 1 MiB 的请求体，而这一跳是 /api/ 的第一道关卡 ——
+        # 于是 /chat/attachments 宣称的 10MB 上限从来没生效过：一个 1.3MB 的 Word
+        # 在这里就被回了一张 HTML 413 错误页，请求根本到不了后端（2026-08-04 实测）。
+        # 12m 而不是 10m：nginx 量的是整个 multipart 请求体（文件 + 分隔符 + 表单头），
+        # 卡在 10m 会让一个刚好 10MB 的文件撞上代理的 HTML 错误页，而不是应用层那句
+        # 「文件超出 10 MB 上限」。留出余量，让 10MB 这个上限由应用来说了算。
+        # 同一条 location 也覆盖 /api/chat/stream：阅读模式的 page_content 上限
+        # 200k 字，中文 UTF-8 下约 600KB，本来离 1m 也只剩一点点。
+        client_max_body_size 12m;
         # CORS for LOD / academic clients (Wikidata bots, Zotero, third-party
         # scrapers). Safe-by-default: only GET/HEAD/OPTIONS. POST endpoints
         # that need write CORS use the stream.fojin.ai block.
@@ -129,6 +138,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
+        # 与 fojin.app 那一跳的 /api/ 保持一致 —— 同一个 /chat/stream 端点，
+        # 阅读模式带 200k 字 page_content 时不该因为走了哪个域名而有不同上限。
+        client_max_body_size 12m;
         proxy_buffering off;
         proxy_cache off;
         proxy_read_timeout 120s;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -30,6 +30,15 @@ server {
     # location that sets its own add_header (nginx drops inherited headers there).
     include /etc/nginx/security-headers.conf;
 
+    # nginx defaults to a 1 MiB request body, which silently voided the 10MB cap
+    # that /api/chat/attachments advertises. On fojin.app the host nginx is what
+    # actually rejects (it owns /api/ — see deploy/host-nginx/), but a plain
+    # `docker compose up` with no proxy in front lands here instead, so this hop
+    # needs the same ceiling or self-hosters hit the identical bug.
+    # 12m, not 10m: nginx measures the whole multipart body, so an exactly-10MB
+    # file must still get through to meet the app's own friendly 413.
+    client_max_body_size 12m;
+
     # Serve pre-compressed .gz files when available
     gzip_static on;
 

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -8,6 +8,7 @@ import { MemoryRouter, useLocation } from "react-router";
 import { message } from "antd";
 import ChatPage from "./ChatPage";
 import { useAuthStore } from "../stores/authStore";
+import { uploadChatAttachment } from "../api/chatAttachments";
 import {
   getApiKeyStatus,
   getChatQuota,
@@ -53,6 +54,10 @@ vi.mock("../api/client", async () => {
     getChunkContext: vi.fn(),
   };
 });
+
+vi.mock("../api/chatAttachments", () => ({
+  uploadChatAttachment: vi.fn(),
+}));
 
 // jsdom 没有实现 scrollIntoView —— ChatPage 的自动跟随会真的调它。
 beforeAll(() => {
@@ -940,5 +945,75 @@ describe("空状态标题", () => {
     const rule = css.match(/\.chat-hero-title\s*\{([^}]*)\}/)?.[1] ?? "";
     expect(rule).toMatch(/color:\s*var\(--fj-cinnabar\)/);
     expect(rule).toMatch(/font-weight:\s*(700|bold)\b/);
+  });
+});
+
+// 用户实测（2026-08-04）：1.3MB 的 Word 上传，界面只说「上传失败，请稍后重试」。
+// 真正发生的是反向代理按 nginx 默认的 client_max_body_size=1m 挡掉了请求，
+// 回了一张 **HTML** 413 错误页 —— 于是 `err.response.data.detail` 取不到，
+// 前端一路掉进兜底文案，把一个「文件太大」说成了「服务出错，再试试」。
+describe("附件上传失败时说的是人话", () => {
+  /** 选一个 1.3MB 的 .docx —— 过得了前端 10MB 自检，会真的发出请求。 */
+  function pickWordFile(container: HTMLElement, sizeBytes = 1_300_000) {
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["stub"], "读书笔记.docx", {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    // File 构造出来的 size 由内容决定，这里要的是「体积大但不占内存」。
+    Object.defineProperty(file, "size", { value: sizeBytes });
+    fireEvent.change(input, { target: { files: [file] } });
+  }
+
+  async function shownMessage() {
+    await waitFor(() => {
+      expect(vi.mocked(message.error)).toHaveBeenCalled();
+    });
+    return vi.mocked(message.error).mock.calls[0][0];
+  }
+
+  it("代理回 413（HTML 页面、没有 detail）时要说文件太大，不能说「稍后重试」", async () => {
+    vi.mocked(uploadChatAttachment).mockRejectedValue({
+      response: {
+        status: 413,
+        // nginx 的 413 body 就长这样：HTML，不是 JSON。
+        data: "<html>\r\n<head><title>413 Request Entity Too Large</title></head>\r\n</html>\r\n",
+      },
+    });
+    const { container } = await renderEmpty();
+    pickWordFile(container);
+
+    const shown = await shownMessage();
+    expect(shown).not.toBe("上传失败，请稍后重试");
+    expect(shown).toContain("10MB");
+  });
+
+  it("后端给了 detail（如 415 不支持的类型）时照原样透出，别被兜底盖掉", async () => {
+    vi.mocked(uploadChatAttachment).mockRejectedValue({
+      response: {
+        status: 415,
+        data: { detail: "暂不支持该文件类型，可上传 PDF / TXT / MD / DOCX / CSV / HTML" },
+      },
+    });
+    const { container } = await renderEmpty();
+    pickWordFile(container, 40_000);
+
+    expect(await shownMessage()).toBe(
+      "暂不支持该文件类型，可上传 PDF / TXT / MD / DOCX / CSV / HTML",
+    );
+  });
+
+  it("422 的 detail 是数组不是字符串，不能把 [object Object] 甩给用户", async () => {
+    vi.mocked(uploadChatAttachment).mockRejectedValue({
+      response: {
+        status: 422,
+        data: { detail: [{ loc: ["body", "file"], msg: "field required", type: "missing" }] },
+      },
+    });
+    const { container } = await renderEmpty();
+    pickWordFile(container, 40_000);
+
+    const shown = await shownMessage();
+    expect(typeof shown).toBe("string");
+    expect(shown).not.toContain("object Object");
   });
 });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1140,10 +1140,18 @@ export default function ChatPage() {
       setAttachments((prev) => [...prev, meta]);
       message.success(t("chat.attachment_uploaded", { filename: meta.filename, n: meta.char_count }));
     } catch (err: unknown) {
-      const detail =
-        (err as { response?: { data?: { detail?: string } } })?.response
-          ?.data?.detail;
-      message.error(detail || t("chat.upload_failed"));
+      const res = (err as { response?: { status?: number; data?: unknown } })?.response;
+      // detail 只在后端自己回 JSON 时才有。两种情况下它不是字符串：反向代理
+      // 挡下请求时 body 是 HTML 错误页；FastAPI 的 422 里 detail 是数组。
+      // 不判类型就 `detail || 兜底`，前者掉进兜底、后者把 [object Object] 甩给用户。
+      const raw = (res?.data as { detail?: unknown } | undefined)?.detail;
+      const detail = typeof raw === "string" ? raw : undefined;
+      // 413 常常不是后端发的：nginx 的 client_max_body_size 先于应用层生效，
+      // 回的是一张没有 detail 的 HTML 页。此时说「稍后重试」是误导 —— 重试多少
+      // 次都一样，用户需要知道的是文件太大。
+      const fallback =
+        res?.status === 413 ? t("chat.attachment_too_large") : t("chat.upload_failed");
+      message.error(detail || fallback);
     } finally {
       setUploadingAttachment(false);
     }


### PR DESCRIPTION
## 用户反馈

上传 1.3MB 的 Word 到 /chat，界面只说「上传失败，请稍后重试」。

## 根因

**两跳 nginx 都没配 `client_max_body_size`，用的是 nginx 默认的 1 MiB。**

`/api/` 由宿主 nginx 直连后端双副本（不经过前端容器），请求在那一跳就被回了一张 HTML 413 错误页，**根本到不了 FastAPI**。所以：

- `/chat/attachments` 文档里写的 ≤10MB
- `attachment_parser.MAX_FILE_BYTES = 10 MiB`
- 前端 `MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024`

三处声明的 10MB 上限**从来没有生效过**，真实上限一直是 1MB。

至于提示为什么是笼统的兜底文案：nginx 回的是 HTML，`err.response.data.detail` 取不到，前端一路掉进 `t("chat.upload_failed")`。

## 证据

**生产实证（2026-08-04）**，用后端会在写盘前就拒绝的 `.xyz` 做对照，不留任何数据：

| 请求 | 结果 |
|---|---|
| 4KB `.xyz` | `415` + JSON `{"detail":"暂不支持该文件类型…"}` — 到达后端 |
| 1.3MB `.xyz` | `413` + `<title>413 Request Entity Too Large</title>` — nginx/1.24.0 拦下 |

**本机 A/B**（同版本 nginx 1.24.0，直接加载仓库这份 `fojin.conf`，上游换成回显 body 大小的 stub）：

| | 1.3MB | 13MB |
|---|---|---|
| 对照组（本 PR 之前） | **413** | 413 |
| 本 PR 之后 | **200，到达上游** | 413（上限仍在） |

对照组精确复现了用户的故障，也证明这一行确实落在了正确的 location 里。

## 改动

1. `deploy/host-nginx/fojin.conf` — `location /api/` 与 `stream.fojin.ai` 的 `/api/chat/stream` 各加 `client_max_body_size 12m`。
2. `frontend/nginx.conf` — 同样加 12m。这一跳对 fojin.app 的 `/api/` 是死代码，但**没有前置代理的 `docker compose up`（自建部署）打的就是它**，不加就是同一个 bug。
3. `ChatPage.tsx` 上传失败提示修两个洞：
   - `413` 且没有 `detail`（代理回的 HTML）→ 说文件太大，而不是「稍后重试」。重试多少次都一样，这句话是误导。
   - `detail` 不是字符串时（FastAPI 422 的 detail 是数组）→ 不再把 `[object Object]` 甩给用户。

**为什么是 12m 不是 10m**：nginx 量的是整个 multipart 请求体（文件 + 分隔符 + 表单头），卡在 10m 会让一个刚好 10MB 的文件撞上代理的 HTML 错误页，而不是应用层那句「文件超出 10 MB 上限」。留出余量，让 10MB 这个上限由应用来说了算。

顺带：同一条 `location /api/` 也覆盖 `/api/chat/stream`，解掉了阅读模式 `page_content`（上限 200k 字，中文 UTF-8 约 600KB）离 1m 已经不远的隐患。

## 测试

`ChatPage.test.tsx` 新增 3 例（附件上传此前零覆盖）。**先验证会红**：413 那条与 422 那条在修复前如实失败（`expected '上传失败，请稍后重试' not to be '上传失败，请稍后重试'`、`expected 'object' to be 'string'`），415 那条本就该绿，作为「别把 detail 透传路径改坏」的回归护栏。

门禁：`vitest 363/363` · `eslint --max-warnings 0` · `tsc -b` · i18n ratchet 全绿。两份 nginx 配置本机 `nginx -t` 通过。

## ⚠️ 合并后仍需手工一步

宿主 nginx **不在 `deploy.sh` 范围内**（见 `deploy/host-nginx/README.md`）。前端两处改动会随 webhook 自动上线，但真正解掉 1MB 的那一跳需要人工执行：

```bash
scp deploy/host-nginx/fojin.conf sg-vps:/tmp/fojin.conf
ssh sg-vps 'sudo cp /tmp/fojin.conf /etc/nginx/conf.d/fojin.conf && sudo nginx -t && sudo systemctl reload nginx'
```

不做这一步，线上照旧卡在 1MB。
