### PR TITLE
chore(deps): cryptography 49.0.0 → 50.0.0 修 CVE-2026-69247

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ elasticsearch[async]==8.17.0
 redis[hiredis]==8.0.1
 httpx==0.28.1
 PyJWT==2.13.0
-cryptography==49.0.0
+cryptography==50.0.0
 bcrypt==4.1.1
 defusedxml==0.7.1
 lxml==6.1.1


### PR DESCRIPTION
## 为什么

`pip-audit` 从 **2026-08-04 03:48**（#1112 合并那次）起在 master 上红。不是代码变了，是漏洞当天才披露 —— 03:48 之前的 master 运行全绿。

**CVE-2026-69247**：`pkcs7_decrypt_der` / `pkcs7_decrypt_pem` / `pkcs7_decrypt_smime` 会以可区分的方式报告 `RecipientInfo.encryptedKey` 的解密结果，其中一种直接泄露 RSA 运算恢复出的长度，时序上同样可观测 —— 构成针对内容加密密钥的 Bleichenbacher oracle。44.0.0 引入，50.0.0 按 RFC 3218 修复。

## 对 fojin 的实际风险：不可达

本仓只用到 cryptography 的两块：

- **Fernet** —— `app/core/crypto.py`，加密用户 BYOK API key
- **x509 读证书** —— `app/services/source_health.py`，解析 not_after 与 SAN

**完全不碰 PKCS#7 / EnvelopedData**，也没有任何「自动解密不可信密文并回显结果」的路径。所以这是门禁该修，不是线上有洞。

## 验证

在 cryptography 50.0.0 下实测了本仓用到的全部 API，行为不变：

| | |
|---|---|
| Fernet · v1-KDF 路径（SHA-256 → urlsafe_b64 → Fernet） | 往返 OK |
| Fernet · `generate_key` 路径 | 往返 OK |
| `InvalidToken` 语义 | 未变（错误 token 仍抛，解密回退逻辑不受影响） |
| `CertificateBuilder` + `not_valid_before/after` | OK |
| `not_valid_after_utc` | 带时区、值正确（`classify_cert` 要和 aware 的 now 比较） |
| SAN 解析 | OK |
| 无 SAN 时抛 `ExtensionNotFound` | 未变（`source_health` 靠它回退到 `[]`） |

## 影响面

一行改动，`backend/requirements.txt`。同时解掉 master 与 #1113 的红灯。