### PR TITLE
fix(chat): 小津气泡带 send=1 —— 落地直接发送，不再吞掉用户那次回车

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -12,6 +12,7 @@ function LocationProbe() {
     <>
       <div data-testid="path">{loc.pathname}</div>
       <div data-testid="q">{new URLSearchParams(loc.search).get("q") ?? ""}</div>
+      <div data-testid="send">{new URLSearchParams(loc.search).get("send") ?? ""}</div>
     </>
   );
 }
@@ -46,7 +47,7 @@ describe("XiaojinPet", () => {
     expect(document.activeElement).toBe(input);
   });
 
-  it("回车把问题带去 /chat，且 q 能原样解回来", () => {
+  it("回车把问题带去 /chat 并带上 send=1（用户已按过回车，落地要直接发送）", () => {
     renderPet();
     openBubble();
     const question = "什么是缘起？";
@@ -56,6 +57,8 @@ describe("XiaojinPet", () => {
 
     expect(screen.getByTestId("path").textContent).toBe("/chat");
     expect(screen.getByTestId("q").textContent).toBe(question);
+    // 没有 send=1 就退化成「只填不发」，吞掉用户在气泡里那次回车
+    expect(screen.getByTestId("send").textContent).toBe("1");
   });
 
   // 不编码的话 & 会把 query 截成两段、# 会变成 hash，深链静默丢内容。

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -44,7 +44,9 @@ export default function XiaojinPet() {
       if (!term) return;
       setOpen(false);
       setQuery("");
-      navigate(`/chat?q=${encodeURIComponent(term)}`);
+      // send=1：ChatPage 会直接发送并从 URL 抹掉参数。裸 ?q= 是只填不发的
+      // （收藏/分享场景），但这里用户已经在气泡里按过回车，意图是问、不是编辑。
+      navigate(`/chat?q=${encodeURIComponent(term)}&send=1`);
     },
     [navigate],
   );

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -1174,3 +1174,47 @@ describe("附件上传失败时说的是人话", () => {
     expect(shown).not.toContain("object Object");
   });
 });
+
+describe("?q= 深链的发送契约", () => {
+  it("send=1（小津气泡）：落地即发送，参数从 URL 抹掉，草稿不残留同文", async () => {
+    const sent: string[] = [];
+    vi.mocked(sendChatMessageStream).mockImplementation(async (m) => {
+      sent.push(m);
+    });
+    renderPage("/chat?q=%E4%BB%80%E4%B9%88%E6%98%AF%E4%B8%89%E6%B3%95%E5%8D%B0%EF%BC%9F&send=1");
+
+    await waitFor(() => expect(sent).toEqual(["什么是三法印？"]));
+    // 参数抹掉：刷新/回退这条 URL 不该重发重扣配额
+    expect(screen.getByTestId("loc").textContent).toBe("/chat");
+    // 草稿残留这里不设断言：handleSendMessage 发送时本就 setInput("")，
+    // 断了也咬不住（实测突变仍绿）。input 初值里对 send=1 的排除防的是
+    // 真浏览器里发送前那一帧的闪现，jsdom 观测不到。
+  });
+
+  it("裸 ?q=（辞典/收藏链接）：只填不发", async () => {
+    const sent: string[] = [];
+    vi.mocked(sendChatMessageStream).mockImplementation(async (m) => {
+      sent.push(m);
+    });
+    renderPage("/chat?q=%E8%88%AC%E8%8B%A5");
+
+    await waitFor(() => expect(screen.getByDisplayValue("般若")).toBeInTheDocument());
+    expect(sent).toEqual([]);
+    // 只填不发的 URL 保持可收藏、可复现
+    expect(screen.getByTestId("loc").textContent).toContain("q=");
+  });
+
+  it("带 context 的 ?q=（阅读页）：包着经文引用发送，不受 send 参数影响", async () => {
+    const sent: string[] = [];
+    vi.mocked(sendChatMessageStream).mockImplementation(async (m) => {
+      sent.push(m);
+    });
+    renderPage("/chat?q=%E8%BF%99%E6%AE%B5%E6%80%8E%E4%B9%88%E8%A7%A3%EF%BC%9F&context=%E8%89%B2%E5%8D%B3%E6%98%AF%E7%A9%BA&source=%E5%BF%83%E7%BB%8F");
+
+    await waitFor(() => expect(sent.length).toBe(1));
+    expect(sent[0]).toContain("《心经》");
+    expect(sent[0]).toContain("> 色即是空");
+    expect(sent[0]).toContain("这段怎么解？");
+    expect(screen.getByTestId("loc").textContent).toBe("/chat");
+  });
+});

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -59,6 +59,19 @@ vi.mock("../api/chatAttachments", () => ({
   uploadChatAttachment: vi.fn(),
 }));
 
+// ChatModelSelector 挂在每个 ChatPage 里，不 mock 的话它会在 jsdom 里真发
+// XHR → Network Error → 异步 console.error。日志落在环境拆除之后就是 CI 那个
+// 「Closing rpc while onUserConsoleLog was pending」的 EnvironmentTeardownError
+// —— 389/389 全绿仍 exit 1（2026-08-06 实锤一次）。
+vi.mock("../api/chatModels", () => ({
+  fetchChatModels: vi.fn().mockResolvedValue([
+    {
+      id: "deepseek-v4-pro", provider: "deepseek", label: "DeepSeek V4 Pro",
+      description: "", vision: false, available: true, requires_byok: false,
+    },
+  ]),
+}));
+
 // jsdom 没有实现 scrollIntoView —— ChatPage 的自动跟随会真的调它。
 beforeAll(() => {
   if (!Element.prototype.scrollIntoView) {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -648,7 +648,9 @@ export default function ChatPage() {
   // 这种 URL 会被收藏、被分享，自动发送等于每打开一次就烧一次配额。
   // 也因此 ?q= 不必从地址栏抹掉 —— 它已经被消费成初值，留着还能让链接可复现。
   const [input, setInput] = useState(
-    () => (searchParams.get("context") ? "" : searchParams.get("q")) ?? "",
+    // send=1（小津气泡）与带 context 的 ?q= 都会被下面的 effect 直接发送，
+    // 不能再灌进输入框，否则消息发出后草稿里还躺着一份同文。
+    () => (searchParams.get("context") || searchParams.get("send") === "1" ? "" : searchParams.get("q")) ?? "",
   );
   const [masterId, setMasterId] = useState<string | null>(null);
   // 祖师长廊: opened from .chat-lineage-btn in the composer toolbar — the sole
@@ -1504,17 +1506,23 @@ export default function ChatPage() {
     const q = searchParams.get("q");
     const context = searchParams.get("context");
     const source = searchParams.get("source");
-    // 这里只管「带 context 的自动发送」。不带 context 的 ?q= 由上面 input 的
-    // useState 初值消费 —— 别把这个守卫拆成两个 return 去在这儿 setInput：
-    // react-hooks/set-state-in-effect 会红（实测），而且那本来就多绕一帧。
-    if (!q || !context || autoSentRef.current) return;
+    // 自动发送只认两种显式意图：带 context（阅读页「问小津」）和 send=1
+    // （首页小津气泡——用户在气泡里已经按过回车，落地再要他点一次等于吞掉
+    // 那次回车）。裸 ?q= 仍然只填不发，由上面 input 的 useState 初值消费——
+    // 那种 URL 会被收藏分享，自动发送等于每打开一次烧一次配额。别在这儿
+    // setInput：react-hooks/set-state-in-effect 会红（实测），而且多绕一帧。
+    const send = searchParams.get("send") === "1";
+    if (!q || (!context && !send) || autoSentRef.current) return;
 
     autoSentRef.current = true;
+    // 发送前把参数从 URL 抹掉：send=1 的链接刷新/回退时不该重发重扣配额。
     setSearchParams({}, { replace: true });
 
-    const msg = source
-      ? `关于《${source}》中的这段经文：\n\n> ${context}\n\n${q}` // i18n-exempt — chat message payload sent to the zh RAG pipeline
-      : `关于这段经文：\n\n> ${context}\n\n${q}`; // i18n-exempt — chat message payload sent to the zh RAG pipeline
+    const msg = context
+      ? source
+        ? `关于《${source}》中的这段经文：\n\n> ${context}\n\n${q}` // i18n-exempt — chat message payload sent to the zh RAG pipeline
+        : `关于这段经文：\n\n> ${context}\n\n${q}` // i18n-exempt — chat message payload sent to the zh RAG pipeline
+      : q;
     handleSendMessage(msg);
   }, [searchParams, setSearchParams, handleSendMessage]);
 


### PR DESCRIPTION
#1122 上线后生产实测发现的收尾问题。

## 问题

小津气泡里按回车跳到 `/chat?q=` 后，问题只是**填进了输入框，没有发送**。

裸 `?q=` 只填不发是既有的有意设计（代码注释写得明白：那种 URL 会被收藏分享，自动发送等于每打开一次烧一次配额）。对辞典词头入口这是对的 —— 来的是词头，用户多半要再改一笔。但小津这里用户已经在气泡里**按过回车**，意图是问、不是编辑；落地还要再点一次发送，等于把那次回车吞了。

## 做法

- 小津跳转改为 `/chat?q=…&send=1`
- ChatPage 深链 effect 把 `send=1` 与带 `context` 的阅读页入口并列为「显式发送意图」；**发送前先把参数从 URL 抹掉**（replace），刷新/回退不会重发重扣配额
- 裸 `?q=` 行为完全不变（只填不发、URL 保留可收藏）
- input 初值对 `send=1` 返回空串，防真浏览器里发送前那一帧的草稿闪现

## 测试

ChatPage 新增三条深链契约用例：`send=1` 即发且 URL 抹净 / 裸 `?q=` 只填不发 / `context` 包经文引用发送。XiaojinPet 断言跳转带 `send=1`。

突变实测三处都会红：去掉 `send` 识别、去掉 URL 抹除、去掉 `&send=1`。

有一处特意**不设**断言：草稿残留 —— `handleSendMessage` 本就 `setInput("")`，断言恒真（实测突变仍绿），不留恒真断言。

全量 vitest 在本机有既有抖动（母分支同样挂 antd 静态方法/Admin 页超时，`vite.config.ts` 里记录的已知问题），新旧用例单独跑均绿。