### PR TITLE
fix(chat): 会话号写回 URL 时清掉一次性入场参数 —— 修「?q=&send= 还魂」

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -1204,6 +1204,24 @@ describe("?q= 深链的发送契约", () => {
     // 真浏览器里发送前那一帧的闪现，jsdom 观测不到。
   });
 
+  it("send=1 深链在会话号写回后不还魂：URL 只剩 ?s=", async () => {
+    // 生产实锤的还魂路径：react-router 函数式 updater 的 prev 来自创建闭包那次
+    // 渲染的 location（带 ?q=&send=1），不是 replace 后的实时 URL。onSessionId
+    // 一写 ?s= 就把抹掉的参数带回来，刷新即重发重扣配额。
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks) => { cb = callbacks; },
+    );
+    renderPage("/chat?q=%E4%BB%80%E4%B9%88%E6%98%AF%E4%B8%89%E6%B3%95%E5%8D%B0%EF%BC%9F&send=1");
+
+    await waitFor(() => expect(cb).toBeDefined());
+    cb!.onSessionId(2726 as unknown as number);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loc").textContent).toBe("/chat?s=2726");
+    });
+  });
+
   it("裸 ?q=（辞典/收藏链接）：只填不发", async () => {
     const sent: string[] = [];
     vi.mocked(sendChatMessageStream).mockImplementation(async (m) => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -962,6 +962,11 @@ export default function ChatPage() {
     setShowJumpToBottom((prev) => (prev === !near ? prev : !near));
   }, [setShowJumpToBottom]);
 
+  /** 深链 effect（下方）是否已经代用户自动发送过。挂在这里（syncSessionParam
+   *  之前）是因为它的闭包要读这个 ref —— 用它区分「自动发送后残留的 ?q=」
+   *  与「用户手动收藏的裸 ?q=」，前者清、后者留。 */
+  const autoSentRef = useRef(false);
+
   /** 把「当前在读哪个会话」写进 URL（?s=）。
    *
    * 两个用处：① 去 /profile 配 Key 再返回时能落回原会话 —— 此前 sessionId 只是
@@ -970,6 +975,16 @@ export default function ChatPage() {
   const syncSessionParam = useCallback((sid: number | undefined) => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
+      // ⚠️ prev 不是实时 URL：react-router 的函数式 updater 读的是创建这个闭包
+      // 那次渲染的 location。onSessionId 的闭包诞生于带 ?q=&send=（或 context）
+      // 的首次渲染 —— 深链 effect 早已把它们 replace 掉，这里的 prev 又原样
+      // 还魂，刷新这条 URL 就会重发一次、重扣一次配额（生产实测）。一次性的
+      // 入场参数在写入会话号时一并清掉；裸 ?q= 的「只填不发、可收藏」不受影响
+      // —— 那条路不发送、不产生会话号，根本走不到这里。
+      next.delete("send");
+      next.delete("context");
+      next.delete("source");
+      if (autoSentRef.current) next.delete("q");
       if (sid === undefined) next.delete("s");
       else next.set("s", String(sid));
       return next;
@@ -1501,7 +1516,6 @@ export default function ChatPage() {
   }, [tabSuggestions, tabIndex]);
 
   // Handle pre-filled message from URL params (e.g. from "Ask XiaoJin" button on reader page)
-  const autoSentRef = useRef(false);
   useEffect(() => {
     const q = searchParams.get("q");
     const context = searchParams.get("context");


### PR DESCRIPTION
#1123 上线后生产实测发现的还魂问题，顺带修掉一个先于本轮就存在的同源老 bug。

## 现象

send=1 深链发送后 URL 确实被 replace 成干净的 `/chat`，但后端回传会话号、`syncSessionParam` 写 `?s=` 那一步，URL 变成了 `?q=…&send=1&s=2726` —— 已抹掉的参数集体还魂。这条 URL 一刷新，`autoSentRef` 随 remount 归零，**重发一次、重扣一次配额**。

## 根因

react-router 的 `setSearchParams` 函数式 updater 里，`prev` 不是实时 URL，而是**创建该闭包那次渲染的 location**。`onSessionId` 的闭包诞生于带 `?q=&send=` 的首次渲染，于是 prev 把它们原样带回。

## 老 bug

阅读页（context 流）一直有同样的问题：`q`、`context`、`source` 会在 `?s=` 写入时还魂，刷新即**整段经文重发**。一并修掉。

## 修法

`syncSessionParam` 写入会话号时显式清掉 `send/context/source`；`q` 仅在 `autoSentRef` 标记「本次挂载确实自动发送过」时清 —— 用户手动收藏的裸 `?q=`（只填不发、可复现）不受影响，那条路不产生会话号也走不到这里。

## 验证

还魂路径在 jsdom 里可复现：新增用例「send=1 深链在会话号写回后不还魂：URL 只剩 ?s=」，去掉四行 delete 实测红（1 failed），还原绿。eslint / tsc / 相关套件 69 passed / build 全绿。