### PR TITLE
feat(home): 小津可以用鼠标拖到页面任意位置

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -160,3 +160,72 @@ describe("XiaojinPet", () => {
     expect(screen.queryByLabelText("问小津")).toBeNull();
   });
 });
+
+describe("XiaojinPet 拖动", () => {
+  const POS_KEY = "fojin_xiaojin_pos";
+
+  function body() {
+    return screen.getByLabelText("问小津");
+  }
+
+  /** jsdom 里 rect 全零，拖动位移即最终坐标（起点 0,0 + delta）。 */
+  function drag(from: [number, number], to: [number, number]) {
+    const el = body();
+    fireEvent.pointerDown(el, { pointerId: 1, isPrimary: true, clientX: from[0], clientY: from[1] });
+    fireEvent.pointerMove(el, { pointerId: 1, clientX: to[0], clientY: to[1] });
+    fireEvent.pointerUp(el, { pointerId: 1, clientX: to[0], clientY: to[1] });
+    // 浏览器在 pointerup 后必补发一次 click —— 模拟它来验证吞掉逻辑
+    fireEvent.click(el);
+  }
+
+  it("拖过阈值：位置更新为 left/top、写入 localStorage，且拖完不弹气泡", () => {
+    renderPet();
+    drag([10, 10], [110, 60]);
+
+    const root = document.querySelector<HTMLElement>(".xiaojin-pet")!;
+    expect(root.style.left).toBe("100px");
+    expect(root.style.top).toBe("50px");
+    expect(JSON.parse(localStorage.getItem(POS_KEY)!)).toEqual({ x: 100, y: 50 });
+    // 拖动的收尾 click 被吞掉，气泡不弹
+    expect(screen.queryByLabelText("问我任何问题…")).toBeNull();
+    // 再点一下（真点击）气泡照常打开 —— 吞 click 只吞一次
+    fireEvent.click(body());
+    expect(screen.getByLabelText("问我任何问题…")).toBeTruthy();
+  });
+
+  it("位移小于阈值算点击：气泡打开、位置不动", () => {
+    renderPet();
+    const el = body();
+    fireEvent.pointerDown(el, { pointerId: 1, isPrimary: true, clientX: 10, clientY: 10 });
+    fireEvent.pointerMove(el, { pointerId: 1, clientX: 12, clientY: 12 });
+    fireEvent.pointerUp(el, { pointerId: 1, clientX: 12, clientY: 12 });
+    fireEvent.click(el);
+
+    expect(screen.getByLabelText("问我任何问题…")).toBeTruthy();
+    expect(document.querySelector<HTMLElement>(".xiaojin-pet")!.style.left).toBe("");
+    expect(localStorage.getItem(POS_KEY)).toBeNull();
+  });
+
+  it("下次进来恢复上次拖到的位置", () => {
+    localStorage.setItem(POS_KEY, JSON.stringify({ x: 50, y: 80 }));
+    renderPet();
+    const root = document.querySelector<HTMLElement>(".xiaojin-pet")!;
+    expect(root.style.left).toBe("50px");
+    expect(root.style.top).toBe("80px");
+  });
+
+  it("存的位置在屏幕外时夹回视口", () => {
+    localStorage.setItem(POS_KEY, JSON.stringify({ x: 99999, y: 99999 }));
+    renderPet();
+    const root = document.querySelector<HTMLElement>(".xiaojin-pet")!;
+    const left = parseInt(root.style.left, 10);
+    const top = parseInt(root.style.top, 10);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left).toBeLessThanOrEqual(window.innerWidth);
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(top).toBeLessThanOrEqual(window.innerHeight);
+  });
+
+  // 气泡朝向（data-v/data-h）依赖真实布局的 getBoundingClientRect，jsdom 里
+  // rect 全零测不出翻转 —— 朝向逻辑在真浏览器里人工验证（拖到顶部气泡开脚下）。
+});

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -7,6 +7,14 @@ import "../styles/xiaojin-pet.css";
 
 /** 用户主动赶走小津后不再出现。私密模式下 localStorage 会抛，一律当没隐藏。 */
 const HIDDEN_KEY = "fojin_xiaojin_hidden";
+/** 用户把小津拖到哪，下次进来还在哪。 */
+const POS_KEY = "fojin_xiaojin_pos";
+/** 指针位移超过这个像素数才算拖动，否则算点击。 */
+const DRAG_THRESHOLD = 5;
+/** 夹取时给视口四边留的呼吸边距。 */
+const EDGE = 8;
+
+type Pos = { x: number; y: number };
 
 function readHidden(): boolean {
   try {
@@ -14,6 +22,33 @@ function readHidden(): boolean {
   } catch {
     return false;
   }
+}
+
+function readPos(): Pos | null {
+  try {
+    const raw = localStorage.getItem(POS_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as Pos;
+    return typeof p?.x === "number" && typeof p?.y === "number" ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+function writePos(p: Pos) {
+  try {
+    localStorage.setItem(POS_KEY, JSON.stringify(p));
+  } catch {
+    // 私密模式：本次会话内有效即可
+  }
+}
+
+/** 把位置夹回视口内 —— 换了窗口尺寸/分辨率后，存下来的坐标可能已在屏幕外。 */
+function clampPos(p: Pos, w: number, h: number): Pos {
+  return {
+    x: Math.min(Math.max(p.x, EDGE), Math.max(EDGE, window.innerWidth - w - EDGE)),
+    y: Math.min(Math.max(p.y, EDGE), Math.max(EDGE, window.innerHeight - h - EDGE)),
+  };
 }
 
 /**
@@ -27,6 +62,12 @@ function readHidden(): boolean {
  *
  * 问题不在这里作答：回车后跳 `/chat?q=`，由 ChatPage 既有的深链逻辑接管并自动发问。
  * 这样它始终只有一条真相来源（/chat 的检索与引文护栏），首页不复制一套流式渲染。
+ *
+ * 可拖动：按住小津本体拖到页面任意位置（pointer events，鼠标/触屏同一套），
+ * 位移超过 5px 算拖动并吞掉随后的 click，否则算点击开气泡。位置持久化到
+ * localStorage，恢复与窗口 resize 时都夹回视口。气泡朝向按小津当前位置自动
+ * 选（上下取空间大的一侧、左右取够放 272px 的一侧），拖到页面顶上气泡开在
+ * 下方，不会伸出屏幕外。
  */
 export default function XiaojinPet() {
   const navigate = useNavigate();
@@ -38,6 +79,87 @@ export default function XiaojinPet() {
   const user = useAuthStore((s) => s.user);
   const inputRef = useRef<HTMLInputElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const figureRef = useRef<HTMLDivElement>(null);
+
+  // null = 没拖过，走 CSS 默认的右下角锚点；有值 = 用户拖过，left/top 直定。
+  // 惰性初始化直接恢复上次位置（夹取用兜底尺寸 80×100 —— 此刻还没有 rect，
+  // 而小津本体最大也就 76px 宽；resize 监听会用真实尺寸再夹一次）。
+  const [pos, setPos] = useState<Pos | null>(() => {
+    const saved = readPos();
+    return saved ? clampPos(saved, 80, 100) : null;
+  });
+  // 气泡朝向：above/below 是相对小津的垂直方向，right/left 是气泡贴齐小津的哪条边。
+  const [placement, setPlacement] = useState<{ v: "above" | "below"; h: "right" | "left" }>({
+    v: "above",
+    h: "right",
+  });
+  // 一次拖动的起点快照；active 在越过阈值后置真。
+  const dragRef = useRef<{ px: number; py: number; x: number; y: number; active: boolean } | null>(null);
+  // 拖动结束后浏览器仍会补发一次 click —— 用这个标记吞掉它，别让拖完弹气泡。
+  const draggedRef = useRef(false);
+
+  const figureSize = () => {
+    const r = figureRef.current?.getBoundingClientRect();
+    return { w: r?.width || 80, h: r?.height || 100 };
+  };
+
+  // 窗口尺寸变化时把小津夹回视口，别让它留在屏幕外找不回来。
+  useEffect(() => {
+    const onResize = () => {
+      setPos((p) => {
+        if (!p) return p;
+        const { w, h } = figureSize();
+        return clampPos(p, w, h);
+      });
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  /** 按小津当前位置选气泡朝向：垂直取空间大的一侧，水平取够放气泡的一侧。 */
+  const computePlacement = useCallback(() => {
+    const r = figureRef.current?.getBoundingClientRect();
+    if (!r) return;
+    setPlacement({
+      v: r.top >= window.innerHeight - r.bottom ? "above" : "below",
+      h: r.right >= window.innerWidth - r.left ? "right" : "left",
+    });
+  }, []);
+
+  const onFigurePointerDown = (e: React.PointerEvent) => {
+    if (!e.isPrimary) return;
+    const r = rootRef.current?.getBoundingClientRect();
+    if (!r) return;
+    dragRef.current = { px: e.clientX, py: e.clientY, x: r.left, y: r.top, active: false };
+    // jsdom 没有 setPointerCapture —— 可选调用
+    (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+  };
+
+  const onFigurePointerMove = (e: React.PointerEvent) => {
+    const d = dragRef.current;
+    if (!d) return;
+    const dx = e.clientX - d.px;
+    const dy = e.clientY - d.py;
+    if (!d.active) {
+      if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+      d.active = true;
+      draggedRef.current = true;
+    }
+    const { w, h } = figureSize();
+    setPos(clampPos({ x: d.x + dx, y: d.y + dy }, w, h));
+  };
+
+  const onFigurePointerUp = () => {
+    const d = dragRef.current;
+    dragRef.current = null;
+    if (!d?.active) return;
+    // 落定：存位置，并按新位置重算气泡该往哪边开。
+    setPos((p) => {
+      if (p) writePos(p);
+      return p;
+    });
+    computePlacement();
+  };
 
   const rawPrompts = t("xiaojin.prompts", { returnObjects: true });
   const prompts: string[] = Array.isArray(rawPrompts) ? rawPrompts : [];
@@ -89,7 +211,14 @@ export default function XiaojinPet() {
   if (hidden) return null;
 
   return (
-    <div className="xiaojin-pet" ref={rootRef} data-open={open ? "" : undefined}>
+    <div
+      className="xiaojin-pet"
+      ref={rootRef}
+      data-open={open ? "" : undefined}
+      data-v={placement.v}
+      data-h={placement.h}
+      style={pos ? { left: pos.x, top: pos.y, right: "auto", bottom: "auto" } : undefined}
+    >
       {open && (
         <div className="xiaojin-bubble" role="dialog" aria-label={t("xiaojin.bubble_label")}>
           <button
@@ -150,11 +279,25 @@ export default function XiaojinPet() {
         </div>
       )}
 
-      <div className="xiaojin-figure">
+      <div className="xiaojin-figure" ref={figureRef}>
         <button
           type="button"
           className="xiaojin-body"
-          onClick={() => setOpen((o) => !o)}
+          onPointerDown={onFigurePointerDown}
+          onPointerMove={onFigurePointerMove}
+          onPointerUp={onFigurePointerUp}
+          onClick={() => {
+            // 刚拖完：这次 click 是拖动的尾巴，不是点击意图。
+            if (draggedRef.current) {
+              draggedRef.current = false;
+              return;
+            }
+            setOpen((o) => {
+              const next = !o;
+              if (next) computePlacement();
+              return next;
+            });
+          }}
           aria-expanded={open}
           aria-label={t("xiaojin.open")}
         >

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -352,8 +352,8 @@ export default function HomePage() {
 
       </section>
 
-      {/* 右下角的小津。position:fixed，不参与 hero 的定高布局。
-          原先占右下角的意见反馈浮球已并入小津气泡底部。 */}
+      {/* 小津：默认右下角，可拖到任意位置（位置记在 localStorage）。
+          position:fixed，不参与 hero 的定高布局；意见反馈入口在它气泡底部。 */}
       <XiaojinPet />
     </div>
   );

--- a/frontend/src/styles/xiaojin-pet.css
+++ b/frontend/src/styles/xiaojin-pet.css
@@ -12,13 +12,10 @@
      ant-layout-footer 恒定压在视口底。bottom 是相对视口算的，给小 18px 会让小津
      有 32px 骑到页脚白条上（实测），所以先让开页脚再垫 10px，让它坐在水面上。 */
   bottom: 60px;
+  /* 用户拖过之后，组件用内联 left/top 覆盖上面的 right/bottom 锚点。 */
   /* 低于 antd Modal(1000) / chat 抽屉(999,1000) / reader 面板(1100)，
      高于首页自身的 0/1 层，所以任何弹窗都能盖住它。 */
   z-index: 90;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 10px;
 
   /* 造型配色 —— 正金 #d6a13c 黄海青 + 赭红祖衣。 */
   --xiaojin-skin: #f2ddc4;
@@ -52,8 +49,12 @@
   border: 0;
   padding: 0;
   background: none;
-  cursor: pointer;
+  cursor: grab;
   line-height: 0;
+  /* 拖动：touch 拖小津时不能同时滚页面；按住时也别选中文字/图形 */
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
   filter: drop-shadow(0 3px 7px rgba(43, 35, 24, 0.2));
   transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -67,6 +68,10 @@
 .xiaojin-body:hover,
 .xiaojin-body:focus-visible {
   transform: translateY(-3px) scale(1.04);
+}
+
+.xiaojin-body:active {
+  cursor: grabbing;
 }
 
 .xiaojin-body:focus-visible {
@@ -146,9 +151,12 @@
   border-color: var(--fj-accent);
 }
 
-/* ---------- 气泡 ---------- */
+/* ---------- 气泡 ----------
+   绝对定位挂在小津身上，朝向由容器上的 data-v / data-h 决定：
+   v=above 开在头顶、below 开在脚下（拖到页面顶部时用）；
+   h=right 气泡右缘贴齐小津（向左伸展）、left 反之。 */
 .xiaojin-bubble {
-  position: relative;
+  position: absolute;
   width: 272px;
   padding: 12px 12px 10px;
   border: 1px solid var(--fj-border);
@@ -156,6 +164,19 @@
   background: var(--fj-surface);
   box-shadow: 0 10px 28px rgba(43, 35, 24, 0.16);
   animation: xiaojin-bubble-in 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.xiaojin-pet[data-v="above"] .xiaojin-bubble {
+  bottom: calc(100% + 10px);
+}
+.xiaojin-pet[data-v="below"] .xiaojin-bubble {
+  top: calc(100% + 10px);
+}
+.xiaojin-pet[data-h="right"] .xiaojin-bubble {
+  right: 0;
+}
+.xiaojin-pet[data-h="left"] .xiaojin-bubble {
+  left: 0;
 }
 
 @keyframes xiaojin-bubble-in {
@@ -169,18 +190,30 @@
   }
 }
 
-/* 指向小津的小尖角 */
+/* 指向小津的小尖角 —— 位置与描边随气泡朝向翻转 */
 .xiaojin-bubble::after {
   content: "";
   position: absolute;
-  right: 28px;
-  bottom: -7px;
   width: 12px;
   height: 12px;
   background: var(--fj-surface);
+  transform: rotate(45deg);
+}
+.xiaojin-pet[data-v="above"] .xiaojin-bubble::after {
+  bottom: -7px;
   border-right: 1px solid var(--fj-border);
   border-bottom: 1px solid var(--fj-border);
-  transform: rotate(45deg);
+}
+.xiaojin-pet[data-v="below"] .xiaojin-bubble::after {
+  top: -7px;
+  border-left: 1px solid var(--fj-border);
+  border-top: 1px solid var(--fj-border);
+}
+.xiaojin-pet[data-h="right"] .xiaojin-bubble::after {
+  right: 28px;
+}
+.xiaojin-pet[data-h="left"] .xiaojin-bubble::after {
+  left: 28px;
 }
 
 .xiaojin-bubble-close {
@@ -318,7 +351,7 @@
     width: 62px;
   }
   .xiaojin-bubble {
-    width: min(272px, calc(100vw - 40px));
+    width: min(272px, calc(100vw - 24px));
   }
   /* 触屏没有 hover，赶走它的按钮就常驻。 */
   .xiaojin-dismiss {


### PR DESCRIPTION
按住小津拖走，松手就落在那儿；位置写进 localStorage，下次进来还在原地。

## 实现要点

- **指针**：统一用 pointer events，鼠标与触屏同一套。本体加 `touch-action:none`（不然手机上拖小津会连页面一起滚）与 `user-select:none`，cursor 走 `grab`/`grabbing`
- **拖 vs 点**：位移超过 **5px** 才算拖动。拖完浏览器还会补发一次 `click` —— 用 `draggedRef` 吞掉它，否则每次拖完都会弹出气泡；只吞一次，紧接着的真点击照常开气泡
- **越界**：拖动中与恢复时都把坐标夹回视口（四边留 8px），窗口 `resize` 也重夹一次，免得换了分辨率后小津留在屏幕外找不回来
- **气泡朝向**：气泡改为 `absolute` 挂在小津身上，由容器 `data-v`/`data-h` 决定四种朝向 —— 垂直取空间大的一侧、水平取够放 272px 的一侧，尾巴与描边跟着翻。**拖到页面顶部时气泡开在脚下**而不是伸出屏幕外

恢复位置用 `useState` 惰性初值而不是 effect：仓库家规里 `react-hooks/set-state-in-effect` 是硬错（实测 eslint 直接红），且惰性初值本就少绕一帧。

## 测试

新增 4 条：拖过阈值 → 更新 left/top + 持久化 + 吞掉尾随 click；未过阈值算点击；下次进来恢复位置；屏幕外坐标夹回视口。

**突变实测四处全红**：不吞 click / 无阈值 / 不持久化 / 恢复不夹取。

气泡朝向依赖真实 `getBoundingClientRect`，jsdom 里 rect 全零测不出翻转 —— 已在测试文件里写明，改由真浏览器验证。

## 真浏览器实测

- 拖动 (1820,762) → (920,202) 生效，且不误弹气泡
- 刷新后恢复原位 (920,202)
- 拖到 (-5000,-5000) 夹回 (8,8)
- 小津在页面上方时 `data-v` 自动翻成 `below`，气泡完整落在视口内
- 390px / 360px 触屏同样正常

**附一条 CDP 假象**：`computer` 工具的 `left_click_drag` 不产生可用的 pointer 序列（反而框选了整页文字）。验证拖动必须在页面里派发真实 `PointerEvent` —— 与仓库既有的「CDP 不是真实浏览器」结论一致，已记进 commit message。

门禁：eslint / tsc / i18n ratchet / vitest **396 passed** / build 全绿。i18n 零新增键。