### PR TITLE
feat(home): 小津改为气泡内就地作答（ryOS Rover 形态），黄便签配色，去掉推荐问题

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1535,9 +1535,7 @@
   "xiaojin.greeting": "Amitabha. I am XiaoJin — ask about doctrine, where a term comes from, or which sutra you need.",
   "xiaojin.placeholder": "Ask me anything…",
   "xiaojin.send": "Send",
-  "xiaojin.prompts": [
-    "Who translated the Heart Sutra?",
-    "What are the Three Marks of Existence?",
-    "Which sutra says 'form is emptiness'?"
-  ]
+  "xiaojin.thinking": "XiaoJin is thinking",
+  "xiaojin.error": "The answer was interrupted — please try again.",
+  "xiaojin.continue": "Open in AI Q&A to verify citations →"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1535,9 +1535,7 @@
   "xiaojin.greeting": "阿彌陀佛。我是小津——想問經論義理、名相出處，還是找哪一部經？",
   "xiaojin.placeholder": "問我任何問題…",
   "xiaojin.send": "發送",
-  "xiaojin.prompts": [
-    "《心經》是誰翻譯的？",
-    "什麼是三法印？",
-    "「色即是空」出自哪部經？"
-  ]
+  "xiaojin.thinking": "小津思索中",
+  "xiaojin.error": "回答中斷了，請稍後再試。",
+  "xiaojin.continue": "去 AI 問答查看完整引文 →"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1535,9 +1535,7 @@
   "xiaojin.greeting": "阿弥陀佛。我是小津——想问经论义理、名相出处，还是找哪一部经？",
   "xiaojin.placeholder": "问我任何问题…",
   "xiaojin.send": "发送",
-  "xiaojin.prompts": [
-    "《心经》是谁翻译的？",
-    "什么是三法印？",
-    "「色即是空」出自哪部经？"
-  ]
+  "xiaojin.thinking": "小津思索中",
+  "xiaojin.error": "回答中断了，请稍后再试。",
+  "xiaojin.continue": "去 AI 问答查看完整引文 →"
 }

--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -1,10 +1,18 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router";
 import XiaojinPet from "./XiaojinPet";
 import { useAuthStore } from "../stores/authStore";
+import { sendChatMessageStream } from "../api/client";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return { ...actual, sendChatMessageStream: vi.fn() };
+});
 
 const HIDDEN_KEY = "fojin_xiaojin_hidden";
+
+type Callbacks = Parameters<typeof sendChatMessageStream>[3];
 
 /** 用真 router，把落点摊到 DOM 上断言，而不是 mock useNavigate。 */
 function LocationProbe() {
@@ -14,6 +22,7 @@ function LocationProbe() {
       <div data-testid="path">{loc.pathname}</div>
       <div data-testid="q">{new URLSearchParams(loc.search).get("q") ?? ""}</div>
       <div data-testid="send">{new URLSearchParams(loc.search).get("send") ?? ""}</div>
+      <div data-testid="s">{new URLSearchParams(loc.search).get("s") ?? ""}</div>
     </>
   );
 }
@@ -32,7 +41,19 @@ const openBubble = () => fireEvent.click(screen.getByLabelText("问小津"));
 beforeEach(() => {
   localStorage.clear();
   useAuthStore.setState({ token: null, user: null });
+  vi.clearAllMocks();
+  vi.mocked(sendChatMessageStream).mockResolvedValue(undefined);
 });
+
+/** 发一问并拿到本轮的流式回调（问题进入迷你对话，不发生任何跳转）。 */
+async function askAndGetCallbacks(question: string): Promise<Callbacks> {
+  const input = screen.getByLabelText("问我任何问题…");
+  fireEvent.change(input, { target: { value: question } });
+  fireEvent.keyDown(input, { key: "Enter" });
+  await waitFor(() => expect(sendChatMessageStream).toHaveBeenCalled());
+  const calls = vi.mocked(sendChatMessageStream).mock.calls;
+  return calls[calls.length - 1][3];
+}
 
 describe("XiaojinPet", () => {
   it("默认收起：只有小津，没有输入框", () => {
@@ -49,46 +70,106 @@ describe("XiaojinPet", () => {
     expect(document.activeElement).toBe(input);
   });
 
-  it("回车把问题带去 /chat 并带上 send=1（用户已按过回车，落地要直接发送）", () => {
+  it("回车就地作答：问题进对话流、答案流式渲染、全程不跳页", async () => {
     renderPet();
     openBubble();
-    const question = "什么是缘起？";
+    const cb = await askAndGetCallbacks("什么是缘起？");
+
+    // 用户消息立即上屏，助手侧先是思索占位
+    expect(screen.getByText("什么是缘起？")).toBeTruthy();
+    expect(screen.getByText(/小津思索中/)).toBeTruthy();
+
+    act(() => {
+      cb.onToken("诸法因缘生，");
+      cb.onToken("诸法因缘灭。");
+      cb.onDone();
+    });
+    expect(screen.getByText("诸法因缘生，诸法因缘灭。")).toBeTruthy();
+    // 关键不变式：始终没离开首页
+    expect(screen.getByTestId("path").textContent).toBe("/");
+    // 问候语让位给对话流
+    expect(screen.queryByText(/阿弥陀佛/)).toBeNull();
+  });
+
+  it("citation correction 到达时整段替换为改写后的全文（与 /chat 落库版本一致）", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("《心经》谁译的？");
+    act(() => {
+      cb.onToken("玄奘译【《心经》第1卷】");
+      cb.onCitationCorrection?.("玄奘译【《般若波罗蜜多心经》第1卷】");
+      cb.onDone();
+    });
+    expect(screen.getByText(/般若波罗蜜多心经/)).toBeTruthy();
+    expect(screen.queryByText(/^玄奘译【《心经》第1卷】$/)).toBeNull();
+  });
+
+  it("流式出错：错误文案上屏、空气泡撤掉、可以再问", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("什么是无我？");
+    act(() => {
+      cb.onError("今日提问次数已用完", "quota");
+    });
+    expect(screen.getByRole("alert").textContent).toBe("今日提问次数已用完");
+    expect(screen.queryByText(/小津思索中/)).toBeNull();
+
+    // 还能继续发第二问（流已收尾、发送不再被锁）
+    const cb2 = await askAndGetCallbacks("再问一次");
+    act(() => {
+      cb2.onToken("好。");
+      cb2.onDone();
+    });
+    expect(screen.getByText("好。")).toBeTruthy();
+    // 新一轮开始时旧错误行已清掉
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("空完成（onDone 但一个 token 没来）：撤空泡并给兜底错误", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("测试空完成");
+    act(() => {
+      cb.onDone();
+    });
+    expect(screen.queryByText(/小津思索中/)).toBeNull();
+    expect(screen.getByRole("alert").textContent).toContain("回答中断了");
+  });
+
+  it("多轮对话把 session id 串给下一问", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("第一问");
+    act(() => {
+      cb.onSessionId(42);
+      cb.onToken("答一");
+      cb.onDone();
+    });
+    await askAndGetCallbacks("第二问");
+    const calls = vi.mocked(sendChatMessageStream).mock.calls;
+    expect(calls[0][1]).toBeUndefined();
+    expect(calls[1][1]).toBe(42);
+  });
+
+  it("流式进行中发送被锁，onDone 后解锁", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("第一问");
+    // 流未结束：再回车不产生第二次调用
     const input = screen.getByLabelText("问我任何问题…");
-    fireEvent.change(input, { target: { value: question } });
+    fireEvent.change(input, { target: { value: "抢答" } });
     fireEvent.keyDown(input, { key: "Enter" });
+    expect(vi.mocked(sendChatMessageStream).mock.calls.length).toBe(1);
 
-    expect(screen.getByTestId("path").textContent).toBe("/chat");
-    expect(screen.getByTestId("q").textContent).toBe(question);
-    // 没有 send=1 就退化成「只填不发」，吞掉用户在气泡里那次回车
-    expect(screen.getByTestId("send").textContent).toBe("1");
+    act(() => {
+      cb.onToken("答");
+      cb.onDone();
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(vi.mocked(sendChatMessageStream).mock.calls.length).toBe(2));
   });
 
-  // 不编码的话 & 会把 query 截成两段、# 会变成 hash，深链静默丢内容。
-  // 上一版用例只测了纯汉字问题，去掉 encodeURIComponent 照样全绿 —— 所以专挑
-  // 会撕裂 query string 的字符。
-  it("问题里带 & 与 # 也能完整送达", () => {
-    renderPet();
-    openBubble();
-    const question = "空 & 有 #不二";
-    fireEvent.change(screen.getByLabelText("问我任何问题…"), { target: { value: question } });
-    fireEvent.keyDown(screen.getByLabelText("问我任何问题…"), { key: "Enter" });
-
-    expect(screen.getByTestId("path").textContent).toBe("/chat");
-    expect(screen.getByTestId("q").textContent).toBe(question);
-  });
-
-  it("点发送按钮与回车等效", () => {
-    renderPet();
-    openBubble();
-    const question = "唯识三性是什么";
-    fireEvent.change(screen.getByLabelText("问我任何问题…"), { target: { value: question } });
-    fireEvent.click(screen.getByLabelText("发送"));
-
-    expect(screen.getByTestId("path").textContent).toBe("/chat");
-    expect(screen.getByTestId("q").textContent).toBe(question);
-  });
-
-  it("空输入不跳转，发送按钮是禁用的", () => {
+  it("空输入不发送", () => {
     renderPet();
     openBubble();
     const send = screen.getByLabelText("发送") as HTMLButtonElement;
@@ -96,17 +177,46 @@ describe("XiaojinPet", () => {
 
     fireEvent.change(screen.getByLabelText("问我任何问题…"), { target: { value: "   " } });
     fireEvent.keyDown(screen.getByLabelText("问我任何问题…"), { key: "Enter" });
-    expect(screen.getByTestId("path").textContent).toBe("/");
+    expect(sendChatMessageStream).not.toHaveBeenCalled();
   });
 
-  it("点推荐问题直接带该问题跳转", () => {
+  it("没有推荐问题（chips 已按需求移除）", () => {
     renderPet();
     openBubble();
-    const chip = screen.getByText("什么是三法印？");
-    fireEvent.click(chip);
+    expect(document.querySelector(".xiaojin-chip")).toBeNull();
+  });
 
+  it("登录用户拿到 session 后出现「查看完整引文」，点击落到 /chat?s=", async () => {
+    useAuthStore.setState({
+      token: "t",
+      user: {
+        id: 1, username: "reader", email: "r@example.com", display_name: null,
+        role: "user", is_active: true, created_at: "2026-01-01T00:00:00Z",
+      },
+    });
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("第一问");
+    act(() => {
+      cb.onSessionId(77);
+      cb.onToken("答");
+      cb.onDone();
+    });
+    fireEvent.click(screen.getByText(/查看完整引文/));
     expect(screen.getByTestId("path").textContent).toBe("/chat");
-    expect(screen.getByTestId("q").textContent).toBe("什么是三法印？");
+    expect(screen.getByTestId("s").textContent).toBe("77");
+  });
+
+  it("游客不显示「查看完整引文」（游客会话不落库，跳过去只会 404）", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("第一问");
+    act(() => {
+      cb.onSessionId(77);
+      cb.onToken("答");
+      cb.onDone();
+    });
+    expect(screen.queryByText(/查看完整引文/)).toBeNull();
   });
 
   it("Esc 关闭气泡", () => {

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../stores/authStore";
+import { sendChatMessageStream } from "../api/client";
 import FeedbackModal from "./FeedbackModal";
 import "../styles/xiaojin-pet.css";
 
@@ -60,8 +61,11 @@ function clampPos(p: Pos, w: number, h: number): Pos {
  * 原先占右下角的意见反馈浮球（FeedbackButton）已删除，反馈入口收进气泡底部
  * （登录用户可见，与原浮球同门槛）——一个角落一个角色，别再放第二个浮动物。
  *
- * 问题不在这里作答：回车后跳 `/chat?q=`，由 ChatPage 既有的深链逻辑接管并自动发问。
- * 这样它始终只有一条真相来源（/chat 的检索与引文护栏），首页不复制一套流式渲染。
+ * 对话就在气泡里进行（ryOS Rover 形态）：回车直接调 /chat/stream，答案在气泡内
+ * 流式渲染，不跳页。走的是与 /chat 完全同一条后端管线（检索 + 引文护栏 +
+ * citation correction），所以答案与引文标记和 /chat 同源；气泡里只render纯文本，
+ * 完整的引文核对 UI 在 /chat —— 登录用户会看到「查看完整引文」入口跳去同一会话。
+ * 游客也能问（后端 get_optional_user + 匿名配额），配额用尽由 onError 文案兜底。
  *
  * 可拖动：按住小津本体拖到页面任意位置（pointer events，鼠标/触屏同一套），
  * 位移超过 5px 算拖动并吞掉随后的 click，否则算点击开气泡。位置持久化到
@@ -80,6 +84,27 @@ export default function XiaojinPet() {
   const inputRef = useRef<HTMLInputElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const figureRef = useRef<HTMLDivElement>(null);
+
+  // ---- 气泡内迷你对话 ----
+  const [messages, setMessages] = useState<{ role: "user" | "assistant"; content: string }[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const [chatError, setChatError] = useState<string | null>(null);
+  // 多轮对话靠它串起同一个会话；也是「查看完整引文」跳 /chat?s= 的凭据。
+  const [sessionId, setSessionId] = useState<number | undefined>(undefined);
+  const sessionRef = useRef<number | undefined>(undefined);
+  const abortRef = useRef<AbortController | null>(null);
+  const msgsRef = useRef<HTMLDivElement>(null);
+  // 本轮是否收到过任何 token —— onDone 用它判「空完成」，不在 updater 里做副作用。
+  const gotTokenRef = useRef(false);
+
+  // 离开首页时掐掉在途的流 —— 没人看的答案不必继续烧 token。
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  // 新 token 到达时贴底 —— 迷你窗口，永远跟随最新内容。
+  useEffect(() => {
+    const el = msgsRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
 
   // null = 没拖过，走 CSS 默认的右下角锚点；有值 = 用户拖过，left/top 直定。
   // 惰性初始化直接恢复上次位置（夹取用兜底尺寸 80×100 —— 此刻还没有 rect，
@@ -161,21 +186,67 @@ export default function XiaojinPet() {
     computePlacement();
   };
 
-  const rawPrompts = t("xiaojin.prompts", { returnObjects: true });
-  const prompts: string[] = Array.isArray(rawPrompts) ? rawPrompts : [];
+  const ask = useCallback((text: string) => {
+    const term = text.trim();
+    if (!term || abortRef.current) return; // 流式进行中不重入
+    setQuery("");
+    setChatError(null);
+    gotTokenRef.current = false;
+    setMessages((m) => [...m, { role: "user", content: term }, { role: "assistant", content: "" }]);
+    setStreaming(true);
 
-  const ask = useCallback(
-    (text: string) => {
-      const term = text.trim();
-      if (!term) return;
-      setOpen(false);
-      setQuery("");
-      // send=1：ChatPage 会直接发送并从 URL 抹掉参数。裸 ?q= 是只填不发的
-      // （收藏/分享场景），但这里用户已经在气泡里按过回车，意图是问、不是编辑。
-      navigate(`/chat?q=${encodeURIComponent(term)}&send=1`);
-    },
-    [navigate],
-  );
+    const ac = new AbortController();
+    abortRef.current = ac;
+    const appendToLast = (chunk: string) => {
+      gotTokenRef.current = true;
+      setMessages((m) => {
+        const next = m.slice();
+        const last = next[next.length - 1];
+        next[next.length - 1] = { ...last, content: last.content + chunk };
+        return next;
+      });
+    };
+    const finish = () => {
+      abortRef.current = null;
+      setStreaming(false);
+    };
+
+    sendChatMessageStream(term, sessionRef.current, null, {
+      onToken: appendToLast,
+      onSources: () => {},
+      onSessionId: (sid) => {
+        sessionRef.current = sid;
+        setSessionId(sid);
+      },
+      // 护栏改写过引文锚点时，用改写后的全文替换 —— 与 /chat 落库的版本保持一致。
+      onCitationCorrection: (corrected) => {
+        gotTokenRef.current = true;
+        setMessages((m) => {
+          const next = m.slice();
+          next[next.length - 1] = { role: "assistant", content: corrected };
+          return next;
+        });
+      },
+      onError: (msg, code) => {
+        if (code === "cancelled") return; // 自己 abort 的，不是故障
+        // 失败的空气泡不留着，错误行来说话
+        setMessages((m) => (m[m.length - 1]?.content === "" ? m.slice(0, -1) : m));
+        setChatError(msg);
+        finish();
+      },
+      onDone: () => {
+        // 流正常结束但一个 token 都没来：按失败兜底，别留无字空泡。
+        if (!gotTokenRef.current) {
+          setMessages((m) => (m[m.length - 1]?.content === "" ? m.slice(0, -1) : m));
+          setChatError(t("xiaojin.error"));
+        }
+        finish();
+      },
+    }, { signal: ac.signal }).catch(() => {
+      // sendChatMessageStream 内部已把错误送进 onError；这里只兜 Promise 链
+      finish();
+    });
+  }, [t]);
 
   // 开合气泡时把焦点送进输入框，键盘用户不必再 Tab 一轮。
   useEffect(() => {
@@ -229,15 +300,30 @@ export default function XiaojinPet() {
           >
             ✕
           </button>
-          <p className="xiaojin-greeting">{t("xiaojin.greeting")}</p>
-          {prompts.length > 0 && (
-            <div className="xiaojin-chips">
-              {prompts.map((p) => (
-                <button type="button" key={p} className="xiaojin-chip" onClick={() => ask(p)}>
-                  {p}
-                </button>
+          {messages.length === 0 && <p className="xiaojin-greeting">{t("xiaojin.greeting")}</p>}
+          {messages.length > 0 && (
+            <div className="xiaojin-msgs" ref={msgsRef}>
+              {messages.map((m, i) => (
+                <div key={i} className={m.role === "user" ? "xiaojin-msg-user" : "xiaojin-msg-assistant"}>
+                  {m.content || (
+                    <span className="xiaojin-thinking">{t("xiaojin.thinking")}</span>
+                  )}
+                </div>
               ))}
             </div>
+          )}
+          {chatError && <p className="xiaojin-error" role="alert">{chatError}</p>}
+          {user && sessionId !== undefined && (
+            <button
+              type="button"
+              className="xiaojin-continue"
+              onClick={() => {
+                setOpen(false);
+                navigate(`/chat?s=${sessionId}`);
+              }}
+            >
+              {t("xiaojin.continue")}
+            </button>
           )}
           <div className="xiaojin-input-row">
             <input
@@ -256,7 +342,7 @@ export default function XiaojinPet() {
               type="button"
               className="xiaojin-send"
               onClick={() => ask(query)}
-              disabled={!query.trim()}
+              disabled={!query.trim() || streaming}
               aria-label={t("xiaojin.send")}
             >
               ↑

--- a/frontend/src/styles/xiaojin-pet.css
+++ b/frontend/src/styles/xiaojin-pet.css
@@ -27,6 +27,13 @@
   --xiaojin-blush: #d1806c;
   /* 五官线条画在浅色肤面上，深浅模式都得是深色 —— 不跟 --fj-ink 走。 */
   --xiaojin-line: #2b2318;
+
+  /* 气泡：ryOS Rover 式淡黄便签纸。宣纸黄一档，别撞散 --fj-gold 的用途。 */
+  --xiaojin-bubble-bg: #fdf5c8;
+  --xiaojin-bubble-border: #d9c17a;
+  --xiaojin-bubble-input: #fffbe6;
+  --xiaojin-bubble-ink: #2b2318;
+  --xiaojin-bubble-muted: #8a774a;
 }
 
 /* 深色底上整体提亮一档，否则金黄发闷、祖衣糊成一块。 */
@@ -38,6 +45,13 @@
   --xiaojin-kesa: #c2532c;
   --xiaojin-collar: #efe8db;
   --xiaojin-blush: #c47a63;
+
+  /* 深色下的黄便签：压暗成琥珀纸，字提亮 */
+  --xiaojin-bubble-bg: #4c4120;
+  --xiaojin-bubble-border: #6e5e2d;
+  --xiaojin-bubble-input: #5a4d25;
+  --xiaojin-bubble-ink: #f0e9d8;
+  --xiaojin-bubble-muted: #c9ba8e;
 }
 
 /* ---------- 小津本体 ---------- */
@@ -159,9 +173,10 @@
   position: absolute;
   width: 272px;
   padding: 12px 12px 10px;
-  border: 1px solid var(--fj-border);
+  border: 1px solid var(--xiaojin-bubble-border);
   border-radius: 12px;
-  background: var(--fj-surface);
+  background: var(--xiaojin-bubble-bg);
+  color: var(--xiaojin-bubble-ink);
   box-shadow: 0 10px 28px rgba(43, 35, 24, 0.16);
   animation: xiaojin-bubble-in 0.22s cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -196,18 +211,18 @@
   position: absolute;
   width: 12px;
   height: 12px;
-  background: var(--fj-surface);
+  background: var(--xiaojin-bubble-bg);
   transform: rotate(45deg);
 }
 .xiaojin-pet[data-v="above"] .xiaojin-bubble::after {
   bottom: -7px;
-  border-right: 1px solid var(--fj-border);
-  border-bottom: 1px solid var(--fj-border);
+  border-right: 1px solid var(--xiaojin-bubble-border);
+  border-bottom: 1px solid var(--xiaojin-bubble-border);
 }
 .xiaojin-pet[data-v="below"] .xiaojin-bubble::after {
   top: -7px;
-  border-left: 1px solid var(--fj-border);
-  border-top: 1px solid var(--fj-border);
+  border-left: 1px solid var(--xiaojin-bubble-border);
+  border-top: 1px solid var(--xiaojin-bubble-border);
 }
 .xiaojin-pet[data-h="right"] .xiaojin-bubble::after {
   right: 28px;
@@ -226,7 +241,7 @@
   border: 0;
   border-radius: 50%;
   background: none;
-  color: var(--fj-ink-muted);
+  color: var(--xiaojin-bubble-muted);
   font-size: 11px;
   line-height: 1;
   cursor: pointer;
@@ -234,39 +249,88 @@
 
 .xiaojin-bubble-close:hover {
   color: var(--fj-accent);
-  background: var(--fj-bg-alt);
+  background: rgba(0, 0, 0, 0.06);
 }
 
 .xiaojin-greeting {
   margin: 0 18px 9px 0;
   font-size: 13px;
   line-height: 1.6;
-  color: var(--fj-ink);
+  color: var(--xiaojin-bubble-ink);
 }
 
-.xiaojin-chips {
+/* ---------- 气泡内迷你对话流 ---------- */
+.xiaojin-msgs {
   display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  margin-bottom: 9px;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 264px;
+  overflow-y: auto;
+  margin: 2px 0 9px;
+  padding-right: 2px;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
 }
 
-.xiaojin-chip {
-  padding: 2px 9px;
-  border: 1px solid var(--fj-border);
-  border-radius: 11px;
-  background: var(--fj-bg-alt);
-  color: var(--fj-ink-light);
+.xiaojin-msg-user {
+  align-self: flex-end;
+  max-width: 88%;
+  padding: 4px 9px;
+  border-radius: 10px 10px 3px 10px;
+  background: rgba(139, 37, 0, 0.1);
+  color: var(--xiaojin-bubble-ink);
+  font-size: 12.5px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.xiaojin-msg-assistant {
+  align-self: stretch;
+  color: var(--xiaojin-bubble-ink);
+  font-size: 12.5px;
+  line-height: 1.75;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.xiaojin-thinking {
+  color: var(--xiaojin-bubble-muted);
+}
+.xiaojin-thinking::after {
+  content: "…";
+  animation: xiaojin-dots 1.4s steps(4, end) infinite;
+}
+@keyframes xiaojin-dots {
+  0% { content: ""; }
+  33% { content: "·"; }
+  66% { content: "··"; }
+  100% { content: "···"; }
+}
+
+.xiaojin-error {
+  margin: 0 0 8px;
   font-size: 11.5px;
-  cursor: pointer;
-  transition:
-    color 0.16s,
-    border-color 0.16s;
+  line-height: 1.5;
+  color: var(--fj-danger);
 }
 
-.xiaojin-chip:hover {
+/* 「查看完整引文」——去 /chat 同一会话核对引文的出口 */
+.xiaojin-continue {
+  display: block;
+  margin: 0 0 8px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--xiaojin-bubble-muted);
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.xiaojin-continue:hover {
   color: var(--fj-accent);
-  border-color: var(--fj-accent);
 }
 
 .xiaojin-input-row {
@@ -274,9 +338,9 @@
   align-items: center;
   gap: 6px;
   padding: 3px 3px 3px 10px;
-  border: 1px solid var(--fj-border);
+  border: 1px solid var(--xiaojin-bubble-border);
   border-radius: 9px;
-  background: var(--fj-bg-alt);
+  background: var(--xiaojin-bubble-input);
 }
 
 .xiaojin-input-row:focus-within {
@@ -288,14 +352,14 @@
   min-width: 0;
   border: 0;
   background: none;
-  color: var(--fj-ink);
+  color: var(--xiaojin-bubble-ink);
   font-size: 13px;
   font-family: inherit;
   outline: none;
 }
 
 .xiaojin-input::placeholder {
-  color: var(--fj-ink-muted);
+  color: var(--xiaojin-bubble-muted);
 }
 
 .xiaojin-send {
@@ -325,13 +389,13 @@
   padding: 0 2px;
   border: 0;
   background: none;
-  color: var(--fj-ink-muted);
+  color: var(--xiaojin-bubble-muted);
   font-size: 11px;
   font-family: inherit;
   cursor: pointer;
   text-decoration: underline;
   text-underline-offset: 2px;
-  text-decoration-color: var(--fj-border);
+  text-decoration-color: var(--xiaojin-bubble-border);
 }
 
 .xiaojin-feedback:hover {
@@ -372,6 +436,10 @@
 @media (prefers-reduced-motion: reduce) {
   .xiaojin-torso {
     animation: none;
+  }
+  .xiaojin-thinking::after {
+    animation: none;
+    content: "…";
   }
   .xiaojin-bubble {
     animation: none;


### PR DESCRIPTION
按用户指定的三点重做小津气泡（参照 [os.ryo.lu](https://os.ryo.lu/) 的 Rover）：

## 1. 黄底

气泡换成 ryOS Rover 式淡黄便签纸：浅色 `#fdf5c8` + `#d9c17a` 金边，深色模式压成琥珀纸 `#4c4120` + 亮字。新增 `--xiaojin-bubble-*` 一组变量，尾巴、输入行、关闭钮、反馈链接全部跟着便签配色走。

## 2. 就地作答，不再跳页

回车直接调 `sendChatMessageStream` —— **与 /chat 完全同一条后端管线**（检索 + 引文护栏 + citation correction + 匿名配额），答案在气泡内流式渲染，多轮对话靠 `onSessionId` 串同一会话。零后端改动。

关键取舍（答案真实性是家规底线）：

- 气泡里只渲染纯文本，引文【《经》第N卷】标记随文可见；完整的引文核对 UI 留在 /chat —— **登录用户**拿到 session 后出现「去 AI 问答查看完整引文」入口，跳 `/chat?s=` 同一会话。游客不显示该入口（游客会话不落库，跳过去只会 404）
- `onCitationCorrection` 到达时**整段替换**为护栏改写后的全文，与 /chat 落库版本保持一致
- 出错（配额/断流）由 `onError` 文案上屏、空气泡撤掉；空完成（onDone 但零 token）兜底成错误行；流式中锁发送防重入
- 离开首页时 abort 在途流；`cancelled` 不当故障显示

## 3. 推荐问题移除

chips 整个删掉，`xiaojin.prompts` 三语键删除；新增 `thinking`/`error`/`continue` 三键。

ChatPage 的 `?q=&send=1` 深链契约保留不动（阅读页 context 流仍在用那套 effect）。

## 测试

重写为流式契约共 22 条。**六处突变实测全红**：不串 session、出错不撤泡、空完成不兜底、不锁发送、忽略 correction、游客也显示入口。

本地实测（dev 无后端，正好走了错误路径）：黄泡、问题进对话流、留在首页、错误行上屏；深色配色取计算值确认。真流式 E2E 待部署后在生产验证（dev 代理指向 localhost:8000 而本机不跑后端，与 #1123 同一套路）。

门禁：eslint / tsc / i18n ratchet / vitest **401 passed** / build 全绿。