### PR TITLE
fix(home): 小津气泡里不再显示 [追问] 建议行

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -104,6 +104,21 @@ describe("XiaojinPet", () => {
     expect(screen.queryByText(/^玄奘译【《心经》第1卷】$/)).toBeNull();
   });
 
+  it("答案尾部的 [追问] 建议行不展示（正文保留）", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("什么是三法印？");
+    act(() => {
+      cb.onToken("三法印者，诸行无常、诸法无我、涅槃寂静。\n\n");
+      cb.onToken("[追问] 三法印与一实相印有何异同？\n");
+      cb.onToken("[追问] 如何理解诸法无我？");
+      cb.onDone();
+    });
+    expect(screen.getByText(/涅槃寂静/)).toBeTruthy();
+    expect(screen.queryByText(/追问/)).toBeNull();
+    expect(screen.queryByText(/一实相印/)).toBeNull();
+  });
+
   it("流式出错：错误文案上屏、空气泡撤掉、可以再问", async () => {
     renderPet();
     openBubble();

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -44,6 +44,20 @@ function writePos(p: Pos) {
   }
 }
 
+/**
+ * 渲染前剥掉 [追问] 行 —— 后端在答案尾部附带的追问建议。/chat 与 ReaderAIPanel
+ * 各有一份 parseFollowUps 把它们解析成按钮；气泡里按用户要求不展示追问，直接
+ * 丢弃。逐行判断，流式中途「[追问] …」前缀一旦成形该行立即隐藏，不会先整段
+ * 露出来再消失。
+ */
+function stripFollowUps(content: string): string {
+  return content
+    .split("\n")
+    .filter((line) => !/^\[追问]/.test(line.trim()))
+    .join("\n")
+    .replace(/\n+$/, "");
+}
+
 /** 把位置夹回视口内 —— 换了窗口尺寸/分辨率后，存下来的坐标可能已在屏幕外。 */
 function clampPos(p: Pos, w: number, h: number): Pos {
   return {
@@ -305,7 +319,9 @@ export default function XiaojinPet() {
             <div className="xiaojin-msgs" ref={msgsRef}>
               {messages.map((m, i) => (
                 <div key={i} className={m.role === "user" ? "xiaojin-msg-user" : "xiaojin-msg-assistant"}>
-                  {m.content || (
+                  {m.content ? (
+                    m.role === "assistant" ? stripFollowUps(m.content) : m.content
+                  ) : (
                     <span className="xiaojin-thinking">{t("xiaojin.thinking")}</span>
                   )}
                 </div>


### PR DESCRIPTION
生产实测截图里答案尾部的 `[追问] …` 三行是后端附带的追问建议 —— /chat 有专门的按钮 UI，气泡里此前被当纯文本渲染。按用户要求剥掉不展示：渲染时逐行过滤 `/^\[追问]/`，流式中途前缀一旦成形该行立即隐藏。state 保留全文，「查看完整引文」跳去 /chat 时追问按钮照常在。新增测试一条，突变（不剥）实测红。