### PR TITLE
fix(home): 小津气泡渲染 markdown，不再裸露 ** 与 -（懒加载，首屏零成本）

### DIFF
--- a/frontend/src/components/XiaojinMarkdown.tsx
+++ b/frontend/src/components/XiaojinMarkdown.tsx
@@ -1,0 +1,57 @@
+import Markdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * 小津气泡里的 markdown 渲染 —— 单独成文件是为了**懒加载边界**：
+ * react-markdown/remark/micromark 打在一个 152K 的共享 chunk 里，而首页是唯一
+ * 静态导入的路由，直接 import 会把这 152K 压进首屏。XiaojinPet 用 React.lazy
+ * 引它，并在用户提问的一刻预取——首字要等好几秒，chunk 在这段等待里就下完了。
+ *
+ * ⚠️ 别从 ChatPage.tsx 里 import 任何东西（哪怕只是一个 helper）：那会把整个
+ * ChatPage 模块拖进首页 chunk，懒加载就白做了。下面的 tightenLists 是照抄
+ * ChatPage 同名函数的有意复制。
+ *
+ * 与 /chat 的差异（有意为之）：
+ * - 不接 fojin-citation:// 协议。引文核对 UI 在 /chat，气泡里那些链接会被
+ *   react-markdown 的 defaultUrlTransform 归零，退化成纯文本，正是想要的。
+ * - 因此也不需要 rehype-sanitize：没有 rehype-raw，原始 HTML 根本不会进树。
+ * - 标题一律降为粗体：272px 宽的气泡放不下 h1/h2 的字号阶梯。
+ */
+
+/** 把松散的有序列表收紧（编号独占一行、项间空行）。照抄 ChatPage 的同名函数。 */
+function tightenLists(md: string): string {
+  return md
+    .replace(/^(\d+\.)\s*\n\n+/gm, "$1 ")
+    .replace(/\n\n+(?=\d+\.\s)/g, "\n");
+}
+
+const COMPONENTS: Components = {
+  // 气泡只有 272px 宽，标题的字号阶梯放不下，统一降成一行粗体。
+  h1: ({ children }) => <p className="xiaojin-md-h">{children}</p>,
+  h2: ({ children }) => <p className="xiaojin-md-h">{children}</p>,
+  h3: ({ children }) => <p className="xiaojin-md-h">{children}</p>,
+  h4: ({ children }) => <p className="xiaojin-md-h">{children}</p>,
+  h5: ({ children }) => <p className="xiaojin-md-h">{children}</p>,
+  h6: ({ children }) => <p className="xiaojin-md-h">{children}</p>,
+  a: ({ href, children }) => (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ),
+  // 窄气泡里表格必须能横向滚，否则撑破布局。
+  table: ({ children }) => (
+    <div className="xiaojin-md-table">
+      <table>{children}</table>
+    </div>
+  ),
+};
+
+export default function XiaojinMarkdown({ content }: { content: string }) {
+  return (
+    <div className="xiaojin-md">
+      <Markdown remarkPlugins={[remarkGfm]} components={COMPONENTS}>
+        {tightenLists(content)}
+      </Markdown>
+    </div>
+  );
+}

--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -84,7 +84,7 @@ describe("XiaojinPet", () => {
       cb.onToken("诸法因缘灭。");
       cb.onDone();
     });
-    expect(screen.getByText("诸法因缘生，诸法因缘灭。")).toBeTruthy();
+    expect(await screen.findByText("诸法因缘生，诸法因缘灭。")).toBeTruthy();
     // 关键不变式：始终没离开首页
     expect(screen.getByTestId("path").textContent).toBe("/");
     // 问候语让位给对话流
@@ -100,7 +100,7 @@ describe("XiaojinPet", () => {
       cb.onCitationCorrection?.("玄奘译【《般若波罗蜜多心经》第1卷】");
       cb.onDone();
     });
-    expect(screen.getByText(/般若波罗蜜多心经/)).toBeTruthy();
+    expect(await screen.findByText(/般若波罗蜜多心经/)).toBeTruthy();
     expect(screen.queryByText(/^玄奘译【《心经》第1卷】$/)).toBeNull();
   });
 
@@ -114,9 +114,27 @@ describe("XiaojinPet", () => {
       cb.onToken("[追问] 如何理解诸法无我？");
       cb.onDone();
     });
-    expect(screen.getByText(/涅槃寂静/)).toBeTruthy();
+    expect(await screen.findByText(/涅槃寂静/)).toBeTruthy();
     expect(screen.queryByText(/追问/)).toBeNull();
     expect(screen.queryByText(/一实相印/)).toBeNull();
+  });
+
+  it("答案里的 markdown 渲染成富文本，不再裸露 ** 与 -", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("你能帮我做什么？");
+    act(() => {
+      cb.onToken("我可以协助您：\n\n- **解读佛典义理**：结合原文与注疏。\n- **查询经文出处**：定位到卷。");
+      cb.onDone();
+    });
+    // 懒加载的 markdown chunk 到位后才有 <strong>
+    const strongs = await screen.findAllByText("解读佛典义理");
+    expect(strongs[0].tagName).toBe("STRONG");
+    expect(document.querySelectorAll(".xiaojin-md li").length).toBe(2);
+    // 星号与减号不再作为字面量出现在正文里
+    const md = document.querySelector(".xiaojin-md")!;
+    expect(md.textContent).not.toContain("**");
+    expect(md.textContent).not.toContain("- ");
   });
 
   it("流式出错：错误文案上屏、空气泡撤掉、可以再问", async () => {
@@ -135,7 +153,7 @@ describe("XiaojinPet", () => {
       cb2.onToken("好。");
       cb2.onDone();
     });
-    expect(screen.getByText("好。")).toBeTruthy();
+    expect(await screen.findByText("好。")).toBeTruthy();
     // 新一轮开始时旧错误行已清掉
     expect(screen.queryByRole("alert")).toBeNull();
   });

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -1,10 +1,15 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, lazy, Suspense } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../stores/authStore";
 import { sendChatMessageStream } from "../api/client";
 import FeedbackModal from "./FeedbackModal";
 import "../styles/xiaojin-pet.css";
+
+/** 见 XiaojinMarkdown.tsx 顶部注释：懒加载是为了不把 152K 的 markdown chunk
+ *  压进首页首屏。提问时预取，等首字的几秒里就下完了。 */
+const XiaojinMarkdown = lazy(() => import("./XiaojinMarkdown"));
+const prefetchMarkdown = () => { void import("./XiaojinMarkdown"); };
 
 /** 用户主动赶走小津后不再出现。私密模式下 localStorage 会抛，一律当没隐藏。 */
 const HIDDEN_KEY = "fojin_xiaojin_hidden";
@@ -206,6 +211,7 @@ export default function XiaojinPet() {
     setQuery("");
     setChatError(null);
     gotTokenRef.current = false;
+    prefetchMarkdown(); // 与 LLM 首字并行下载，用户感知不到
     setMessages((m) => [...m, { role: "user", content: term }, { role: "assistant", content: "" }]);
     setStreaming(true);
 
@@ -319,10 +325,16 @@ export default function XiaojinPet() {
             <div className="xiaojin-msgs" ref={msgsRef}>
               {messages.map((m, i) => (
                 <div key={i} className={m.role === "user" ? "xiaojin-msg-user" : "xiaojin-msg-assistant"}>
-                  {m.content ? (
-                    m.role === "assistant" ? stripFollowUps(m.content) : m.content
-                  ) : (
+                  {!m.content ? (
                     <span className="xiaojin-thinking">{t("xiaojin.thinking")}</span>
+                  ) : m.role === "assistant" ? (
+                    // fallback 是纯文本：chunk 万一没到（或加载失败）答案照样读得了，
+                    // 只是 markdown 语法裸露——不会白屏。
+                    <Suspense fallback={<span className="xiaojin-md-plain">{stripFollowUps(m.content)}</span>}>
+                      <XiaojinMarkdown content={stripFollowUps(m.content)} />
+                    </Suspense>
+                  ) : (
+                    m.content
                   )}
                 </div>
               ))}

--- a/frontend/src/styles/xiaojin-pet.css
+++ b/frontend/src/styles/xiaojin-pet.css
@@ -54,6 +54,11 @@
   --xiaojin-bubble-muted: #c9ba8e;
 }
 
+:root[data-theme="dark"] .xiaojin-md code,
+:root[data-theme="dark"] .xiaojin-md pre {
+  background: rgba(255, 255, 255, 0.1);
+}
+
 /* ---------- 小津本体 ---------- */
 .xiaojin-figure {
   position: relative;
@@ -290,8 +295,99 @@
   color: var(--xiaojin-bubble-ink);
   font-size: 12.5px;
   line-height: 1.75;
-  white-space: pre-wrap;
   word-break: break-word;
+}
+
+/* markdown chunk 还没到时的兜底：纯文本按原样换行 */
+.xiaojin-md-plain {
+  white-space: pre-wrap;
+}
+
+/* ---------- 气泡里的 markdown：272px 宽，一切从紧 ---------- */
+.xiaojin-md > :first-child {
+  margin-top: 0;
+}
+.xiaojin-md > :last-child {
+  margin-bottom: 0;
+}
+
+.xiaojin-md p {
+  margin: 0 0 6px;
+}
+
+/* 标题已在组件里降为这一行粗体（h1-h6 同款） */
+.xiaojin-md-h {
+  margin: 8px 0 4px;
+  font-weight: 600;
+}
+
+.xiaojin-md ul,
+.xiaojin-md ol {
+  margin: 0 0 6px;
+  padding-left: 18px;
+}
+
+.xiaojin-md li {
+  margin: 0 0 2px;
+}
+
+.xiaojin-md strong {
+  font-weight: 600;
+}
+
+.xiaojin-md a {
+  color: var(--fj-accent);
+  text-underline-offset: 2px;
+}
+
+.xiaojin-md code {
+  padding: 0 3px;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.07);
+  font-size: 0.92em;
+  word-break: break-all;
+}
+
+.xiaojin-md pre {
+  margin: 0 0 6px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.07);
+  overflow-x: auto;
+}
+.xiaojin-md pre code {
+  padding: 0;
+  background: none;
+  word-break: normal;
+}
+
+.xiaojin-md blockquote {
+  margin: 0 0 6px;
+  padding-left: 8px;
+  border-left: 2px solid var(--xiaojin-bubble-border);
+  color: var(--xiaojin-bubble-muted);
+}
+
+/* 表格在窄气泡里必须能横向滚，否则撑破布局 */
+.xiaojin-md-table {
+  margin: 0 0 6px;
+  overflow-x: auto;
+}
+.xiaojin-md-table table {
+  border-collapse: collapse;
+  font-size: 11.5px;
+}
+.xiaojin-md-table th,
+.xiaojin-md-table td {
+  padding: 2px 6px;
+  border: 1px solid var(--xiaojin-bubble-border);
+  white-space: nowrap;
+}
+
+.xiaojin-md hr {
+  margin: 8px 0;
+  border: 0;
+  border-top: 1px solid var(--xiaojin-bubble-border);
 }
 
 .xiaojin-thinking {


### PR DESCRIPTION
#1127 上线后生产实测发现的洞：答案里的 markdown 是**原样显示**的 —— `- **解读佛典义理**：` 那串星号减号直接露在气泡里，而 /chat 那边渲染成粗体和项目符号。

## 关键约束：不能把 152K 压进首屏

react-markdown/remark/micromark 打在一个 **152K 的共享 chunk**（`lib-*.js`）里，而首页是**唯一静态导入的路由** —— 直接 `import` 会把这 152K 加进首页首屏。

所以：

- 渲染器单独成 `XiaojinMarkdown.tsx`，`XiaojinPet` 用 `React.lazy` 引
- **在 `ask()` 的一刻 prefetch**，与 LLM 首字并行下载（首字基线 6.5-18.3s，chunk 在这段等待里早下完，用户感知不到）
- `Suspense` fallback 是纯文本 —— chunk 万一没到或加载失败，答案照样读得了，不会白屏

**实测代价：入口 898206 → 898607 字节（+401，纯 lazy 接线）**，152K 的 markdown chunk 确认不在 `index.html` 预载列表里。

⚠️ `XiaojinMarkdown.tsx` 里**不能从 ChatPage.tsx import 任何东西**（哪怕一个 helper）—— 那会把整个 ChatPage 模块拖进首页 chunk，懒加载就白做了。5 行的 `tightenLists` 是照抄，注释写明了。

## 与 /chat 的有意差异

- 不接 `fojin-citation://` 协议：引文核对 UI 在 /chat，气泡里那些链接被 `defaultUrlTransform` 归零退化成纯文本，正是想要的
- 因此也不需要 `rehype-sanitize`：没有 `rehype-raw`，原始 HTML 根本不进树
- 标题 h1-h6 一律降为一行粗体 —— 272px 宽的气泡放不下字号阶梯
- 表格套横向滚动容器，否则撑破布局

## 测试

新增「markdown 渲染成富文本」：断言 `<strong>` 标签与 `li` 数量，且正文里不含字面量 `**` 和 `- `。因 markdown 现在懒加载，几条断言助手文本的用例改用 `findBy` 等 Suspense 解开。**突变（退回纯文本渲染）实测红。**

门禁：eslint / tsc / i18n / vitest **403 passed** / build 全绿。