### PR TITLE
fix(home): 小津气泡不再把真实错误盖成「回答中断了」

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -142,7 +142,12 @@ describe("XiaojinPet", () => {
     openBubble();
     const cb = await askAndGetCallbacks("什么是无我？");
     act(() => {
+      // 真实客户端契约（api/client.ts）：每条错误路径 onError 之后必补一次
+      // onDone（401/非200/网络/超时/取消全如此）。用例必须照这个顺序打，
+      // 否则「onDone 把真实错误改写成通用兜底」这类 bug 测不出来——
+      // 2026-08-06 生产实锤：配额/登录过期的具体文案全被盖成「回答中断了」。
       cb.onError("今日提问次数已用完", "quota");
+      cb.onDone();
     });
     expect(screen.getByRole("alert").textContent).toBe("今日提问次数已用完");
     expect(screen.queryByText(/小津思索中/)).toBeNull();
@@ -155,6 +160,17 @@ describe("XiaojinPet", () => {
     });
     expect(await screen.findByText("好。")).toBeTruthy();
     // 新一轮开始时旧错误行已清掉
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("cancelled（用户自己停的）后跟 onDone：不显示任何错误", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("被中断的一问");
+    act(() => {
+      cb.onError("已停止", "cancelled");
+      cb.onDone();
+    });
     expect(screen.queryByRole("alert")).toBeNull();
   });
 

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -115,6 +115,10 @@ export default function XiaojinPet() {
   const msgsRef = useRef<HTMLDivElement>(null);
   // 本轮是否收到过任何 token —— onDone 用它判「空完成」，不在 updater 里做副作用。
   const gotTokenRef = useRef(false);
+  // 本轮是否已走过 onError。客户端契约（api/client.ts）：每条错误路径 onError
+  // 之后必补一次 onDone —— 不做这个标记，onDone 的空完成兜底会把配额/登录过期
+  // 等真实错误文案覆盖成通用「回答中断了」（2026-08-06 生产实锤）。
+  const erroredRef = useRef(false);
 
   // 离开首页时掐掉在途的流 —— 没人看的答案不必继续烧 token。
   useEffect(() => () => abortRef.current?.abort(), []);
@@ -211,6 +215,7 @@ export default function XiaojinPet() {
     setQuery("");
     setChatError(null);
     gotTokenRef.current = false;
+    erroredRef.current = false;
     prefetchMarkdown(); // 与 LLM 首字并行下载，用户感知不到
     setMessages((m) => [...m, { role: "user", content: term }, { role: "assistant", content: "" }]);
     setStreaming(true);
@@ -248,6 +253,7 @@ export default function XiaojinPet() {
         });
       },
       onError: (msg, code) => {
+        erroredRef.current = true; // 含 cancelled：onDone 不得再伪造空完成错误
         if (code === "cancelled") return; // 自己 abort 的，不是故障
         // 失败的空气泡不留着，错误行来说话
         setMessages((m) => (m[m.length - 1]?.content === "" ? m.slice(0, -1) : m));
@@ -256,9 +262,15 @@ export default function XiaojinPet() {
       },
       onDone: () => {
         // 流正常结束但一个 token 都没来：按失败兜底，别留无字空泡。
-        if (!gotTokenRef.current) {
+        // erroredRef 守卫：onError 之后客户端必补一次 onDone，真实错误文案
+        // （配额/登录过期/上游故障）不能被这里覆盖成通用兜底。
+        if (!gotTokenRef.current && !erroredRef.current) {
           setMessages((m) => (m[m.length - 1]?.content === "" ? m.slice(0, -1) : m));
           setChatError(t("xiaojin.error"));
+        }
+        // cancelled 后残留的空泡也要撤（onError 分支 return 得早，没走撤泡）
+        if (!gotTokenRef.current && erroredRef.current) {
+          setMessages((m) => (m[m.length - 1]?.content === "" ? m.slice(0, -1) : m));
         }
         finish();
       },


### PR DESCRIPTION
生产实锤（用户截图）：问「金刚经」得到通用的「回答中断了，请稍后再试」—— 真实失败原因被吞掉。

## 根因

我对流式客户端契约的误读。`api/client.ts` 里**每条错误路径在 `onError` 之后都会再补一次 `onDone`**（401 登录过期 / HTTP 非 200 / 网络错误 / 超时 / 取消，全部如此）。而小津的 `onDone` 写的是「零 token → 改写成通用兜底」—— 于是配额、登录过期、上游故障的具体文案先上屏、随即被紧跟的 `onDone` 覆盖。

最伤的组合是 **8h JWT 过期**：401 → 客户端自动登出并给出「登录已过期」→ 被盖成毫无线索的「回答中断了」。

## 修法

`erroredRef` 标记本轮已走过 `onError`（含 cancelled）；`onDone` 的空完成兜底仅在「真空完成」（零 token 且未出错）时生效；cancelled 后残留的空泡也在 `onDone` 里撤掉、不伪造错误行。

## 验证

**先红后绿**：把既有错误用例改成按真实契约打事件（`onError` 后跟 `onDone`），未修复时 2 条红（quota 文案被盖 / cancelled 后伪造错误），修复后 25 全绿；突变（去掉 `erroredRef` 置位）实测红。用例注释写明了契约，防止后人再按「onError 与 onDone 互斥」的想象写测试。