### PR TITLE
feat(home): 小津默认坐在背景山水的山尖上，静候时不时睁眼眨一下

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -43,6 +43,13 @@ beforeEach(() => {
   useAuthStore.setState({ token: null, user: null });
   vi.clearAllMocks();
   vi.mocked(sendChatMessageStream).mockResolvedValue(undefined);
+  // 首帧定位在 rAF 回调里 setPlaced(true)；jsdom 的 rAF 不随断言推进，
+  // visibility:hidden 会把可访问性树整个藏掉（getByRole 全灭）。打成同步。
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
 });
 
 /** 发一问并拿到本轮的流式回调（问题进入迷你对话，不发生任何跳转）。 */
@@ -56,10 +63,14 @@ async function askAndGetCallbacks(question: string): Promise<Callbacks> {
 }
 
 describe("XiaojinPet", () => {
-  it("默认收起：只有小津，没有输入框", () => {
+  it("默认收起：只有小津，没有输入框；首帧定位完成后不再隐藏", () => {
     renderPet();
     expect(screen.getByLabelText("问小津")).toBeTruthy();
     expect(screen.queryByLabelText("问我任何问题…")).toBeNull();
+    // jsdom 无山水背景 → 锚点回退 CSS 右下角，但 placed 必须置真（不能永远藏着）
+    const root = document.querySelector<HTMLElement>(".xiaojin-pet")!;
+    expect(root.style.visibility).not.toBe("hidden");
+    expect(root.style.left).toBe(""); // 无锚点 → 不写内联坐标，走 CSS 默认
   });
 
   it("点一下展开气泡，焦点落进输入框", () => {

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../stores/authStore";
 import { sendChatMessageStream } from "../api/client";
+import { BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS, coverPoint } from "./xiaojinPeak";
 import "../styles/xiaojin-pet.css";
 
 /** 见 XiaojinMarkdown.tsx 顶部注释：懒加载是为了不把 152K 的 markdown chunk
@@ -85,6 +86,9 @@ function clampPos(p: Pos, w: number, h: number): Pos {
  * 完整的引文核对 UI 在 /chat —— 登录用户会看到「查看完整引文」入口跳去同一会话。
  * 游客也能问（后端 get_optional_user + 匿名配额），配额用尽由 onError 文案兜底。
  *
+ * 默认落点：背景山水图的山尖（cover 裁切实时换算，见 xiaojinPeak.ts；窄屏裁掉
+ * 山尖时退回右下角 CSS 锚点）。用户拖过之后以拖为准并持久化。
+ *
  * 可拖动：按住小津本体拖到页面任意位置（pointer events，鼠标/触屏同一套），
  * 位移超过 5px 算拖动并吞掉随后的 click，否则算点击开气泡。位置持久化到
  * localStorage，恢复与窗口 resize 时都夹回视口。气泡朝向按小津当前位置自动
@@ -134,6 +138,11 @@ export default function XiaojinPet() {
     const saved = readPos();
     return saved ? clampPos(saved, 80, 100) : null;
   });
+  // 山尖锚点（无拖动记录时的默认落点）。null = 山尖被裁出视口/测不到，退回 CSS 右下角。
+  const [anchor, setAnchor] = useState<Pos | null>(null);
+  // 首帧定位完成前隐藏，避免「右下角闪现一帧再跳上山顶」。拖过的（pos 有值）直接可见。
+  const [placed, setPlaced] = useState(() => readPos() !== null);
+
   // 气泡朝向：above/below 是相对小津的垂直方向，right/left 是气泡贴齐小津的哪条边。
   const [placement, setPlacement] = useState<{ v: "above" | "below"; h: "right" | "left" }>({
     v: "above",
@@ -149,18 +158,47 @@ export default function XiaojinPet() {
     return { w: r?.width || 80, h: r?.height || 100 };
   };
 
-  // 窗口尺寸变化时把小津夹回视口，别让它留在屏幕外找不回来。
+  /** 山尖的视口坐标 → 小津左上角（骑坐在尖上：水平居中、底部叠进尖 6px）。
+   *  山尖被 cover 裁出视口（窄屏竖屏）或页面没有山水背景时返回 null。 */
+  const computePeakAnchor = useCallback((): Pos | null => {
+    const hero = document.querySelector(".home-hero-bg");
+    if (!hero) return null;
+    const r = hero.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) return null;
+    const pt = coverPoint(r.width, r.height, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS);
+    const { w, h } = figureSize();
+    const px = r.left + pt.x;
+    const py = r.top + pt.y;
+    if (px - w / 2 < EDGE || px + w / 2 > window.innerWidth - EDGE || py - h < EDGE) return null;
+    // +28：SVG viewBox 底部留白 ≈13px + 山尖雾冠（apex 检测点之上的半透明过渡）
+    // ≈9px + 骑坐叠入 6px。真机逐档试出来的值 —— 调小会悬空，调大会陷进山里。
+    return { x: px - w / 2, y: py - h + 28 };
+  }, []);
+
+  // 首帧定位：rAF 回调里测 DOM 再 setState（effect 体内同步 setState 会被
+  // react-hooks/set-state-in-effect 判硬错，rAF 回调不在此列）。
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      setAnchor(computePeakAnchor());
+      setPlaced(true);
+    });
+    return () => cancelAnimationFrame(id);
+  }, [computePeakAnchor]);
+
+  // 窗口尺寸变化：拖过的夹回视口；没拖过的重算山尖锚点（cover 裁切随尺寸变）。
+  // pos 进依赖：监听器随之重挂，闭包里永远是当前值，不必维护一个渲染期 ref。
   useEffect(() => {
     const onResize = () => {
-      setPos((p) => {
-        if (!p) return p;
+      if (pos) {
         const { w, h } = figureSize();
-        return clampPos(p, w, h);
-      });
+        setPos(clampPos(pos, w, h));
+      } else {
+        setAnchor(computePeakAnchor());
+      }
     };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, []);
+  }, [pos, computePeakAnchor]);
 
   /** 按小津当前位置选气泡朝向：垂直取空间大的一侧，水平取够放气泡的一侧。 */
   const computePlacement = useCallback(() => {
@@ -318,7 +356,12 @@ export default function XiaojinPet() {
       data-open={open ? "" : undefined}
       data-v={placement.v}
       data-h={placement.h}
-      style={pos ? { left: pos.x, top: pos.y, right: "auto", bottom: "auto" } : undefined}
+      style={{
+        ...((pos ?? anchor)
+          ? { left: (pos ?? anchor)!.x, top: (pos ?? anchor)!.y, right: "auto", bottom: "auto" }
+          : {}),
+        ...(placed ? {} : { visibility: "hidden" as const }),
+      }}
     >
       {open && (
         <div className="xiaojin-bubble" role="dialog" aria-label={t("xiaojin.bubble_label")}>

--- a/frontend/src/components/xiaojinPeak.test.ts
+++ b/frontend/src/components/xiaojinPeak.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { coverPoint, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS } from "./xiaojinPeak";
+
+/**
+ * cover 数学的两种裁切方向各验一例，期望值全部手算：
+ * 图 1280×717，山尖比例 (0.8172, 0.4003)，object-position center 70%。
+ */
+describe("coverPoint（cover 裁切下的比例点→容器坐标）", () => {
+  it("宽容器（按宽放大、裁上下）：1920×809 → 山尖 (1569.0, 244.1)", () => {
+    // s = max(1920/1280, 809/717) = 1.5 → 渲染 1920×1075.5
+    // ox = (1920-1920)*0.5 = 0; oy = (809-1075.5)*0.7 = -186.55
+    // x = 0 + 0.8172*1920 = 1569.024; y = -186.55 + 0.4003*1075.5 = 243.97
+    const pt = coverPoint(1920, 809, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS);
+    expect(pt.x).toBeCloseTo(1569.02, 1);
+    expect(pt.y).toBeCloseTo(243.97, 1);
+  });
+
+  it("窄容器（按高放大、裁左右）：390×640 → 山尖溢出右缘（x > 390）", () => {
+    // s = max(390/1280, 640/717) = 0.8926 → 渲染 1142.6×640
+    // ox = (390-1142.6)*0.5 = -376.3; x = -376.3 + 0.8172*1142.6 = 557.4 —— 出画
+    const pt = coverPoint(390, 640, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS);
+    expect(pt.x).toBeGreaterThan(390); // 窄屏山尖被裁掉 → 组件应回退右下角锚点
+    expect(pt.x).toBeCloseTo(557.4, 0);
+    expect(pt.y).toBeCloseTo(256.2, 0);
+  });
+
+  it("object-position 的偏移方向：y=0.7 意味着上边裁得多（山尖上移）", () => {
+    const at70 = coverPoint(1920, 809, BG_NATURAL, PEAK_FRACTION, { x: 0.5, y: 0.7 });
+    const at50 = coverPoint(1920, 809, BG_NATURAL, PEAK_FRACTION, { x: 0.5, y: 0.5 });
+    expect(at70.y).toBeLessThan(at50.y);
+  });
+});

--- a/frontend/src/components/xiaojinPeak.ts
+++ b/frontend/src/components/xiaojinPeak.ts
@@ -1,0 +1,37 @@
+/**
+ * 小津默认落点 = 首页背景山水图的山尖。
+ *
+ * 背景图是 object-fit: cover + object-position: center 70%（home.css），山尖在
+ * **视口**里的坐标随窗口尺寸/裁切变动 —— 固定坐标必然跑偏，必须按 cover 的
+ * 数学实时换算。这里放纯函数与常量，DOM 测量留在组件里，便于单测。
+ *
+ * PEAK_FRACTION 是脚本实测：对 public/landscape-bg.webp 右半幅逐列扫「连续
+ * 8 像素山体色」的最高点，apex 在 (1046, 287)，即 (0.8172, 0.4003)。换图必须
+ * 重测这组常量。
+ */
+
+export const BG_NATURAL = { w: 1280, h: 717 };
+export const PEAK_FRACTION = { fx: 0.8172, fy: 0.4003 };
+/** home.css `.home-hero-bg img { object-position: center 70% }` */
+export const BG_OBJECT_POS = { x: 0.5, y: 0.7 };
+
+/**
+ * cover 裁切下，图内比例点 → 容器内像素坐标。
+ *
+ * cover 的定义：scale = max(cw/iw, ch/ih)，溢出的那一轴按 object-position
+ * 分配裁掉的部分（0.5 = 两边均裁，0.7 = 上边裁 70%）。
+ */
+export function coverPoint(
+  cw: number,
+  ch: number,
+  natural: { w: number; h: number },
+  frac: { fx: number; fy: number },
+  objPos: { x: number; y: number },
+): { x: number; y: number } {
+  const s = Math.max(cw / natural.w, ch / natural.h);
+  const rw = natural.w * s;
+  const rh = natural.h * s;
+  const ox = (cw - rw) * objPos.x;
+  const oy = (ch - rh) * objPos.y;
+  return { x: ox + frac.fx * rw, y: oy + frac.fy * rh };
+}

--- a/frontend/src/styles/xiaojin-pet.css
+++ b/frontend/src/styles/xiaojin-pet.css
@@ -130,6 +130,24 @@
   opacity: 1;
   transition: opacity 0.2s ease;
 }
+
+/* 静候时不时睁眼眨一下（用户要求）。只在「没 hover、没聚焦、气泡收起」时跑
+   —— 动画属性在 cascade 里压过普通声明，交互态必须用 :not() 摘掉动画，
+   否则 hover 睁眼会被动画盖回去。 */
+.xiaojin-pet:not([data-open]) .xiaojin-figure:not(:hover):not(:focus-within) .xiaojin-eyes-open {
+  animation: xiaojin-peek 6.4s ease-in-out infinite;
+}
+.xiaojin-pet:not([data-open]) .xiaojin-figure:not(:hover):not(:focus-within) .xiaojin-eyes-closed {
+  animation: xiaojin-peek-closed 6.4s ease-in-out infinite;
+}
+@keyframes xiaojin-peek {
+  0%, 78%, 92%, 100% { opacity: 0; }
+  82%, 88% { opacity: 1; }
+}
+@keyframes xiaojin-peek-closed {
+  0%, 78%, 92%, 100% { opacity: 1; }
+  82%, 88% { opacity: 0; }
+}
 .xiaojin-figure:hover .xiaojin-eyes-open,
 .xiaojin-body:focus-visible .xiaojin-eyes-open,
 .xiaojin-pet[data-open] .xiaojin-eyes-open {
@@ -515,6 +533,10 @@
   .xiaojin-thinking::after {
     animation: none;
     content: "…";
+  }
+  .xiaojin-eyes-open,
+  .xiaojin-eyes-closed {
+    animation: none;
   }
   .xiaojin-bubble {
     animation: none;


### PR DESCRIPTION
用户指定：默认落点为首页背景图右侧山峰之巅（附参考截图），眼睛不时眨动。

## 山尖落点 —— 难点在 cover 裁切

背景是 `object-fit:cover + object-position:center 70%`，**山尖的视口坐标随窗口尺寸变** —— 固定坐标必然跑偏。

- 新增 `xiaojinPeak.ts`：纯函数 `coverPoint` 做「图内比例点 → 容器坐标」换算；`PEAK_FRACTION=(0.8172, 0.4003)` 是脚本对 `landscape-bg.webp` 右半幅逐列扫「连续 8 像素山体色」实测的 apex（换背景图必须重测，注释已写明）
- rAF 回调里测 `.home-hero-bg` rect 后 setAnchor（effect 体内同步 setState 是仓库 lint 硬错）；resize 时拖过的夹回视口、没拖过的重算山尖；首帧定位前 `visibility:hidden` 防「右下角闪一帧再跳上山」
- 骑坐叠入 **+28px 是真机逐档试出来的**（SVG 底部留白 ≈13 + apex 之上的雾冠 ≈9 + 叠坐 6）；红点标定法验证过计算点落在山体上
- 优先级：**用户拖过 > 山尖锚点 > CSS 右下角**；窄屏 cover 裁掉山尖时回退右下角（单测断言 390×640 下 x=557>390 溢出）
- 视口换算实测精确命中：911 高时 top=235、856 高时 top=196，差值与 cover 的 oy 项手算一致

## 眨眼

静候时每 6.4s 睁眼一瞬（82-88% 关键帧）。动画属性在 cascade 里**压过普通声明**，交互态（hover / focus-within / 气泡展开）用 `:not()` 摘掉动画 —— 否则「靠近时睁眼看你」会被动画盖回去。`prefers-reduced-motion` 下关闭。真机截图恰好抓到 load 后 ~5.3s 的睁眼瞬间。

## 测试

`xiaojinPeak.test.ts` 三条，期望值全部手算；**突变实测红**（cover 写成 contain 杀 3 条、忽略 object-position 杀 2 条）。XiaojinPet 测试把 rAF 打成同步 —— jsdom 的 rAF 不随断言推进，`visibility:hidden` 会把可访问性树整个藏掉。全量 **406 passed**。

真机验证：拖走→刷新在原位；清记录→刷新回山尖；两种视口高度下均精确骑在尖上。