### PR TITLE
fix(home): 小津改为悬浮在山尖上方 ~30px —— 用户对比后选定悬空版

### DIFF
--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -170,9 +170,10 @@ export default function XiaojinPet() {
     const px = r.left + pt.x;
     const py = r.top + pt.y;
     if (px - w / 2 < EDGE || px + w / 2 > window.innerWidth - EDGE || py - h < EDGE) return null;
-    // +28：SVG viewBox 底部留白 ≈13px + 山尖雾冠（apex 检测点之上的半透明过渡）
-    // ≈9px + 骑坐叠入 6px。真机逐档试出来的值 —— 调小会悬空，调大会陷进山里。
-    return { x: px - w / 2, y: py - h + 28 };
+    // +6：让小津悬浮在山尖上方 ~30px —— 打坐悬空的意境，用户对比过贴地版
+    // （+28，SVG 底部留白+雾冠+叠坐的实测和）后拍板选了悬空。要改回贴地就
+    // 把叠入量调回 +28。
+    return { x: px - w / 2, y: py - h + 6 };
   }, []);
 
   // 首帧定位：rAF 回调里测 DOM 再 setState（effect 体内同步 setState 会被


### PR DESCRIPTION
#1132 的 +28 让小津贴地坐在山尖上；用户看过两版对比后拍板选悬空 ~30px（打坐悬浮的意境）。叠入量退回 +6，注释保留贴地版调法（+28）备查。纯常量改动，27 条相关测试全绿。