### PR TITLE
fix(home): 小津居中到山尖正上方（fx 0.826），并修锚点首帧竞态

### DIFF
--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -158,13 +158,16 @@ export default function XiaojinPet() {
     return { w: r?.width || 80, h: r?.height || 100 };
   };
 
-  /** 山尖的视口坐标 → 小津左上角（骑坐在尖上：水平居中、底部叠进尖 6px）。
-   *  山尖被 cover 裁出视口（窄屏竖屏）或页面没有山水背景时返回 null。 */
-  const computePeakAnchor = useCallback((): Pos | null => {
+  /** 山尖的视口坐标 → 小津左上角（悬浮在尖上方：水平居中）。
+   *  返回三态：Pos = 算出来了；null = 山尖被 cover 裁出视口（窄屏）→ 回退右下角；
+   *  undefined = hero 还没排版好（rect≈0，dev 下样式异步加载时必现）→ 下一帧重试。
+   *  三态是 2026-08-06 的实锤修复：之前把「没排好版」也当 null 一锤定音，
+   *  小津就永远落在右下角兜底位了。 */
+  const computePeakAnchor = useCallback((): Pos | null | undefined => {
     const hero = document.querySelector(".home-hero-bg");
     if (!hero) return null;
     const r = hero.getBoundingClientRect();
-    if (r.width < 2 || r.height < 2) return null;
+    if (r.width < 2 || r.height < 2) return undefined;
     const pt = coverPoint(r.width, r.height, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS);
     const { w, h } = figureSize();
     const px = r.left + pt.x;
@@ -177,13 +180,23 @@ export default function XiaojinPet() {
   }, []);
 
   // 首帧定位：rAF 回调里测 DOM 再 setState（effect 体内同步 setState 会被
-  // react-hooks/set-state-in-effect 判硬错，rAF 回调不在此列）。
+  // react-hooks/set-state-in-effect 判硬错，rAF 回调不在此列）。hero 未排版
+  // （undefined）就逐帧重试，封顶 ~1s —— 已排版但山尖被裁（null）立即落定，
+  // 不让窄屏用户白等一秒的隐身。
   useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      setAnchor(computePeakAnchor());
-      setPlaced(true);
-    });
-    return () => cancelAnimationFrame(id);
+    let raf = 0;
+    let tries = 0;
+    const attempt = () => {
+      const a = computePeakAnchor();
+      if (a !== undefined || tries++ > 60) {
+        setAnchor(a ?? null);
+        setPlaced(true);
+        return;
+      }
+      raf = requestAnimationFrame(attempt);
+    };
+    raf = requestAnimationFrame(attempt);
+    return () => cancelAnimationFrame(raf);
   }, [computePeakAnchor]);
 
   // 窗口尺寸变化：拖过的夹回视口；没拖过的重算山尖锚点（cover 裁切随尺寸变）。
@@ -194,7 +207,7 @@ export default function XiaojinPet() {
         const { w, h } = figureSize();
         setPos(clampPos(pos, w, h));
       } else {
-        setAnchor(computePeakAnchor());
+        setAnchor(computePeakAnchor() ?? null);
       }
     };
     window.addEventListener("resize", onResize);

--- a/frontend/src/components/xiaojinPeak.test.ts
+++ b/frontend/src/components/xiaojinPeak.test.ts
@@ -6,21 +6,21 @@ import { coverPoint, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS } from "./xiaojinP
  * 图 1280×717，山尖比例 (0.8172, 0.4003)，object-position center 70%。
  */
 describe("coverPoint（cover 裁切下的比例点→容器坐标）", () => {
-  it("宽容器（按宽放大、裁上下）：1920×809 → 山尖 (1569.0, 244.1)", () => {
+  it("宽容器（按宽放大、裁上下）：1920×809 → 山尖 (1585.9, 244.0)", () => {
     // s = max(1920/1280, 809/717) = 1.5 → 渲染 1920×1075.5
     // ox = (1920-1920)*0.5 = 0; oy = (809-1075.5)*0.7 = -186.55
-    // x = 0 + 0.8172*1920 = 1569.024; y = -186.55 + 0.4003*1075.5 = 243.97
+    // x = 0 + 0.826*1920 = 1585.92; y = -186.55 + 0.4003*1075.5 = 243.97
     const pt = coverPoint(1920, 809, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS);
-    expect(pt.x).toBeCloseTo(1569.02, 1);
+    expect(pt.x).toBeCloseTo(1585.92, 1);
     expect(pt.y).toBeCloseTo(243.97, 1);
   });
 
   it("窄容器（按高放大、裁左右）：390×640 → 山尖溢出右缘（x > 390）", () => {
-    // s = max(390/1280, 640/717) = 0.8926 → 渲染 1142.6×640
-    // ox = (390-1142.6)*0.5 = -376.3; x = -376.3 + 0.8172*1142.6 = 557.4 —— 出画
+    // s = max(390/1280, 640/717) = 0.8926 → 渲染 1142.5×640
+    // ox = (390-1142.5)*0.5 = -376.3; x = -376.3 + 0.826*1142.5 = 567.5 —— 出画
     const pt = coverPoint(390, 640, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS);
     expect(pt.x).toBeGreaterThan(390); // 窄屏山尖被裁掉 → 组件应回退右下角锚点
-    expect(pt.x).toBeCloseTo(557.4, 0);
+    expect(pt.x).toBeCloseTo(567.5, 0);
     expect(pt.y).toBeCloseTo(256.2, 0);
   });
 

--- a/frontend/src/components/xiaojinPeak.ts
+++ b/frontend/src/components/xiaojinPeak.ts
@@ -11,7 +11,9 @@
  */
 
 export const BG_NATURAL = { w: 1280, h: 717 };
-export const PEAK_FRACTION = { fx: 0.8172, fy: 0.4003 };
+/** fx 说明：0.8172 是「最高像素」所在列，但这座峰左肩先到顶、冠部向右倾，
+ *  视觉尖端在更右。0.826 是真机三档对比（0.822/0.826/0.830）眼选的正中值。 */
+export const PEAK_FRACTION = { fx: 0.826, fy: 0.4003 };
 /** home.css `.home-hero-bg img { object-position: center 70% }` */
 export const BG_OBJECT_POS = { x: 0.5, y: 0.7 };
 


### PR DESCRIPTION
用户实测截图指出小津偏左。两处修复：

## 1. 中线校正（0.8172 → 0.826）

0.8172 是「最高像素」所在列，但这座峰**左肩先到顶、冠部向右倾**，视觉尖端在更右。脚本测山体各深度中线得 ~0.822，真机三档对比（0.822 / 0.826 / 0.830）眼选 **0.826** 为正中值。两条手算测试期望同步更新。

## 2. 锚点首帧竞态（调试中途撞出的真 bug）

挂载后第一帧 `.home-hero-bg` 可能还没排版（rect≈0，dev 下样式异步加载**必现**，prod 也可能偶发），原逻辑把这一帧的 null 一锤定音 —— 小津永远落在右下角兜底位。

`computePeakAnchor` 改三态：`Pos`=算出；`null`=山尖被裁（窄屏）→ **立即**回退，不让窄屏用户白等隐身；`undefined`=hero 未排版 → 逐帧重试封顶 ~1s。真机验证：干净加载即落 (1531,213)，不再需要手动 resize 才归位。

全量 vitest 406 passed。