### PR TITLE
fix(home): 山尖锚点改 rAF+定时器双驱动 —— 后台标签页里 rAF 停摆导致小津不落位

### DIFF
--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -185,18 +185,43 @@ export default function XiaojinPet() {
   // 不让窄屏用户白等一秒的隐身。
   useEffect(() => {
     let raf = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     let tries = 0;
+    let done = false;
+    // rAF + 定时器双驱动：前台标签页 rAF 先到（绘制前定位，无闪跳）；
+    // 后台标签页 rAF 停摆（实锤：CDP 后台页里循环整个不走），定时器兜底。
+    const schedule = () => {
+      raf = requestAnimationFrame(attempt);
+      timer = setTimeout(attempt, 250);
+    };
     const attempt = () => {
+      if (done) return;
+      cancelAnimationFrame(raf);
+      clearTimeout(timer);
       const a = computePeakAnchor();
-      if (a !== undefined || tries++ > 60) {
+      if (a !== undefined) {
+        done = true;
         setAnchor(a ?? null);
         setPlaced(true);
         return;
       }
-      raf = requestAnimationFrame(attempt);
+      tries += 1;
+      // ~1s 还没排好版：先在 CSS 兜底位现身，别让用户一直看不见小津；
+      // 后台继续找山尖（dev 冷启样式加载可超 1s），找到再挪上去，够久就放弃。
+      if (tries === 20) setPlaced(true);
+      if (tries > 160) {
+        done = true;
+        setAnchor(null);
+        return;
+      }
+      schedule();
     };
-    raf = requestAnimationFrame(attempt);
-    return () => cancelAnimationFrame(raf);
+    schedule();
+    return () => {
+      done = true;
+      cancelAnimationFrame(raf);
+      clearTimeout(timer);
+    };
   }, [computePeakAnchor]);
 
   // 窗口尺寸变化：拖过的夹回视口；没拖过的重算山尖锚点（cover 裁切随尺寸变）。


### PR DESCRIPTION
用户报默认位置不对（附参考截图）。**逐像素比对后确认参考位置与当前默认完全一致**（同一判据下袍底→实心山尖 9.6px vs 10.4px，水平居中一致）—— 位置常量不动。

真正的问题在排查中撞出：**后台标签页里 `requestAnimationFrame` 完全不执行**（CDP 后台页实锤：重试循环整个停摆，小津 `visibility:hidden` 卡死）。恢复会话、后台打开首页再切过来的用户，会先看到小津不在山上。另外 dev 冷启样式加载可超过原先 1s 的重试上限。

修法：重试循环改 **rAF + setTimeout(250ms) 双驱动** —— 前台 rAF 先到（绘制前定位，无闪跳），后台定时器兜底推进；~1s 未定位先在 CSS 兜底位现身（别让用户一直看不见小津），后台继续找山尖，封顶后放弃回退。

真机验证：后台标签页干净加载，(1548, 213) 正常落位、visible。24 条组件测试全绿。