### PR TITLE
fix(home): 小津左移 2px（fx 0.822 → 0.821）

### DIFF
--- a/frontend/src/components/xiaojinPeak.test.ts
+++ b/frontend/src/components/xiaojinPeak.test.ts
@@ -6,21 +6,21 @@ import { coverPoint, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS } from "./xiaojinP
  * 图 1280×717，山尖比例 (0.8172, 0.4003)，object-position center 70%。
  */
 describe("coverPoint（cover 裁切下的比例点→容器坐标）", () => {
-  it("宽容器（按宽放大、裁上下）：1920×809 → 山尖 (1578.2, 244.0)", () => {
+  it("宽容器（按宽放大、裁上下）：1920×809 → 山尖 (1576.3, 244.0)", () => {
     // s = max(1920/1280, 809/717) = 1.5 → 渲染 1920×1075.5
     // ox = (1920-1920)*0.5 = 0; oy = (809-1075.5)*0.7 = -186.55
-    // x = 0 + 0.822*1920 = 1578.24; y = -186.55 + 0.4003*1075.5 = 243.97
+    // x = 0 + 0.821*1920 = 1576.32; y = -186.55 + 0.4003*1075.5 = 243.97
     const pt = coverPoint(1920, 809, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS);
-    expect(pt.x).toBeCloseTo(1578.24, 1);
+    expect(pt.x).toBeCloseTo(1576.32, 1);
     expect(pt.y).toBeCloseTo(243.97, 1);
   });
 
   it("窄容器（按高放大、裁左右）：390×640 → 山尖溢出右缘（x > 390）", () => {
     // s = max(390/1280, 640/717) = 0.8926 → 渲染 1142.5×640
-    // ox = (390-1142.5)*0.5 = -376.3; x = -376.3 + 0.822*1142.5 = 562.9 —— 出画
+    // ox = (390-1142.5)*0.5 = -376.3; x = -376.3 + 0.821*1142.5 = 561.7 —— 出画
     const pt = coverPoint(390, 640, BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS);
     expect(pt.x).toBeGreaterThan(390); // 窄屏山尖被裁掉 → 组件应回退右下角锚点
-    expect(pt.x).toBeCloseTo(562.9, 0);
+    expect(pt.x).toBeCloseTo(561.7, 0);
     expect(pt.y).toBeCloseTo(256.2, 0);
   });
 

--- a/frontend/src/components/xiaojinPeak.ts
+++ b/frontend/src/components/xiaojinPeak.ts
@@ -14,8 +14,10 @@ export const BG_NATURAL = { w: 1280, h: 717 };
 /** fx 说明：0.8172 是「最高像素」所在列（左肩），0.826 是一次目测误标——
  *  目测值不锚定图像特征，误差会随窗口宽度漂移（用户两次方向相反的投诉
  *  ±0.327 袍宽完美对称，中点 0.8216 与原图山脊中线扫描 0.822 汇合）。
- *  0.822 = apex 下方 16-32px 处山体左右边界的中点，是稳定的图像特征。 */
-export const PEAK_FRACTION = { fx: 0.822, fy: 0.4003 };
+ *  0.822 = apex 下方 16-32px 处山体左右边界的中点，是稳定的图像特征；
+ *  0.8210 是在它基础上按用户「往左一点点，差不多 2px」微调的终值
+ *  （2px ÷ 渲染宽 1920px ≈ 0.00104）。 */
+export const PEAK_FRACTION = { fx: 0.821, fy: 0.4003 };
 /** home.css `.home-hero-bg img { object-position: center 70% }` */
 export const BG_OBJECT_POS = { x: 0.5, y: 0.7 };
 


### PR DESCRIPTION
用户在 0.822 版上目视微调：「往左一点点点，差不多 2px」。换算：2px ÷ 该视口下背景渲染宽 1920px ≈ 0.00104 fx。两条手算测试期望同步更新，27 passed。