### PR TITLE
fix(home): 关闭小津改为刷新即回，并清掉存量的永久隐藏键

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1522,7 +1522,7 @@
   "chat.configure_other_models": "Use another provider…",
   "xiaojin.open": "Ask XiaoJin",
   "xiaojin.close": "Close",
-  "xiaojin.dismiss": "Hide XiaoJin",
+  "xiaojin.dismiss": "Hide XiaoJin for now (back on refresh)",
   "xiaojin.bubble_label": "Ask XiaoJin",
   "xiaojin.greeting": "Amitabha. I am XiaoJin — ask about doctrine, where a term comes from, or which sutra you need. 🙏",
   "xiaojin.placeholder": "Ask me anything…",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1522,7 +1522,7 @@
   "chat.configure_other_models": "設定其他廠商模型…",
   "xiaojin.open": "問小津",
   "xiaojin.close": "關閉",
-  "xiaojin.dismiss": "不再顯示小津",
+  "xiaojin.dismiss": "暫時關閉小津（重新整理後回來）",
   "xiaojin.bubble_label": "小津問答",
   "xiaojin.greeting": "阿彌陀佛。我是小津——想問經論義理、名相出處，還是找哪一部經？🙏",
   "xiaojin.placeholder": "問我任何問題…",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1522,7 +1522,7 @@
   "chat.configure_other_models": "配置其他厂商模型…",
   "xiaojin.open": "问小津",
   "xiaojin.close": "关闭",
-  "xiaojin.dismiss": "不再显示小津",
+  "xiaojin.dismiss": "暂时关闭小津（刷新后回来）",
   "xiaojin.bubble_label": "小津问答",
   "xiaojin.greeting": "阿弥陀佛。我是小津——想问经论义理、名相出处，还是找哪一部经？🙏",
   "xiaojin.placeholder": "问我任何问题…",

--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -40,6 +40,7 @@ const openBubble = () => fireEvent.click(screen.getByLabelText("问小津"));
 
 beforeEach(() => {
   localStorage.clear();
+  sessionStorage.clear();
   useAuthStore.setState({ token: null, user: null });
   vi.clearAllMocks();
   vi.mocked(sendChatMessageStream).mockResolvedValue(undefined);
@@ -294,11 +295,32 @@ describe("XiaojinPet", () => {
     expect(screen.queryByLabelText("问我任何问题…")).toBeNull();
   });
 
-  it("赶走它之后本次立刻消失，并记进 localStorage", () => {
+  it("按 ✕ 立刻消失，但不落任何存储（刷新即回，不是单向门）", () => {
     renderPet();
-    fireEvent.click(screen.getByLabelText("不再显示小津"));
+    fireEvent.click(screen.getByLabelText("暂时关闭小津（刷新后回来）"));
     expect(screen.queryByLabelText("问小津")).toBeNull();
-    expect(localStorage.getItem(HIDDEN_KEY)).toBe("1");
+    // 落 localStorage = 永久单向门；落 sessionStorage 同标签页刷新照样还在
+    // （实测），两者都不满足「刷新回来」。
+    expect(localStorage.getItem(HIDDEN_KEY)).toBeNull();
+    expect(sessionStorage.getItem(HIDDEN_KEY)).toBeNull();
+  });
+
+  it("关掉后重新挂载（等价于刷新）小津就回来", () => {
+    const { unmount } = renderPet();
+    fireEvent.click(screen.getByLabelText("暂时关闭小津（刷新后回来）"));
+    expect(screen.queryByLabelText("问小津")).toBeNull();
+    unmount();
+    renderPet();
+    expect(screen.getByLabelText("问小津")).toBeTruthy();
+  });
+
+  it("迁移：旧的永久隐藏键被清掉，小津回来", () => {
+    localStorage.setItem(HIDDEN_KEY, "1");
+    sessionStorage.setItem(HIDDEN_KEY, "1");
+    renderPet();
+    expect(screen.getByLabelText("问小津")).toBeTruthy();
+    expect(localStorage.getItem(HIDDEN_KEY)).toBeNull();
+    expect(sessionStorage.getItem(HIDDEN_KEY)).toBeNull();
   });
 
   it("气泡里没有意见反馈入口（2026-08-06 用户要求整个移除，含登录态）", () => {
@@ -315,11 +337,7 @@ describe("XiaojinPet", () => {
     expect(document.querySelector(".xiaojin-feedback")).toBeNull();
   });
 
-  it("已被赶走过就整个不渲染", () => {
-    localStorage.setItem(HIDDEN_KEY, "1");
-    renderPet();
-    expect(screen.queryByLabelText("问小津")).toBeNull();
-  });
+
 });
 
 describe("XiaojinPet 拖动", () => {

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -11,7 +11,15 @@ import "../styles/xiaojin-pet.css";
 const XiaojinMarkdown = lazy(() => import("./XiaojinMarkdown"));
 const prefetchMarkdown = () => { void import("./XiaojinMarkdown"); };
 
-/** 用户主动赶走小津后不再出现。私密模式下 localStorage 会抛，一律当没隐藏。 */
+/**
+ * 旧的「永久隐藏」键。现在按 ✕ 只改内存 state —— **刷新即回**，不落任何存储。
+ *
+ * 沿革：曾写 localStorage 做永久隐藏，但站内没有任何找回入口，等于单向门：
+ * 点一下（移动端 ✕ 常驻，误触很容易）小津就永远消失，只能开 DevTools 清键
+ * 自救。2026-08-07 用户实际撞上并报障。中途一度改 sessionStorage，实测发现
+ * **同标签页刷新它照样还在**（只有关标签页才清），仍然不满足「刷新回来」，
+ * 遂改为不落存储。这个常量只剩一个用途：清掉存量用户的旧键。
+ */
 const HIDDEN_KEY = "fojin_xiaojin_hidden";
 /** 用户把小津拖到哪，下次进来还在哪。 */
 const POS_KEY = "fojin_xiaojin_pos";
@@ -22,12 +30,16 @@ const EDGE = 8;
 
 type Pos = { x: number; y: number };
 
+/** 恒为 false —— 顺带清掉存量用户的旧永久隐藏键，让被单向门关掉的小津回来。
+ *  几个版本后（存量键清完）这个函数连同 HIDDEN_KEY 可以一起删。 */
 function readHidden(): boolean {
   try {
-    return localStorage.getItem(HIDDEN_KEY) === "1";
+    localStorage.removeItem(HIDDEN_KEY);
+    sessionStorage.removeItem(HIDDEN_KEY);
   } catch {
-    return false;
+    // 私密模式：本来就没存过
   }
+  return false;
 }
 
 function readPos(): Pos | null {
@@ -377,14 +389,8 @@ export default function XiaojinPet() {
     };
   }, [open]);
 
-  const dismiss = () => {
-    try {
-      localStorage.setItem(HIDDEN_KEY, "1");
-    } catch {
-      // 私密模式：这次会话内隐藏即可，不必persist
-    }
-    setHidden(true);
-  };
+  // 只改内存 state：刷新/切走再回来，小津就回来了。刻意不落存储——见 HIDDEN_KEY 注释。
+  const dismiss = () => setHidden(true);
 
   if (hidden) return null;
 


### PR DESCRIPTION
用户报障：点了小津的 ✕ 之后刷新，小津再也不出现。

## 根因：这个 ✕ 是单向门

它把 `fojin_xiaojin_hidden` 写进 **localStorage 做永久隐藏**，而站内**没有任何找回入口** —— 点一下（移动端 ✕ 还是常驻的，误触很容易）小津就永远消失，只能开 DevTools 清键自救。

## 修法

- `dismiss` 只改内存 state，**不落任何存储** → 刷新 / 切走再回来，小津就回来
- `readHidden` 顺手**清掉存量用户的旧键**（localStorage + sessionStorage）→ 已经被单向门关掉的人，升级后自动恢复
- aria-label 改为「暂时关闭小津（刷新后回来）」，三语同步 —— 旧文案「不再显示小津」承诺的是永久，名不副实

## 中途踩的坑（记录在案）

一度改用 sessionStorage，真机实测发现**同标签页刷新它照样还在**（只有关标签页才清），仍不满足用户要的「刷新回来」，遂改为不落存储。

## 验证

新增三条测试（不落存储 / 重新挂载即回 / 旧键被清）；**突变实测红**（退回 localStorage 永久隐藏、不清旧键各挂一条）。真机验证：模拟存量旧键 → 升级后小津回来且旧键已清；关闭 → 刷新 → 回来。全量 **407 passed**。