### PR TITLE
feat(home): 小津加右键菜单——新对话 / 切换祖师 / 持久退出（配页脚找回入口）

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1529,5 +1529,12 @@
   "xiaojin.send": "Send",
   "xiaojin.thinking": "XiaoJin is thinking",
   "xiaojin.error": "The answer was interrupted — please try again.",
-  "xiaojin.continue": "Open in AI Q&A to verify citations →"
+  "xiaojin.continue": "Open in AI Q&A to verify citations →",
+  "xiaojin.menu_label": "XiaoJin menu",
+  "xiaojin.menu_new_chat": "New conversation",
+  "xiaojin.menu_master": "Answer in the voice of",
+  "xiaojin.menu_master_default": "XiaoJin (general)",
+  "xiaojin.menu_quit": "Quit XiaoJin",
+  "xiaojin.speaking_as": "Speaking as {{name}}",
+  "xiaojin.recall": "Bring back XiaoJin"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1529,5 +1529,12 @@
   "xiaojin.send": "發送",
   "xiaojin.thinking": "小津思索中",
   "xiaojin.error": "回答中斷了，請稍後再試。",
-  "xiaojin.continue": "去 AI 問答查看完整引文 →"
+  "xiaojin.continue": "去 AI 問答查看完整引文 →",
+  "xiaojin.menu_label": "小津選單",
+  "xiaojin.menu_new_chat": "新對話",
+  "xiaojin.menu_master": "以誰的口吻作答",
+  "xiaojin.menu_master_default": "小津（通用）",
+  "xiaojin.menu_quit": "退出小津",
+  "xiaojin.speaking_as": "正以 {{name}} 的口吻作答",
+  "xiaojin.recall": "喚回小津"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1529,5 +1529,12 @@
   "xiaojin.send": "发送",
   "xiaojin.thinking": "小津思索中",
   "xiaojin.error": "回答中断了，请稍后再试。",
-  "xiaojin.continue": "去 AI 问答查看完整引文 →"
+  "xiaojin.continue": "去 AI 问答查看完整引文 →",
+  "xiaojin.menu_label": "小津菜单",
+  "xiaojin.menu_new_chat": "新对话",
+  "xiaojin.menu_master": "以谁的口吻作答",
+  "xiaojin.menu_master_default": "小津（通用）",
+  "xiaojin.menu_quit": "退出小津",
+  "xiaojin.speaking_as": "正以 {{name}} 的口吻作答",
+  "xiaojin.recall": "唤回小津"
 }

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route, useLocation } from "react-router";
 import Layout from "./Layout";
+import { useXiaojinStore } from "../stores/xiaojinStore";
 
 /** 把当前路径渲染出来，供断言导航是否真的发生 */
 function LocationProbe() {
@@ -45,5 +46,24 @@ describe("Layout 顶部导航", () => {
     for (const label of ["数据源", "AI 问答", "佛学辞典", "知识图谱", "佛教地理", "经典专题"]) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
+  });
+});
+
+
+describe("页脚的「唤回小津」", () => {
+  beforeEach(() => useXiaojinStore.setState({ hidden: false, masterId: null }));
+
+  it("小津在场时不显示（别添无用的噪音）", () => {
+    renderLayout();
+    expect(screen.queryByText("唤回小津")).not.toBeInTheDocument();
+  });
+
+  it("退出后出现，点一下把小津放回来 —— 持久退出必须成对配这个入口", () => {
+    useXiaojinStore.setState({ hidden: true });
+    renderLayout();
+    const recall = screen.getByText("唤回小津");
+    fireEvent.click(recall);
+    expect(useXiaojinStore.getState().hidden).toBe(false);
+    expect(screen.queryByText("唤回小津")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -26,6 +26,7 @@ import { useTranslation } from "react-i18next";
 import { currentUILang } from "../i18n";
 import ThemeToggle from "./ThemeToggle";
 import { useAuthStore } from "../stores/authStore";
+import { useXiaojinStore } from "../stores/xiaojinStore";
 import { getAdminPendingSummary, type AdminPendingSummary } from "../api/client";
 import NotificationBell from "./NotificationBell";
 import CursorGlow from "./CursorGlow";
@@ -38,6 +39,8 @@ export default function Layout() {
   const { user, logout } = useAuthStore();
   const { t, i18n } = useTranslation();
   const isHome = location.pathname === "/";
+  const xiaojinHidden = useXiaojinStore((st) => st.hidden);
+  const recallXiaojin = useXiaojinStore((st) => st.show);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const handleLogout = () => {
@@ -391,6 +394,29 @@ export default function Layout() {
         }}
       >
         {t("footer.copyright")}
+        {/* 「退出小津」的找回入口。持久退出必须成对配一个恢复口，否则就是
+            2026-08-07 那个单向门 bug。只在首页（小津的地盘）且确实退出了才露。 */}
+        {isHome && xiaojinHidden && (
+          <>
+            <span style={{ margin: "0 8px", opacity: 0.4 }}>|</span>
+            <button
+              type="button"
+              onClick={recallXiaojin}
+              style={{
+                border: 0,
+                background: "none",
+                color: "inherit",
+                font: "inherit",
+                cursor: "pointer",
+                textDecoration: "underline",
+                textUnderlineOffset: 2,
+                padding: 0,
+              }}
+            >
+              {t("xiaojin.recall")}
+            </button>
+          </>
+        )}
         <span style={{ margin: "0 8px", opacity: 0.4 }}>|</span>
         <a
           href="https://github.com/xr843/fojin"

--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -3,11 +3,13 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { MemoryRouter, useLocation } from "react-router";
 import XiaojinPet from "./XiaojinPet";
 import { useAuthStore } from "../stores/authStore";
+import { useXiaojinStore } from "../stores/xiaojinStore";
+import { getMasters } from "../api/client";
 import { sendChatMessageStream } from "../api/client";
 
 vi.mock("../api/client", async () => {
   const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
-  return { ...actual, sendChatMessageStream: vi.fn() };
+  return { ...actual, sendChatMessageStream: vi.fn(), getMasters: vi.fn() };
 });
 
 const HIDDEN_KEY = "fojin_xiaojin_hidden";
@@ -44,6 +46,11 @@ beforeEach(() => {
   useAuthStore.setState({ token: null, user: null });
   vi.clearAllMocks();
   vi.mocked(sendChatMessageStream).mockResolvedValue(undefined);
+  vi.mocked(getMasters).mockResolvedValue([
+    { id: "huineng", name_zh: "慧能", name_en: "Huineng", tradition: "禅宗", dates: "638–713", description: "", epigraph: null },
+    { id: "xuanzang", name_zh: "玄奘", name_en: "Xuanzang", tradition: "唯识", dates: "602–664", description: "", epigraph: null },
+  ]);
+  useXiaojinStore.setState({ hidden: false, masterId: null });
   // 首帧定位在 rAF 回调里 setPlaced(true)；jsdom 的 rAF 不随断言推进，
   // visibility:hidden 会把可访问性树整个藏掉（getByRole 全灭）。打成同步。
   vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
@@ -295,26 +302,22 @@ describe("XiaojinPet", () => {
     expect(screen.queryByLabelText("问我任何问题…")).toBeNull();
   });
 
-  it("按 ✕ 立刻消失，但不落任何存储（刷新即回，不是单向门）", () => {
+  it("按 ✕ 退出：小津消失且状态进 store（持久，靠页脚唤回）", () => {
     renderPet();
     fireEvent.click(screen.getByLabelText("暂时关闭小津（刷新后回来）"));
     expect(screen.queryByLabelText("问小津")).toBeNull();
-    // 落 localStorage = 永久单向门；落 sessionStorage 同标签页刷新照样还在
-    // （实测），两者都不满足「刷新回来」。
-    expect(localStorage.getItem(HIDDEN_KEY)).toBeNull();
-    expect(sessionStorage.getItem(HIDDEN_KEY)).toBeNull();
+    expect(useXiaojinStore.getState().hidden).toBe(true);
   });
 
-  it("关掉后重新挂载（等价于刷新）小津就回来", () => {
-    const { unmount } = renderPet();
+  it("store 里 show() 之后小津回来（页脚「唤回小津」走的就是这条）", () => {
+    renderPet();
     fireEvent.click(screen.getByLabelText("暂时关闭小津（刷新后回来）"));
     expect(screen.queryByLabelText("问小津")).toBeNull();
-    unmount();
-    renderPet();
+    act(() => useXiaojinStore.getState().show());
     expect(screen.getByLabelText("问小津")).toBeTruthy();
   });
 
-  it("迁移：旧的永久隐藏键被清掉，小津回来", () => {
+  it("迁移：上古的永久隐藏键被清掉，小津回来", () => {
     localStorage.setItem(HIDDEN_KEY, "1");
     sessionStorage.setItem(HIDDEN_KEY, "1");
     renderPet();
@@ -407,4 +410,108 @@ describe("XiaojinPet 拖动", () => {
 
   // 气泡朝向（data-v/data-h）依赖真实布局的 getBoundingClientRect，jsdom 里
   // rect 全零测不出翻转 —— 朝向逻辑在真浏览器里人工验证（拖到顶部气泡开脚下）。
+});
+
+describe("XiaojinPet 右键菜单", () => {
+  const openMenu = async () => {
+    fireEvent.contextMenu(screen.getByLabelText("问小津"), { clientX: 100, clientY: 100 });
+    await waitFor(() => expect(screen.getByRole("menu")).toBeTruthy());
+  };
+
+  it("右键弹菜单，含新对话 / 祖师列表 / 退出", async () => {
+    renderPet();
+    await openMenu();
+    expect(screen.getByText("新对话")).toBeTruthy();
+    expect(screen.getByText("退出小津")).toBeTruthy();
+    // 祖师是懒加载的：开菜单才拉
+    expect(await screen.findByText("慧能")).toBeTruthy();
+    expect(screen.getByText("玄奘")).toBeTruthy();
+    expect(getMasters).toHaveBeenCalledTimes(1);
+  });
+
+  it("首页默认不拉祖师列表（不为菜单花一次请求）", () => {
+    renderPet();
+    expect(getMasters).not.toHaveBeenCalled();
+  });
+
+  it("新对话：清空往来并断开会话，下一问不带旧 session", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("第一问");
+    act(() => {
+      cb.onSessionId(42);
+      cb.onToken("答一");
+      cb.onDone();
+    });
+    expect(await screen.findByText("答一")).toBeTruthy();
+
+    await openMenu();
+    fireEvent.click(screen.getByText("新对话"));
+    // 往来清空
+    expect(screen.queryByText("答一")).toBeNull();
+    expect(screen.queryByText("第一问")).toBeNull();
+
+    await askAndGetCallbacks("第二问");
+    const calls = vi.mocked(sendChatMessageStream).mock.calls;
+    // 关键：不带旧 sessionId，否则「新对话」名不副实（上下文还串着）
+    expect(calls[calls.length - 1][1]).toBeUndefined();
+  });
+
+  it("选祖师：masterId 进 store、传给流式接口，并重开一局", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("第一问");
+    act(() => {
+      cb.onSessionId(7);
+      cb.onToken("答");
+      cb.onDone();
+    });
+
+    await openMenu();
+    fireEvent.click(await screen.findByText("慧能"));
+    expect(useXiaojinStore.getState().masterId).toBe("huineng");
+    // 换人必须重开：旧上下文是上一位祖师的
+    expect(screen.queryByText("答")).toBeNull();
+
+    await askAndGetCallbacks("以六祖口吻");
+    const calls = vi.mocked(sendChatMessageStream).mock.calls;
+    expect(calls[calls.length - 1][2]).toBe("huineng");
+    expect(calls[calls.length - 1][1]).toBeUndefined();
+  });
+
+  it("选中的祖师在气泡里有标识（选完气泡直接开着，不必再点一次）", async () => {
+    renderPet();
+    await openMenu();
+    fireEvent.click(await screen.findByText("玄奘"));
+    // startNewConversation 会把气泡打开——再点小津反而是关掉它
+    expect(screen.getByLabelText("问我任何问题…")).toBeTruthy();
+    expect(await screen.findByText(/正以 玄奘 的口吻作答/)).toBeTruthy();
+  });
+
+  it("菜单里的退出＝持久退出", async () => {
+    renderPet();
+    await openMenu();
+    fireEvent.click(screen.getByText("退出小津"));
+    expect(screen.queryByLabelText("问小津")).toBeNull();
+    expect(useXiaojinStore.getState().hidden).toBe(true);
+  });
+});
+
+describe("XiaojinPet 祖师列表的失败恢复", () => {
+  it("首次拉取失败后再开菜单会重试（不永久降级成只剩「通用」）", async () => {
+    vi.mocked(getMasters).mockRejectedValueOnce(new Error("network"));
+    renderPet();
+    const body = screen.getByLabelText("问小津");
+
+    fireEvent.contextMenu(body, { clientX: 100, clientY: 100 });
+    await waitFor(() => expect(getMasters).toHaveBeenCalledTimes(1));
+    // 失败这轮只有「通用」
+    await waitFor(() => expect(screen.queryByText("慧能")).toBeNull());
+
+    // 关掉再开：必须重试。把失败结果记成 [] 的写法会让这里永远拉不到。
+    fireEvent.mouseDown(document.body);
+    fireEvent.contextMenu(body, { clientX: 100, clientY: 100 });
+    expect(await screen.findByText("慧能")).toBeTruthy();
+    expect(getMasters).toHaveBeenCalledTimes(2);
+  });
 });

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -2,7 +2,8 @@ import { useState, useRef, useEffect, useCallback, lazy, Suspense } from "react"
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../stores/authStore";
-import { sendChatMessageStream } from "../api/client";
+import { useXiaojinStore } from "../stores/xiaojinStore";
+import { sendChatMessageStream, getMasters, type MasterProfile } from "../api/client";
 import { BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS, coverPoint } from "./xiaojinPeak";
 import "../styles/xiaojin-pet.css";
 
@@ -12,13 +13,10 @@ const XiaojinMarkdown = lazy(() => import("./XiaojinMarkdown"));
 const prefetchMarkdown = () => { void import("./XiaojinMarkdown"); };
 
 /**
- * 旧的「永久隐藏」键。现在按 ✕ 只改内存 state —— **刷新即回**，不落任何存储。
- *
- * 沿革：曾写 localStorage 做永久隐藏，但站内没有任何找回入口，等于单向门：
- * 点一下（移动端 ✕ 常驻，误触很容易）小津就永远消失，只能开 DevTools 清键
- * 自救。2026-08-07 用户实际撞上并报障。中途一度改 sessionStorage，实测发现
- * **同标签页刷新它照样还在**（只有关标签页才清），仍然不满足「刷新回来」，
- * 遂改为不落存储。这个常量只剩一个用途：清掉存量用户的旧键。
+ * 上古的「永久隐藏」键。隐藏状态现在归 useXiaojinStore（持久），配页脚的
+ * 「唤回小津」做找回入口 —— 成对才成立：2026-08-07 曾只写这个键、站内无处
+ * 恢复，用户点一次小津就永远消失，只能开 DevTools 自救。
+ * 这个常量只剩一个用途：清掉存量用户的旧键，几个版本后可连同 readHidden 删除。
  */
 const HIDDEN_KEY = "fojin_xiaojin_hidden";
 /** 用户把小津拖到哪，下次进来还在哪。 */
@@ -30,16 +28,14 @@ const EDGE = 8;
 
 type Pos = { x: number; y: number };
 
-/** 恒为 false —— 顺带清掉存量用户的旧永久隐藏键，让被单向门关掉的小津回来。
- *  几个版本后（存量键清完）这个函数连同 HIDDEN_KEY 可以一起删。 */
-function readHidden(): boolean {
+/** 清掉存量用户的旧永久隐藏键（新状态归 useXiaojinStore）。 */
+function clearLegacyHiddenKey() {
   try {
     localStorage.removeItem(HIDDEN_KEY);
     sessionStorage.removeItem(HIDDEN_KEY);
   } catch {
     // 私密模式：本来就没存过
   }
-  return false;
 }
 
 function readPos(): Pos | null {
@@ -110,7 +106,15 @@ function clampPos(p: Pos, w: number, h: number): Pos {
 export default function XiaojinPet() {
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const [hidden, setHidden] = useState(readHidden);
+  const hidden = useXiaojinStore((st) => st.hidden);
+  const hide = useXiaojinStore((st) => st.hide);
+  const masterId = useXiaojinStore((st) => st.masterId);
+  const setMasterId = useXiaojinStore((st) => st.setMasterId);
+  const [legacyCleared] = useState(() => {
+    clearLegacyHiddenKey();
+    return true;
+  });
+  void legacyCleared;
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const user = useAuthStore((s) => s.user);
@@ -129,6 +133,8 @@ export default function XiaojinPet() {
   const msgsRef = useRef<HTMLDivElement>(null);
   // 本轮是否收到过任何 token —— onDone 用它判「空完成」，不在 updater 里做副作用。
   const gotTokenRef = useRef(false);
+  // 当前祖师：用 ref 供 ask 读取，免得把 masterId 塞进 useCallback 依赖。
+  const masterIdRef = useRef<string | null>(null);
   // 本轮是否已走过 onError。客户端契约（api/client.ts）：每条错误路径 onError
   // 之后必补一次 onDone —— 不做这个标记，onDone 的空完成兜底会把配额/登录过期
   // 等真实错误文案覆盖成通用「回答中断了」（2026-08-06 生产实锤）。
@@ -136,6 +142,10 @@ export default function XiaojinPet() {
 
   // 离开首页时掐掉在途的流 —— 没人看的答案不必继续烧 token。
   useEffect(() => () => abortRef.current?.abort(), []);
+
+  useEffect(() => {
+    masterIdRef.current = masterId;
+  }, [masterId]);
 
   // 新 token 到达时贴底 —— 迷你窗口，永远跟随最新内容。
   useEffect(() => {
@@ -160,6 +170,12 @@ export default function XiaojinPet() {
     v: "above",
     h: "right",
   });
+  // 右键（触屏长按）菜单：null = 未开；有值 = 菜单左上角的视口坐标。
+  const [menu, setMenu] = useState<Pos | null>(null);
+  // 祖师列表：只在第一次开菜单时拉，首页默认不为它花一次请求。
+  const [masters, setMasters] = useState<MasterProfile[] | null>(null);
+  const longPressRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
   // 一次拖动的起点快照；active 在越过阈值后置真。
   const dragRef = useRef<{ px: number; py: number; x: number; y: number; active: boolean } | null>(null);
   // 拖动结束后浏览器仍会补发一次 click —— 用这个标记吞掉它，别让拖完弹气泡。
@@ -323,7 +339,7 @@ export default function XiaojinPet() {
       setStreaming(false);
     };
 
-    sendChatMessageStream(term, sessionRef.current, null, {
+    sendChatMessageStream(term, sessionRef.current, masterIdRef.current, {
       onToken: appendToLast,
       onSources: () => {},
       onSessionId: (sid) => {
@@ -389,8 +405,62 @@ export default function XiaojinPet() {
     };
   }, [open]);
 
-  // 只改内存 state：刷新/切走再回来，小津就回来了。刻意不落存储——见 HIDDEN_KEY 注释。
-  const dismiss = () => setHidden(true);
+  /** 新对话：断掉在途的流、清空气泡里的往来与会话号，下一问从零开始。
+   *  没有这个入口时，气泡里的 sessionId 一旦建立就一直串下去——想换话题
+   *  只能刷新整页。 */
+  const startNewConversation = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    sessionRef.current = undefined;
+    setSessionId(undefined);
+    setMessages([]);
+    setChatError(null);
+    setStreaming(false);
+    setMenu(null);
+    setOpen(true);
+  }, []);
+
+  const activeMaster = masterId ? (masters ?? []).find((m) => m.id === masterId) ?? null : null;
+
+  const openMenu = useCallback((x: number, y: number) => {
+    setOpen(false);
+    // 菜单宽 176 / 高约 44+条目；夹进视口，别开出屏幕
+    setMenu({
+      x: Math.min(x, window.innerWidth - 184),
+      y: Math.min(y, window.innerHeight - 220),
+    });
+    if (!masters) {
+      // 失败时保持 null 而不是设成 []：[] 会让下面这个 !masters 守卫永远为假，
+      // 一次瞬时网络失败就把祖师列表永久降级到只剩「通用」，直到刷新整页。
+      // 菜单是用户手动开的、频率低，失败后下次再开重试没有风暴风险。
+      getMasters()
+        .then(setMasters)
+        .catch(() => {});
+    }
+  }, [masters]);
+
+  // 菜单开着时：Esc 或点别处关掉
+  useEffect(() => {
+    if (!menu) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenu(null);
+    };
+    const onDown = (e: MouseEvent) => {
+      if (!(e.target as Element)?.closest?.(".xiaojin-menu")) setMenu(null);
+    };
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onDown);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onDown);
+    };
+  }, [menu]);
+
+  // 持久退出。找回入口在页脚（Layout 的「唤回小津」），两者必须成对存在。
+  const dismiss = () => {
+    setMenu(null);
+    hide();
+  };
 
   if (hidden) return null;
 
@@ -418,6 +488,11 @@ export default function XiaojinPet() {
           >
             ✕
           </button>
+          {activeMaster && (
+            <div className="xiaojin-persona">
+              {t("xiaojin.speaking_as", { name: activeMaster.name_zh })}
+            </div>
+          )}
           {messages.length === 0 && <p className="xiaojin-greeting">{t("xiaojin.greeting")}</p>}
           {messages.length > 0 && (
             <div className="xiaojin-msgs" ref={msgsRef}>
@@ -481,9 +556,31 @@ export default function XiaojinPet() {
         <button
           type="button"
           className="xiaojin-body"
-          onPointerDown={onFigurePointerDown}
-          onPointerMove={onFigurePointerMove}
-          onPointerUp={onFigurePointerUp}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            openMenu(e.clientX, e.clientY);
+          }}
+          onPointerDown={(e) => {
+            onFigurePointerDown(e);
+            // 触屏没有右键：长按 550ms 弹菜单。指针一动（拖动）就取消。
+            if (e.pointerType === "touch") {
+              clearTimeout(longPressRef.current);
+              const { clientX, clientY } = e;
+              longPressRef.current = setTimeout(() => {
+                dragRef.current = null; // 别让这次长按尾随成一次拖动
+                draggedRef.current = true; // 吞掉随后的 click，免得同时弹气泡
+                openMenu(clientX, clientY);
+              }, 550);
+            }
+          }}
+          onPointerMove={(e) => {
+            clearTimeout(longPressRef.current);
+            onFigurePointerMove(e);
+          }}
+          onPointerUp={() => {
+            clearTimeout(longPressRef.current);
+            onFigurePointerUp();
+          }}
           onClick={() => {
             // 刚拖完：这次 click 是拖动的尾巴，不是点击意图。
             if (draggedRef.current) {
@@ -510,6 +607,58 @@ export default function XiaojinPet() {
           ✕
         </button>
       </div>
+
+      {menu && (
+        <div
+          className="xiaojin-menu"
+          role="menu"
+          aria-label={t("xiaojin.menu_label")}
+          style={{ left: menu.x, top: menu.y }}
+        >
+          <button type="button" role="menuitem" className="xiaojin-menu-item" onClick={startNewConversation}>
+            {t("xiaojin.menu_new_chat")}
+          </button>
+          <div className="xiaojin-menu-sep" />
+          <div className="xiaojin-menu-title">{t("xiaojin.menu_master")}</div>
+          <div className="xiaojin-menu-scroll">
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked={masterId === null}
+              className="xiaojin-menu-item"
+              onClick={() => {
+                setMasterId(null);
+                startNewConversation();
+              }}
+            >
+              <span className="xiaojin-menu-tick">{masterId === null ? "✓" : ""}</span>
+              {t("xiaojin.menu_master_default")}
+            </button>
+            {(masters ?? []).map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                role="menuitemradio"
+                aria-checked={masterId === m.id}
+                className="xiaojin-menu-item"
+                onClick={() => {
+                  setMasterId(m.id);
+                  // 换人重开一局：旧上下文是上一位祖师的，串下去会串味
+                  startNewConversation();
+                }}
+              >
+                <span className="xiaojin-menu-tick">{masterId === m.id ? "✓" : ""}</span>
+                {m.name_zh}
+                <span className="xiaojin-menu-hint">{m.tradition}</span>
+              </button>
+            ))}
+          </div>
+          <div className="xiaojin-menu-sep" />
+          <button type="button" role="menuitem" className="xiaojin-menu-item" onClick={dismiss}>
+            {t("xiaojin.menu_quit")}
+          </button>
+        </div>
+      )}
 
     </div>
   );

--- a/frontend/src/stores/xiaojinStore.ts
+++ b/frontend/src/stores/xiaojinStore.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * 小津的跨组件偏好。
+ *
+ * 为什么要个 store：隐藏状态由小津自己（HomePage 内）写，却要被页脚的
+ * 「唤回小津」读——两者不在同一棵子树上。持久退出必须**成对**配一个找回
+ * 入口，否则就是 2026-08-07 那个单向门 bug（写了 localStorage 却无处恢复，
+ * 用户只能开 DevTools 自救）。ryOS 的「退出助理」敢做持久，也是因为它有
+ * 控制面板做找回入口。
+ */
+interface XiaojinState {
+  /** 用户主动退出小津。持久；靠页脚的「唤回小津」恢复。 */
+  hidden: boolean;
+  /** 以哪位祖师的口吻作答；null = 通用助手小津。持久。 */
+  masterId: string | null;
+  hide: () => void;
+  show: () => void;
+  setMasterId: (id: string | null) => void;
+}
+
+export const useXiaojinStore = create<XiaojinState>()(
+  persist(
+    (set) => ({
+      hidden: false,
+      masterId: null,
+      hide: () => set({ hidden: true }),
+      show: () => set({ hidden: false }),
+      setMasterId: (masterId) => set({ masterId }),
+    }),
+    { name: "fojin-xiaojin" },
+  ),
+);

--- a/frontend/src/styles/xiaojin-pet.css
+++ b/frontend/src/styles/xiaojin-pet.css
@@ -548,3 +548,84 @@
     transform: none;
   }
 }
+
+/* ---------- 右键 / 长按菜单 ---------- */
+.xiaojin-menu {
+  position: fixed;
+  z-index: 95; /* 压过小津(90)，仍低于 antd Modal(1000) */
+  width: 176px;
+  padding: 4px;
+  border: 1px solid var(--xiaojin-bubble-border);
+  border-radius: 10px;
+  background: var(--xiaojin-bubble-bg);
+  color: var(--xiaojin-bubble-ink);
+  box-shadow: 0 10px 28px rgba(43, 35, 24, 0.2);
+  font-size: 12.5px;
+  animation: xiaojin-bubble-in 0.14s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.xiaojin-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.xiaojin-menu-item:hover {
+  background: rgba(139, 37, 0, 0.1);
+}
+
+/* 勾选位固定宽度：选中与未选中的条目左缘对齐，菜单不会跳 */
+.xiaojin-menu-tick {
+  flex: 0 0 12px;
+  color: var(--fj-accent);
+}
+
+.xiaojin-menu-hint {
+  margin-left: auto;
+  padding-left: 6px;
+  font-size: 10.5px;
+  color: var(--xiaojin-bubble-muted);
+}
+
+.xiaojin-menu-title {
+  padding: 4px 8px 2px;
+  font-size: 10.5px;
+  color: var(--xiaojin-bubble-muted);
+}
+
+/* 祖师有十几位，菜单不能顶破视口 */
+.xiaojin-menu-scroll {
+  max-height: 196px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+.xiaojin-menu-sep {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--xiaojin-bubble-border);
+  opacity: 0.7;
+}
+
+/* 气泡顶部的「正以 X 的口吻作答」 */
+.xiaojin-persona {
+  margin: 0 18px 6px 0;
+  font-size: 11px;
+  color: var(--xiaojin-bubble-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .xiaojin-menu {
+    animation: none;
+  }
+}


### PR DESCRIPTION
对照 ryOS 的 `AssistantOverlay` 右键菜单（语音 / 角色 / 新对话 / 助理设置 / 退出助理）逐项评估后落地三项。语音单独立项；**「助理设置」不做** —— 那是它的 control-panels 应用架构，fojin 没有，硬造一个是为对齐而对齐。

## 1. 右键菜单

桌面右键、触屏长按 550ms（指针一动即取消，不和拖动打架；长按弹出时置 `draggedRef` 吞掉随后的 click，免得同时弹气泡）。Esc / 点外部关闭，位置夹进视口。

菜单自绘而非用 antd Dropdown —— 便签配色要跟着 `--xiaojin-*` 走，几十行的事不值得多拉一个组件。

## 2. 新对话

**真缺口**：气泡的 sessionId 一旦建立就一直串下去，想换话题只能刷新整页。清空往来 + 断开 session + abort 在途流。

## 3. 角色 ▸ 切换祖师

**这项 fojin 比 ryOS 强**：它换的是 Clippy/Rover 贴图，我们换的是**回答的人** —— 后端 `master_profiles` 现成 15 位，而 `sendChatMessageStream` 的 `masterId` 参数此前一直写死传 `null`。接上即可，**零后端改动**。

换人时强制重开一局（旧上下文属于上一位祖师，串下去会串味），气泡顶部显示「正以 X 的口吻作答」。祖师列表**懒加载**：只在首次开菜单时拉，首页默认不为它花一次请求。

## 4. 持久退出 + 页脚「唤回小津」

两者**必须成对** —— 2026-08-07 的单向门 bug 就是只写了持久隐藏、站内无处恢复。ryOS 敢做持久退出，也是因为它有控制面板做找回入口。

隐藏与祖师偏好收进 `useXiaojinStore`（zustand persist），因为状态要跨子树（小津在 HomePage，找回入口在 Layout 页脚）。

## 顺手修一个自己写出来的缺陷

祖师拉取失败时原本 `setMasters([])`，而守卫是 `if (!masters)` —— `[]` 为真，于是**一次瞬时网络失败就把列表永久降级到只剩「通用」**，直到刷新整页。改为失败保持 `null`，下次开菜单重试（用户手动触发，无风暴风险）。

## 测试

+7 条（菜单三项俱在 / 懒加载不预拉 / 新对话断 session / 选祖师传 masterId 且重开 / 气泡标识 / 菜单退出进 store / 失败后重试）＋ Layout 两条（在场不显示入口、退出后点一下回来）。

**突变实测全红**：新对话不清 session、masterId 不传、换人不重开、挂载即拉、失败设 `[]`、页脚不渲染入口。全量 **416 passed**。

本地 dev server 的后端代理反复 socket hang up（与本改动无关），菜单在真数据下的渲染留待生产验证 —— 已确认生产 `/api/chat/masters` 返回 15 位且形状匹配 `MasterProfile`。