### PR TITLE
fix(home): 祖师名固定一行——长宗派标签不再把名字挤换行

### DIFF
--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -424,9 +424,9 @@ export default function XiaojinPet() {
 
   const openMenu = useCallback((x: number, y: number) => {
     setOpen(false);
-    // 菜单宽 176 / 高约 44+条目；夹进视口，别开出屏幕
+    // 菜单宽 216 / 高约 44+条目；夹进视口，别开出屏幕
     setMenu({
-      x: Math.min(x, window.innerWidth - 184),
+      x: Math.min(x, window.innerWidth - 224),
       y: Math.min(y, window.innerHeight - 220),
     });
     if (!masters) {
@@ -632,7 +632,7 @@ export default function XiaojinPet() {
               }}
             >
               <span className="xiaojin-menu-tick">{masterId === null ? "✓" : ""}</span>
-              {t("xiaojin.menu_master_default")}
+              <span className="xiaojin-menu-name">{t("xiaojin.menu_master_default")}</span>
             </button>
             {(masters ?? []).map((m) => (
               <button
@@ -648,8 +648,10 @@ export default function XiaojinPet() {
                 }}
               >
                 <span className="xiaojin-menu-tick">{masterId === m.id ? "✓" : ""}</span>
-                {m.name_zh}
-                <span className="xiaojin-menu-hint">{m.tradition}</span>
+                <span className="xiaojin-menu-name">{m.name_zh}</span>
+                <span className="xiaojin-menu-hint" title={m.tradition}>
+                  {m.tradition}
+                </span>
               </button>
             ))}
           </div>

--- a/frontend/src/styles/xiaojin-pet.css
+++ b/frontend/src/styles/xiaojin-pet.css
@@ -553,7 +553,7 @@
 .xiaojin-menu {
   position: fixed;
   z-index: 95; /* 压过小津(90)，仍低于 antd Modal(1000) */
-  width: 176px;
+  width: 216px;
   padding: 4px;
   border: 1px solid var(--xiaojin-bubble-border);
   border-radius: 10px;
@@ -589,11 +589,24 @@
   color: var(--fj-accent);
 }
 
+/* 祖师名永远一行：不收缩、不换行。长宗派标签（「藏传·格鲁派」「南传·上座部
+   论师」）此前会把名字挤到第二行——名字是主体，标签才该让位。 */
+.xiaojin-menu-name {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+/* 标签让位并截断；完整文字挂 title，悬停可看全。 */
 .xiaojin-menu-hint {
+  flex: 0 1 auto;
+  min-width: 0;
   margin-left: auto;
   padding-left: 6px;
   font-size: 10.5px;
   color: var(--xiaojin-bubble-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .xiaojin-menu-title {


### PR DESCRIPTION
用户实测截图：宗喀巴大师、阿底峡尊者、觉音尊者、马哈希尊者都断成两行 —— 宗派标签太长（「藏传·格鲁派」「南传·上座部论师」）把名字空间挤没了。

**名字是主体，标签才该让位**：名字 `flex:0 0 auto` + `nowrap` 永不收缩；标签 `flex:0 1 auto` + `min-width:0` + 省略号截断，完整文字挂 `title` 可悬停看全；菜单 176 → 216px 减少截断（视口夹取阈值同步）。

jsdom 无真实布局量不出换行，这条只能真浏览器验 —— 上线后按条目实际高度核对。