### PR TITLE
fix(home): 退出小津不再持久——刷新页面自动回来

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -302,11 +302,13 @@ describe("XiaojinPet", () => {
     expect(screen.queryByLabelText("问我任何问题…")).toBeNull();
   });
 
-  it("按 ✕ 退出：小津消失且状态进 store（持久，靠页脚唤回）", () => {
+  it("按 ✕ 退出：小津消失，但不写盘（刷新自动回来，见 xiaojinStore.test）", () => {
     renderPet();
     fireEvent.click(screen.getByLabelText("暂时关闭小津（刷新后回来）"));
     expect(screen.queryByLabelText("问小津")).toBeNull();
     expect(useXiaojinStore.getState().hidden).toBe(true);
+    const persisted = JSON.parse(localStorage.getItem("fojin-xiaojin") ?? "{}");
+    expect(persisted.state?.hidden).toBeUndefined();
   });
 
   it("store 里 show() 之后小津回来（页脚「唤回小津」走的就是这条）", () => {

--- a/frontend/src/stores/xiaojinStore.test.ts
+++ b/frontend/src/stores/xiaojinStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useXiaojinStore } from "./xiaojinStore";
+
+const KEY = "fojin-xiaojin";
+
+/** 让 persist 中间件按当前 localStorage 重新水合一次（等价于刷新页面）。 */
+async function rehydrate() {
+  await useXiaojinStore.persist.rehydrate();
+}
+
+describe("xiaojinStore 持久化边界", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useXiaojinStore.setState({ hidden: false, masterId: null });
+  });
+
+  it("退出不写盘：hidden 只活在内存里", () => {
+    useXiaojinStore.getState().hide();
+    expect(useXiaojinStore.getState().hidden).toBe(true);
+
+    const persisted = JSON.parse(localStorage.getItem(KEY) ?? "{}");
+    // 写进盘就意味着刷新后小津还是不出现——用户明确要求刷新要自动弹出
+    expect(persisted.state?.hidden).toBeUndefined();
+  });
+
+  it("祖师偏好照常写盘（那是真偏好，该记住）", () => {
+    useXiaojinStore.getState().setMasterId("huineng");
+    const persisted = JSON.parse(localStorage.getItem(KEY) ?? "{}");
+    expect(persisted.state?.masterId).toBe("huineng");
+  });
+
+  it("存量用户盘里残留的 hidden:true 在水合时被强制清掉", async () => {
+    // 上一版（#1142）把 hidden 也写进了盘。只做 partialize 不够：默认 merge
+    // 会把这个残留灌回内存，小津照样不出现——必须在 merge 里强制 false。
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ state: { hidden: true, masterId: "xuanzang" }, version: 0 }),
+    );
+    await rehydrate();
+
+    expect(useXiaojinStore.getState().hidden).toBe(false);
+    // 祖师偏好不能跟着一起丢
+    expect(useXiaojinStore.getState().masterId).toBe("xuanzang");
+  });
+
+  it("退出后水合一次（＝刷新）小津就回来", async () => {
+    useXiaojinStore.getState().hide();
+    expect(useXiaojinStore.getState().hidden).toBe(true);
+    await rehydrate();
+    expect(useXiaojinStore.getState().hidden).toBe(false);
+  });
+});

--- a/frontend/src/stores/xiaojinStore.ts
+++ b/frontend/src/stores/xiaojinStore.ts
@@ -11,7 +11,11 @@ import { persist } from "zustand/middleware";
  * 控制面板做找回入口。
  */
 interface XiaojinState {
-  /** 用户主动退出小津。持久；靠页脚的「唤回小津」恢复。 */
+  /**
+   * 用户退出小津 —— **只管这一次浏览，刷新自动回来**（不持久化，见下方
+   * partialize/merge）。用户 2026-08-07 明确要求：按了退出，下次刷新页面
+   * 仍要自动弹出小津。页脚的「唤回小津」用于不刷新就叫回来。
+   */
   hidden: boolean;
   /** 以哪位祖师的口吻作答；null = 通用助手小津。持久。 */
   masterId: string | null;
@@ -29,6 +33,18 @@ export const useXiaojinStore = create<XiaojinState>()(
       show: () => set({ hidden: false }),
       setMasterId: (masterId) => set({ masterId }),
     }),
-    { name: "fojin-xiaojin" },
+    {
+      name: "fojin-xiaojin",
+      // 只持久化祖师偏好。hidden 刻意不写盘 —— 刷新必须让小津回来。
+      partialize: (s) => ({ masterId: s.masterId }),
+      // merge 里强制 hidden:false：光靠 partialize 不够 —— 存量用户的
+      // localStorage 里还留着上一版写进去的 hidden:true，默认 merge 会把它
+      // 灌回来，小津照样不出现。
+      merge: (persisted, current) => ({
+        ...current,
+        ...(persisted as Partial<XiaojinState>),
+        hidden: false,
+      }),
+    },
   ),
 );


### PR DESCRIPTION
用户要求：按了「退出」之后，**每次刷新页面仍要自动弹出小津**。

#1142 按用户当时选的「持久退出 + 页脚找回入口」把 `hidden` 写进了 localStorage，所以刷新后小津不出现。现改回会话内行为：

- `partialize` 只持久化 `masterId`（祖师是真偏好，该记住）；`hidden` 不写盘
- **`merge` 里强制 `hidden:false`** —— 光靠 `partialize` 不够：存量用户盘里还留着 #1142 写进去的 `hidden:true`，zustand 默认 merge 会把它灌回内存，小津照样不出现。这条是本次修复的关键，突变实测能杀两条用例
- 页脚「唤回小津」保留：不刷新也能把它叫回来

## 测试

新增 `stores/xiaojinStore.test.ts` 四条（退出不写盘 / 祖师照常写盘 / 存量残留 `hidden:true` 水合时被清且不误伤 masterId / 退出后水合即回）。

**突变实测三处全红**：hidden 写盘、去掉 merge 强制项、merge 顺手清掉 masterId。全量 **420 passed**。