### PR TITLE
fix(home): 拖动位置不再跨刷新记忆——每次进首页小津都回山尖

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -362,19 +362,45 @@ describe("XiaojinPet 拖动", () => {
     fireEvent.click(el);
   }
 
-  it("拖过阈值：位置更新为 left/top、写入 localStorage，且拖完不弹气泡", () => {
+  it("拖过阈值：位置更新为 left/top，且拖完不弹气泡", () => {
     renderPet();
     drag([10, 10], [110, 60]);
 
     const root = document.querySelector<HTMLElement>(".xiaojin-pet")!;
     expect(root.style.left).toBe("100px");
     expect(root.style.top).toBe("50px");
-    expect(JSON.parse(localStorage.getItem(POS_KEY)!)).toEqual({ x: 100, y: 50 });
     // 拖动的收尾 click 被吞掉，气泡不弹
     expect(screen.queryByLabelText("问我任何问题…")).toBeNull();
     // 再点一下（真点击）气泡照常打开 —— 吞 click 只吞一次
     fireEvent.click(body());
     expect(screen.getByLabelText("问我任何问题…")).toBeTruthy();
+  });
+
+  it("拖动不写盘：刷新要回默认落点（用户 2026-08-07 要求）", () => {
+    renderPet();
+    drag([10, 10], [110, 60]);
+    expect(document.querySelector<HTMLElement>(".xiaojin-pet")!.style.left).toBe("100px");
+    // 写盘就意味着刷新后还停在拖到的地方
+    expect(localStorage.getItem(POS_KEY)).toBeNull();
+  });
+
+  it("重新挂载（＝刷新）后回到默认落点，不留拖动残迹", () => {
+    const { unmount } = renderPet();
+    drag([10, 10], [110, 60]);
+    expect(document.querySelector<HTMLElement>(".xiaojin-pet")!.style.left).toBe("100px");
+
+    unmount();
+    renderPet();
+    // jsdom 无山水背景 → 锚点回退 CSS 默认，不写内联坐标
+    expect(document.querySelector<HTMLElement>(".xiaojin-pet")!.style.left).toBe("");
+  });
+
+  it("迁移：存量用户盘里的旧坐标被清掉，不再把人送回上次拖到的地方", () => {
+    localStorage.setItem(POS_KEY, JSON.stringify({ x: 50, y: 80 }));
+    renderPet();
+    const root = document.querySelector<HTMLElement>(".xiaojin-pet")!;
+    expect(root.style.left).toBe("");
+    expect(localStorage.getItem(POS_KEY)).toBeNull();
   });
 
   it("位移小于阈值算点击：气泡打开、位置不动", () => {
@@ -387,27 +413,6 @@ describe("XiaojinPet 拖动", () => {
 
     expect(screen.getByLabelText("问我任何问题…")).toBeTruthy();
     expect(document.querySelector<HTMLElement>(".xiaojin-pet")!.style.left).toBe("");
-    expect(localStorage.getItem(POS_KEY)).toBeNull();
-  });
-
-  it("下次进来恢复上次拖到的位置", () => {
-    localStorage.setItem(POS_KEY, JSON.stringify({ x: 50, y: 80 }));
-    renderPet();
-    const root = document.querySelector<HTMLElement>(".xiaojin-pet")!;
-    expect(root.style.left).toBe("50px");
-    expect(root.style.top).toBe("80px");
-  });
-
-  it("存的位置在屏幕外时夹回视口", () => {
-    localStorage.setItem(POS_KEY, JSON.stringify({ x: 99999, y: 99999 }));
-    renderPet();
-    const root = document.querySelector<HTMLElement>(".xiaojin-pet")!;
-    const left = parseInt(root.style.left, 10);
-    const top = parseInt(root.style.top, 10);
-    expect(left).toBeGreaterThanOrEqual(0);
-    expect(left).toBeLessThanOrEqual(window.innerWidth);
-    expect(top).toBeGreaterThanOrEqual(0);
-    expect(top).toBeLessThanOrEqual(window.innerHeight);
   });
 
   // 气泡朝向（data-v/data-h）依赖真实布局的 getBoundingClientRect，jsdom 里

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -19,7 +19,12 @@ const prefetchMarkdown = () => { void import("./XiaojinMarkdown"); };
  * 这个常量只剩一个用途：清掉存量用户的旧键，几个版本后可连同 readHidden 删除。
  */
 const HIDDEN_KEY = "fojin_xiaojin_hidden";
-/** 用户把小津拖到哪，下次进来还在哪。 */
+/**
+ * 上古的拖动位置键。**位置现在不再跨刷新记忆**：用户 2026-08-07 明确要求
+ * 每次刷新首页小津都回到默认落点（山尖正上方）。拖动只在本次浏览内有效。
+ * 这个常量只剩一个用途：清掉存量用户盘里的旧坐标，否则他们刷新后还是会被
+ * 送回上次拖到的地方（与「退出」那条同一类坑，见 xiaojinStore 的 merge）。
+ */
 const POS_KEY = "fojin_xiaojin_pos";
 /** 指针位移超过这个像素数才算拖动，否则算点击。 */
 const DRAG_THRESHOLD = 5;
@@ -38,23 +43,14 @@ function clearLegacyHiddenKey() {
   }
 }
 
+/** 清掉存量用户的旧坐标。恒返回 null —— 每次进页面都从默认落点重新算起。 */
 function readPos(): Pos | null {
   try {
-    const raw = localStorage.getItem(POS_KEY);
-    if (!raw) return null;
-    const p = JSON.parse(raw) as Pos;
-    return typeof p?.x === "number" && typeof p?.y === "number" ? p : null;
+    localStorage.removeItem(POS_KEY);
   } catch {
-    return null;
+    // 私密模式：本来就没存过
   }
-}
-
-function writePos(p: Pos) {
-  try {
-    localStorage.setItem(POS_KEY, JSON.stringify(p));
-  } catch {
-    // 私密模式：本次会话内有效即可
-  }
+  return null;
 }
 
 /**
@@ -153,17 +149,13 @@ export default function XiaojinPet() {
     if (el) el.scrollTop = el.scrollHeight;
   }, [messages]);
 
-  // null = 没拖过，走 CSS 默认的右下角锚点；有值 = 用户拖过，left/top 直定。
-  // 惰性初始化直接恢复上次位置（夹取用兜底尺寸 80×100 —— 此刻还没有 rect，
-  // 而小津本体最大也就 76px 宽；resize 监听会用真实尺寸再夹一次）。
-  const [pos, setPos] = useState<Pos | null>(() => {
-    const saved = readPos();
-    return saved ? clampPos(saved, 80, 100) : null;
-  });
+  // null = 本次还没拖过 → 用山尖锚点；有值 = 本次拖过，left/top 直定。
+  // 不从存储恢复：刷新必须回到默认落点。readPos 只负责清掉存量旧坐标。
+  const [pos, setPos] = useState<Pos | null>(() => readPos());
   // 山尖锚点（无拖动记录时的默认落点）。null = 山尖被裁出视口/测不到，退回 CSS 右下角。
   const [anchor, setAnchor] = useState<Pos | null>(null);
   // 首帧定位完成前隐藏，避免「右下角闪现一帧再跳上山顶」。拖过的（pos 有值）直接可见。
-  const [placed, setPlaced] = useState(() => readPos() !== null);
+  const [placed, setPlaced] = useState(false);
 
   // 气泡朝向：above/below 是相对小津的垂直方向，right/left 是气泡贴齐小津的哪条边。
   const [placement, setPlacement] = useState<{ v: "above" | "below"; h: "right" | "left" }>({
@@ -304,11 +296,7 @@ export default function XiaojinPet() {
     const d = dragRef.current;
     dragRef.current = null;
     if (!d?.active) return;
-    // 落定：存位置，并按新位置重算气泡该往哪边开。
-    setPos((p) => {
-      if (p) writePos(p);
-      return p;
-    });
+    // 落定：只按新位置重算气泡朝向。刻意不写盘——刷新要回默认落点。
     computePlacement();
   };
 


### PR DESCRIPTION
用户要求：刷新首页时小津必须回到**默认落点（山尖正上方）**，而不是停在上次拖到的地方。

- 拖动落定不再 `writePos`；`writePos` 整个删掉
- `pos` 初值不再读盘，恒从 `null` 起（→ 走山尖锚点）
- `readPos` 只剩一个用途：**清掉存量用户盘里的旧坐标** —— 不清不行：存量的 `fojin_xiaojin_pos` 还在，虽然新代码不读它了，但留着毫无意义且会让人误以为仍在生效（与 #1144 那条 merge 强制项是同一类存量残留）
- `placed` 初值改为 `false`：它原来靠「盘上有坐标」判断能否立即显形，现在一律等首帧锚点算完再现身

拖动本身不变，仍可随手挪；只是不跨刷新。

## 测试

拖动四条重写为新契约（拖动生效且吞收尾 click / 不写盘 / 重新挂载回默认落点 / 存量旧坐标被清）。**突变实测三处全红**：落定又写盘、不清存量、`readPos` 仍从盘恢复。全量 **421 passed**。