### PR TITLE
fix(home): 菜单栏目「以谁的口吻作答」改为「请谁作答」

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1532,7 +1532,7 @@
   "xiaojin.continue": "Open in AI Q&A to verify citations →",
   "xiaojin.menu_label": "XiaoJin menu",
   "xiaojin.menu_new_chat": "New conversation",
-  "xiaojin.menu_master": "Answer in the voice of",
+  "xiaojin.menu_master": "Who shall answer",
   "xiaojin.menu_master_default": "XiaoJin (general)",
   "xiaojin.menu_quit": "Quit XiaoJin",
   "xiaojin.speaking_as": "Speaking as {{name}}",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1532,7 +1532,7 @@
   "xiaojin.continue": "去 AI 問答查看完整引文 →",
   "xiaojin.menu_label": "小津選單",
   "xiaojin.menu_new_chat": "新對話",
-  "xiaojin.menu_master": "以誰的口吻作答",
+  "xiaojin.menu_master": "請誰作答",
   "xiaojin.menu_master_default": "小津（通用）",
   "xiaojin.menu_quit": "退出小津",
   "xiaojin.speaking_as": "正以 {{name}} 的口吻作答",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1532,7 +1532,7 @@
   "xiaojin.continue": "去 AI 问答查看完整引文 →",
   "xiaojin.menu_label": "小津菜单",
   "xiaojin.menu_new_chat": "新对话",
-  "xiaojin.menu_master": "以谁的口吻作答",
+  "xiaojin.menu_master": "请谁作答",
   "xiaojin.menu_master_default": "小津（通用）",
   "xiaojin.menu_quit": "退出小津",
   "xiaojin.speaking_as": "正以 {{name}} 的口吻作答",


### PR DESCRIPTION
用户提议「角色选择」并征求意见。未采用：游戏味术语，且 ryOS 用「角色」是因为它换的真是皮肤，fojin 换的是**由哪位祖师作答**。「请谁作答」四字：短、含义完整、「请」字对祖师存敬意。三语同步，i18n ratchet 与 33 条组件测试全绿。