### PR TITLE
fix(home): 小津菜单贴近底部时向上翻，不再被视口裁掉

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -436,6 +436,23 @@ describe("XiaojinPet 右键菜单", () => {
     expect(getMasters).toHaveBeenCalledTimes(1);
   });
 
+  it("贴近底部右键：菜单锚定底边向上展开，不被视口裁掉（jsdom innerHeight=768）", async () => {
+    renderPet();
+    fireEvent.contextMenu(screen.getByLabelText("问小津"), { clientX: 900, clientY: 700 });
+    const menu = await screen.findByRole("menu");
+    // 700 > 768-330 → 向上翻：bottom = 768-700 = 68，top 不设
+    expect((menu as HTMLElement).style.bottom).toBe("68px");
+    expect((menu as HTMLElement).style.top).toBe("");
+  });
+
+  it("上半屏右键：菜单照常向下展开（top 锚定）", async () => {
+    renderPet();
+    fireEvent.contextMenu(screen.getByLabelText("问小津"), { clientX: 100, clientY: 120 });
+    const menu = await screen.findByRole("menu");
+    expect((menu as HTMLElement).style.top).toBe("120px");
+    expect((menu as HTMLElement).style.bottom).toBe("");
+  });
+
   it("首页默认不拉祖师列表（不为菜单花一次请求）", () => {
     renderPet();
     expect(getMasters).not.toHaveBeenCalled();

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -169,8 +169,9 @@ export default function XiaojinPet() {
     v: "above",
     h: "right",
   });
-  // 右键（触屏长按）菜单：null = 未开；有值 = 菜单左上角的视口坐标。
-  const [menu, setMenu] = useState<Pos | null>(null);
+  // 右键（触屏长按）菜单：null = 未开。up=true 时锚定底边向上展开——
+  // 小津默认在右下角，向下弹必然被视口裁掉（2026-08-07 用户实测截图）。
+  const [menu, setMenu] = useState<{ x: number; y: number; up: boolean } | null>(null);
   // 祖师列表：只在第一次开菜单时拉，首页默认不为它花一次请求。
   const [masters, setMasters] = useState<MasterProfile[] | null>(null);
   const longPressRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -417,12 +418,17 @@ export default function XiaojinPet() {
 
   const activeMaster = masterId ? (masters ?? []).find((m) => m.id === masterId) ?? null : null;
 
+  /** 菜单实测高度 ≈303px（16 条目时）。取整加余量做翻转判据。 */
+  const MENU_EST = 330;
+
   const openMenu = useCallback((x: number, y: number) => {
     setOpen(false);
-    // 菜单宽 216 / 高约 44+条目；夹进视口，别开出屏幕
+    // 下方放不下就向上翻（锚 bottom），放得下才向下（锚 top）。
+    const up = y > window.innerHeight - MENU_EST;
     setMenu({
       x: Math.min(x, window.innerWidth - 224),
-      y: Math.min(y, window.innerHeight - 220),
+      y,
+      up,
     });
     if (!masters) {
       // 失败时保持 null 而不是设成 []：[] 会让下面这个 !masters 守卫永远为假，
@@ -608,7 +614,11 @@ export default function XiaojinPet() {
           className="xiaojin-menu"
           role="menu"
           aria-label={t("xiaojin.menu_label")}
-          style={{ left: menu.x, top: menu.y }}
+          style={
+            menu.up
+              ? { left: menu.x, bottom: Math.max(8, window.innerHeight - menu.y) }
+              : { left: menu.x, top: menu.y }
+          }
         >
           <button type="button" role="menuitem" className="xiaojin-menu-item" onClick={startNewConversation}>
             {t("xiaojin.menu_new_chat")}

--- a/frontend/src/styles/xiaojin-pet.css
+++ b/frontend/src/styles/xiaojin-pet.css
@@ -554,6 +554,9 @@
   position: fixed;
   z-index: 95; /* 压过小津(90)，仍低于 antd Modal(1000) */
   width: 216px;
+  /* 极矮视口（横屏手机）上下都放不下时的兜底：整个菜单可滚，别裁掉「退出」 */
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   padding: 4px;
   border: 1px solid var(--xiaojin-bubble-border);
   border-radius: 10px;


### PR DESCRIPTION
小津默认改到右下角后（#1147），右键菜单向下弹必被裁 —— 菜单实测高 ≈303px（16 条目），原位置夹取按 220 估的，祖师列表后半段和「退出」全在屏外（用户实测截图）。

按真右键菜单的惯例：**下方放不下（y > innerHeight−330）就锚定 bottom 向上展开**，放得下才锚 top 向下。另给菜单 `max-height: calc(100vh-16px)` + overflow 兜底极矮视口。

翻转是纯样式计算，jsdom 可断言：新增两条（贴底 → bottom=68px 且无 top / 上半屏 → top 锚定）；**突变（永远向下）实测红**。全量 423 passed。