### PR TITLE
fix(home): 菜单锚定小津本体上下缘——不再盖住小和尚

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -436,20 +436,30 @@ describe("XiaojinPet 右键菜单", () => {
     expect(getMasters).toHaveBeenCalledTimes(1);
   });
 
-  it("贴近底部右键：菜单锚定底边向上展开，不被视口裁掉（jsdom innerHeight=768）", async () => {
+  /** jsdom 的 rect 全零，给 figure 钉一个真实矩形，才能断言「菜单避开小津」。 */
+  function stubFigureRect(top: number, bottom: number) {
+    const fig = document.querySelector(".xiaojin-figure") as HTMLElement;
+    fig.getBoundingClientRect = () =>
+      ({ top, bottom, left: 1820, right: 1900, width: 80, height: bottom - top, x: 1820, y: top, toJSON: () => ({}) }) as DOMRect;
+  }
+
+  it("小津贴底（右下角默认位）：菜单整体落在头顶之上，不盖身体", async () => {
     renderPet();
-    fireEvent.contextMenu(screen.getByLabelText("问小津"), { clientX: 900, clientY: 700 });
+    stubFigureRect(650, 740); // spaceBelow=28 < 330 → 向上翻
+    fireEvent.contextMenu(screen.getByLabelText("问小津"), { clientX: 1850, clientY: 700 });
     const menu = await screen.findByRole("menu");
-    // 700 > 768-330 → 向上翻：bottom = 768-700 = 68，top 不设
-    expect((menu as HTMLElement).style.bottom).toBe("68px");
+    // bottom = innerHeight(768) - headTop(650) + 8 = 126 → 菜单底边在头顶上方 8px
+    expect((menu as HTMLElement).style.bottom).toBe("126px");
     expect((menu as HTMLElement).style.top).toBe("");
   });
 
-  it("上半屏右键：菜单照常向下展开（top 锚定）", async () => {
+  it("小津在上半屏（拖上去了）：菜单整体落在脚下，不盖身体", async () => {
     renderPet();
-    fireEvent.contextMenu(screen.getByLabelText("问小津"), { clientX: 100, clientY: 120 });
+    stubFigureRect(100, 190); // spaceBelow=578 ≥ 330 → 向下
+    fireEvent.contextMenu(screen.getByLabelText("问小津"), { clientX: 1850, clientY: 150 });
     const menu = await screen.findByRole("menu");
-    expect((menu as HTMLElement).style.top).toBe("120px");
+    // top = feetBottom(190) + 8 = 198 → 菜单顶边在脚下 8px
+    expect((menu as HTMLElement).style.top).toBe("198px");
     expect((menu as HTMLElement).style.bottom).toBe("");
   });
 

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -169,9 +169,10 @@ export default function XiaojinPet() {
     v: "above",
     h: "right",
   });
-  // 右键（触屏长按）菜单：null = 未开。up=true 时锚定底边向上展开——
-  // 小津默认在右下角，向下弹必然被视口裁掉（2026-08-07 用户实测截图）。
-  const [menu, setMenu] = useState<{ x: number; y: number; up: boolean } | null>(null);
+  // 右键（触屏长按）菜单：null = 未开。定位以**小津本体**为锚而不是点击点：
+  // up=true 整个菜单在头顶之上（bottom 锚），否则在脚下（top 锚）——右键都发生
+  // 在小津身上，按点击点摆菜单必然盖住它（2026-08-07 用户两轮实测截图）。
+  const [menu, setMenu] = useState<{ x: number; top: number; bottom: number; up: boolean } | null>(null);
   // 祖师列表：只在第一次开菜单时拉，首页默认不为它花一次请求。
   const [masters, setMasters] = useState<MasterProfile[] | null>(null);
   const longPressRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -423,11 +424,15 @@ export default function XiaojinPet() {
 
   const openMenu = useCallback((x: number, y: number) => {
     setOpen(false);
-    // 下方放不下就向上翻（锚 bottom），放得下才向下（锚 top）。
-    const up = y > window.innerHeight - MENU_EST;
+    // 锚在小津本体的上/下缘（留 8px 空隙），避开身体；figure 量不到时退回点击点。
+    const fr = figureRef.current?.getBoundingClientRect();
+    const headTop = fr && fr.height > 1 ? fr.top : y;
+    const feetBottom = fr && fr.height > 1 ? fr.bottom : y;
+    const up = window.innerHeight - feetBottom < MENU_EST;
     setMenu({
       x: Math.min(x, window.innerWidth - 224),
-      y,
+      top: feetBottom + 8,
+      bottom: Math.max(8, window.innerHeight - headTop + 8),
       up,
     });
     if (!masters) {
@@ -616,8 +621,8 @@ export default function XiaojinPet() {
           aria-label={t("xiaojin.menu_label")}
           style={
             menu.up
-              ? { left: menu.x, bottom: Math.max(8, window.innerHeight - menu.y) }
-              : { left: menu.x, top: menu.y }
+              ? { left: menu.x, bottom: menu.bottom }
+              : { left: menu.x, top: menu.top }
           }
         >
           <button type="button" role="menuitem" className="xiaojin-menu-item" onClick={startNewConversation}>


### PR DESCRIPTION
#1148 向上翻后菜单底边贴在**点击点**上，而右键必然发生在小津身上，菜单正好压住上半身（用户实测截图）。改为以 figure rect 为锚：向上翻时整个菜单落在**头顶之上 8px**，向下开时落在**脚下 8px**；figure 量不到时退回点击点。

测试给 figure stub 真实矩形（jsdom rect 全零量不出遮挡），两条重写为不遮挡契约；**突变（退回点击点锚）实测杀 2 条**。全量 423 passed。