### PR TITLE
feat: 游客消息也进每日统计——只记数不落内容，管理面板补上第四条线

### DIFF
--- a/backend/alembic/versions/0175_add_daily_metric_counts.py
+++ b/backend/alembic/versions/0175_add_daily_metric_counts.py
@@ -1,0 +1,29 @@
+"""按天累加的匿名计数器（首个指标：游客消息数）
+
+Revision ID: 0175
+Revises: 0174
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0175"
+down_revision: str | None = "0174"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "daily_metric_counts",
+        sa.Column("day", sa.Date(), nullable=False),
+        sa.Column("metric", sa.String(length=64), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=False, server_default="0"),
+        sa.PrimaryKeyConstraint("day", "metric"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("daily_metric_counts")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.chat import (
     ChatSession,
     TextEmbedding,
 )
+from app.models.daily_metric import DailyMetricCount
 from app.models.dictionary import DictionaryEntry
 from app.models.feed import AcademicFeed, SourceUpdate
 from app.models.gaiji import Gaiji
@@ -43,6 +44,7 @@ __all__ = [
     "ChatAttachment",
     "ChatMessage",
     "ChatSession",
+    "DailyMetricCount",
     "DataSource",
     "DictionaryEntry",
     "Gaiji",

--- a/backend/app/models/daily_metric.py
+++ b/backend/app/models/daily_metric.py
@@ -1,0 +1,23 @@
+"""按天累加的匿名计数器。
+
+第一位用户：游客消息数（metric='anonymous_messages'）。游客的对话内容刻意
+不落库（隐私 —— 无账号即无删除入口），但管理面板的每日统计只数
+chat_messages 就只覆盖注册用户；这张表补上"数"而不碰"内容"。
+
+通用的 (day, metric) 结构是为了下一个同类计数不再走一遍迁移。
+"""
+
+from datetime import date
+
+from sqlalchemy import Date, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class DailyMetricCount(Base):
+    __tablename__ = "daily_metric_counts"
+
+    day: Mapped[date] = mapped_column(Date, primary_key=True)
+    metric: Mapped[str] = mapped_column(String(64), primary_key=True)
+    count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -44,6 +44,9 @@ class DailyCount(BaseModel):
 class AdminTrends(BaseModel):
     registrations: list[DailyCount]
     messages: list[DailyCount]
+    # 游客消息数（daily_metric_counts）：内容不落库，只记数——没有它，
+    # 每日统计只覆盖注册用户
+    anonymous_messages: list[DailyCount] = []
     active_users: list[DailyCount]
 
 

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -11,6 +11,7 @@ from app.models.alignment_candidate import AlignmentCandidate
 from app.models.annotation import Annotation
 from app.models.audit import AdminAuditLog
 from app.models.chat import ChatMessage, ChatSession
+from app.models.daily_metric import DailyMetricCount
 from app.models.source import SourceSuggestion
 from app.models.user import ReadingHistory, User
 from app.schemas.admin import (
@@ -19,6 +20,7 @@ from app.schemas.admin import (
     AdminOverview,
     DailyCount,
 )
+from app.services.daily_metrics import ANONYMOUS_MESSAGES
 
 logger = logging.getLogger(__name__)
 
@@ -130,12 +132,14 @@ async def get_trends(db: AsyncSession, days: int = 30, redis=None) -> dict:
     registrations = await _daily_counts(db, User, User.created_at, since_dt, date_grid)
     messages = await _daily_counts(db, ChatMessage, ChatMessage.created_at, since_dt, date_grid)
     active_users = await _daily_active_users(db, since_dt, date_grid)
+    anonymous_messages = await _daily_metric_series(db, ANONYMOUS_MESSAGES, date_grid)
 
     # Stored as plain dicts so the Redis JSON round-trip is lossless;
     # AdminTrends(**result) coerces them back into DailyCount either way.
     result = {
         "registrations": [d.model_dump() for d in registrations],
         "messages": [d.model_dump() for d in messages],
+        "anonymous_messages": [d.model_dump() for d in anonymous_messages],
         "active_users": [d.model_dump() for d in active_users],
     }
     await _cache_set(redis, cache_key, result)
@@ -170,6 +174,21 @@ async def _daily_counts(
     )
     rows = {row[0]: row[1] for row in result.all()}
     return _fill_missing_days(rows, date_grid)
+
+
+async def _daily_metric_series(
+    db: AsyncSession, metric: str, date_grid: list[date]
+) -> list[DailyCount]:
+    """daily_metric_counts 里某个 metric 按 date_grid 对齐输出（缺日补零）。
+    该表按服务器本地日（CST）写入，天生与 _local_day 的口径一致。"""
+    result = await db.execute(
+        select(DailyMetricCount.day, DailyMetricCount.count).where(
+            DailyMetricCount.metric == metric,
+            DailyMetricCount.day >= date_grid[0],
+        )
+    )
+    rows = {row[0]: row[1] for row in result.all()}
+    return [DailyCount(date=d.isoformat(), count=rows.get(d, 0)) for d in date_grid]
 
 
 async def _daily_active_users(

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -46,6 +46,7 @@ from app.services.chat_sessions import (  # noqa: F401
 )
 from app.services.chat_trust import build_trust_status, persist_answer_diagnostic
 from app.services.citation_guard import enforce_citation_whitelist, log_mutations
+from app.services.daily_metrics import ANONYMOUS_MESSAGES, increment_daily_metric
 
 # Moved to app.services.hot_questions in the P1-3 split; re-imported here so
 # `from app.services.chat import get_hot_questions` (api layer) and
@@ -139,6 +140,23 @@ _PREP_ERROR_CODES = {
 }
 
 # Provider → base URL mapping (most are OpenAI-compatible; Anthropic uses its own format)
+
+
+async def _record_anonymous_message(sessionmaker, answer: str) -> None:
+    """游客（无会话）成功答案的日计数 +1。
+
+    内容刻意不落库（隐私——无账号即无删除入口），但管理面板的每日消息数
+    只数 chat_messages 会漏掉全部游客流量，这里只记"数"。口径与登录侧
+    对齐：失败/空答不计。计数失败绝不能影响用户——他已经拿到答案了。
+    """
+    if _is_failed_answer(answer):
+        return
+    try:
+        async with sessionmaker() as db_cnt:
+            await increment_daily_metric(db_cnt, ANONYMOUS_MESSAGES)
+            await db_cnt.commit()
+    except Exception:
+        logger.exception("chat/stream anonymous daily-count failed")
 
 
 async def _build_llm_http_client(
@@ -1272,6 +1290,8 @@ async def send_message_stream(
                 + json.dumps({"type": "message_id", "id": assistant_msg_id})
                 + "\n\n"
             )
+    else:
+        await _record_anonymous_message(sessionmaker, corrected_answer)
     yield f"data: {json.dumps({'type': 'done'})}\n\n"
 
 

--- a/backend/app/services/daily_metrics.py
+++ b/backend/app/services/daily_metrics.py
@@ -1,0 +1,31 @@
+"""按天累加的匿名计数器（daily_metric_counts 的读写）。
+
+游客对话内容刻意不落库（隐私），这里只记"数"。写入用 Postgres UPSERT，
+并发下两个游客同秒提问也不会丢数或撞主键。
+"""
+
+import logging
+from datetime import date
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.daily_metric import DailyMetricCount
+
+logger = logging.getLogger(__name__)
+
+ANONYMOUS_MESSAGES = "anonymous_messages"
+
+
+async def increment_daily_metric(
+    db: AsyncSession, metric: str, day: date | None = None, by: int = 1
+) -> None:
+    """当天 metric 计数 +by（UPSERT，幂等安全）。调用方负责 commit。"""
+    stmt = pg_insert(DailyMetricCount).values(
+        day=day or date.today(), metric=metric, count=by
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[DailyMetricCount.day, DailyMetricCount.metric],
+        set_={"count": DailyMetricCount.count + by},
+    )
+    await db.execute(stmt)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,6 @@ tiktoken==0.13.0
 opencc-python-reimplemented==0.1.7
 Pillow==12.3.0
 python-multipart==0.0.32
-pypdf==6.14.2
+pypdf==6.15.0
 python-docx==1.2.0
 beautifulsoup4==4.15.0

--- a/backend/tests/test_chat_stream_session_lifecycle.py
+++ b/backend/tests/test_chat_stream_session_lifecycle.py
@@ -400,10 +400,13 @@ async def test_save_phase_failure_still_yields_done():
 
 @pytest.mark.anyio
 async def test_anonymous_user_skips_save_phase():
-    """Anonymous users (chat_session is None) only need the prep session;
-    no save session should be opened. The legacy shape held one session
-    for the whole stream regardless — the refactor cleanly avoids the
-    save-phase open when there's nothing to save.
+    """Anonymous users (chat_session is None) must not open a message-save
+    session — their conversation content is deliberately never persisted.
+
+    Since the daily-count feature they DO open one extra short session to
+    bump daily_metric_counts (count only, no content — see
+    tests/test_daily_metrics.py). So the contract is now: prep + counter
+    = exactly 2 opens, and never a third (message save).
     """
     sources = _make_fake_sources()
     # Anonymous: chat_session is None per _prepare_chat contract
@@ -425,10 +428,11 @@ async def test_anonymous_user_skips_save_phase():
         ):
             chunks.append(chunk)
 
-    assert len(counting.opens) == 1, (
-        f"anonymous flow should open exactly one session (prep), got {len(counting.opens)}"
+    assert len(counting.opens) == 2, (
+        "anonymous flow should open exactly two sessions (prep + daily "
+        f"counter), got {len(counting.opens)}"
     )
-    assert len(counting.closes) == 1
+    assert len(counting.closes) == 2
 
 
 class _DetachOnCloseSessionmaker:

--- a/backend/tests/test_daily_metrics.py
+++ b/backend/tests/test_daily_metrics.py
@@ -1,0 +1,87 @@
+"""游客消息日计数：UPSERT 语句、口径（失败不计）、序列补零。
+
+背景：游客对话内容刻意不落库（隐私），管理面板每日消息数只数 chat_messages
+就只覆盖注册用户。daily_metric_counts 补"数"不碰"内容"。
+"""
+
+from contextlib import asynccontextmanager
+from datetime import date
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.admin_service import _daily_metric_series
+from app.services.chat import _record_anonymous_message
+from app.services.daily_metrics import ANONYMOUS_MESSAGES, increment_daily_metric
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_increment_compiles_to_pg_upsert():
+    """语句必须是 Postgres UPSERT（ON CONFLICT 累加）——并发游客同秒提问
+    不丢数不撞主键。用 postgresql 方言编译验证，防止被改成朴素 INSERT。"""
+    db = AsyncMock()
+    await increment_daily_metric(db, ANONYMOUS_MESSAGES, day=date(2026, 8, 8))
+
+    stmt = db.execute.call_args.args[0]
+    from sqlalchemy.dialects import postgresql
+
+    sql = str(stmt.compile(dialect=postgresql.dialect()))
+    assert "INSERT INTO daily_metric_counts" in sql
+    assert "ON CONFLICT" in sql
+    assert "count + " in sql  # 累加而非覆盖
+
+
+def _sessionmaker_returning(db):
+    @asynccontextmanager
+    async def _ctx():
+        yield db
+
+    return _ctx
+
+
+async def test_anonymous_success_counts_and_commits():
+    db = AsyncMock()
+    with patch("app.services.chat.increment_daily_metric", new=AsyncMock()) as inc:
+        await _record_anonymous_message(_sessionmaker_returning(db), "诸行无常，是生灭法。")
+        inc.assert_awaited_once()
+        assert inc.await_args.args[1] == ANONYMOUS_MESSAGES
+    db.commit.assert_awaited_once()
+
+
+async def test_anonymous_failed_answer_not_counted():
+    """口径对齐登录侧（_save_messages 跳过失败答案）：失败/空答不计数。"""
+    db = AsyncMock()
+    with patch("app.services.chat.increment_daily_metric", new=AsyncMock()) as inc:
+        # 真实失败哨兵前缀之一（prompt_builder._FAILED_ANSWER_PREFIXES）
+        await _record_anonymous_message(
+            _sessionmaker_returning(db), "抱歉，AI 服务暂时不可用，请稍后重试。"
+        )
+        inc.assert_not_awaited()
+    db.commit.assert_not_awaited()
+
+
+async def test_count_failure_never_raises():
+    """计数失败绝不能炸掉流——用户已经拿到答案了。"""
+    db = AsyncMock()
+    with patch(
+        "app.services.chat.increment_daily_metric",
+        new=AsyncMock(side_effect=RuntimeError("pg down")),
+    ):
+        await _record_anonymous_message(_sessionmaker_returning(db), "如是我闻。")  # 不抛即过
+
+
+async def test_daily_metric_series_zero_fills():
+    """缺日补零：图表的 date_grid 每天都要有点，不能有洞。"""
+    d0, d1, d2 = date(2026, 8, 6), date(2026, 8, 7), date(2026, 8, 8)
+    db = AsyncMock()
+    db.execute.return_value.all = lambda: [(d1, 5)]
+
+    series = await _daily_metric_series(db, ANONYMOUS_MESSAGES, [d0, d1, d2])
+    # DailyCount.date 是 isoformat 字符串（与 _daily_counts 同约定）——
+    # 第一版实现传了 date 对象，被这条测试当场抓出。
+    assert [(s.date, s.count) for s in series] == [
+        ("2026-08-06", 0),
+        ("2026-08-07", 5),
+        ("2026-08-08", 0),
+    ]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "antd": "^5.22.0",
         "axios": "^1.7.9",
         "d3": "^7.9.0",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.13",
         "html2canvas-pro": "^2.0.2",
         "i18next": "^26.3.6",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -6963,9 +6963,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "antd": "^5.22.0",
     "axios": "^1.7.9",
     "d3": "^7.9.0",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.13",
     "html2canvas-pro": "^2.0.2",
     "i18next": "^26.3.6",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1536,5 +1536,6 @@
   "xiaojin.menu_master_default": "XiaoJin (general)",
   "xiaojin.menu_quit": "Quit XiaoJin",
   "xiaojin.speaking_as": "Speaking as {{name}}",
-  "xiaojin.recall": "Bring back XiaoJin"
+  "xiaojin.recall": "Bring back XiaoJin",
+  "admin_dashboard.trends.series.anonymous_messages": "Guest messages"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1536,5 +1536,6 @@
   "xiaojin.menu_master_default": "小津（通用）",
   "xiaojin.menu_quit": "退出小津",
   "xiaojin.speaking_as": "正以 {{name}} 的口吻作答",
-  "xiaojin.recall": "喚回小津"
+  "xiaojin.recall": "喚回小津",
+  "admin_dashboard.trends.series.anonymous_messages": "訪客訊息數"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1536,5 +1536,6 @@
   "xiaojin.menu_master_default": "小津（通用）",
   "xiaojin.menu_quit": "退出小津",
   "xiaojin.speaking_as": "正以 {{name}} 的口吻作答",
-  "xiaojin.recall": "唤回小津"
+  "xiaojin.recall": "唤回小津",
+  "admin_dashboard.trends.series.anonymous_messages": "游客消息数"
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1187,6 +1187,8 @@ export interface DailyCount {
 export interface AdminTrends {
   registrations: DailyCount[];
   messages: DailyCount[];
+  /** 游客消息数（内容不落库，只记数）。可选：滚动部署期旧后端没有此字段。 */
+  anonymous_messages?: DailyCount[];
   active_users: DailyCount[];
 }
 

--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -237,6 +237,29 @@ describe("XiaojinPet", () => {
     await waitFor(() => expect(vi.mocked(sendChatMessageStream).mock.calls.length).toBe(2));
   });
 
+  it("发送时打 xiaojin_chat 的 Umami 事件，问题截断 30 字（与 /chat 同隐私口径）", async () => {
+    const track = vi.fn();
+    vi.stubGlobal("umami", { track });
+    renderPet();
+    openBubble();
+    const long = "这是一条非常长的问题".repeat(5); // 50 字
+    await askAndGetCallbacks(long);
+    expect(track).toHaveBeenCalledWith("xiaojin_chat", { question: long.slice(0, 30) });
+    expect((track.mock.calls[0][1] as { question: string }).question.length).toBe(30);
+    vi.unstubAllGlobals();
+  });
+
+  it("Umami 未加载（被广告拦截器挡掉）时发送照常，不炸", async () => {
+    renderPet();
+    openBubble();
+    const cb = await askAndGetCallbacks("无 umami 也要能问");
+    act(() => {
+      cb.onToken("答");
+      cb.onDone();
+    });
+    expect(await screen.findByText("答")).toBeTruthy();
+  });
+
   it("空输入不发送", () => {
     renderPet();
     openBubble();

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -316,6 +316,11 @@ export default function XiaojinPet() {
     setChatError(null);
     gotTokenRef.current = false;
     erroredRef.current = false;
+    // Umami：与 /chat 页同口径（截断 30 字保隐私），事件名独立成 xiaojin_chat
+    // —— 既补上气泡提问在 Umami 里的缺口，也把「首页气泡 vs /chat 页」区分开。
+    if (typeof umami !== "undefined") {
+      umami.track("xiaojin_chat", { question: term.slice(0, 30) });
+    }
     prefetchMarkdown(); // 与 LLM 首字并行下载，用户感知不到
     setMessages((m) => [...m, { role: "user", content: term }, { role: "assistant", content: "" }]);
     setStreaming(true);

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -250,9 +250,15 @@ export default function AdminDashboardPage() {
   // color domain below all reference the exact same strings (a mismatch would
   // silently drop a series back to a default color).
   const S_MESSAGES = t("admin_dashboard.trends.series.messages");
+  const S_ANON_MESSAGES = t("admin_dashboard.trends.series.anonymous_messages");
   const S_NEW_USERS = t("admin_dashboard.trends.series.new_users");
   const S_ACTIVE_USERS = t("admin_dashboard.trends.series.active_users");
-  const messagesData = trends.messages.map((d) => ({ ...d, type: S_MESSAGES }));
+  // 游客消息数（内容不落库，只记数）——没有它，这张图只覆盖注册用户。
+  // ?? []：滚动部署期间旧后端还没有这个字段，别让 map 炸掉整页。
+  const messagesData = [
+    ...trends.messages.map((d) => ({ ...d, type: S_MESSAGES })),
+    ...(trends.anonymous_messages ?? []).map((d) => ({ ...d, type: S_ANON_MESSAGES })),
+  ];
   const usersData = [
     ...trends.registrations.map((d) => ({ ...d, type: S_NEW_USERS })),
     ...trends.active_users.map((d) => ({ ...d, type: S_ACTIVE_USERS })),
@@ -269,8 +275,8 @@ export default function AdminDashboardPage() {
   // both land on orange. Declaring the SAME full domain→range on both children
   // pins every series to a distinct color: 消息数 蓝 / 新增用户 橙 / 活跃用户 绿.
   const seriesColor = {
-    domain: [S_MESSAGES, S_NEW_USERS, S_ACTIVE_USERS],
-    range: ["#1677ff", "#fa8c16", "#52c41a"],
+    domain: [S_MESSAGES, S_ANON_MESSAGES, S_NEW_USERS, S_ACTIVE_USERS],
+    range: ["#1677ff", "#13c2c2", "#fa8c16", "#52c41a"],
   };
   // G2 draws into a <canvas>, so the --fj-* custom properties never reach it: the
   // chart kept G2's light theme and painted its axis labels a dark grey that is


### PR DESCRIPTION
用户指出管理面板的每日「消息数」只覆盖注册用户（游客刻意不落库），统计不全。方案：**记数不记内容** —— 游客对话内容继续不落库（隐私：无账号即无删除入口），新表 `daily_metric_counts(day, metric, count)` 只累加数字。

## 后端

- 迁移 **0175** + 模型 `DailyMetricCount`（通用 `(day, metric)` 结构，下一个同类计数不用再走迁移）
- `increment_daily_metric`：Postgres **UPSERT**（ON CONFLICT 累加），并发游客同秒提问不丢数不撞主键
- chat.py 流水线 phase-3：登录用户走原 save；游客走 `_record_anonymous_message` —— 口径与登录侧对齐（失败/空答不计），计数失败只记日志绝不影响用户
- admin timeseries 加 `anonymous_messages` 序列（缺日补零）

## 前端

- 管理面板趋势图加第四条线「游客消息数」（青色；G2 颜色域四元组同步，否则序列循环撞色）。滚动部署期旧后端无此字段时 `?? []` 兜底不炸页
- 小津气泡发送补 Umami 埋点 `xiaojin_chat`（截断 30 字与 /chat 同隐私口径）—— 顺手填掉「Umami 看不到气泡提问」与「分不清来源」两个缺口

## 测试自己抓出两处实现 bug（合并前已修）

1. `DailyCount.date` 是 isoformat 字符串，第一版序列 helper 传了 date 对象
2. **更严重**：else 分支把 `message_id` 的 yield 吞进了游客路径 —— 登录用户流式完不再发 message_id，反馈/分享按钮会打到不存在的 id（当年生产反馈率为零的老 bug 复活）。`test_stream_endpoint_full_event_sequence` 当场按住

`test_anonymous_user_skips_save_phase` 按新契约更新：游客恰好开两个会话（prep + 计数），**永不出现第三个（消息 save）** —— 「不落内容」的守护意图保留。

后端 5 新用例全过、1540 passed（3 挂为 health_check_probe 既有基线问题，master 同红）；CI 版 ruff 0.9.7 全过。前端 425 passed；Umami 两突变（不截断/不打点）实测红。