### PR TITLE
feat(xiaojin): 小津随传承换装——选谁作答就穿哪个传承的衣

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -50,7 +50,7 @@ beforeEach(() => {
     { id: "huineng", name_zh: "慧能", name_en: "Huineng", tradition: "禅宗", dates: "638–713", description: "", epigraph: null },
     { id: "xuanzang", name_zh: "玄奘", name_en: "Xuanzang", tradition: "唯识", dates: "602–664", description: "", epigraph: null },
   ]);
-  useXiaojinStore.setState({ hidden: false, masterId: null });
+  useXiaojinStore.setState({ hidden: false, masterId: null, masterTradition: null });
   // 首帧定位在 rAF 回调里 setPlaced(true)；jsdom 的 rAF 不随断言推进，
   // visibility:hidden 会把可访问性树整个藏掉（getByRole 全灭）。打成同步。
   vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
@@ -551,6 +551,55 @@ describe("XiaojinPet 右键菜单", () => {
     fireEvent.click(screen.getByText("退出小津"));
     expect(screen.queryByLabelText("问小津")).toBeNull();
     expect(useXiaojinStore.getState().hidden).toBe(true);
+  });
+});
+
+describe("XiaojinPet 随传承换装", () => {
+  const openMenu = async () => {
+    fireEvent.contextMenu(screen.getByLabelText("问小津"), { clientX: 100, clientY: 100 });
+    await waitFor(() => expect(screen.getByRole("menu")).toBeTruthy());
+  };
+  const rootAttire = () => document.querySelector<HTMLElement>(".xiaojin-pet")!.dataset.attire;
+
+  it("默认（无祖师）是汉传装", () => {
+    renderPet();
+    expect(rootAttire()).toBe("han");
+  });
+
+  it("选格鲁派祖师 → 换黄帽装；换回通用 → 回汉传装", async () => {
+    vi.mocked(getMasters).mockResolvedValue([
+      { id: "tsongkhapa", name_zh: "宗喀巴", name_en: "Tsongkhapa", tradition: "藏传·格鲁派", dates: "1357–1419", description: "", epigraph: null },
+    ]);
+    renderPet();
+    await openMenu();
+    fireEvent.click(await screen.findByText("宗喀巴"));
+    expect(rootAttire()).toBe("gelug");
+    expect(useXiaojinStore.getState().masterTradition).toBe("藏传·格鲁派");
+    // 格鲁装的可见证据：班智达帽路径进了 SVG
+    expect(document.querySelectorAll('.xiaojin-figure path[fill="var(--xiaojin-hat)"]').length).toBeGreaterThan(0);
+
+    await openMenu();
+    fireEvent.click(screen.getByText(/通用/));
+    expect(rootAttire()).toBe("han");
+    expect(useXiaojinStore.getState().masterTradition).toBeNull();
+  });
+
+  it("老用户回填：persist 里只有 masterId 没 tradition → 静默拉一次列表补上", async () => {
+    useXiaojinStore.setState({ masterId: "huineng", masterTradition: null });
+    renderPet();
+    // 不开菜单也要发起回填（否则老用户的换装永远不生效）
+    await waitFor(() => expect(getMasters).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(useXiaojinStore.getState().masterTradition).toBe("禅宗"));
+    expect(rootAttire()).toBe("han"); // 禅宗仍是汉传装——但字段已补齐
+  });
+
+  it("菜单里每位祖师名前有传承色点", async () => {
+    renderPet();
+    await openMenu();
+    await screen.findByText("慧能");
+    const dots = document.querySelectorAll<HTMLElement>(".xiaojin-menu-dot");
+    expect(dots.length).toBe(2); // 慧能 + 玄奘（「通用」不带点）
+    expect(dots[0].style.background).toBe("rgb(214, 161, 60)"); // 禅宗 → han #d6a13c
   });
 });
 

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../stores/authStore";
 import { useXiaojinStore } from "../stores/xiaojinStore";
 import { sendChatMessageStream, getMasters, type MasterProfile } from "../api/client";
+import { traditionToAttire, ATTIRE_DOT } from "./xiaojinAttire";
 import { BG_NATURAL, PEAK_FRACTION, BG_OBJECT_POS, coverPoint } from "./xiaojinPeak";
 import "../styles/xiaojin-pet.css";
 
@@ -112,7 +113,8 @@ export default function XiaojinPet() {
   const hidden = useXiaojinStore((st) => st.hidden);
   const hide = useXiaojinStore((st) => st.hide);
   const masterId = useXiaojinStore((st) => st.masterId);
-  const setMasterId = useXiaojinStore((st) => st.setMasterId);
+  const masterTradition = useXiaojinStore((st) => st.masterTradition);
+  const setMaster = useXiaojinStore((st) => st.setMaster);
   const [legacyCleared] = useState(() => {
     clearLegacyHiddenKey();
     return true;
@@ -423,6 +425,21 @@ export default function XiaojinPet() {
   }, []);
 
   const activeMaster = masterId ? (masters ?? []).find((m) => m.id === masterId) ?? null : null;
+  // 衣着随传承换（见 xiaojinAttire.ts 的原则注释：不画祖师本人，只换衣制）
+  const attire = traditionToAttire(masterTradition);
+
+  // 老用户升级边角：先前只存了 masterId 没存 tradition —— 补拉一次祖师表回填，
+  // 否则选过宗喀巴的人升级后要重选一次才见黄帽。
+  useEffect(() => {
+    if (!masterId || masterTradition) return;
+    getMasters()
+      .then((ms) => {
+        const m = ms.find((x) => x.id === masterId);
+        if (m) setMaster(m.id, m.tradition);
+        setMasters((cur) => cur ?? ms);
+      })
+      .catch(() => {});
+  }, [masterId, masterTradition, setMaster]);
 
   /** 菜单实测高度 ≈303px（16 条目时）。取整加余量做翻转判据。 */
   const MENU_EST = 330;
@@ -482,6 +499,7 @@ export default function XiaojinPet() {
       data-open={open ? "" : undefined}
       data-v={placement.v}
       data-h={placement.h}
+      data-attire={attire}
       style={{
         ...((pos ?? anchor)
           ? { left: (pos ?? anchor)!.x, top: (pos ?? anchor)!.y, right: "auto", bottom: "auto" }
@@ -607,7 +625,7 @@ export default function XiaojinPet() {
           aria-expanded={open}
           aria-label={t("xiaojin.open")}
         >
-          <XiaojinFigure />
+          <XiaojinFigure attire={attire} />
         </button>
         <button
           type="button"
@@ -642,7 +660,7 @@ export default function XiaojinPet() {
               aria-checked={masterId === null}
               className="xiaojin-menu-item"
               onClick={() => {
-                setMasterId(null);
+                setMaster(null, null);
                 startNewConversation();
               }}
             >
@@ -657,12 +675,16 @@ export default function XiaojinPet() {
                 aria-checked={masterId === m.id}
                 className="xiaojin-menu-item"
                 onClick={() => {
-                  setMasterId(m.id);
+                  setMaster(m.id, m.tradition);
                   // 换人重开一局：旧上下文是上一位祖师的，串下去会串味
                   startNewConversation();
                 }}
               >
                 <span className="xiaojin-menu-tick">{masterId === m.id ? "✓" : ""}</span>
+                <span
+                  className="xiaojin-menu-dot"
+                  style={{ background: ATTIRE_DOT[traditionToAttire(m.tradition)] }}
+                />
                 <span className="xiaojin-menu-name">{m.name_zh}</span>
                 <span className="xiaojin-menu-hint" title={m.tradition}>
                   {m.tradition}
@@ -686,9 +708,11 @@ export default function XiaojinPet() {
  * 一切颜色走 CSS 变量，深色模式由 xiaojin-pet.css 整体提亮，避免暗底上发闷。
  * 平时垂目，鼠标靠近或气泡展开时睁眼——闭着的眼睛「眨」不出效果，睁眼才读得出反应。
  */
-function XiaojinFigure() {
+function XiaojinFigure({ attire }: { attire: "han" | "indian" | "theravada" | "gelug" | "kagyu" }) {
+  // 帽尖高出头顶：格鲁装 viewBox 上探 14 个单位，同宽下身高相应变高（戴帽当然更高）
+  const viewBox = attire === "gelug" ? "0 -14 100 126" : "0 0 100 112";
   return (
-    <svg viewBox="0 0 100 112" width="76" aria-hidden="true" focusable="false">
+    <svg viewBox={viewBox} width="76" aria-hidden="true" focusable="false">
       <ellipse className="xiaojin-shadow" cx="50" cy="104" rx="31" ry="4" />
       <g className="xiaojin-torso">
         {/* 结跏趺坐 */}
@@ -699,17 +723,29 @@ function XiaojinFigure() {
         {/* 双膝 */}
         <ellipse cx="26" cy="92" rx="12.5" ry="7.5" fill="var(--xiaojin-robe-d)" />
         <ellipse cx="74" cy="92" rx="12.5" ry="7.5" fill="var(--xiaojin-robe-d)" />
-        {/* 祖衣斜披 */}
-        <path d="M40 50 L66.5 88 l-12 4.5 L31.5 57z" fill="var(--xiaojin-kesa)" opacity="0.92" />
-        {/* 交领 */}
-        <path
-          d="M43 49.5 l7 11.5 7-11.5"
-          fill="none"
-          stroke="var(--xiaojin-collar)"
-          strokeWidth="3.2"
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        {/* 袒右肩（南传）：右肩露肤，袍从左肩斜覆 —— 衣制上与汉传最鲜明的区别 */}
+        {attire === "theravada" && (
+          <path d="M51 48 C62 48 70.5 56 76.5 72 L68 76 C64 64 58 56 49.5 52.5 Z" fill="var(--xiaojin-skin)" />
+        )}
+        {/* 祖衣斜披：印度论师素衣不披；噶举以白禅带代之；其余按 --xiaojin-kesa */}
+        {attire !== "indian" && (
+          <path
+            d="M40 50 L66.5 88 l-12 4.5 L31.5 57z"
+            fill={attire === "kagyu" ? "var(--xiaojin-collar)" : "var(--xiaojin-kesa)"}
+            opacity={attire === "kagyu" ? "0.95" : "0.92"}
+          />
+        )}
+        {/* 交领（袒肩装无领） */}
+        {attire !== "theravada" && (
+          <path
+            d="M43 49.5 l7 11.5 7-11.5"
+            fill="none"
+            stroke="var(--xiaojin-collar)"
+            strokeWidth="3.2"
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+        )}
         {/* 定印 */}
         <ellipse cx="50" cy="88.5" rx="11.5" ry="5" fill="var(--xiaojin-skin)" />
         <ellipse cx="50" cy="85.2" rx="8.2" ry="3.6" fill="var(--xiaojin-skin-d)" />
@@ -718,6 +754,16 @@ function XiaojinFigure() {
         <ellipse cx="26" cy="35" rx="3.7" ry="6" fill="var(--xiaojin-skin)" />
         <ellipse cx="74" cy="35" rx="3.7" ry="6" fill="var(--xiaojin-skin)" />
         <circle cx="50" cy="31" r="24.5" fill="var(--xiaojin-skin)" />
+        {attire === "gelug" && (
+          <g>
+            {/* 班智达帽：帽体沿头顶弧线扣实 + 前倾中峰（宗喀巴/阿底峡的图像学标准件） */}
+            <path
+              d="M27.9 20.5 A24.5 24.5 0 0 1 72.1 20.5 Q50 13 27.9 20.5 Z"
+              fill="var(--xiaojin-hat)"
+            />
+            <path d="M44.5 10.5 Q46 -2 54.5 -7.5 Q53.5 1 56.5 10.5 Q50 7.5 44.5 10.5 Z" fill="var(--xiaojin-hat)" />
+          </g>
+        )}
         {/* 垂目 */}
         <g className="xiaojin-eyes-closed">
           <path

--- a/frontend/src/components/xiaojinAttire.test.ts
+++ b/frontend/src/components/xiaojinAttire.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { ATTIRE_DOT, traditionToAttire } from "./xiaojinAttire";
+
+describe("traditionToAttire", () => {
+  // 生产 /api/chat/masters 的 15 条真实 tradition 字符串（2026-08-08 实测），
+  // 一条不落——后端改字符串导致换装失灵时，这里先红。
+  it.each([
+    ["印度·中观", "indian"], // 龙树
+    ["天台宗", "han"], // 智顗
+    ["禅宗", "han"], // 慧能
+    ["法相唯识宗", "han"], // 玄奘
+    ["华严宗", "han"], // 法藏
+    ["三论宗/中观", "indian"], // 鸠摩罗什
+    ["净土宗", "han"], // 印光
+    ["天台/净土·跨宗派", "han"], // 蕅益
+    ["禅宗·五宗兼嗣", "han"], // 虚云
+    ["藏传·噶举派", "kagyu"], // 米拉日巴
+    ["南传·泰国森林禅林派", "theravada"], // 阿姜查
+    ["藏传·格鲁派", "gelug"], // 宗喀巴
+    ["藏传·噶当派 (印藏桥梁)", "gelug"], // 阿底峡——含「印」字但必须归格鲁装
+    ["南传·上座部论师", "theravada"], // 觉音
+    ["南传·缅甸内观传统", "theravada"], // 马哈希
+  ] as const)("%s → %s", (tradition, expected) => {
+    expect(traditionToAttire(tradition)).toBe(expected);
+  });
+
+  it("空值与未知传承一律兜底汉传", () => {
+    expect(traditionToAttire(null)).toBe("han");
+    expect(traditionToAttire(undefined)).toBe("han");
+    expect(traditionToAttire("")).toBe("han");
+    expect(traditionToAttire("某个未来新加的传承")).toBe("han");
+  });
+
+  it("每个变体都有菜单色点", () => {
+    const variants = ["han", "indian", "theravada", "gelug", "kagyu"] as const;
+    for (const v of variants) {
+      expect(ATTIRE_DOT[v]).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+});

--- a/frontend/src/components/xiaojinAttire.ts
+++ b/frontend/src/components/xiaojinAttire.ts
@@ -1,0 +1,32 @@
+/**
+ * 小津「随传承换装」的映射与配色。
+ *
+ * 原则（沿祖师长廊的无画像不变式）：**不画祖师本人**。小津代某位祖师作答时，
+ * 换上那个传承的如法衣着——身份仍是小津（气泡里写着「正以 X 的口吻作答」），
+ * 变的只是衣制。按传承 5 套，不按人 15 套。
+ *
+ * 映射关键词按生产 /api/chat/masters 的真实 tradition 字符串写成（2026-08-08
+ * 实测 15 位）；后端加新祖师时若引入新传承词，落到 han 兜底，不会炸。
+ */
+
+export type AttireVariant = "han" | "indian" | "theravada" | "gelug" | "kagyu";
+
+export function traditionToAttire(tradition: string | null | undefined): AttireVariant {
+  const t = tradition ?? "";
+  // 顺序有讲究：藏传三派先于「中观」——阿底峡（噶当）等藏传条目不含中观字样，
+  // 但未来若出现「藏传·中观」应归藏传装。
+  if (t.includes("南传")) return "theravada"; // i18n-exempt — 觉音 / 马哈希 / 阿姜查：偏袒右肩
+  if (t.includes("格鲁") || t.includes("噶当")) return "gelug"; // i18n-exempt — 宗喀巴 / 阿底峡：黄班智达帽
+  if (t.includes("噶举")) return "kagyu"; // i18n-exempt — 米拉日巴：白禅带
+  if (t.includes("印度") || t.includes("中观")) return "indian"; // i18n-exempt — 龙树 / 鸠摩罗什：素赭袈裟
+  return "han"; // 天台 / 禅 / 唯识 / 华严 / 净土 …：正金海青 + 赭红祖衣
+}
+
+/** 右键菜单里每位祖师名前的小色点（亮色端取袍色主调）。 */
+export const ATTIRE_DOT: Record<AttireVariant, string> = {
+  han: "#d6a13c",
+  indian: "#a8763e",
+  theravada: "#d97b29",
+  gelug: "#e3b93d",
+  kagyu: "#9c3f2f",
+};

--- a/frontend/src/stores/xiaojinStore.test.ts
+++ b/frontend/src/stores/xiaojinStore.test.ts
@@ -11,7 +11,7 @@ async function rehydrate() {
 describe("xiaojinStore 持久化边界", () => {
   beforeEach(() => {
     localStorage.clear();
-    useXiaojinStore.setState({ hidden: false, masterId: null });
+    useXiaojinStore.setState({ hidden: false, masterId: null, masterTradition: null });
   });
 
   it("退出不写盘：hidden 只活在内存里", () => {
@@ -23,10 +23,17 @@ describe("xiaojinStore 持久化边界", () => {
     expect(persisted.state?.hidden).toBeUndefined();
   });
 
-  it("祖师偏好照常写盘（那是真偏好，该记住）", () => {
-    useXiaojinStore.getState().setMasterId("huineng");
+  it("祖师偏好照常写盘（含传承——决定换哪套衣着）", () => {
+    useXiaojinStore.getState().setMaster("huineng", "禅宗");
     const persisted = JSON.parse(localStorage.getItem(KEY) ?? "{}");
     expect(persisted.state?.masterId).toBe("huineng");
+    expect(persisted.state?.masterTradition).toBe("禅宗");
+  });
+
+  it("清空祖师时传承一并清空（不留孤儿传承）", () => {
+    useXiaojinStore.getState().setMaster("tsongkhapa", "藏传·格鲁派");
+    useXiaojinStore.getState().setMaster(null, "藏传·格鲁派");
+    expect(useXiaojinStore.getState().masterTradition).toBeNull();
   });
 
   it("存量用户盘里残留的 hidden:true 在水合时被强制清掉", async () => {

--- a/frontend/src/stores/xiaojinStore.ts
+++ b/frontend/src/stores/xiaojinStore.ts
@@ -19,9 +19,11 @@ interface XiaojinState {
   hidden: boolean;
   /** 以哪位祖师的口吻作答；null = 通用助手小津。持久。 */
   masterId: string | null;
+  /** 该祖师的传承字符串（决定小津换哪套衣着）。与 masterId 同生同灭，持久。 */
+  masterTradition: string | null;
   hide: () => void;
   show: () => void;
-  setMasterId: (id: string | null) => void;
+  setMaster: (id: string | null, tradition: string | null) => void;
 }
 
 export const useXiaojinStore = create<XiaojinState>()(
@@ -29,14 +31,16 @@ export const useXiaojinStore = create<XiaojinState>()(
     (set) => ({
       hidden: false,
       masterId: null,
+      masterTradition: null,
       hide: () => set({ hidden: true }),
       show: () => set({ hidden: false }),
-      setMasterId: (masterId) => set({ masterId }),
+      setMaster: (masterId, masterTradition) =>
+        set({ masterId, masterTradition: masterId === null ? null : masterTradition }),
     }),
     {
       name: "fojin-xiaojin",
       // 只持久化祖师偏好。hidden 刻意不写盘 —— 刷新必须让小津回来。
-      partialize: (s) => ({ masterId: s.masterId }),
+      partialize: (s) => ({ masterId: s.masterId, masterTradition: s.masterTradition }),
       // merge 里强制 hidden:false：光靠 partialize 不够 —— 存量用户的
       // localStorage 里还留着上一版写进去的 hidden:true，默认 merge 会把它
       // 灌回来，小津照样不出现。

--- a/frontend/src/styles/xiaojin-pet.css
+++ b/frontend/src/styles/xiaojin-pet.css
@@ -36,6 +36,31 @@
   --xiaojin-bubble-muted: #8a774a;
 }
 
+/* ---------- 随传承换装（不画祖师本人，只换衣制——见 xiaojinAttire.ts） ---------- */
+/* 印度论师（龙树/鸠摩罗什）：素赭袈裟，无祖衣 */
+.xiaojin-pet[data-attire="indian"] {
+  --xiaojin-robe: #a8763e;
+  --xiaojin-robe-d: #8c5f2e;
+}
+/* 南传（觉音/马哈希/阿姜查）：偏袒右肩的橙黄袍 */
+.xiaojin-pet[data-attire="theravada"] {
+  --xiaojin-robe: #d97b29;
+  --xiaojin-robe-d: #b76118;
+  --xiaojin-kesa: #a04e10;
+}
+/* 藏传·格鲁/噶当（宗喀巴/阿底峡）：绛红僧裙 + 黄班智达帽 */
+.xiaojin-pet[data-attire="gelug"] {
+  --xiaojin-robe: #8f3a2e;
+  --xiaojin-robe-d: #732c22;
+  --xiaojin-kesa: #5f221a;
+  --xiaojin-hat: #e3b93d;
+}
+/* 藏传·噶举（米拉日巴）：绛红僧裙 + 白禅带 */
+.xiaojin-pet[data-attire="kagyu"] {
+  --xiaojin-robe: #9c3f2f;
+  --xiaojin-robe-d: #7d3023;
+}
+
 /* 深色底上整体提亮一档，否则金黄发闷、祖衣糊成一块。 */
 :root[data-theme="dark"] .xiaojin-pet {
   --xiaojin-skin: #e8d2b6;
@@ -52,6 +77,26 @@
   --xiaojin-bubble-input: #5a4d25;
   --xiaojin-bubble-ink: #f0e9d8;
   --xiaojin-bubble-muted: #c9ba8e;
+}
+
+:root[data-theme="dark"] .xiaojin-pet[data-attire="indian"] {
+  --xiaojin-robe: #c08d50;
+  --xiaojin-robe-d: #a1743c;
+}
+:root[data-theme="dark"] .xiaojin-pet[data-attire="theravada"] {
+  --xiaojin-robe: #e8933f;
+  --xiaojin-robe-d: #cc7827;
+  --xiaojin-kesa: #b25e1c;
+}
+:root[data-theme="dark"] .xiaojin-pet[data-attire="gelug"] {
+  --xiaojin-robe: #ab5140;
+  --xiaojin-robe-d: #8f3f31;
+  --xiaojin-kesa: #77362a;
+  --xiaojin-hat: #eec858;
+}
+:root[data-theme="dark"] .xiaojin-pet[data-attire="kagyu"] {
+  --xiaojin-robe: #b25443;
+  --xiaojin-robe-d: #944335;
 }
 
 :root[data-theme="dark"] .xiaojin-md code,
@@ -584,6 +629,15 @@
 
 .xiaojin-menu-item:hover {
   background: rgba(139, 37, 0, 0.1);
+}
+
+/* 传承色点：一眼分辨这位祖师会换哪套衣（色值=该装袍色主调） */
+.xiaojin-menu-dot {
+  flex: 0 0 8px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 /* 勾选位固定宽度：选中与未选中的条目左缘对齐，菜单不会跳 */


### PR DESCRIPTION
## 做什么

用户在右键菜单里「请谁作答」选定祖师后，小津换上**那个传承**的如法衣着。不画祖师本人（沿祖师长廊的无画像不变式），身份仍是小津，变的只是衣制——按传承 5 套，不按人 15 套。

| 装束 | 覆盖祖师 | 特征 |
|---|---|---|
| 汉传（现状） | 智顗 慧能 玄奘 法藏 印光 蕅益 虚云 | 正金海青 + 赭红祖衣 |
| 印度论师 | 龙树 鸠摩罗什 | 素赭袈裟，无祖衣 |
| 南传 | 觉音 马哈希 阿姜查 | 偏袒右肩的橙黄袍 |
| 藏传·格鲁/噶当 | 宗喀巴 阿底峡 | 绛红僧裙 + 黄班智达帽 |
| 藏传·噶举 | 米拉日巴 | 绛红僧裙 + 白禅带 |

## 怎么做

- `xiaojinAttire.ts`：tradition 字符串 → 5 变体的映射，关键词按生产 15 条真实串写成；未知传承落汉传兜底；藏传关键词先于「中观」判（阿底峡是噶当装不是印度装）
- `XiaojinFigure` 按变体条件渲染：袒肩肤楔 / 班智达帽（viewBox 上探 14 单位给帽尖让位，戴帽自然变高）/ 白禅带复用祖衣路径换色 / 印度装隐藏祖衣与交领
- store 持久化 `masterTradition`；老用户 persist 里只有 masterId 时静默拉一次列表回填
- 右键菜单每位祖师名前加传承色点；亮暗两套配色

## 测试

- 映射表驱动测试逐条覆盖 15 条生产真实 tradition 串（突变验证：改错南传/删噶当关键词均红）
- 组件测试：选格鲁祖师 → data-attire 翻转 + 帽子路径出现（突变验证：焊死 han 即红）；换回通用还原；老用户回填；菜单色点
- 全套门禁绿：eslint / i18n ratchet（数据匹配关键词标 i18n-exempt）/ tsc / vitest 447 / build