### PR TITLE
fix(xiaojin): 刷新永远回默认汉传形象——祖师偏好不再写盘

### DIFF
--- a/frontend/src/components/XiaojinPet.test.tsx
+++ b/frontend/src/components/XiaojinPet.test.tsx
@@ -584,13 +584,16 @@ describe("XiaojinPet 随传承换装", () => {
     expect(useXiaojinStore.getState().masterTradition).toBeNull();
   });
 
-  it("老用户回填：persist 里只有 masterId 没 tradition → 静默拉一次列表补上", async () => {
-    useXiaojinStore.setState({ masterId: "huineng", masterTradition: null });
+  it("存量用户盘里的旧祖师偏好：不读、且挂载时把键清掉", () => {
+    // #1154 曾持久化偏好；现口径是刷新回默认汉传形象（用户 2026-08-08 拍板）。
+    localStorage.setItem(
+      "fojin-xiaojin",
+      JSON.stringify({ state: { masterId: "nagarjuna", masterTradition: "印度·中观" }, version: 0 }),
+    );
     renderPet();
-    // 不开菜单也要发起回填（否则老用户的换装永远不生效）
-    await waitFor(() => expect(getMasters).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(useXiaojinStore.getState().masterTradition).toBe("禅宗"));
-    expect(rootAttire()).toBe("han"); // 禅宗仍是汉传装——但字段已补齐
+    expect(rootAttire()).toBe("han"); // 不是印度装——盘里那份不算数
+    expect(useXiaojinStore.getState().masterId).toBeNull();
+    expect(localStorage.getItem("fojin-xiaojin")).toBeNull(); // 键也清了
   });
 
   it("菜单里每位祖师名前有传承色点", async () => {

--- a/frontend/src/components/XiaojinPet.tsx
+++ b/frontend/src/components/XiaojinPet.tsx
@@ -41,11 +41,16 @@ const EDGE = 8;
 
 type Pos = { x: number; y: number };
 
-/** 清掉存量用户的旧永久隐藏键（新状态归 useXiaojinStore）。 */
-function clearLegacyHiddenKey() {
+/**
+ * 清掉存量用户盘里的旧键：旧永久隐藏键 + 旧祖师偏好键（fojin-xiaojin，
+ * #1154 曾持久化 masterId/masterTradition，2026-08-08 用户定「刷新回默认
+ * 汉传形象」后不再写盘——不清的话虽然没人读它，但会一直躺在用户盘里）。
+ */
+function clearLegacyKeys() {
   try {
     localStorage.removeItem(HIDDEN_KEY);
     sessionStorage.removeItem(HIDDEN_KEY);
+    localStorage.removeItem("fojin-xiaojin");
   } catch {
     // 私密模式：本来就没存过
   }
@@ -116,7 +121,7 @@ export default function XiaojinPet() {
   const masterTradition = useXiaojinStore((st) => st.masterTradition);
   const setMaster = useXiaojinStore((st) => st.setMaster);
   const [legacyCleared] = useState(() => {
-    clearLegacyHiddenKey();
+    clearLegacyKeys();
     return true;
   });
   void legacyCleared;
@@ -427,19 +432,6 @@ export default function XiaojinPet() {
   const activeMaster = masterId ? (masters ?? []).find((m) => m.id === masterId) ?? null : null;
   // 衣着随传承换（见 xiaojinAttire.ts 的原则注释：不画祖师本人，只换衣制）
   const attire = traditionToAttire(masterTradition);
-
-  // 老用户升级边角：先前只存了 masterId 没存 tradition —— 补拉一次祖师表回填，
-  // 否则选过宗喀巴的人升级后要重选一次才见黄帽。
-  useEffect(() => {
-    if (!masterId || masterTradition) return;
-    getMasters()
-      .then((ms) => {
-        const m = ms.find((x) => x.id === masterId);
-        if (m) setMaster(m.id, m.tradition);
-        setMasters((cur) => cur ?? ms);
-      })
-      .catch(() => {});
-  }, [masterId, masterTradition, setMaster]);
 
   /** 菜单实测高度 ≈303px（16 条目时）。取整加余量做翻转判据。 */
   const MENU_EST = 330;

--- a/frontend/src/stores/xiaojinStore.test.ts
+++ b/frontend/src/stores/xiaojinStore.test.ts
@@ -1,33 +1,25 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useXiaojinStore } from "./xiaojinStore";
 
-const KEY = "fojin-xiaojin";
-
-/** 让 persist 中间件按当前 localStorage 重新水合一次（等价于刷新页面）。 */
-async function rehydrate() {
-  await useXiaojinStore.persist.rehydrate();
-}
-
-describe("xiaojinStore 持久化边界", () => {
+describe("xiaojinStore（一切只活在本次浏览，不写盘）", () => {
   beforeEach(() => {
     localStorage.clear();
     useXiaojinStore.setState({ hidden: false, masterId: null, masterTradition: null });
   });
 
-  it("退出不写盘：hidden 只活在内存里", () => {
+  it("退出、选祖师都不落 localStorage —— 刷新即回默认（汉传通用小津）", () => {
+    // 上一版把祖师偏好写盘，用户打开首页看到的是上次选的印度论师装，
+    // 被明确否掉（「默认的应该是汉传形象」）。谁往这个 store 加 persist，
+    // 这条先红。
     useXiaojinStore.getState().hide();
-    expect(useXiaojinStore.getState().hidden).toBe(true);
-
-    const persisted = JSON.parse(localStorage.getItem(KEY) ?? "{}");
-    // 写进盘就意味着刷新后小津还是不出现——用户明确要求刷新要自动弹出
-    expect(persisted.state?.hidden).toBeUndefined();
+    useXiaojinStore.getState().setMaster("tsongkhapa", "藏传·格鲁派");
+    expect(localStorage.length).toBe(0);
   });
 
-  it("祖师偏好照常写盘（含传承——决定换哪套衣着）", () => {
+  it("setMaster 会话内生效（换装与口吻都靠它）", () => {
     useXiaojinStore.getState().setMaster("huineng", "禅宗");
-    const persisted = JSON.parse(localStorage.getItem(KEY) ?? "{}");
-    expect(persisted.state?.masterId).toBe("huineng");
-    expect(persisted.state?.masterTradition).toBe("禅宗");
+    expect(useXiaojinStore.getState().masterId).toBe("huineng");
+    expect(useXiaojinStore.getState().masterTradition).toBe("禅宗");
   });
 
   it("清空祖师时传承一并清空（不留孤儿传承）", () => {
@@ -36,24 +28,10 @@ describe("xiaojinStore 持久化边界", () => {
     expect(useXiaojinStore.getState().masterTradition).toBeNull();
   });
 
-  it("存量用户盘里残留的 hidden:true 在水合时被强制清掉", async () => {
-    // 上一版（#1142）把 hidden 也写进了盘。只做 partialize 不够：默认 merge
-    // 会把这个残留灌回内存，小津照样不出现——必须在 merge 里强制 false。
-    localStorage.setItem(
-      KEY,
-      JSON.stringify({ state: { hidden: true, masterId: "xuanzang" }, version: 0 }),
-    );
-    await rehydrate();
-
-    expect(useXiaojinStore.getState().hidden).toBe(false);
-    // 祖师偏好不能跟着一起丢
-    expect(useXiaojinStore.getState().masterId).toBe("xuanzang");
-  });
-
-  it("退出后水合一次（＝刷新）小津就回来", async () => {
+  it("退出只在内存：hide 后 show 能叫回来（页脚「唤回小津」的路径）", () => {
     useXiaojinStore.getState().hide();
     expect(useXiaojinStore.getState().hidden).toBe(true);
-    await rehydrate();
+    useXiaojinStore.getState().show();
     expect(useXiaojinStore.getState().hidden).toBe(false);
   });
 });

--- a/frontend/src/stores/xiaojinStore.ts
+++ b/frontend/src/stores/xiaojinStore.ts
@@ -1,54 +1,39 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 
 /**
- * 小津的跨组件偏好。
+ * 小津的跨组件状态。
  *
  * 为什么要个 store：隐藏状态由小津自己（HomePage 内）写，却要被页脚的
- * 「唤回小津」读——两者不在同一棵子树上。持久退出必须**成对**配一个找回
- * 入口，否则就是 2026-08-07 那个单向门 bug（写了 localStorage 却无处恢复，
- * 用户只能开 DevTools 自救）。ryOS 的「退出助理」敢做持久，也是因为它有
- * 控制面板做找回入口。
+ * 「唤回小津」读——两者不在同一棵子树上。
+ *
+ * **一切只活在本次浏览，刻意不持久化**（2026-08-08 用户定的完整口径，与拖动
+ * 位置、退出同一模式）：刷新首页永远回到默认——汉传装的通用小津。会话内
+ * 选谁作答照常换装。上一版曾把 masterId/masterTradition 写盘，结果用户一打开
+ * 首页看到的是上次选的印度论师装，被明确否掉（「默认的应该是汉传形象」）。
+ * 存量盘里的 fojin-xiaojin 键由 XiaojinPet 挂载时清掉。
  */
 interface XiaojinState {
   /**
-   * 用户退出小津 —— **只管这一次浏览，刷新自动回来**（不持久化，见下方
-   * partialize/merge）。用户 2026-08-07 明确要求：按了退出，下次刷新页面
-   * 仍要自动弹出小津。页脚的「唤回小津」用于不刷新就叫回来。
+   * 用户退出小津 —— 只管这一次浏览，刷新自动回来（2026-08-07 用户明确要求）。
+   * 页脚的「唤回小津」用于不刷新就叫回来；持久退出必须成对配找回入口，否则
+   * 就是那个单向门 bug（写了 localStorage 却无处恢复，用户只能开 DevTools 自救）。
    */
   hidden: boolean;
-  /** 以哪位祖师的口吻作答；null = 通用助手小津。持久。 */
+  /** 以哪位祖师的口吻作答；null = 通用助手小津。 */
   masterId: string | null;
-  /** 该祖师的传承字符串（决定小津换哪套衣着）。与 masterId 同生同灭，持久。 */
+  /** 该祖师的传承字符串（决定小津换哪套衣着）。与 masterId 同生同灭。 */
   masterTradition: string | null;
   hide: () => void;
   show: () => void;
   setMaster: (id: string | null, tradition: string | null) => void;
 }
 
-export const useXiaojinStore = create<XiaojinState>()(
-  persist(
-    (set) => ({
-      hidden: false,
-      masterId: null,
-      masterTradition: null,
-      hide: () => set({ hidden: true }),
-      show: () => set({ hidden: false }),
-      setMaster: (masterId, masterTradition) =>
-        set({ masterId, masterTradition: masterId === null ? null : masterTradition }),
-    }),
-    {
-      name: "fojin-xiaojin",
-      // 只持久化祖师偏好。hidden 刻意不写盘 —— 刷新必须让小津回来。
-      partialize: (s) => ({ masterId: s.masterId, masterTradition: s.masterTradition }),
-      // merge 里强制 hidden:false：光靠 partialize 不够 —— 存量用户的
-      // localStorage 里还留着上一版写进去的 hidden:true，默认 merge 会把它
-      // 灌回来，小津照样不出现。
-      merge: (persisted, current) => ({
-        ...current,
-        ...(persisted as Partial<XiaojinState>),
-        hidden: false,
-      }),
-    },
-  ),
-);
+export const useXiaojinStore = create<XiaojinState>()((set) => ({
+  hidden: false,
+  masterId: null,
+  masterTradition: null,
+  hide: () => set({ hidden: true }),
+  show: () => set({ hidden: false }),
+  setMaster: (masterId, masterTradition) =>
+    set({ masterId, masterTradition: masterId === null ? null : masterTradition }),
+}));


### PR DESCRIPTION
## 为什么

用户打开首页看到小津穿着上次选的印度论师装。拍板：**默认必须是汉传形象**（通用小津、玄奘这一类）。

## 口径统一

小津的一切状态与拖动位置、退出同一待遇——**只活在本次浏览**：

| 状态 | 刷新后 |
|---|---|
| 拖动位置 | 回默认落点（已是） |
| 退出 | 自动回来（已是） |
| 对话往来 | 清空（已是） |
| **祖师选择/换装** | **回通用·汉传装（本 PR）** |

会话内换祖师、换装照常生效。

## 改动

- `xiaojinStore` 去掉 persist → 纯内存 store；顺带删掉 merge 强制 `hidden:false` 的补丁（它只为对冲写盘残留而存在）
- 挂载时清掉存量用户盘里的 `fojin-xiaojin` 键（沿 `fojin_xiaojin_pos` 清理先例）
- 老用户回填 effect 删除——不写盘后「有 masterId 无 tradition」不可能出现

## 测试

- 新用例：盘里预置旧偏好 → 不读（仍汉传装）且键被清（突变验证：删掉清键行即红）
- store 测试重写：hide/setMaster 均不落 localStorage（谁加回 persist 这条先红）
- 全套 446 绿