### PR TITLE
feat(mcp): streamable-HTTP transport for the hosted mcp.fojin.ai endpoint

### DIFF
--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -47,6 +47,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if not redis_client:
             return await call_next(request)
 
+        # Internal callers — the hosted fojin-mcp container, compose
+        # healthchecks — reach this port over the docker network or loopback.
+        # The only public path is nginx, and nginx always appends
+        # X-Forwarded-For, so a request without that header cannot have come
+        # from the internet. Per-IP limiting such traffic is worse than
+        # useless: every internal caller shares one 172.x address, so all
+        # fojin-mcp users would burn a single /api/search/semantic budget.
+        if "x-forwarded-for" not in request.headers:
+            return await call_next(request)
+
         # Behind Nginx reverse proxy, request.client.host is always the
         # internal Docker IP. Use the shared helper to extract the real
         # client IP from X-Forwarded-For — taking the LAST entry, since

--- a/backend/tests/test_rate_limit_internal_exemption.py
+++ b/backend/tests/test_rate_limit_internal_exemption.py
@@ -1,0 +1,68 @@
+"""Internal (no-X-Forwarded-For) traffic must bypass the per-IP rate limiter.
+
+The only public route to the backend is nginx, which always appends
+X-Forwarded-For. Direct docker-network callers — the hosted fojin-mcp
+container, compose healthchecks — carry no XFF and all share one internal
+address, so keying them into the per-IP window would make every fojin-mcp
+user worldwide share a single /api/search/semantic budget (20/min): the
+hosted MCP endpoint would 429 itself to death on day one.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+from app.core.rate_limit import RateLimitMiddleware
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.incr_calls = 0
+
+    async def incr(self, key):
+        self.incr_calls += 1
+        return 1
+
+    async def expire(self, key, ttl):
+        return True
+
+
+def _request(headers: dict[str, str], redis) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/search/semantic",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+        "query_string": b"",
+        "client": ("172.18.0.9", 40000),
+        "app": SimpleNamespace(state=SimpleNamespace(redis=redis)),
+    }
+    return Request(scope)
+
+
+async def _ok(_request):
+    return PlainTextResponse("ok")
+
+
+@pytest.mark.asyncio
+async def test_no_xff_skips_rate_limiting():
+    """No X-Forwarded-For ⇒ internal caller ⇒ no redis window consumed."""
+    redis = _FakeRedis()
+    mw = RateLimitMiddleware(app=None)
+    resp = await mw.dispatch(_request({}, redis), _ok)
+    assert resp.status_code == 200
+    assert redis.incr_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_xff_traffic_still_rate_limited():
+    """Anything nginx forwarded keeps consuming its per-IP window."""
+    redis = _FakeRedis()
+    mw = RateLimitMiddleware(app=None)
+    resp = await mw.dispatch(
+        _request({"X-Forwarded-For": "1.2.3.4, 5.6.7.8"}, redis), _ok
+    )
+    assert resp.status_code == 200
+    assert redis.incr_calls == 1

--- a/deploy/host-nginx/fojin.conf
+++ b/deploy/host-nginx/fojin.conf
@@ -160,3 +160,38 @@ server {
     server_name stream.fojin.ai;
     return 301 https://$host$request_uri;
 }
+
+# mcp.fojin.ai — hosted MCP endpoint (behind Cloudflare proxy, HTTP only).
+# Unlike stream.fojin.ai this CAN sit behind Cloudflare: the MCP server runs
+# stateless JSON request/response (json_response=True — no long SSE streams),
+# so CF's 125s proxy timeout and response buffering never come into play.
+# The container does its own per-client rate limiting keyed on
+# CF-Connecting-IP (passed through by proxy_pass untouched).
+server {
+    listen 80;
+    server_name mcp.fojin.ai;
+    include /etc/nginx/cloudflare-real-ip.conf;
+
+    add_header X-Content-Type-Options "nosniff" always;
+
+    location = /healthz {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_set_header Host $host;
+    }
+
+    location = /mcp {
+        # Matches the MCP server's own 4 MB request-body cap.
+        client_max_body_size 4m;
+        proxy_pass http://127.0.0.1:8765;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -296,6 +296,36 @@ services:
       # a proxy can set FRONTEND_BIND=0.0.0.0.
       - "${FRONTEND_BIND:-127.0.0.1}:${FRONTEND_PORT:-3000}:80"
 
+  # Hosted MCP endpoint (mcp.fojin.ai) — fojin's corpus tools for AI agents.
+  # Talks to the backend directly over the compose network (no nginx hop):
+  # internal traffic carries no X-Forwarded-For, which is what exempts it from
+  # the backend's per-IP limiter (app/core/rate_limit.py) — this container
+  # runs its own per-client window keyed on CF-Connecting-IP instead.
+  mcp:
+    build:
+      context: ./mcp-server
+      dockerfile: Dockerfile
+    container_name: fojin-mcp
+    restart: always
+    logging: *default-logging
+    mem_limit: 192m
+    cpus: 0.25
+    environment:
+      FOJIN_API_BASE_URL: http://backend:8000/api
+      FOJIN_MCP_PUBLIC_HOSTS: ${FOJIN_MCP_PUBLIC_HOSTS:-mcp.fojin.ai}
+      FOJIN_MCP_RATE_LIMIT: ${FOJIN_MCP_RATE_LIMIT:-30}
+    ports:
+      - "127.0.0.1:${MCP_PORT:-8765}:8765"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/healthz')"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    depends_on:
+      backend:
+        condition: service_healthy
+
 volumes:
   pgdata:
   esdata:

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,21 @@
+# Hosted fojin-mcp (mcp.fojin.ai) — streamable-HTTP MCP endpoint.
+# The stdio install path for end users stays PyPI (`uvx fojin-mcp`); this
+# image only exists so docker-compose can run the hosted endpoint.
+FROM python:3.12-slim
+
+WORKDIR /srv/fojin-mcp
+
+# Package metadata + source only; tests/CI never enter the image.
+COPY pyproject.toml README.md ./
+COPY fojin_mcp ./fojin_mcp
+
+RUN pip install --no-cache-dir ".[http]" && \
+    useradd --system --no-create-home fojin-mcp
+
+USER fojin-mcp
+
+EXPOSE 8765
+
+# --host 0.0.0.0 is container-internal only: compose publishes the port
+# bound to the host's loopback, nginx/Cloudflare are the public path.
+CMD ["fojin-mcp", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8765"]

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -9,6 +9,17 @@ instead of inventing scripture.
 
 Read-only by construction: it only issues GETs against fojin's public API.
 
+Two ways to use it:
+
+1. **Hosted endpoint (zero install)** — `https://mcp.fojin.ai/mcp`, streamable
+   HTTP, anonymous, rate-limited. One line in Claude Code:
+
+   ```bash
+   claude mcp add --transport http fojin https://mcp.fojin.ai/mcp
+   ```
+
+2. **Local over stdio** — `uvx fojin-mcp`, the classic MCP install (below).
+
 ## Tools
 
 | Tool | What it returns |
@@ -70,7 +81,35 @@ from a checkout.) Restart Claude Desktop; the six fojin tools then appear.
 ### ChatGPT / other MCP clients
 
 Any client that speaks MCP over stdio can launch `uvx fojin-mcp` (or the
-`fojin-mcp` console script) and will discover the six tools automatically.
+`fojin-mcp` console script); any client that speaks streamable HTTP can point
+at `https://mcp.fojin.ai/mcp`. Both discover the six tools automatically.
+
+## Hosting the HTTP endpoint (self-host)
+
+The same package serves streamable HTTP (requires the `http` extra, which adds
+uvicorn):
+
+```bash
+pip install 'fojin-mcp[http]'
+fojin-mcp --transport streamable-http --port 8765 --public-host mcp.example.com
+```
+
+The hosted mode is **stateless JSON request/response** (`stateless_http` +
+`json_response`): every tool call is one plain POST — no SSE streams, so it
+sits safely behind Cloudflare's proxy and behind multi-worker uvicorn. It adds:
+
+- **Per-client rate limiting** — sliding window keyed on `CF-Connecting-IP` /
+  `X-Real-IP` (falling back to the socket peer). Tune with
+  `--rate-limit`/`--rate-window` or `FOJIN_MCP_RATE_LIMIT`/`FOJIN_MCP_RATE_WINDOW`.
+- **Host-header validation** (DNS-rebinding protection) pinned to
+  `--public-host` / `FOJIN_MCP_PUBLIC_HOSTS` (default `mcp.fojin.ai`).
+- **Access + tool logs** — one JSON line per request (`fojin_mcp.access`) and
+  per tool call (`fojin_mcp.tools`) on stdout/stderr.
+- **`/healthz`** for container/proxy healthchecks.
+
+The production deployment is the `mcp` service in the repo's
+`docker-compose.yml` (it talks to the backend container directly) plus the
+`mcp.fojin.ai` server block in `deploy/host-nginx/fojin.conf`.
 
 ## Design
 
@@ -83,7 +122,9 @@ Any client that speaks MCP over stdio can launch `uvx fojin-mcp` (or the
   `get_parallels` enriches each parallel's URN via a bounded, concurrent,
   best-effort `text_id → cbeta_id` lookup (a miss just leaves `urn: null`).
 - **Testable core.** All HTTP + reshaping lives in `client.py` and is tested
-  against a mocked transport; `server.py` is a thin FastMCP wiring layer.
+  against a mocked transport; `server.py` is a thin MCP wiring layer (SDK v2 —
+  `mcp>=2` is required; 2.0 removed the 1.x module this package imported
+  through 0.1.0), and the hosted-edge concerns live in `http.py`.
 - **Fails soft.** An upstream error returns `{"error": "..."}` to the model
   rather than crashing the tool call.
 
@@ -101,7 +142,7 @@ every change under `mcp-server/`. To release to PyPI, bump `version` in
 `pyproject.toml`, then push a tag:
 
 ```bash
-git tag mcp-v0.1.0 && git push origin mcp-v0.1.0
+git tag mcp-v0.2.0 && git push origin mcp-v0.2.0
 ```
 
 `.github/workflows/mcp-publish.yml` builds and uploads. It needs credentials

--- a/mcp-server/fojin_mcp/__init__.py
+++ b/mcp-server/fojin_mcp/__init__.py
@@ -1,3 +1,4 @@
-"""fojin MCP server package — cross-canon Buddhist corpus tools over stdio."""
+"""fojin MCP server package — cross-canon Buddhist corpus tools over stdio or
+streamable HTTP (the hosted endpoint at mcp.fojin.ai)."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/mcp-server/fojin_mcp/client.py
+++ b/mcp-server/fojin_mcp/client.py
@@ -57,6 +57,9 @@ class FojinClient:
             timeout=timeout, headers={"User-Agent": USER_AGENT}
         )
         self._owns_client = client is None
+        # text_id → cbeta_id is static corpus metadata; caching it collapses the
+        # 1+N fan-out of repeated get_parallels calls on a long-lived client.
+        self._cbeta_cache: dict[int, str] = {}
 
     async def __aenter__(self) -> FojinClient:
         return self
@@ -113,12 +116,23 @@ class FojinClient:
         return shaped
 
     async def _text_cbeta_id(self, text_id: int) -> str | None:
-        """Best-effort text_id → cbeta_id via /texts/{id}; None on any failure."""
+        """Best-effort text_id → cbeta_id via /texts/{id}; None on any failure.
+
+        Successful lookups are cached for the client's lifetime (the mapping is
+        static); failures are not, so a transient error can heal on retry."""
+        if text_id in self._cbeta_cache:
+            return self._cbeta_cache[text_id]
         try:
             meta = await self._get(f"/texts/{text_id}")
         except FojinAPIError:
             return None
-        return meta.get("cbeta_id") if isinstance(meta, dict) else None
+        cbeta_id = meta.get("cbeta_id") if isinstance(meta, dict) else None
+        if isinstance(cbeta_id, str) and cbeta_id:
+            if len(self._cbeta_cache) >= 100_000:  # paranoia bound, ~10K texts real
+                self._cbeta_cache.clear()
+            self._cbeta_cache[text_id] = cbeta_id
+            return cbeta_id
+        return None
 
     async def _enrich_parallel_urns(self, parallels: list[dict[str, Any]]) -> None:
         """Fill each parallel's ``urn`` in place from its reader_ref.text_id.
@@ -158,15 +172,19 @@ class FojinClient:
 
     async def lookup_entity(self, query: str, limit: int = 10) -> dict[str, Any]:
         """Knowledge-graph entity search (persons, places, works, terms)."""
+        # /kg/entities takes `limit` (not `size` like search/dictionary do);
+        # FastAPI silently drops unknown params, so the wrong name means the
+        # caller's limit never arrives.
         data = await self._get(
-            "/kg/entities", {"q": query, "size": _clamp(limit, 1, 50)}
+            "/kg/entities", {"q": query, "limit": _clamp(limit, 1, 50)}
         )
         return {"query": query, "entities": _as_list(data, "results", "entities")}
 
     async def resolve_urn(self, urn: str) -> dict[str, Any]:
         """Resolve a fojin URN → reader URL + existence (server-authoritative)."""
-        # Anchor '#' must be percent-encoded or the server sees an anchorless URN.
-        return await self._get("/urn/resolve", {"urn": urn.replace("#", "%23")})
+        # httpx percent-encodes '#' in query params; pre-encoding here would
+        # double-encode it into a literal "%23" on the server side.
+        return await self._get("/urn/resolve", {"urn": urn})
 
 
 # ── pure reshaping (unit-tested with plain dicts) ────────────────────────

--- a/mcp-server/fojin_mcp/http.py
+++ b/mcp-server/fojin_mcp/http.py
@@ -1,0 +1,251 @@
+"""Public streamable-HTTP edge for the fojin MCP server.
+
+This module owns everything that only matters when fojin-mcp is *hosted* (at
+``mcp.fojin.ai``) rather than launched over stdio by a local client:
+
+- :class:`RateLimitMiddleware` — per-client-IP sliding-window limiter. The
+  hosted endpoint is anonymous, so the client IP (``CF-Connecting-IP`` when
+  behind Cloudflare/nginx, else the socket peer) is the quota key. This is the
+  middle belt of a three-belt design: Cloudflare WAF outside, this per-IP
+  window here, and the backend's own limits (with the MCP host exempted)
+  underneath.
+- :class:`AccessLogMiddleware` — one structured JSON line per request to the
+  ``fojin_mcp.access`` logger: the adoption observability the stdio server
+  never had. Logs the ``Mcp-Name`` header (tool name) when a client sends it.
+- :func:`build_http_app` — assembles the Starlette app: MCP streamable HTTP in
+  stateless + json_response mode (each call is one plain JSON POST — no long
+  SSE streams, so Cloudflare's proxy timeout/buffering never enters the
+  picture), DNS-rebinding Host validation pinned to the public hostnames, and
+  the two middlewares above.
+
+Everything here is import-safe without uvicorn; only ``serve_http`` needs it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections import deque
+from typing import Any
+
+from starlette.applications import Starlette
+
+DEFAULT_RATE_LIMIT = 30          # requests per window per client IP
+DEFAULT_RATE_WINDOW = 60.0       # seconds
+DEFAULT_PUBLIC_HOSTS = ["mcp.fojin.ai"]
+_EXEMPT_PATHS = frozenset({"/healthz"})
+
+access_logger = logging.getLogger("fojin_mcp.access")
+
+
+def _header(scope: dict[str, Any], name: bytes) -> str | None:
+    for k, v in scope.get("headers") or ():
+        if k == name:
+            return v.decode("latin-1")
+    return None
+
+
+def client_ip_from_scope(scope: dict[str, Any], *, trust_proxy_headers: bool) -> str:
+    """Client IP for quota/logging.
+
+    ``CF-Connecting-IP`` is set by Cloudflare and passed through by our nginx;
+    ``X-Real-IP`` is what nginx sets from its own real-ip resolution. Only
+    trusted when the process sits behind that chain (the deployment binds to
+    loopback, so untrusted direct exposure never sees these headers spoofed
+    from the internet — but the flag keeps local/dev runs honest)."""
+    if trust_proxy_headers:
+        for h in (b"cf-connecting-ip", b"x-real-ip"):
+            val = _header(scope, h)
+            if val:
+                return val.strip()
+    client = scope.get("client")
+    return client[0] if client else "unknown"
+
+
+class RateLimitMiddleware:
+    """Sliding-window per-IP rate limiter (pure ASGI, in-process memory).
+
+    In-process state is correct for the single-container deployment; if the
+    endpoint ever scales to N containers the window becomes N× looser, which
+    the outer Cloudflare WAF rule still bounds."""
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        limit: int = DEFAULT_RATE_LIMIT,
+        window: float = DEFAULT_RATE_WINDOW,
+        trust_proxy_headers: bool = True,
+    ) -> None:
+        self.app = app
+        self.limit = limit
+        self.window = window
+        self.trust_proxy_headers = trust_proxy_headers
+        self._hits: dict[str, deque[float]] = {}
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope["type"] != "http" or scope.get("path") in _EXEMPT_PATHS:
+            await self.app(scope, receive, send)
+            return
+        ip = client_ip_from_scope(scope, trust_proxy_headers=self.trust_proxy_headers)
+        now = time.monotonic()
+        dq = self._hits.setdefault(ip, deque())
+        while dq and now - dq[0] > self.window:
+            dq.popleft()
+        if len(dq) >= self.limit:
+            retry_after = max(1, int(self.window - (now - dq[0])) + 1)
+            body = json.dumps(
+                {
+                    "error": "rate_limited",
+                    "detail": (
+                        f"fojin MCP allows {self.limit} requests per "
+                        f"{int(self.window)}s per client; retry after "
+                        f"{retry_after}s."
+                    ),
+                }
+            ).encode()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 429,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"retry-after", str(retry_after).encode()),
+                        (b"content-length", str(len(body)).encode()),
+                    ],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+        dq.append(now)
+        # Opportunistic GC so one-off IPs don't accumulate forever.
+        if len(self._hits) > 10_000:
+            cutoff = now - self.window
+            self._hits = {
+                k: v for k, v in self._hits.items() if v and v[-1] >= cutoff
+            }
+        await self.app(scope, receive, send)
+
+
+class AccessLogMiddleware:
+    """One JSON line per request: ts, ip, method, path, status, ms, tool, ua.
+
+    This is the server's adoption dashboard — `docker logs` + grep answers
+    "who is actually calling which tool", the question the PyPI package could
+    never answer."""
+
+    def __init__(self, app: Any, *, trust_proxy_headers: bool = True) -> None:
+        self.app = app
+        self.trust_proxy_headers = trust_proxy_headers
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        start = time.monotonic()
+        status_holder = {"status": 0}
+
+        async def send_wrapper(message: dict[str, Any]) -> None:
+            if message["type"] == "http.response.start":
+                status_holder["status"] = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            access_logger.info(
+                "%s",
+                json.dumps(
+                    {
+                        "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                        "ip": client_ip_from_scope(
+                            scope, trust_proxy_headers=self.trust_proxy_headers
+                        ),
+                        "method": scope.get("method"),
+                        "path": scope.get("path"),
+                        "status": status_holder["status"],
+                        "ms": round((time.monotonic() - start) * 1000, 1),
+                        "tool": _header(scope, b"mcp-name"),
+                        "ua": _header(scope, b"user-agent"),
+                    },
+                    ensure_ascii=False,
+                ),
+            )
+
+
+def build_http_app(
+    *,
+    public_hosts: list[str] | None = None,
+    rate_limit: int = DEFAULT_RATE_LIMIT,
+    rate_window: float = DEFAULT_RATE_WINDOW,
+    trust_proxy_headers: bool = True,
+    local_port: int | None = None,
+) -> Starlette:
+    """Build the hosted Starlette app around the MCP server.
+
+    stateless_http + json_response: every tool call is a single self-contained
+    JSON POST — safe behind Cloudflare's proxy (no SSE stream to buffer or
+    time out) and safe under multi-worker uvicorn (no in-process session).
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    from .server import mcp  # deferred: avoid import cycle at module load
+
+    hosts = list(public_hosts) if public_hosts is not None else list(DEFAULT_PUBLIC_HOSTS)
+    allowed: list[str] = []
+    for h in hosts:
+        allowed.extend([h, f"{h}:443", f"{h}:80"])
+    for local in ("127.0.0.1", "localhost"):
+        allowed.append(f"{local}:{local_port}" if local_port else local)
+        if local_port:
+            allowed.append(local)
+    security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=sorted(set(allowed)),
+        # MCP clients are not browsers and send no Origin; an Origin-bearing
+        # (browser) request has no business here, so none are allowed.
+        allowed_origins=[],
+    )
+    app = mcp.streamable_http_app(
+        json_response=True,
+        stateless_http=True,
+        transport_security=security,
+    )
+    # Order matters: log outermost so 429s are logged too.
+    app.add_middleware(
+        RateLimitMiddleware,
+        limit=rate_limit,
+        window=rate_window,
+        trust_proxy_headers=trust_proxy_headers,
+    )
+    app.add_middleware(AccessLogMiddleware, trust_proxy_headers=trust_proxy_headers)
+    return app
+
+
+def serve_http(
+    *,
+    host: str,
+    port: int,
+    public_hosts: list[str] | None = None,
+    rate_limit: int = DEFAULT_RATE_LIMIT,
+    rate_window: float = DEFAULT_RATE_WINDOW,
+    trust_proxy_headers: bool = True,
+) -> None:
+    """Run the hosted endpoint under uvicorn (requires the ``http`` extra)."""
+    try:
+        import uvicorn
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(
+            "The streamable-http transport needs uvicorn: "
+            "pip install 'fojin-mcp[http]'"
+        ) from exc
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    app = build_http_app(
+        public_hosts=public_hosts,
+        rate_limit=rate_limit,
+        rate_window=rate_window,
+        trust_proxy_headers=trust_proxy_headers,
+        local_port=port,
+    )
+    uvicorn.run(app, host=host, port=port, log_level="info", access_log=False)

--- a/mcp-server/fojin_mcp/server.py
+++ b/mcp-server/fojin_mcp/server.py
@@ -10,24 +10,65 @@ side of fojin's "每一句都能点回原典" contract.
 Read-only by construction: the client only issues GETs against public
 endpoints. Configure the target with ``FOJIN_API_BASE_URL`` (defaults to prod).
 
-Run over stdio (the default MCP transport):
+Two transports:
 
-    python -m fojin_mcp
+    fojin-mcp                                  # stdio (local clients, default)
+    fojin-mcp --transport streamable-http      # hosted endpoint (mcp.fojin.ai)
+
+The hosted mode is stateless JSON request/response (no long SSE streams) and
+adds per-IP rate limiting + access logging — see :mod:`fojin_mcp.http`.
 """
 
 from __future__ import annotations
 
+import argparse
+import asyncio
+import logging
 import os
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
+from . import __version__
 from .client import DEFAULT_BASE_URL, FojinAPIError, FojinClient
 
 _BASE_URL = os.environ.get("FOJIN_API_BASE_URL", DEFAULT_BASE_URL)
 
-mcp = FastMCP(
+tool_logger = logging.getLogger("fojin_mcp.tools")
+
+# Process-wide client shared across tool calls (one connection pool, one
+# cbeta-id cache) — created by the lifespan below unless something (tests,
+# an embedder) already installed one.
+_client: FojinClient | None = None
+
+# Backend courtesy cap: at most N tool executions in flight at once (each may
+# fan out further upstream calls, bounded by the client's own enrich cap).
+_upstream_gate = asyncio.Semaphore(int(os.environ.get("FOJIN_MCP_MAX_CONCURRENCY", "8")))
+
+
+@asynccontextmanager
+async def _lifespan(_server: MCPServer) -> AsyncIterator[dict[str, Any]]:
+    global _client
+    created = _client is None
+    if created:
+        _client = FojinClient(_BASE_URL)
+    try:
+        yield {}
+    finally:
+        if created and _client is not None:
+            client, _client = _client, None
+            await client.aclose()
+
+
+mcp = MCPServer(
     "fojin",
+    version=__version__,
+    website_url="https://fojin.app",
     instructions=(
         "Tools over fojin's cross-canon Buddhist digital-text platform. Prefer "
         "these over your own memory for any claim about a Buddhist text: they "
@@ -37,18 +78,40 @@ mcp = FastMCP(
         "scripture. Use get_parallels to compare a passage across the Chinese, "
         "Pali and Tibetan canons."
     ),
+    lifespan=_lifespan,
 )
 
 
-async def _call(coro_factory: Any) -> Any:
+async def _call(tool: str, coro_factory: Any) -> Any:
     """Run one client call, mapping FojinAPIError to a tool-visible error dict
     instead of raising — a failed upstream call should tell the model what went
     wrong, not crash the tool invocation."""
-    async with FojinClient(_BASE_URL) as client:
-        try:
-            return await coro_factory(client)
-        except FojinAPIError as exc:
-            return {"error": str(exc)}
+    start = time.monotonic()
+    ok = True
+    try:
+        async with _upstream_gate:
+            client = _client
+            if client is not None:
+                try:
+                    return await coro_factory(client)
+                except FojinAPIError as exc:
+                    ok = False
+                    return {"error": str(exc)}
+            # No lifespan ran (e.g. embedded use) — fall back to an ephemeral
+            # client so the tool still works, just without pooling.
+            async with FojinClient(_BASE_URL) as tmp:
+                try:
+                    return await coro_factory(tmp)
+                except FojinAPIError as exc:
+                    ok = False
+                    return {"error": str(exc)}
+    finally:
+        tool_logger.info(
+            '{"tool": "%s", "ms": %.1f, "ok": %s}',
+            tool,
+            (time.monotonic() - start) * 1000,
+            "true" if ok else "false",
+        )
 
 
 @mcp.tool()
@@ -59,7 +122,7 @@ async def search_corpus(query: str, limit: int = 10, lang: str | None = None) ->
     similarity score. `lang` optionally filters by language code
     (lzh=Classical Chinese, pi=Pali, sa=Sanskrit, bo=Tibetan, en=English).
     """
-    return await _call(lambda c: c.search_corpus(query, limit=limit, lang=lang))
+    return await _call("search_corpus", lambda c: c.search_corpus(query, limit=limit, lang=lang))
 
 
 @mcp.tool()
@@ -69,7 +132,7 @@ async def read_passage(text_id: int, juan_num: int) -> dict:
     Use the `text_id`/`juan_num` from a search_corpus hit. Returns the actual
     canonical text — quote from this, not from memory.
     """
-    return await _call(lambda c: c.read_passage(text_id, juan_num))
+    return await _call("read_passage", lambda c: c.read_passage(text_id, juan_num))
 
 
 @mcp.tool()
@@ -80,32 +143,107 @@ async def get_parallels(text_id: int, juan_num: int) -> dict:
     Pali/Tibetan/Sanskrit parallels (each with its own `urn`) so you can compare
     how a passage is rendered across traditions.
     """
-    return await _call(lambda c: c.get_parallels(text_id, juan_num))
+    return await _call("get_parallels", lambda c: c.get_parallels(text_id, juan_num))
 
 
 @mcp.tool()
 async def lookup_dictionary(term: str, limit: int = 10) -> dict:
     """Look up a Buddhist term across fojin's dictionaries (748K+ entries)."""
-    return await _call(lambda c: c.lookup_dictionary(term, limit=limit))
+    return await _call("lookup_dictionary", lambda c: c.lookup_dictionary(term, limit=limit))
 
 
 @mcp.tool()
 async def lookup_entity(query: str, limit: int = 10) -> dict:
     """Search fojin's knowledge graph for entities — people, places, works,
     doctrinal terms — matching `query`."""
-    return await _call(lambda c: c.lookup_entity(query, limit=limit))
+    return await _call("lookup_entity", lambda c: c.lookup_entity(query, limit=limit))
 
 
 @mcp.tool()
 async def resolve_urn(urn: str) -> dict:
     """Resolve a fojin URN (e.g. fojin:cbeta/T0001.1) to a reader URL and confirm
     it exists in the corpus. Use to verify or dereference a citation."""
-    return await _call(lambda c: c.resolve_urn(urn))
+    return await _call("resolve_urn", lambda c: c.resolve_urn(urn))
 
 
-def main() -> None:
-    """Console-script / ``python -m fojin_mcp`` entry point (stdio transport)."""
-    mcp.run()
+@mcp.custom_route("/healthz", methods=["GET"])
+async def healthz(_request: Request) -> JSONResponse:
+    """Liveness for the hosted endpoint (nginx/compose healthchecks)."""
+    return JSONResponse({"status": "ok", "service": "fojin-mcp", "version": __version__})
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="fojin-mcp",
+        description="MCP server over fojin's cross-canon Buddhist corpus.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default=os.environ.get("FOJIN_MCP_TRANSPORT", "stdio"),
+        help="stdio for local clients (default); streamable-http to host an endpoint",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("FOJIN_MCP_HOST", "127.0.0.1"),
+        help="bind address for streamable-http (default 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("FOJIN_MCP_PORT", "8765")),
+        help="bind port for streamable-http (default 8765)",
+    )
+    parser.add_argument(
+        "--public-host",
+        action="append",
+        dest="public_hosts",
+        default=None,
+        help=(
+            "public hostname(s) accepted in the Host header (repeatable); "
+            "default from FOJIN_MCP_PUBLIC_HOSTS or mcp.fojin.ai"
+        ),
+    )
+    parser.add_argument(
+        "--rate-limit",
+        type=int,
+        default=int(os.environ.get("FOJIN_MCP_RATE_LIMIT", "30")),
+        help="requests per window per client IP (default 30)",
+    )
+    parser.add_argument(
+        "--rate-window",
+        type=float,
+        default=float(os.environ.get("FOJIN_MCP_RATE_WINDOW", "60")),
+        help="rate-limit window in seconds (default 60)",
+    )
+    parser.add_argument(
+        "--no-trust-proxy-headers",
+        action="store_true",
+        help="ignore CF-Connecting-IP/X-Real-IP (when not behind nginx/Cloudflare)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Console-script / ``python -m fojin_mcp`` entry point."""
+    args = _parse_args(argv)
+    if args.transport == "stdio":
+        mcp.run()
+        return
+    from .http import serve_http
+
+    public_hosts = args.public_hosts
+    if public_hosts is None:
+        env_hosts = os.environ.get("FOJIN_MCP_PUBLIC_HOSTS", "")
+        public_hosts = [h.strip() for h in env_hosts.split(",") if h.strip()] or None
+    serve_http(
+        host=args.host,
+        port=args.port,
+        public_hosts=public_hosts,
+        rate_limit=args.rate_limit,
+        rate_window=args.rate_window,
+        trust_proxy_headers=not args.no_trust_proxy_headers,
+    )
 
 
 if __name__ == "__main__":

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fojin-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server exposing fojin's verified cross-canon Buddhist corpus (cited, URN-addressable passages) to AI research tools."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -19,8 +19,11 @@ classifiers = [
     "Topic :: Religion",
     "Topic :: Text Processing :: Linguistic",
 ]
+# mcp 2.x is required: 2.0 removed the 1.x `mcp.server.fastmcp` module this
+# package previously imported, so 0.1.0 breaks on any fresh install that
+# resolves mcp>=1.2 to 2.x. 0.2.0 is the v2 migration.
 dependencies = [
-    "mcp>=1.2",
+    "mcp>=2,<3",
     "httpx>=0.27",
 ]
 
@@ -30,6 +33,9 @@ Repository = "https://github.com/xr843/fojin"
 Issues = "https://github.com/xr843/fojin/issues"
 
 [project.optional-dependencies]
+http = [
+    "uvicorn>=0.30",
+]
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.23",

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -17,7 +17,6 @@ from fojin_mcp.client import (
     shape_search_results,
 )
 
-
 # ── pure reshaping ───────────────────────────────────────────────────────
 
 
@@ -135,19 +134,42 @@ async def test_read_passage_path_and_urn():
 
 
 @pytest.mark.asyncio
-async def test_resolve_urn_percent_encodes_anchor():
+async def test_resolve_urn_encodes_anchor_exactly_once():
     seen = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
-        # httpx exposes the DECODED param; assert the anchor survived (wasn't
-        # stripped as a fragment) by checking the raw query carries %2523/%23.
         seen["raw_query"] = request.url.query.decode()
+        seen["urn_param"] = request.url.params.get("urn")
         return httpx.Response(200, json={"urn": "fojin:cbeta/T0001.1", "exists": True})
 
     async with _client_with(handler) as c:
         await c.resolve_urn("fojin:cbeta/T0001.1#p0001a01")
-    # The '#' was replaced with %23 before sending, so no fragment was dropped.
-    assert "p0001a01" in seen["raw_query"]
+    # httpx encodes '#' once → wire carries %23; a manual pre-encode would
+    # double it to %2523 and the server would see a literal "%23".
+    assert "%23p0001a01" in seen["raw_query"]
+    assert "%2523" not in seen["raw_query"]
+    # What the server decodes must be the original URN, anchor intact.
+    assert seen["urn_param"] == "fojin:cbeta/T0001.1#p0001a01"
+
+
+@pytest.mark.asyncio
+async def test_lookup_entity_sends_limit_param():
+    """/kg/entities takes `limit` — sending `size` is silently ignored by
+    FastAPI and the caller's limit never applies."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"results": [{"name": "龍樹"}]})
+
+    async with _client_with(handler) as c:
+        out = await c.lookup_entity("龙树", limit=5)
+
+    assert seen["path"] == "/api/kg/entities"
+    assert seen["params"]["limit"] == "5"
+    assert "size" not in seen["params"]
+    assert out["entities"] == [{"name": "龍樹"}]
 
 
 @pytest.mark.asyncio
@@ -196,6 +218,34 @@ async def test_get_parallels_survives_enrichment_lookup_failure():
     async with _client_with(handler) as c:
         out = await c.get_parallels(5, 1)
     assert out["parallels"][0]["urn"] is None
+
+
+@pytest.mark.asyncio
+async def test_cbeta_lookup_cached_across_calls():
+    """text_id→cbeta_id is static; a long-lived client must not re-fetch it on
+    every get_parallels (the hosted endpoint shares one client process-wide)."""
+    text_lookups = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.startswith("/api/alignment"):
+            return httpx.Response(200, json={"text_id": 5, "juan_num": 1,
+                "total_chunks": 1, "chunks_with_parallels": 1,
+                "entries": [{"chunk_index": 0, "chunk_text": "源", "parallels": [
+                    {"text_id": 99, "juan_num": 2, "chunk_index": 0, "lang": "pi",
+                     "title": "M10", "chunk_text": "p", "confidence": 0.9,
+                     "source": "fojin"}]}]})
+        if request.url.path == "/api/texts/99":
+            text_lookups["n"] += 1
+            return httpx.Response(200, json={"text_id": 99, "cbeta_id": "SC-mn10"})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    async with _client_with(handler) as c:
+        first = await c.get_parallels(5, 1)
+        second = await c.get_parallels(5, 1)
+
+    assert first["parallels"][0]["urn"] == "fojin:sc/mn10.2"
+    assert second["parallels"][0]["urn"] == "fojin:sc/mn10.2"
+    assert text_lookups["n"] == 1     # second call served from cache
 
 
 @pytest.mark.asyncio

--- a/mcp-server/tests/test_http.py
+++ b/mcp-server/tests/test_http.py
@@ -1,0 +1,134 @@
+"""Tests for the hosted streamable-HTTP edge (fojin_mcp.http).
+
+Uses Starlette's TestClient against the real MCP ASGI app in stateless
+json_response mode, with FojinClient swapped for a mocked transport — so these
+exercise the actual MCP protocol path (tools/list, tools/call) plus the edge
+concerns (rate limiting, Host validation, healthz) without any network.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from starlette.testclient import TestClient
+
+import fojin_mcp.server as server_mod
+from fojin_mcp.client import FojinClient
+from fojin_mcp.http import build_http_app
+
+MCP_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+}
+
+
+def _rpc(method: str, params: dict | None = None, id_: int = 1) -> dict:
+    msg: dict = {"jsonrpc": "2.0", "id": id_, "method": method}
+    if params is not None:
+        msg["params"] = params
+    return msg
+
+
+@pytest.fixture()
+def mock_fojin_client():
+    """Install a FojinClient with a mocked transport as the shared client."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/search/semantic":
+            return httpx.Response(200, json={"total": 1, "results": [
+                {"text_id": 5, "juan_num": 1, "title_zh": "心經",
+                 "cbeta_id": "T0251", "snippet": "色即是空",
+                 "similarity_score": 0.9}]})
+        return httpx.Response(404, json={"detail": "unexpected " + request.url.path})
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+    client = FojinClient("http://test/api", client=http)
+    server_mod._client = client
+    yield client
+    server_mod._client = None
+
+
+def _test_app(**kwargs):
+    kwargs.setdefault("public_hosts", ["testserver"])
+    return build_http_app(**kwargs)
+
+
+def test_healthz_ok():
+    with TestClient(_test_app()) as tc:
+        resp = tc.get("/healthz")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "fojin-mcp"
+
+
+def test_tools_list_over_streamable_http():
+    with TestClient(_test_app()) as tc:
+        resp = tc.post("/mcp", json=_rpc("tools/list"), headers=MCP_HEADERS)
+    assert resp.status_code == 200, resp.text
+    tools = {t["name"] for t in resp.json()["result"]["tools"]}
+    assert tools == {
+        "search_corpus", "read_passage", "get_parallels",
+        "lookup_dictionary", "lookup_entity", "resolve_urn",
+    }
+
+
+def test_tools_call_search_corpus(mock_fojin_client):
+    with TestClient(_test_app()) as tc:
+        resp = tc.post(
+            "/mcp",
+            json=_rpc("tools/call", {
+                "name": "search_corpus",
+                "arguments": {"query": "空", "limit": 3},
+            }),
+            headers=MCP_HEADERS,
+        )
+    assert resp.status_code == 200, resp.text
+    result = resp.json()["result"]
+    assert not result.get("isError"), result
+    # Bare-dict tools carry their JSON in content[0].text (no output schema →
+    # no structuredContent).
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["results"][0]["urn"] == "fojin:cbeta/T0251.1"
+
+
+def test_rate_limit_kicks_in_and_healthz_exempt():
+    app = _test_app(rate_limit=2, rate_window=60.0)
+    with TestClient(app) as tc:
+        codes = [
+            tc.post("/mcp", json=_rpc("tools/list"), headers=MCP_HEADERS).status_code
+            for _ in range(3)
+        ]
+        limited = tc.post("/mcp", json=_rpc("tools/list"), headers=MCP_HEADERS)
+        health = tc.get("/healthz")
+    assert codes[0] == 200 and codes[1] == 200
+    assert codes[2] == 429
+    assert limited.status_code == 429
+    assert "retry-after" in {k.lower() for k in limited.headers}
+    assert limited.json()["error"] == "rate_limited"
+    assert health.status_code == 200          # exempt from the limiter
+
+
+def test_rate_limit_keyed_on_cf_connecting_ip():
+    app = _test_app(rate_limit=1, rate_window=60.0)
+    with TestClient(app) as tc:
+        a1 = tc.post("/mcp", json=_rpc("tools/list"),
+                     headers={**MCP_HEADERS, "CF-Connecting-IP": "203.0.113.7"})
+        a2 = tc.post("/mcp", json=_rpc("tools/list"),
+                     headers={**MCP_HEADERS, "CF-Connecting-IP": "203.0.113.7"})
+        b1 = tc.post("/mcp", json=_rpc("tools/list"),
+                     headers={**MCP_HEADERS, "CF-Connecting-IP": "198.51.100.9"})
+    assert a1.status_code == 200
+    assert a2.status_code == 429              # same client exhausted
+    assert b1.status_code == 200              # different client unaffected
+
+
+def test_host_header_validation_rejects_unknown_host():
+    """DNS-rebinding protection: an app built for mcp.fojin.ai must reject the
+    TestClient's default Host (testserver)."""
+    app = build_http_app(public_hosts=["mcp.fojin.ai"])
+    with TestClient(app) as tc:
+        resp = tc.post("/mcp", json=_rpc("tools/list"), headers=MCP_HEADERS)
+    assert resp.status_code >= 400


### PR DESCRIPTION
## What

fojin-mcp **0.2.0** — the stdio-only PyPI server becomes hostable at **mcp.fojin.ai**, turning fojin's corpus tools into zero-install infrastructure any MCP client can point at:

```bash
claude mcp add --transport http fojin https://mcp.fojin.ai/mcp
```

## Why now

**mcp 2.0 removed `mcp.server.fastmcp`** — fojin-mcp 0.1.0 with `mcp>=1.2` breaks on every fresh install that resolves to 2.x (i.e. all of them, today). The v2 migration is a bugfix regardless of hosting.

## Changes

- **SDK v2 migration** (`mcp>=2,<3`): `MCPServer`, lifespan-managed shared `FojinClient` (one connection pool + `text_id→cbeta_id` cache collapsing `get_parallels`' 1+20 fan-out), concurrency gate.
- **`--transport streamable-http`**: stateless `json_response` mode — each tool call is one plain JSON POST, so it sits behind Cloudflare's proxy (no SSE stream to buffer / time out) and under multi-worker uvicorn. Host-header validation (DNS-rebinding protection) pinned to the public hostname; per-client-IP sliding-window rate limiter; JSON access + tool logs (first real adoption observability); `/healthz`.
- **Client bugfixes**: `lookup_entity` sent `size=` where `/kg/entities` takes `limit=` (FastAPI silently ignored it → always 20 rows); `resolve_urn` pre-encoded `#` → httpx double-encoded → server saw a literal `%23`.
- **Deploy**: `mcp` compose service (loopback-bound, healthchecked, backend via compose network) + `mcp.fojin.ai` nginx block (modeled on the CF-proxied `fojin.app` block, not the DNS-only stream one — stateless JSON doesn't need it).
- **Backend**: requests without `X-Forwarded-For` (docker-network/loopback callers; nginx always appends it) skip the per-IP limiter — otherwise every hosted-MCP user worldwide shares one 20/min `search/semantic` bucket keyed on the container IP. The MCP layer limits per real client (`CF-Connecting-IP`) instead.

## Tests

- mcp-server: 36 passed (17 existing + 19 new: HTTP protocol path via TestClient, rate limiting incl. CF-Connecting-IP keying, Host validation, healthz, cache, both bugfixes locked with tightened assertions — the old `resolve_urn` test passed under both single and double encoding).
- backend: new `test_rate_limit_internal_exemption.py` (2) + existing rate-limit tests green.
- ruff clean under CI-pinned 0.9.7.
- stdio handshake verified against a 2025-06-18 client (backwards compat).

## After merge (ops, not automated)

1. `docker compose up -d --build mcp` on sg-vps
2. scp the nginx block + reload (per deploy/host-nginx/README)
3. Cloudflare: add `mcp.fojin.ai` A/CNAME (proxied) in the fojin.ai zone
4. Tag `mcp-v0.2.0` → PyPI publish
5. MCP registry submission (separate step)