### PR TITLE
chore(nginx): serve MCP registry domain-verification well-known

### DIFF
--- a/deploy/host-nginx/fojin.conf
+++ b/deploy/host-nginx/fojin.conf
@@ -12,7 +12,19 @@ upstream fojin_backend {
 server {
     listen 80;
     server_name fojin.ai www.fojin.ai;
-    return 301 https://fojin.app$request_uri;
+
+    # MCP registry domain verification (namespace ai.fojin/*): mcp-publisher
+    # `login http --domain fojin.ai` fetches this exact path; it must answer
+    # before the blanket 301. Key material lives off-server (the private key
+    # never leaves the maintainer's machine); this is only the public half.
+    location = /.well-known/mcp-registry-auth {
+        default_type text/plain;
+        return 200 "v=MCPv1; k=ed25519; p=NJWxIkTvqZLE3YKNE+e7YSa1CTUlEotnxvM7INsKnXI=";
+    }
+
+    location / {
+        return 301 https://fojin.app$request_uri;
+    }
 }
 
 # Umami Analytics — analytics.fojin.app
@@ -43,6 +55,15 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # MCP registry domain verification (namespace app.fojin/*). Same public
+    # key as the fojin.ai copy above — that one is unreachable while the
+    # Cloudflare edge redirect rule for the fojin.ai zone stands, so this
+    # block is the one mcp-publisher actually verifies against.
+    location = /.well-known/mcp-registry-auth {
+        default_type text/plain;
+        return 200 "v=MCPv1; k=ed25519; p=NJWxIkTvqZLE3YKNE+e7YSa1CTUlEotnxvM7INsKnXI=";
+    }
 
     # GitHub webhook for auto-deploy
     location /webhook/deploy {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "app.fojin/fojin-mcp",
+  "title": "fojin — Buddhist Canon Tools",
+  "description": "Buddhist canon tools: search, passages, cross-canon parallels, dictionaries — all URN-cited.",
+  "version": "0.2.0",
+  "websiteUrl": "https://fojin.app",
+  "repository": {
+    "url": "https://github.com/xr843/fojin",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.fojin.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Serves `/.well-known/mcp-registry-auth` (public key only) on the fojin.app block — already applied to prod and verified through Cloudflare; this PR keeps the repo copy drift-zero. The fojin.ai copy is dormant behind that zone's CF edge redirect rule.