### PR TITLE
feat(verify): open-world verbatim quote verification — /api/verify/quote + MCP verify_quote

### DIFF
--- a/backend/app/api/verification.py
+++ b/backend/app/api/verification.py
@@ -1,0 +1,44 @@
+"""Public quote-verification endpoint — the AI-facing half of fojin's
+"每一句都能点回原典" contract.
+
+GET /api/verify/quote?q=…&cite=…&juan=…
+
+Any agent that has written a Buddhist-canon quote can ask, in one call,
+whether that quote exists verbatim in the corpus (and where), instead of
+serving its readers an invented citation. Read-only; strict-rate-limited
+(paid nothing, but ES + source-text reads are not free).
+"""
+
+from elasticsearch import AsyncElasticsearch
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.elasticsearch import get_es
+from app.database import get_db
+from app.schemas.verification import QuoteVerdict
+from app.services.quote_lookup import QuoteTooShortError, verify_quote
+
+router = APIRouter(prefix="/verify", tags=["verification"])
+
+
+@router.get("/quote", response_model=QuoteVerdict)
+async def verify_quote_endpoint(
+    q: str = Query(..., min_length=1, max_length=400, description="待核验的引文"),
+    cite: str | None = Query(
+        None,
+        max_length=120,
+        description="出处提示：CBETA 编号(T0374)或 fojin URN(fojin:cbeta/T0374.13)",
+    ),
+    juan: int | None = Query(None, ge=1, le=999, description="卷号提示"),
+    db: AsyncSession = Depends(get_db),
+) -> QuoteVerdict:
+    """逐字引文核验（开放世界）。
+
+    Verify a quote verbatim against the whole corpus. Returns where it was
+    found (URN-cited), or the closest near-miss window when it wasn't.
+    Rate limit: strict (see rate_limit_verify_quote)."""
+    es: AsyncElasticsearch = get_es()
+    try:
+        return await verify_quote(db, es, q, cite=cite, juan=juan)
+    except QuoteTooShortError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -163,6 +163,10 @@ class Settings(BaseSettings):
     rate_limit_semantic: int = 20
     rate_limit_research: int = 10
     rate_limit_ai_diff: int = 10
+    # Open-world quote verification: no paid inference, but each call is an
+    # ES phrase search plus full-fascicle source reads — same cost class as
+    # /api/search/content (30/min).
+    rate_limit_verify_quote: int = 30
     # Chat (AI Q&A) — the most expensive endpoint: RAG retrieval always uses the
     # platform embedding key (even for BYOK users) plus a long streaming LLM
     # call and a DB pool slot. 30/min/IP is generous for real use (a stream

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -25,6 +25,9 @@ STRICT_PATHS: dict[str, int] = {
     "/api/search/semantic": settings.rate_limit_semantic,
     "/api/research/query": settings.rate_limit_research,
     "/api/alignment/ai-diff": settings.rate_limit_ai_diff,
+    # Open-world quote verification — ES phrase search + fascicle reads per
+    # call; the hosted MCP endpoint fronts it with its own per-client window.
+    "/api/verify/quote": settings.rate_limit_verify_quote,
     # Chat / AI Q&A — the most expensive endpoint (platform-key RAG embedding +
     # streaming LLM + a held DB pool slot), previously left at the loose
     # default. Exact-path map (STRICT_PATHS.get(path)), so both routes are

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -90,6 +90,7 @@ from app.api import (
     stats,
     texts,
     urn,
+    verification,
     works,
 )
 
@@ -490,6 +491,9 @@ app.include_router(citations.router, prefix="/api")
 
 # URN resolver — stable text references
 app.include_router(urn.router, prefix="/api")
+
+# Quote verification — open-world verbatim check (AI-facing)
+app.include_router(verification.router, prefix="/api")
 
 # Phase 4 routers
 # Off by default — see settings.enable_open_data_exports.

--- a/backend/app/schemas/verification.py
+++ b/backend/app/schemas/verification.py
@@ -1,0 +1,58 @@
+"""Schemas for the public quote-verification API (/api/verify/quote).
+
+The response is designed for AI-agent consumers: every claim the verdict
+makes is either machine-checkable (URNs resolve via /api/urn/resolve) or
+explicitly caveated (``caveats``). ``verbatim`` answers the open-world
+question — "does this quote exist verbatim anywhere in the corpus?" — which
+is deliberately different from the chat pipeline's closed-world check
+against a single answer's retrieved chunks.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class QuoteMatch(BaseModel):
+    """One fascicle where the quote was confirmed verbatim (substring test
+    on the normalised source text — the authoritative check, not ES)."""
+
+    text_id: int
+    cbeta_id: str | None = None
+    title_zh: str | None = None
+    juan_num: int
+    urn: str | None = None
+    # True/False only when the caller hinted a juan; None otherwise.
+    juan_matched: bool | None = None
+
+
+class ClosestMiss(BaseModel):
+    """Best near-match window when the quote is NOT verbatim anywhere we
+    looked. ``window_normalised`` is in normalised space (NFKC + 繁→简 +
+    punctuation stripped) — the exact space the verdict is computed in."""
+
+    text_id: int
+    juan_num: int
+    urn: str | None = None
+    similarity: float
+    window_normalised: str
+
+
+class QuoteVerdict(BaseModel):
+    quote: str
+    normalised_quote: str
+    verbatim: bool
+    bucket: Literal["exact", "near_miss", "absent"]
+    # 1.0 for exact; otherwise the best windowed SequenceMatcher ratio found.
+    similarity: float
+    matches: list[QuoteMatch] = []
+    closest: ClosestMiss | None = None
+    # None when no cite hint was given.
+    cite_resolved: bool | None = None
+    # True when the quote was confirmed inside the hinted text (and juan, if
+    # one was hinted). Deliberately NOT inherited from the chat verifier's
+    # any-juan fallback — a quote found in juan 16 does not validate a
+    # citation claiming juan 13.
+    cite_matched: bool | None = None
+    lang: str = "lzh"
+    caveats: list[str] = []

--- a/backend/app/services/quote_lookup.py
+++ b/backend/app/services/quote_lookup.py
@@ -1,0 +1,399 @@
+"""Open-world verbatim quote lookup against the full corpus.
+
+The chat-path verifier (``quote_verifier.py``) is *closed-world*: it tests a
+quote against the chunks retrieved for one conversation. This service answers
+the open question — "does this quote exist verbatim anywhere in the canon?" —
+for the public ``/api/verify/quote`` endpoint and the hosted MCP tool.
+
+Design contract (keep these invariants):
+
+- **ES shortlists, Postgres decides.** The ES ``text_contents`` index
+  (analyzer ``cjk_content`` ≈ ``normalise_for_match``) is used only to find
+  candidate fascicles. The authoritative verbatim decision is always the
+  normalised substring test against the source text — so "verbatim" has one
+  definition system-wide (the chat verifier's).
+- **No silent juan fallback.** When the caller hints a juan, a hit in a
+  different juan is reported with ``juan_matched=False`` instead of being
+  passed off as confirmation (the chat pipeline's any-juan fallback is a
+  known fascicle-accuracy leak; the public API must not inherit it).
+- **lzh only, gaiji not folded** in v1 — both stated in ``caveats`` so the
+  verdict is honest about its blind spots.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+from elasticsearch import AsyncElasticsearch
+from sqlalchemy import text as sql_text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.verification import ClosestMiss, QuoteMatch, QuoteVerdict
+from app.services.quote_verifier import (
+    MIN_QUOTE_CHARS,
+    NEAR_MISS_THRESHOLD,
+    normalise_for_match,
+)
+from app.services.urn import build_urn, parse_urn, resolve_urn
+
+logger = logging.getLogger(__name__)
+
+# How many ES phrase candidates we confirm against Postgres.
+_MAX_CANDIDATES = 5
+# Fuzzy fallback candidates when the phrase query finds nothing.
+_MAX_FUZZY_CANDIDATES = 3
+# Full-text-scan ceiling: scanning every juan of a hinted text is allowed
+# only under this fascicle count (T0220 has 600 juans of ~100k chars — a
+# blind full scan there is a several-hundred-MB read).
+_MAX_FULL_SCAN_JUANS = 60
+# Same window cap as quote_verifier._windowed_ratio.
+_MAX_RATIO_WINDOWS = 256
+
+_CAVEATS = [
+    "lzh (Classical Chinese) corpus only; Pali/Tibetan/Sanskrit parallels are not searched.",
+    "CBETA gaiji variant characters are not folded yet; a quote using a common "
+    "variant form may miss a source encoded with a composition expression.",
+]
+
+# Loose shape check for a bare cbeta-style work id (T0374, X0600, SC-mn10,
+# 84K-toh123…). Resolution against buddhist_texts is the real validator.
+_CBETA_HINT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9\-]{0,30}$")
+
+
+class QuoteTooShortError(ValueError):
+    """Raised when the quote normalises to fewer than MIN_QUOTE_CHARS chars."""
+
+
+@dataclass(frozen=True)
+class _CiteTarget:
+    text_id: int
+    cbeta_id: str | None
+    title_zh: str | None
+    juan: int | None
+
+
+def windowed_best_span(needle: str, haystack: str) -> tuple[float, int, int]:
+    """Best SequenceMatcher ratio of ``needle`` against any same-length window
+    of ``haystack``, plus that window's [start, end) span.
+
+    Same windowing scheme as ``quote_verifier._windowed_ratio`` (coarse step,
+    capped window count, tail always included) — kept span-returning here so
+    the hot chat-path function stays untouched. ``test_verify_quote`` asserts
+    the two agree on ratios. Inputs must already be normalised.
+    """
+    if not needle or not haystack:
+        return 0.0, 0, 0
+    nlen = len(needle)
+    if len(haystack) <= nlen:
+        return (
+            SequenceMatcher(None, needle, haystack, autojunk=False).ratio(),
+            0,
+            len(haystack),
+        )
+    step = max(1, nlen // 4)
+    starts = list(range(0, len(haystack) - nlen + 1, step))
+    tail = len(haystack) - nlen
+    if starts[-1] != tail:
+        starts.append(tail)
+    if len(starts) > _MAX_RATIO_WINDOWS:
+        stride = len(starts) / _MAX_RATIO_WINDOWS
+        starts = [starts[int(i * stride)] for i in range(_MAX_RATIO_WINDOWS)]
+    best, best_start = 0.0, 0
+    for s in starts:
+        r = SequenceMatcher(None, needle, haystack[s : s + nlen], autojunk=False).ratio()
+        if r > best:
+            best, best_start = r, s
+            if best >= 0.999:
+                break
+    return best, best_start, best_start + nlen
+
+
+async def _resolve_cite(
+    db: AsyncSession, cite: str, juan: int | None
+) -> _CiteTarget | None:
+    """Resolve a cite hint (bare cbeta id or fojin URN) to a text target.
+
+    A juan inside a URN wins over the separate ``juan`` param only when the
+    latter is absent — an explicit param is the more deliberate signal.
+    """
+    cite = cite.strip()
+    text_id: int | None = None
+    urn_juan: int | None = None
+    if cite.lower().startswith("fojin:"):
+        try:
+            parsed = parse_urn(cite)
+        except ValueError:
+            return None
+        urn_juan = parsed.juan
+        text_id, _ = await resolve_urn(db, parsed)
+    elif _CBETA_HINT_RE.match(cite):
+        row = (
+            await db.execute(
+                sql_text(
+                    "SELECT id FROM buddhist_texts WHERE cbeta_id = :c "
+                    "ORDER BY id ASC LIMIT 1"
+                ),
+                {"c": cite},
+            )
+        ).fetchone()
+        text_id = row[0] if row else None
+    if text_id is None:
+        return None
+    meta = (
+        await db.execute(
+            sql_text("SELECT cbeta_id, title_zh FROM buddhist_texts WHERE id = :t"),
+            {"t": text_id},
+        )
+    ).fetchone()
+    return _CiteTarget(
+        text_id=text_id,
+        cbeta_id=meta[0] if meta else None,
+        title_zh=meta[1] if meta else None,
+        juan=juan if juan is not None else urn_juan,
+    )
+
+
+async def _fetch_juan(db: AsyncSession, text_id: int, juan_num: int) -> str | None:
+    row = (
+        await db.execute(
+            sql_text(
+                "SELECT content FROM text_contents "
+                "WHERE text_id = :t AND juan_num = :j AND lang = 'lzh' LIMIT 1"
+            ),
+            {"t": text_id, "j": juan_num},
+        )
+    ).fetchone()
+    return row[0] if row else None
+
+
+async def _juan_count(db: AsyncSession, text_id: int) -> int:
+    row = (
+        await db.execute(
+            sql_text(
+                "SELECT COUNT(*) FROM text_contents "
+                "WHERE text_id = :t AND lang = 'lzh'"
+            ),
+            {"t": text_id},
+        )
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+async def _all_juans(db: AsyncSession, text_id: int) -> list[tuple[int, str]]:
+    rows = (
+        await db.execute(
+            sql_text(
+                "SELECT juan_num, content FROM text_contents "
+                "WHERE text_id = :t AND lang = 'lzh' ORDER BY juan_num"
+            ),
+            {"t": text_id},
+        )
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+async def _es_candidates(
+    es: AsyncElasticsearch,
+    quote: str,
+    *,
+    text_id: int | None,
+    phrase: bool,
+    size: int,
+) -> list[dict]:
+    """Candidate fascicles from ES. ``phrase=True`` is the precise pass
+    (cjk_content analyzer makes match_phrase ≈ normalised-substring recall);
+    ``phrase=False`` is the fuzzy fallback used only to find *closest* text
+    for a near-miss verdict."""
+    query_type = "match_phrase" if phrase else "match"
+    content_query: dict = {
+        query_type: {"content": {"query": quote, "analyzer": "cjk_content"}}
+    }
+    filters: list[dict] = [{"term": {"lang": "lzh"}}]
+    if text_id is not None:
+        filters.append({"term": {"text_id": text_id}})
+    body = {
+        "query": {"bool": {"must": [content_query], "filter": filters}},
+        "size": size,
+        "_source": ["text_id", "cbeta_id", "title_zh", "juan_num"],
+    }
+    try:
+        resp = await es.search(index="text_contents", body=body)
+    except Exception:  # pragma: no cover - ES outage degrades, not crashes
+        logger.warning("verify_quote ES candidate search failed", exc_info=True)
+        return []
+    hits = resp.get("hits", {}).get("hits", []) if isinstance(resp, dict) else []
+    out = []
+    for h in hits:
+        src = h.get("_source") or {}
+        if isinstance(src.get("text_id"), int) and isinstance(src.get("juan_num"), int):
+            out.append(src)
+    return out
+
+
+def _match_from(
+    src: dict, *, hinted_juan: int | None
+) -> QuoteMatch:
+    juan_num = src["juan_num"]
+    return QuoteMatch(
+        text_id=src["text_id"],
+        cbeta_id=src.get("cbeta_id"),
+        title_zh=src.get("title_zh"),
+        juan_num=juan_num,
+        urn=build_urn(src.get("cbeta_id"), juan_num),
+        juan_matched=(juan_num == hinted_juan) if hinted_juan is not None else None,
+    )
+
+
+async def verify_quote(
+    db: AsyncSession,
+    es: AsyncElasticsearch,
+    quote: str,
+    *,
+    cite: str | None = None,
+    juan: int | None = None,
+) -> QuoteVerdict:
+    """Open-world verbatim check of ``quote`` against the corpus."""
+    needle = normalise_for_match(quote)
+    if len(needle) < MIN_QUOTE_CHARS:
+        raise QuoteTooShortError(
+            f"quote must normalise to at least {MIN_QUOTE_CHARS} chars "
+            f"(got {len(needle)})"
+        )
+
+    target: _CiteTarget | None = None
+    cite_resolved: bool | None = None
+    if cite:
+        target = await _resolve_cite(db, cite, juan)
+        cite_resolved = target is not None
+
+    hinted_juan = target.juan if target else None
+    matches: list[QuoteMatch] = []
+    best_miss: tuple[float, int, int, str] | None = None  # ratio, text_id, juan, window
+
+    def _note_miss(ratio: float, text_id: int, juan_num: int, window: str) -> None:
+        nonlocal best_miss
+        if best_miss is None or ratio > best_miss[0]:
+            best_miss = (ratio, text_id, juan_num, window)
+
+    async def _confirm(src: dict) -> bool:
+        body = await _fetch_juan(db, src["text_id"], src["juan_num"])
+        if body is None:
+            return False
+        norm_body = normalise_for_match(body)
+        if needle in norm_body:
+            matches.append(_match_from(src, hinted_juan=hinted_juan))
+            return True
+        ratio, start, end = windowed_best_span(needle, norm_body)
+        _note_miss(ratio, src["text_id"], src["juan_num"], norm_body[start:end])
+        return False
+
+    if target is not None:
+        # Hinted-text paths. Never scan-blind on huge texts.
+        base_src = {
+            "text_id": target.text_id,
+            "cbeta_id": target.cbeta_id,
+            "title_zh": target.title_zh,
+        }
+        if target.juan is not None:
+            await _confirm({**base_src, "juan_num": target.juan})
+        if not matches:
+            # ES narrows within the hinted text (finds hits in other juans —
+            # reported honestly as juan_matched=False when a juan was hinted).
+            cands = await _es_candidates(
+                es, quote, text_id=target.text_id, phrase=True, size=_MAX_CANDIDATES
+            )
+            for src in cands:
+                if src["juan_num"] != target.juan:
+                    await _confirm({**base_src, "juan_num": src["juan_num"]})
+            # ES found nothing phrase-exact in this text; a bounded full
+            # scan catches ES/normalisation drift on small texts.
+            if (
+                not matches
+                and not cands
+                and await _juan_count(db, target.text_id) <= _MAX_FULL_SCAN_JUANS
+            ):
+                for juan_num, body in await _all_juans(db, target.text_id):
+                    if juan_num == target.juan:
+                        continue  # already tested
+                    norm_body = normalise_for_match(body)
+                    if needle in norm_body:
+                        matches.append(
+                            _match_from(
+                                {**base_src, "juan_num": juan_num},
+                                hinted_juan=hinted_juan,
+                            )
+                        )
+                        if len(matches) >= _MAX_CANDIDATES:
+                            break
+                    else:
+                        ratio, start, end = windowed_best_span(needle, norm_body)
+                        _note_miss(ratio, target.text_id, juan_num, norm_body[start:end])
+
+    if not matches:
+        # Open-world pass (also runs when a cite hint resolved but missed —
+        # "not where you said, but it IS here" is the useful answer).
+        for src in await _es_candidates(
+            es, quote, text_id=None, phrase=True, size=_MAX_CANDIDATES
+        ):
+            if len(matches) >= _MAX_CANDIDATES:
+                break
+            await _confirm(src)
+
+    if not matches and best_miss is None:
+        # Nothing phrase-exact anywhere: fuzzy fallback purely to locate the
+        # closest text for the near_miss/absent verdict.
+        for src in await _es_candidates(
+            es, quote, text_id=None, phrase=False, size=_MAX_FUZZY_CANDIDATES
+        ):
+            await _confirm(src)
+
+    verbatim = bool(matches)
+    if verbatim:
+        bucket, similarity, closest = "exact", 1.0, None
+    else:
+        similarity = best_miss[0] if best_miss else 0.0
+        bucket = "near_miss" if similarity >= NEAR_MISS_THRESHOLD else "absent"
+        closest = None
+        if best_miss:
+            ratio, text_id, juan_num, window = best_miss
+            meta = (
+                await db.execute(
+                    sql_text("SELECT cbeta_id FROM buddhist_texts WHERE id = :t"),
+                    {"t": text_id},
+                )
+            ).fetchone()
+            closest = ClosestMiss(
+                text_id=text_id,
+                juan_num=juan_num,
+                urn=build_urn(meta[0] if meta else None, juan_num),
+                similarity=round(ratio, 4),
+                window_normalised=window,
+            )
+
+    cite_matched: bool | None = None
+    if cite:
+        if target is None:
+            cite_matched = False
+        elif hinted_juan is not None:
+            cite_matched = any(
+                m.text_id == target.text_id and m.juan_num == hinted_juan
+                for m in matches
+            )
+        else:
+            cite_matched = any(m.text_id == target.text_id for m in matches)
+
+    return QuoteVerdict(
+        quote=quote,
+        normalised_quote=needle,
+        verbatim=verbatim,
+        bucket=bucket,
+        similarity=round(similarity, 4) if not verbatim else 1.0,
+        matches=matches,
+        closest=closest,
+        cite_resolved=cite_resolved,
+        cite_matched=cite_matched,
+        caveats=list(_CAVEATS),
+    )

--- a/backend/tests/test_verify_quote.py
+++ b/backend/tests/test_verify_quote.py
@@ -1,0 +1,228 @@
+"""Open-world quote verification (services/quote_lookup + /api/verify/quote).
+
+Service-level tests with fake DB/ES doubles — no network, no real ES. The
+contract under test:
+
+- ES only shortlists; the verdict comes from the normalised substring test.
+- juan_matched honesty: a hit in a different juan than hinted must NOT count
+  as cite confirmation (the chat pipeline's any-juan fallback is a known
+  fascicle-accuracy leak the public API must not inherit).
+- windowed_best_span must agree with quote_verifier._windowed_ratio, since it
+  re-implements the same windowing to add span output.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure elasticsearch stub exists before any app import (test_kg.py pattern).
+if "elasticsearch" not in sys.modules:
+    _es_stub = MagicMock()
+    _es_stub.AsyncElasticsearch = MagicMock
+    sys.modules["elasticsearch"] = _es_stub
+
+from app.config import settings
+from app.core.rate_limit import STRICT_PATHS
+from app.services.quote_lookup import (
+    QuoteTooShortError,
+    verify_quote,
+    windowed_best_span,
+)
+from app.services.quote_verifier import _windowed_ratio, normalise_for_match
+
+# 雪山偈 — long enough to clear MIN_QUOTE_CHARS after normalisation.
+SNOW_VERSE = "諸行無常，是生滅法，生滅滅已，寂滅為樂"
+JUAN_13 = f"爾時世尊而說偈言：{SNOW_VERSE}。是時獵師聞偈歡喜。"
+JUAN_16 = f"復次善男子，{SNOW_VERSE}，是名大涅槃義。"
+JUAN_OTHER = "如是我聞，一時佛在王舍城耆闍崛山中，與大比丘眾俱。"
+
+
+# ── fakes ────────────────────────────────────────────────────────────────
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+
+class FakeDB:
+    """Routes the service's raw SQL by prefix onto in-memory fixtures."""
+
+    def __init__(self, texts, contents):
+        # texts: {text_id: (cbeta_id, title_zh)}; contents: {(text_id, juan): str}
+        self.texts = texts
+        self.contents = contents
+
+    async def execute(self, statement, params=None):
+        sql = " ".join(str(statement).split())
+        p = params or {}
+        if not p and hasattr(statement, "compile"):
+            # ORM select() carries its bound values inside the statement.
+            p = statement.compile().params
+        if sql.startswith("SELECT id FROM buddhist_texts WHERE cbeta_id"):
+            rows = [(tid,) for tid, (cb, _) in self.texts.items() if cb == p["c"]]
+            return _Result(sorted(rows)[:1])
+        if sql.startswith("SELECT buddhist_texts.id FROM buddhist_texts"):
+            # ORM-compiled form used by services.text.get_text_id_by_cbeta
+            # (the URN cite-hint path).
+            cb_wanted = p.get("cbeta_id_1")
+            rows = [(tid,) for tid, (cb, _) in self.texts.items() if cb == cb_wanted]
+
+            class _Scalar(_Result):
+                def scalar_one_or_none(self):
+                    return self._rows[0][0] if self._rows else None
+
+            return _Scalar(sorted(rows)[:1])
+        if sql.startswith("SELECT cbeta_id, title_zh FROM buddhist_texts"):
+            t = self.texts.get(p["t"])
+            return _Result([t] if t else [])
+        if sql.startswith("SELECT cbeta_id FROM buddhist_texts"):
+            t = self.texts.get(p["t"])
+            return _Result([(t[0],)] if t else [])
+        if sql.startswith("SELECT content FROM text_contents"):
+            body = self.contents.get((p["t"], p["j"]))
+            return _Result([(body,)] if body is not None else [])
+        if sql.startswith("SELECT COUNT(*) FROM text_contents"):
+            n = sum(1 for (tid, _j) in self.contents if tid == p["t"])
+            return _Result([(n,)])
+        if sql.startswith("SELECT juan_num, content FROM text_contents"):
+            rows = sorted(
+                (j, body) for (tid, j), body in self.contents.items() if tid == p["t"]
+            )
+            return _Result(rows)
+        raise AssertionError(f"unrouted SQL in test double: {sql}")
+
+
+class FakeES:
+    def __init__(self, hits_by_type=None):
+        # hits_by_type: {"match_phrase": [...], "match": [...]}
+        self.hits_by_type = hits_by_type or {}
+        self.calls = []
+
+    async def search(self, index, body):
+        self.calls.append(body)
+        (qtype,) = body["query"]["bool"]["must"][0].keys()
+        hits = self.hits_by_type.get(qtype, [])
+        # Honour the text_id term filter like real ES would.
+        for f in body["query"]["bool"]["filter"]:
+            if "term" in f and "text_id" in f["term"]:
+                hits = [h for h in hits if h["text_id"] == f["term"]["text_id"]]
+        return {"hits": {"hits": [{"_source": h} for h in hits]}}
+
+
+def _hit(text_id, juan, cbeta="T0374", title="大般涅槃經"):
+    return {"text_id": text_id, "cbeta_id": cbeta, "title_zh": title, "juan_num": juan}
+
+
+DB = FakeDB(
+    texts={15: ("T0374", "大般涅槃經")},
+    contents={(15, 13): JUAN_13, (15, 16): JUAN_16, (15, 1): JUAN_OTHER},
+)
+
+
+# ── windowing parity ─────────────────────────────────────────────────────
+
+
+def test_windowed_best_span_agrees_with_quote_verifier_ratio():
+    needle = normalise_for_match(SNOW_VERSE)
+    for haystack_raw in (JUAN_13, JUAN_16, JUAN_OTHER, SNOW_VERSE, "短"):
+        haystack = normalise_for_match(haystack_raw)
+        ratio, start, end = windowed_best_span(needle, haystack)
+        assert ratio == pytest.approx(_windowed_ratio(needle, haystack))
+        assert 0 <= start <= end <= len(haystack)
+
+
+# ── service verdicts ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exact_hit_with_cite_and_juan():
+    out = await verify_quote(DB, FakeES(), SNOW_VERSE, cite="T0374", juan=13)
+    assert out.verbatim is True
+    assert out.bucket == "exact"
+    assert out.similarity == 1.0
+    assert out.cite_resolved is True
+    assert out.cite_matched is True
+    m = out.matches[0]
+    assert (m.text_id, m.juan_num, m.juan_matched) == (15, 13, True)
+    assert m.urn == "fojin:cbeta/T0374.13"
+
+
+@pytest.mark.asyncio
+async def test_wrong_juan_hint_is_honest():
+    """Quote真身在卷13/16，提示卷1：verbatim 仍为 True（开放世界事实），
+    但 cite_matched 必须是 False，命中行标 juan_matched=False。"""
+    es = FakeES({"match_phrase": [_hit(15, 13), _hit(15, 16)]})
+    out = await verify_quote(DB, es, SNOW_VERSE, cite="T0374", juan=1)
+    assert out.verbatim is True
+    assert out.cite_matched is False
+    assert all(m.juan_matched is False for m in out.matches)
+    assert {m.juan_num for m in out.matches} == {13, 16}
+
+
+@pytest.mark.asyncio
+async def test_open_world_no_cite():
+    es = FakeES({"match_phrase": [_hit(15, 13)]})
+    out = await verify_quote(DB, es, SNOW_VERSE)
+    assert out.verbatim is True
+    assert out.cite_resolved is None and out.cite_matched is None
+    assert out.matches[0].juan_matched is None
+
+
+@pytest.mark.asyncio
+async def test_near_miss_reports_closest_window():
+    corrupted = "諸行無常，是生滅法，生滅滅已，寂滅最樂也"  # 為→最 + 也
+    es = FakeES({"match_phrase": [], "match": [_hit(15, 13)]})
+    out = await verify_quote(DB, es, corrupted)
+    assert out.verbatim is False
+    assert out.bucket == "near_miss"
+    assert out.similarity >= 0.85
+    assert out.closest is not None
+    assert out.closest.urn == "fojin:cbeta/T0374.13"
+    assert "生灭灭已" in out.closest.window_normalised  # normalised (simplified) space
+
+
+@pytest.mark.asyncio
+async def test_absent_when_nothing_close():
+    es = FakeES({"match_phrase": [], "match": [_hit(15, 1)]})
+    out = await verify_quote(DB, es, "此句純屬虛構絕不在藏經之中者也")
+    assert out.verbatim is False
+    assert out.bucket == "absent"
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_cite_still_searches_open_world():
+    es = FakeES({"match_phrase": [_hit(15, 13)]})
+    out = await verify_quote(DB, es, SNOW_VERSE, cite="T9999")
+    assert out.cite_resolved is False
+    assert out.cite_matched is False
+    assert out.verbatim is True  # found anyway — the useful answer
+
+
+@pytest.mark.asyncio
+async def test_urn_cite_hint_carries_juan():
+    out = await verify_quote(DB, FakeES(), SNOW_VERSE, cite="fojin:cbeta/T0374.13")
+    assert out.cite_resolved is True
+    assert out.cite_matched is True
+    assert out.matches[0].juan_matched is True
+
+
+@pytest.mark.asyncio
+async def test_too_short_quote_rejected():
+    with pytest.raises(QuoteTooShortError):
+        await verify_quote(DB, FakeES(), "諸行無常")
+
+
+# ── rate limit registration ──────────────────────────────────────────────
+
+
+def test_verify_quote_is_strict_rate_limited():
+    assert STRICT_PATHS["/api/verify/quote"] == settings.rate_limit_verify_quote
+    assert settings.rate_limit_verify_quote <= settings.rate_limit_default

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -30,6 +30,7 @@ Two ways to use it:
 | `lookup_dictionary(term, limit)` | Entries across fojin's 32 dictionaries |
 | `lookup_entity(query, limit)` | Knowledge-graph entities (people, places, works, terms) |
 | `resolve_urn(urn)` | Resolve/verify a `fojin:` URN → reader URL + existence |
+| `verify_quote(quote, cite?, juan?)` | **Open-world verbatim check**: does this quote exist anywhere in the canon? Returns URN-cited matches, honest `cite_matched`/`juan_matched`, or the closest near-miss window. Call it before serving any quoted scripture — LLMs invent quotes |
 
 Every result that names a canonical passage carries a **`urn`** — fojin's stable
 cross-canon identifier, interoperable with CBETA / SuttaCentral (`sc/`) / 84000

--- a/mcp-server/fojin_mcp/__init__.py
+++ b/mcp-server/fojin_mcp/__init__.py
@@ -1,4 +1,4 @@
 """fojin MCP server package — cross-canon Buddhist corpus tools over stdio or
 streamable HTTP (the hosted endpoint at mcp.fojin.ai)."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/mcp-server/fojin_mcp/client.py
+++ b/mcp-server/fojin_mcp/client.py
@@ -186,6 +186,20 @@ class FojinClient:
         # double-encode it into a literal "%23" on the server side.
         return await self._get("/urn/resolve", {"urn": urn})
 
+    async def verify_quote(
+        self, quote: str, *, cite: str | None = None, juan: int | None = None
+    ) -> dict[str, Any]:
+        """Open-world verbatim quote verification against the whole corpus.
+
+        The server's verdict shape is already agent-facing (verbatim/bucket/
+        matches-with-URNs/closest/caveats), so it passes through unshaped."""
+        params: dict[str, Any] = {"q": quote}
+        if cite:
+            params["cite"] = cite
+        if juan is not None:
+            params["juan"] = juan
+        return await self._get("/verify/quote", params)
+
 
 # ── pure reshaping (unit-tested with plain dicts) ────────────────────────
 

--- a/mcp-server/fojin_mcp/server.py
+++ b/mcp-server/fojin_mcp/server.py
@@ -166,6 +166,22 @@ async def resolve_urn(urn: str) -> dict:
     return await _call("resolve_urn", lambda c: c.resolve_urn(urn))
 
 
+@mcp.tool()
+async def verify_quote(quote: str, cite: str | None = None, juan: int | None = None) -> dict:
+    """Verify that a Buddhist-canon quote exists VERBATIM in the corpus.
+
+    Call this before presenting any quoted scripture to a reader: LLMs
+    routinely invent plausible-looking quotes. Returns `verbatim` (bool),
+    where it was found (`matches`, each with a resolvable `urn`), or the
+    closest near-miss window when it wasn't. `cite` optionally narrows the
+    search — a CBETA id ("T0374") or fojin URN ("fojin:cbeta/T0374.13") —
+    and `cite_matched` reports honestly whether the quote is where you
+    claimed (a hit in a different fascicle does NOT confirm your citation).
+    Quote must be ≥12 CJK chars after normalisation; Classical Chinese only.
+    """
+    return await _call("verify_quote", lambda c: c.verify_quote(quote, cite=cite, juan=juan))
+
+
 @mcp.custom_route("/healthz", methods=["GET"])
 async def healthz(_request: Request) -> JSONResponse:
     """Liveness for the hosted endpoint (nginx/compose healthchecks)."""

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fojin-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCP server exposing fojin's verified cross-canon Buddhist corpus (cited, URN-addressable passages) to AI research tools."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "app.fojin/fojin-mcp",
   "title": "fojin — Buddhist Canon Tools",
   "description": "Buddhist canon tools: search, passages, cross-canon parallels, dictionaries — all URN-cited.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "websiteUrl": "https://fojin.app",
   "repository": {
     "url": "https://github.com/xr843/fojin",

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -221,6 +221,33 @@ async def test_get_parallels_survives_enrichment_lookup_failure():
 
 
 @pytest.mark.asyncio
+async def test_verify_quote_params_and_passthrough():
+    """verify_quote sends q/cite/juan (omitting absent hints) and passes the
+    server's agent-facing verdict through unshaped."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={
+            "verbatim": True, "bucket": "exact", "similarity": 1.0,
+            "matches": [{"urn": "fojin:cbeta/T0374.13", "juan_matched": True}]})
+
+    async with _client_with(handler) as c:
+        out = await c.verify_quote("諸行無常，是生滅法", cite="T0374", juan=13)
+
+    assert seen["path"] == "/api/verify/quote"
+    assert seen["params"] == {"q": "諸行無常，是生滅法", "cite": "T0374", "juan": "13"}
+    assert out["verbatim"] is True
+    assert out["matches"][0]["urn"] == "fojin:cbeta/T0374.13"
+
+    seen.clear()
+    async with _client_with(handler) as c:
+        await c.verify_quote("諸行無常，是生滅法")
+    assert seen["params"] == {"q": "諸行無常，是生滅法"}   # no None params leak
+
+
+@pytest.mark.asyncio
 async def test_cbeta_lookup_cached_across_calls():
     """text_id→cbeta_id is static; a long-lived client must not re-fetch it on
     every get_parallels (the hosted endpoint shares one client process-wide)."""

--- a/mcp-server/tests/test_http.py
+++ b/mcp-server/tests/test_http.py
@@ -71,7 +71,7 @@ def test_tools_list_over_streamable_http():
     tools = {t["name"] for t in resp.json()["result"]["tools"]}
     assert tools == {
         "search_corpus", "read_passage", "get_parallels",
-        "lookup_dictionary", "lookup_entity", "resolve_urn",
+        "lookup_dictionary", "lookup_entity", "resolve_urn", "verify_quote",
     }
 
 


### PR DESCRIPTION
## What

**Layer 2**: any AI agent can now ask, in one call, whether a Buddhist-canon quote exists **verbatim** — and where — instead of serving invented scripture.

```
GET /api/verify/quote?q=諸行無常，是生滅法，生滅滅已，寂滅為樂&cite=T0374&juan=13
→ { verbatim: true, matches: [{urn: "fojin:cbeta/T0374.13", juan_matched: true}], … }
```

MCP: `verify_quote(quote, cite?, juan?)` — fojin-mcp **0.3.0** (7th tool).

## Design (from the pipeline recon)

- The chat verifier is **closed-world** (per-answer retrieved chunks); this is the **open-world** twin. **ES shortlists, Postgres decides**: match_phrase on the `cjk_content` analyzer (≈ `normalise_for_match` semantics) finds candidate fascicles; the verdict is always the normalised substring test on source text — one definition of verbatim system-wide.
- **Honesty upgrades over the chat path**: no any-juan fallback (`juan_matched`/`cite_matched` reported explicitly — a hit in juan 16 does not confirm a juan-13 cite); `caveats` states lzh-only + gaiji-not-folded blind spots; unresolvable cite still searches open-world ("not where you said, but it IS here").
- **Bounded cost**: hinted-juan path reads one fascicle; blind full-scan only ≤60 juans (T0220's 600×100k chars can't be pulled); fuzzy fallback capped at 3 candidates, windowed ratio capped at 256 windows. Strict rate limit 30/min (`rate_limit_verify_quote`).
- `windowed_best_span` is a span-returning twin of `_windowed_ratio` — the hot chat-path function is untouched; a parity test locks the two together.

## Deferred (documented)

gaiji folding (needs attribution run first), char-level diff with original-text offsets, non-lzh canons, title-form cite hints.

## Tests

- backend: 10 new (wrong-juan honesty, near-miss closest window, absent, URN hint carries juan, too-short 422, STRICT_PATHS assertion, windowing parity) — 15 green with neighbors
- mcp-server: 37 green (verify_quote params/passthrough + 7-tool listing)
- ruff clean both sides

## After merge

backend auto-deploys (webhook); then `docker compose up -d --build mcp`, E2E via mcp.fojin.ai, tag `mcp-v0.3.0` → PyPI, registry republish 0.3.0.