### PR TITLE
fix(verify): stop discarding real ES hits — ObjectApiResponse is not a dict

### DIFF
--- a/backend/app/services/quote_lookup.py
+++ b/backend/app/services/quote_lookup.py
@@ -221,10 +221,13 @@ async def _es_candidates(
     }
     try:
         resp = await es.search(index="text_contents", body=body)
+        # elasticsearch-py 8.x returns ObjectApiResponse (Mapping-like, NOT a
+        # dict) — subscript it; an isinstance(resp, dict) guard silently
+        # discards every real result while passing dict-based test doubles.
+        hits = resp["hits"]["hits"]
     except Exception:  # pragma: no cover - ES outage degrades, not crashes
         logger.warning("verify_quote ES candidate search failed", exc_info=True)
         return []
-    hits = resp.get("hits", {}).get("hits", []) if isinstance(resp, dict) else []
     out = []
     for h in hits:
         src = h.get("_source") or {}


### PR DESCRIPTION
Prod E2E caught it: ES returns 36 phrase hits for the full 雪山偈 (T2919 etc.), but `/api/verify/quote` said absent/0.0 — `isinstance(resp, dict)` is False for elasticsearch-py 8.x's ObjectApiResponse, so every real candidate list was silently emptied while dict-based test doubles passed. One-line reshape: subscript inside the existing try/except so a shape mismatch degrades exactly like an ES outage (logged), never silently.

Verified locally: 10 verify_quote tests green; will re-run the prod E2E (real verse + fabricated quote) after merge.