### PR TITLE
chore(workers): recover the fojin.ai edge worker into the repo, point / at the portal

### DIFF
--- a/deploy/host-nginx/fojin.conf
+++ b/deploy/host-nginx/fojin.conf
@@ -8,15 +8,22 @@ upstream fojin_backend {
     server 127.0.0.1:8001 max_fails=1 fail_timeout=10s;
 }
 
-# fojin.ai → 301 redirect to fojin.app
+# fojin.ai → fojin.app
+#
+# Note this block is effectively unreachable: the fojin.ai zone is fronted by
+# the `fojin-ai-sw-killswitch` Worker on fojin.ai/* and www.fojin.ai/*, which
+# answers every request at the edge (see workers/fojin-ai-edge/). Requests do
+# not arrive here at all. Kept as the origin's own answer in case that route
+# is ever removed — the two must not disagree.
 server {
     listen 80;
     server_name fojin.ai www.fojin.ai;
 
     # MCP registry domain verification (namespace ai.fojin/*): mcp-publisher
-    # `login http --domain fojin.ai` fetches this exact path; it must answer
-    # before the blanket 301. Key material lives off-server (the private key
-    # never leaves the maintainer's machine); this is only the public half.
+    # `login http --domain fojin.ai` fetches this exact path. Dormant for the
+    # same reason as the rest of this block — the live copy is the fojin.app
+    # one below. Key material lives off-server (the private key never leaves
+    # the maintainer's machine); this is only the public half.
     location = /.well-known/mcp-registry-auth {
         default_type text/plain;
         return 200 "v=MCPv1; k=ed25519; p=NJWxIkTvqZLE3YKNE+e7YSa1CTUlEotnxvM7INsKnXI=";
@@ -57,9 +64,11 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # MCP registry domain verification (namespace app.fojin/*). Same public
-    # key as the fojin.ai copy above — that one is unreachable while the
-    # Cloudflare edge redirect rule for the fojin.ai zone stands, so this
-    # block is the one mcp-publisher actually verifies against.
+    # key as the fojin.ai copy above, but this is the one mcp-publisher
+    # actually verifies against: the fojin.ai copy never receives traffic,
+    # because the fojin-ai-sw-killswitch Worker answers that zone at the edge
+    # (workers/fojin-ai-edge/). It is a Worker route, not a redirect rule —
+    # the zone's Redirect Rule of that name is disabled.
     location = /.well-known/mcp-registry-auth {
         default_type text/plain;
         return 200 "v=MCPv1; k=ed25519; p=NJWxIkTvqZLE3YKNE+e7YSa1CTUlEotnxvM7INsKnXI=";

--- a/workers/fojin-ai-edge/README.md
+++ b/workers/fojin-ai-edge/README.md
@@ -1,0 +1,62 @@
+# fojin.ai edge worker
+
+Deployed as **`fojin-ai-sw-killswitch`**, routed on `fojin.ai/*` and
+`www.fojin.ai/*`. Nothing else runs on that zone — the "fojin.ai 301 to
+fojin.app" Redirect Rule in the dashboard is **disabled**, and there are no
+Page Rules or Bulk Redirects. If you are trying to work out why fojin.ai
+redirects, it is this worker, not a rule.
+
+## What it does
+
+| Path | Response |
+| --- | --- |
+| `/sw.js` | A service worker whose only job is to drop every cache, unregister itself, and navigate the client to fojin.app |
+| `/registerSW.js` | The same clean-up from the page side, for clients that fetch the vite-pwa register shim |
+| `/` | **302 → `https://fojin.app/agents`** — the agent portal's short address |
+| everything else | **301 → `https://fojin.app<path><query>`** |
+
+### Why the kill-switch still matters
+
+fojin.ai is the app's former domain, and the app was a PWA. A visitor who
+installed it back then still has a service worker registered on that origin,
+and that SW serves the old build from its own cache — it never reaches the
+network, so it never sees the redirect. Browsers re-fetch a registered SW
+script at least every 24 hours, so answering `/sw.js` with an unregistering
+script is what eventually frees those clients. **Do not delete those two
+branches**, even though the traffic they serve is invisible in analytics.
+
+## Deploying
+
+The worker predates this directory; it was created in the dashboard and its
+source lived nowhere. `src/index.js` was recovered from the deployed script,
+so what is here matches what is live.
+
+```bash
+cd workers/fojin-ai-edge
+npx wrangler deploy          # needs Workers Scripts:Edit on the account
+```
+
+If `wrangler` is unavailable, the same upload over the REST API:
+
+```bash
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/scripts/fojin-ai-sw-killswitch" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -F 'metadata={"main_module":"index.js","compatibility_date":"2026-04-17"};type=application/json' \
+  -F 'index.js=@src/index.js;type=application/javascript+module'
+```
+
+A script upload does not touch the zone's Worker routes — those are separate
+resources — so a bad deploy is recovered by re-uploading, not by re-routing.
+
+## Checking it after a deploy
+
+```bash
+curl -sI https://fojin.ai/            | grep -iE '^HTTP|^location'  # 302 → /agents
+curl -sI https://fojin.ai/chat        | grep -iE '^HTTP|^location'  # 301 → fojin.app/chat
+curl -s  https://fojin.ai/sw.js       | head -3                     # kill-switch SW
+curl -sI https://mcp.fojin.ai/healthz | head -1                     # unaffected (own route)
+```
+
+Cache-bust with a query string when re-testing: the edge and the browser both
+cache these redirects.

--- a/workers/fojin-ai-edge/src/index.js
+++ b/workers/fojin-ai-edge/src/index.js
@@ -1,0 +1,100 @@
+// fojin.ai edge worker (deployed as `fojin-ai-sw-killswitch`).
+//
+// fojin.ai is the app's former domain. This worker has two jobs:
+//
+//   1. Un-register the legacy service worker that domain left behind in
+//      returning visitors' browsers. A stale SW would keep serving the old
+//      app from its own cache and never see the redirect below, so /sw.js
+//      and /registerSW.js answer with scripts whose only purpose is to drop
+//      every cache, unregister themselves, and navigate the client onward.
+//      Browsers re-fetch a registered SW script at least every 24h, which is
+//      what makes this eventually reach everyone. Do not remove.
+//
+//   2. Send the domain's traffic to fojin.app, path-preserving — except the
+//      bare root, which is the short address of the agent portal.
+//
+// The worker predates this directory: it was created and routed by hand in
+// the Cloudflare dashboard, and the source lived nowhere. This file is that
+// source, recovered from the deployed script so the next change is a diff
+// rather than an archaeology exercise. See README.md for how to deploy.
+
+const KILL_SW = `// fojin.ai kill-switch service worker
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    try {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    } catch (e) {}
+    try {
+      await self.registration.unregister();
+    } catch (e) {}
+    const clients = await self.clients.matchAll({ type: 'window' });
+    for (const client of clients) {
+      const target = client.url.replace(/^https?:\\/\\/(www\\.)?fojin\\.ai/, 'https://fojin.app');
+      try { client.navigate(target); } catch (e) {}
+    }
+  })());
+});
+// Never intercept — always hit network (which will redirect to fojin.app)
+self.addEventListener('fetch', () => {});
+`;
+
+const KILL_REGISTER_SW = `// fojin.ai kill-switch registerSW
+(async () => {
+  if ('serviceWorker' in navigator) {
+    try {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      for (const r of regs) { try { await r.unregister(); } catch (e) {} }
+    } catch (e) {}
+    try {
+      await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+    } catch (e) {}
+  }
+  if (typeof caches !== 'undefined') {
+    try {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    } catch (e) {}
+  }
+  const here = location.href;
+  const target = here.replace(/^https?:\\/\\/(www\\.)?fojin\\.ai/, 'https://fojin.app');
+  if (target !== here) {
+    location.replace(target);
+  }
+})();
+`;
+
+const JS_HEADERS = {
+  "content-type": "application/javascript; charset=utf-8",
+  "cache-control": "no-store, no-cache, must-revalidate",
+  "service-worker-allowed": "/",
+};
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/sw.js") {
+      return new Response(KILL_SW, { headers: JS_HEADERS });
+    }
+    if (url.pathname === "/registerSW.js") {
+      return new Response(KILL_REGISTER_SW, { headers: JS_HEADERS });
+    }
+
+    // The bare domain is the agent portal's short address: fojin.ai is the
+    // AI-facing name, and /agents is that front door. 302 rather than 301 —
+    // the previous permanent redirect to fojin.app/ is already cached in some
+    // clients, so a permanent one here would be just as hard to take back.
+    if (url.pathname === "/") {
+      return Response.redirect("https://fojin.app/agents", 302);
+    }
+
+    // Every other path keeps its permanent, path-preserving redirect to the
+    // reader, so old fojin.ai deep links still land where they used to.
+    const target = new URL(url.pathname + url.search, "https://fojin.app");
+    return Response.redirect(target.toString(), 301);
+  },
+};

--- a/workers/fojin-ai-edge/wrangler.toml
+++ b/workers/fojin-ai-edge/wrangler.toml
@@ -1,0 +1,13 @@
+name = "fojin-ai-sw-killswitch"
+main = "src/index.js"
+compatibility_date = "2026-04-17"
+
+# Both hostnames of the fojin.ai zone. The routes were added by hand in the
+# dashboard long before this file existed; they are declared here so a
+# `wrangler deploy` reproduces them instead of leaving the script unrouted.
+# Keep the script name as-is — renaming it would create a second Worker and
+# leave these routes pointing at the old one.
+routes = [
+  { pattern = "fojin.ai/*", zone_name = "fojin.ai" },
+  { pattern = "www.fojin.ai/*", zone_name = "fojin.ai" },
+]


### PR DESCRIPTION
## Why this exists

The worker routed on `fojin.ai/*` and `www.fojin.ai/*` was created by hand in the dashboard and **its source lived nowhere**. `deploy/host-nginx/fojin.conf` even carries a comment blaming a "Cloudflare edge redirect rule" for the fojin.ai 301 — that is wrong. The Redirect Rule named *fojin.ai 301 to fojin.app* is **disabled**; Page Rules are 0/3 and Bulk Redirects 0/5. It was always this worker.

`src/index.js` is that source, recovered from the deployed script, so the next change is a diff rather than archaeology.

## The one behaviour change

| Path | Before | After |
| --- | --- | --- |
| `/` | 301 → `fojin.app/` | **302 → `fojin.app/agents`** |
| everything else | 301 → `fojin.app<path>` | unchanged |
| `/sw.js`, `/registerSW.js` | kill-switch scripts | unchanged |

fojin.ai becomes the agent portal's short address. **302, not 301**: the previous permanent redirect to `fojin.app/` is already cached in clients, and a second permanent one would be just as hard to take back.

Evidence it is safe: the fojin.ai zone saw ~220 requests in 24h, from US/DE/UK/CH — scanners, not the site's Chinese-speaking readers — alongside 4,397 blocked attacks.

## Do not delete the kill-switch branches

They look dead and are not. fojin.ai is the app's former domain and the app is a PWA: a visitor from back then still has a service worker registered on that origin, and it serves the old build **from its own cache without ever reaching the network**, so it never sees any redirect. Browsers re-fetch a registered SW script at least every 24h — answering `/sw.js` with an unregistering script is what eventually frees those clients. That traffic is invisible in analytics.

## Verified in production before this commit

```
fojin.ai/            → 302 https://fojin.app/agents      ✓
www.fojin.ai/        → 302 https://fojin.app/agents      ✓
fojin.ai/chat        → 301 https://fojin.app/chat        ✓ (path-preserving)
fojin.ai/sw.js       → kill-switch service worker        ✓
mcp.fojin.ai/healthz → {"status":"ok",…}                 ✓ (own route, untouched)
```

A script upload does not touch the zone's Worker routes — those are separate resources — so a bad deploy is recovered by re-uploading. A copy of the pre-change script is kept off-repo at `/home/lqsxi/secrets/fojin-cf-workers/`.