### PR TITLE
fix: two defects found while acceptance-testing the three layers

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -136,7 +136,16 @@ export default defineConfig({
         // with the SW installed), and /llms.txt isn't in globPatterns at all so
         // it is never precached. Crawlers don't run a SW and so never saw this;
         // only returning humans would.
-        navigateFallbackDenylist: [/^\/api\//, /^\/agents$/, /^\/llms\.txt$/],
+        // The `(\?|$)` is load-bearing: workbox tests these against
+        // `pathname + search`, not pathname, so an anchored `/^\/agents$/`
+        // stops matching the moment a link carries `?utm_source=…` — and the
+        // navigation falls back to the SPA shell, which has no /agents route.
+        // A shared link is exactly the case that carries query params.
+        navigateFallbackDenylist: [
+          /^\/api\//,
+          /^\/agents(\?|$)/,
+          /^\/llms\.txt(\?|$)/,
+        ],
         skipWaiting: true,
         clientsClaim: true,
       },

--- a/mcp-server/fojin_mcp/__init__.py
+++ b/mcp-server/fojin_mcp/__init__.py
@@ -1,4 +1,4 @@
 """fojin MCP server package — cross-canon Buddhist corpus tools over stdio or
 streamable HTTP (the hosted endpoint at mcp.fojin.ai)."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/mcp-server/fojin_mcp/client.py
+++ b/mcp-server/fojin_mcp/client.py
@@ -36,6 +36,29 @@ class FojinAPIError(RuntimeError):
     safe to surface to the calling model as a tool error."""
 
 
+def _error_detail(response: httpx.Response) -> str:
+    """The server's own reason for a 4xx, as a suffix for the error message.
+
+    A bare status code is useless to the model on the other end of the tool:
+    ``422`` does not say "your quote is 8 characters and the minimum is 12",
+    so the model cannot correct the call and just gives up. FastAPI puts that
+    sentence in ``{"detail": …}`` — pass it through.
+
+    5xx bodies are deliberately not surfaced: they carry nothing the caller
+    can act on, and are the shape most likely to leak internals.
+    """
+    if not 400 <= response.status_code < 500:
+        return ""
+    try:
+        payload = response.json()
+    except ValueError:
+        return ""
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if isinstance(detail, str) and detail.strip():
+        return f": {detail.strip()[:300]}"
+    return ""
+
+
 class FojinClient:
     """Thin async wrapper over the fojin HTTP API.
 
@@ -80,6 +103,7 @@ class FojinClient:
         except httpx.HTTPStatusError as exc:
             raise FojinAPIError(
                 f"fojin API {exc.response.status_code} for {path}"
+                f"{_error_detail(exc.response)}"
             ) from exc
         except httpx.HTTPError as exc:
             raise FojinAPIError(f"fojin API request failed for {path}: {exc}") from exc

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fojin-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server exposing fojin's verified cross-canon Buddhist corpus (cited, URN-addressable passages) to AI research tools."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "app.fojin/fojin-mcp",
   "title": "fojin — Buddhist Canon Tools",
   "description": "Buddhist canon tools: search, passages, cross-canon parallels, dictionaries — all URN-cited.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "websiteUrl": "https://fojin.app",
   "repository": {
     "url": "https://github.com/xr843/fojin",

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -281,5 +281,36 @@ async def test_http_error_becomes_fojin_api_error():
         return httpx.Response(500, json={"detail": "boom"})
 
     async with _client_with(handler) as c:
-        with pytest.raises(FojinAPIError):
+        with pytest.raises(FojinAPIError) as exc:
             await c.read_passage(1, 1)
+    # 5xx detail is NOT surfaced — it says nothing the caller can act on.
+    assert "boom" not in str(exc.value)
+    assert "500" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_client_error_surfaces_server_reason():
+    """A 4xx must carry the server's sentence, not just the status code: the
+    model on the other end can only correct the call if it is told what was
+    wrong with it."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422, json={"detail": "quote must normalise to at least 12 chars (got 8)"}
+        )
+
+    async with _client_with(handler) as c:
+        with pytest.raises(FojinAPIError) as exc:
+            await c.verify_quote("應無所住而生其心")
+    assert "at least 12 chars (got 8)" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_non_json_client_error_still_reports_status():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="<html>Too Many Requests</html>")
+
+    async with _client_with(handler) as c:
+        with pytest.raises(FojinAPIError) as exc:
+            await c.lookup_dictionary("空")
+    assert "429" in str(exc.value)
+    assert "<html>" not in str(exc.value)


### PR DESCRIPTION
Both found by exercising the shipped surfaces rather than re-reading the code.

## 1. A 4xx told the model nothing it could act on (`mcp-server`)

Calling `verify_quote` with an 8-character quote returned, to the model:

```json
{ "error": "fojin API 422 for /verify/quote" }
```

while the server had actually said **"quote must normalise to at least 12 chars (got 8)"**. A bare status code cannot be corrected against, so the tool call is simply lost — which defeats the point of an agent-facing API.

`_get` now appends FastAPI's `{"detail": …}` for 4xx. 5xx bodies stay suppressed (nothing actionable, most likely shape to leak internals); non-JSON error bodies fall back to the status code rather than echoing HTML. Three tests cover the three paths. **fojin-mcp 0.3.1.**

## 2. `/agents` fell back to the SPA whenever the URL carried a query

Loading `https://fojin.app/agents?v=2` in a browser with the service worker installed rendered **the SPA home page**, not the portal.

workbox's `NavigationRoute` tests denylist patterns against `pathname + search`, so `/^\/agents$/` stops matching the moment a link carries `?utm_source=…` — precisely the shape of a *shared* link — and the navigation falls through to the precached `index.html`, which has no `/agents` route.

**curl could not see this.** Crawlers and curl do not run a service worker, so every non-browser check passed, including the ones I ran at merge time. Anchored on `(\?|$)` instead.

## Verification

- mcp-server: 39 tests green, ruff clean.
- All seven tools exercised against the live `mcp.fojin.ai` endpoint, including `get_parallels` (388 Tibetan parallel segments for 瑜伽師地論 juan 1, 16 of 17 chunks aligned) which had not been covered before.
- The SPA-fallback fix will be re-checked in a real browser after deploy.