### PR TITLE
fix(nginx): declare UTF-8 on llms.txt — it was rendering as mojibake

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -243,6 +243,17 @@ server {
         try_files /agents.html /index.html;
     }
 
+    # llms.txt is UTF-8 and, unlike an HTML page, has nowhere in-band to say
+    # so. nginx's `charset` is off by default, so it went out as bare
+    # `text/plain` and the browser fell back to a legacy encoding: the title
+    # rendered as "fojin 浣涙触" instead of "fojin 佛津". Byte-level consumers
+    # (curl, crawlers, agents) were fine, which is why every non-browser check
+    # passed. Scoped to this file rather than set server-wide so nothing else
+    # changes its Content-Type; any future UTF-8 .txt needs the same line.
+    location = /llms.txt {
+        charset utf-8;
+    }
+
     # 上面这批路由的大小写变体 → 301 回规范小写。
     #
     # 对用户来说 /CHAT 其实是能用的：React Router 的路径匹配默认不区分大小写，


### PR DESCRIPTION
Third defect from the same acceptance pass, and the third one **curl could not see**.

In a browser, `https://fojin.app/llms.txt` opened as:

```
# fojin 浣涙触
```

instead of `# fojin 佛津`. nginx's `charset` directive is off by default, so the file goes out as bare `text/plain`; a `.txt` has no in-band `<meta charset>`, so the browser falls back to a legacy encoding and reads the UTF-8 bytes as GBK.

Byte-level consumers — curl, crawlers, and the agents this file is actually written for — were never affected. But the portal links to it prominently, and a human following that link saw garbage.

Scoped to `location = /llms.txt` rather than a server-wide `charset utf-8` so nothing else's Content-Type changes. Syntax-checked against `nginx:stable-bookworm`; will re-verify in a real browser after deploy.