### PR TITLE
feat(verify): say where the quote differs, not just how far off it is

### DIFF
--- a/backend/app/schemas/verification.py
+++ b/backend/app/schemas/verification.py
@@ -12,6 +12,8 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+__all__ = ["ClosestMiss", "DiffOp", "QuoteMatch", "QuoteVerdict"]
+
 
 class QuoteMatch(BaseModel):
     """One fascicle where the quote was confirmed verbatim (substring test
@@ -26,6 +28,21 @@ class QuoteMatch(BaseModel):
     juan_matched: bool | None = None
 
 
+class DiffOp(BaseModel):
+    """One span of agreement or disagreement between the submitted quote and
+    the closest source window, in normalised space.
+
+    ``quote`` is what the caller sent, ``source`` is what the canon actually
+    reads. For ``equal`` both are the same text; for ``delete`` the source
+    side is empty (the caller has words the source does not) and for
+    ``insert`` the quote side is empty (the source has words the caller
+    dropped)."""
+
+    op: Literal["equal", "replace", "delete", "insert"]
+    quote: str
+    source: str
+
+
 class ClosestMiss(BaseModel):
     """Best near-match window when the quote is NOT verbatim anywhere we
     looked. ``window_normalised`` is in normalised space (NFKC + 繁→简 +
@@ -36,6 +53,13 @@ class ClosestMiss(BaseModel):
     urn: str | None = None
     similarity: float
     window_normalised: str
+    # Character-level differences against window_normalised. Reported in
+    # normalised space only: normalisation folds 繁→简 phrase-wise and drops
+    # punctuation, so a character index cannot be mapped back to the original
+    # text without inventing an alignment. Saying "here, in the space the
+    # verdict was computed in" is answerable; "here, in your original string"
+    # is not.
+    diff: list[DiffOp] = []
 
 
 class QuoteVerdict(BaseModel):

--- a/backend/app/services/quote_lookup.py
+++ b/backend/app/services/quote_lookup.py
@@ -31,7 +31,7 @@ from elasticsearch import AsyncElasticsearch
 from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.schemas.verification import ClosestMiss, QuoteMatch, QuoteVerdict
+from app.schemas.verification import ClosestMiss, DiffOp, QuoteMatch, QuoteVerdict
 from app.services.quote_verifier import (
     MIN_QUOTE_CHARS,
     NEAR_MISS_THRESHOLD,
@@ -75,14 +75,42 @@ class _CiteTarget:
     juan: int | None
 
 
+def _anchor_starts(needle: str, haystack: str, nlen: int) -> list[int]:
+    """Window starts guessed by finding an exact run of the quote in the source.
+
+    The scan below steps by ``nlen // 4`` and is then subsampled to at most
+    ``_MAX_RATIO_WINDOWS``, so over a 100k-character fascicle it only lands
+    every few hundred characters — enough to score a near-miss, far too coarse
+    to frame it. A near-miss almost always shares a long verbatim run with its
+    source, so a plain ``str.find`` of a slice of the quote locates the true
+    offset in O(n) and lets the window be cut where a reader would cut it.
+    Best-effort: any miss just leaves the coarse scan's answer standing.
+    """
+    starts: list[int] = []
+    for probe_len in (nlen // 2, nlen // 4, 8):
+        if probe_len < 4:
+            continue
+        offset = (nlen - probe_len) // 2
+        pos = haystack.find(needle[offset : offset + probe_len])
+        if pos != -1:
+            starts.append(max(0, min(pos - offset, len(haystack) - nlen)))
+    return starts
+
+
 def windowed_best_span(needle: str, haystack: str) -> tuple[float, int, int]:
     """Best SequenceMatcher ratio of ``needle`` against any same-length window
     of ``haystack``, plus that window's [start, end) span.
 
-    Same windowing scheme as ``quote_verifier._windowed_ratio`` (coarse step,
-    capped window count, tail always included) — kept span-returning here so
-    the hot chat-path function stays untouched. ``test_verify_quote`` asserts
-    the two agree on ratios. Inputs must already be normalised.
+    Uses ``quote_verifier._windowed_ratio``'s scan (coarse step, capped window
+    count, tail always included) and additionally tries anchor-derived starts,
+    so the reported window is framed on the match rather than merely near it —
+    which is what makes the character-level diff readable.
+
+    That extra candidate means this can score a window the chat-path function
+    misses, so its ratio is ``>=`` that one, never ``<``. The chat path is
+    deliberately left alone: its numbers are the baseline the faithfulness
+    metrics are tracked against, and improving them silently would break the
+    comparison. Inputs must already be normalised.
     """
     if not needle or not haystack:
         return 0.0, 0, 0
@@ -101,6 +129,7 @@ def windowed_best_span(needle: str, haystack: str) -> tuple[float, int, int]:
     if len(starts) > _MAX_RATIO_WINDOWS:
         stride = len(starts) / _MAX_RATIO_WINDOWS
         starts = [starts[int(i * stride)] for i in range(_MAX_RATIO_WINDOWS)]
+    starts.extend(_anchor_starts(needle, haystack, nlen))
     best, best_start = 0.0, 0
     for s in starts:
         r = SequenceMatcher(None, needle, haystack[s : s + nlen], autojunk=False).ratio()
@@ -109,6 +138,23 @@ def windowed_best_span(needle: str, haystack: str) -> tuple[float, int, int]:
             if best >= 0.999:
                 break
     return best, best_start, best_start + nlen
+
+
+def diff_ops(quote: str, window: str) -> list[DiffOp]:
+    """Character-level differences between the quote and the source window.
+
+    Both inputs are already normalised, and the result stays in that space —
+    see ``DiffOp``. Inputs are bounded by the endpoint's 400-character limit
+    on ``q``, so the op list is short enough to return whole; nothing is
+    truncated, because a silently shortened diff is worse than none.
+    """
+    if not quote or not window:
+        return []
+    ops: list[DiffOp] = []
+    matcher = SequenceMatcher(None, quote, window, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        ops.append(DiffOp(op=tag, quote=quote[i1:i2], source=window[j1:j2]))
+    return ops
 
 
 async def _resolve_cite(
@@ -374,6 +420,7 @@ async def verify_quote(
                 urn=build_urn(meta[0] if meta else None, juan_num),
                 similarity=round(ratio, 4),
                 window_normalised=window,
+                diff=diff_ops(needle, window),
             )
 
     cite_matched: bool | None = None

--- a/backend/tests/test_verify_quote.py
+++ b/backend/tests/test_verify_quote.py
@@ -26,6 +26,7 @@ from app.config import settings
 from app.core.rate_limit import STRICT_PATHS
 from app.services.quote_lookup import (
     QuoteTooShortError,
+    diff_ops,
     verify_quote,
     windowed_best_span,
 )
@@ -130,13 +131,44 @@ DB = FakeDB(
 # ── windowing parity ─────────────────────────────────────────────────────
 
 
-def test_windowed_best_span_agrees_with_quote_verifier_ratio():
+def test_windowed_best_span_never_scores_below_the_chat_path():
+    """The public scan adds anchor-derived window starts the chat-path scan
+    never tries, so it can only find an equal or better window — never a worse
+    one. quote_verifier is deliberately not changed: its numbers are the
+    baseline the faithfulness metrics are tracked against."""
     needle = normalise_for_match(SNOW_VERSE)
     for haystack_raw in (JUAN_13, JUAN_16, JUAN_OTHER, SNOW_VERSE, "短"):
         haystack = normalise_for_match(haystack_raw)
         ratio, start, end = windowed_best_span(needle, haystack)
-        assert ratio == pytest.approx(_windowed_ratio(needle, haystack))
+        assert ratio >= _windowed_ratio(needle, haystack) - 1e-9
+        assert ratio <= 1.0
         assert 0 <= start <= end <= len(haystack)
+
+
+def test_anchoring_frames_the_window_on_the_match():
+    """A long fascicle scanned coarsely lands the window *near* the match; the
+    anchor pass has to land it *on* the match, or the diff is unreadable."""
+    needle = normalise_for_match(SNOW_VERSE)
+    haystack = normalise_for_match("如是我聞" * 400 + SNOW_VERSE + "爾時世尊" * 400)
+    ratio, start, end = windowed_best_span(needle, haystack)
+    assert ratio == pytest.approx(1.0)
+    assert haystack[start:end] == needle
+
+
+def test_diff_ops_name_the_actual_substitution():
+    quote = normalise_for_match("諸行無常，是生滅法，生滅滅已，寂滅最樂")
+    source = normalise_for_match(SNOW_VERSE)
+    ops = diff_ops(quote, source)
+    assert [o.op for o in ops if o.op != "equal"], "a changed character must show up"
+    replaced = [(o.quote, o.source) for o in ops if o.op == "replace"]
+    assert ("最", "为") in replaced          # 最 ← 為, both normalised to 简
+    assert "".join(o.quote for o in ops) == quote
+    assert "".join(o.source for o in ops) == source
+
+
+def test_diff_ops_empty_when_either_side_missing():
+    assert diff_ops("", "abc") == []
+    assert diff_ops("abc", "") == []
 
 
 # ── service verdicts ─────────────────────────────────────────────────────
@@ -187,6 +219,12 @@ async def test_near_miss_reports_closest_window():
     assert out.closest is not None
     assert out.closest.urn == "fojin:cbeta/T0374.13"
     assert "生灭灭已" in out.closest.window_normalised  # normalised (simplified) space
+    # "差异在哪": the verdict must name the changed characters, not merely
+    # score the miss.
+    changed = [(o.op, o.quote, o.source) for o in out.closest.diff if o.op != "equal"]
+    assert changed, "a near miss must come with the differences spelled out"
+    assert "".join(o.quote for o in out.closest.diff) == out.normalised_quote
+    assert "".join(o.source for o in out.closest.diff) == out.closest.window_normalised
 
 
 @pytest.mark.asyncio

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -15,7 +15,7 @@ If you are an agent working with Buddhist material: prefer these tools over reca
 
 ## Verify a quotation
 
-- [GET /api/verify/quote](https://fojin.app/api/verify/quote?q=%E8%AB%B8%E8%A1%8C%E7%84%A1%E5%B8%B8%EF%BC%8C%E6%98%AF%E7%94%9F%E6%BB%85%E6%B3%95%EF%BC%8C%E7%94%9F%E6%BB%85%E6%BB%85%E5%B7%B2%EF%BC%8C%E5%AF%82%E6%BB%85%E7%82%BA%E6%A8%82&cite=T0374): Open-world verbatim check against the whole corpus. Params: `q` (the quotation, ≥12 CJK chars after normalisation), optional `cite` (a CBETA id such as `T0374` or a URN such as `fojin:cbeta/T0374.13`), optional `juan`. Returns `verbatim`, URN-cited `matches`, and — separately — `cite_matched`, so "the quote is real" and "the citation is right" are never conflated. When nothing matches, `closest` gives the nearest passage and its similarity.
+- [GET /api/verify/quote](https://fojin.app/api/verify/quote?q=%E8%AB%B8%E8%A1%8C%E7%84%A1%E5%B8%B8%EF%BC%8C%E6%98%AF%E7%94%9F%E6%BB%85%E6%B3%95%EF%BC%8C%E7%94%9F%E6%BB%85%E6%BB%85%E5%B7%B2%EF%BC%8C%E5%AF%82%E6%BB%85%E7%82%BA%E6%A8%82&cite=T0374): Open-world verbatim check against the whole corpus. Params: `q` (the quotation, ≥12 CJK chars after normalisation), optional `cite` (a CBETA id such as `T0374` or a URN such as `fojin:cbeta/T0374.13`), optional `juan`. Returns `verbatim`, URN-cited `matches`, and — separately — `cite_matched`, so "the quote is real" and "the citation is right" are never conflated. When nothing matches, `closest` gives the nearest passage, its similarity, and a character-level `diff` naming each substitution, so a wrong quotation can be repaired rather than dropped.
 
 ## Read-only HTTP API
 


### PR DESCRIPTION
Third acceptance follow-up, and the one real gap against the original spec: it asked for **「能/不能逐字找到，差异在哪」** and only the first half shipped. A near miss reported a similarity and a source window, and left the caller to eyeball two strings.

## What a near miss now returns

```
=  诸行无常是生灭法生灭灭已寂灭
✗  quote='最'   source='为'
=  乐
✗  quote='也'   source='是'
```

A model can repair the quotation from that. It could not from `similarity: 0.88`.

## Why the diff is in normalised space, and stays there

Mapping an index back to the caller's original string would mean inverting the normaliser, and **it is not invertible**: OpenCC converts 繁→简 phrase-wise, so character counts are not preserved. Any offset map would be a guess dressed up as an answer. The response already exposes `normalised_quote` and `window_normalised`, so a diff between exactly those two is well-defined — and the schema says as much rather than leaving the caller to assume.

## The window had to be anchored first

The scan steps by `len/4` and is then subsampled to 256 windows, so across a 100k-character fascicle it lands every few hundred characters — enough to *score* a miss, far too coarse to *frame* it, and an unframed window makes the diff unreadable. A near miss almost always shares a long verbatim run with its source, so `str.find` of a slice of the quote locates the true offset in O(n).

`quote_verifier` is deliberately left alone: its numbers are the baseline the faithfulness metrics are tracked against, and improving them silently would break that comparison. The parity test therefore asserts **`>=`** instead of `==`, and says why.

## Tests

13 green, including: the anchor must frame the window exactly on a match buried in 3,200 characters of padding; the diff must name `最`→`为`; and both diff sides must reconstruct their inputs exactly (`"".join(quote parts) == normalised_quote`), so a dropped op cannot pass unnoticed. `llms.txt` updated to describe the new field.