### PR TITLE
feat(commentary): 一段经文，历代各家怎么注（MCP 第八个工具）

### DIFF
--- a/backend/app/api/commentary.py
+++ b/backend/app/api/commentary.py
@@ -1,0 +1,131 @@
+"""经注对读端点 —— 一段经文，历代各家怎么注。
+
+汉传注疏里「哪一段疏注哪一句经」这层关系，CBETA 对古代注疏基本没有标记；
+这里提供的是把它抽出来之后的查询结果。数据本身不随本仓库发布（见
+services/commentary 的说明），接口只回答问题。
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import text as sql_text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.commentary import CommentaryHit, CorpusInfo, PassageCommentaries
+from app.services import commentary as svc
+from app.services.urn import absolute_reader_url, build_urn, reader_path
+
+router = APIRouter(prefix="/commentary", tags=["commentary"])
+
+_NO_DATA = (
+    "本节点未安装经注对读数据包，因此没有可回答的经。这不是查询出错。"
+)
+
+
+async def _reader_urls(db: AsyncSession, work_ids: list[str]) -> dict[str, tuple]:
+    """CBETA 书号 → (urn, 绝对阅读链接)。一次查库，查不到的留空。
+
+    注疏多半收在卍续藏、藏外等丛书里，未必都在 fojin 的语料内——查不到就
+    老实留 None，不要拼一个点不开的链接。
+    """
+    want = {w: svc.to_cbeta_id(w) for w in work_ids}
+    ids = [c for c in want.values() if c]
+    if not ids:
+        return {}
+    rows = (
+        await db.execute(
+            sql_text("SELECT cbeta_id, id FROM buddhist_texts WHERE cbeta_id = ANY(:ids)"),
+            {"ids": ids},
+        )
+    ).fetchall()
+    by_cbeta = {r[0]: r[1] for r in rows}
+    out = {}
+    for w, c in want.items():
+        tid = by_cbeta.get(c)
+        out[w] = (
+            build_urn(c) if c else None,
+            absolute_reader_url(reader_path(tid)) if tid else None,
+        )
+    return out
+
+
+@router.get("/corpus", response_model=CorpusInfo)
+async def corpus():
+    """哪些经有经注对读数据。"""
+    sutras = svc.available()
+    return CorpusInfo(
+        sutras=sutras,
+        caveats=[_NO_DATA] if not sutras else [
+            "对齐由程序产出、非人工校订；tier A/B/C 是该部注疏的质检档次。",
+            "覆盖不完整：一部注疏实际所注，约一半没有被对齐出来。列出的注家"
+            "不等于全部注家。",
+        ],
+    )
+
+
+@router.get("/passage", response_model=PassageCommentaries)
+async def passage(
+    q: str = Query(..., min_length=2, max_length=200, description="一句经文"),
+    limit: int = Query(svc.DEFAULT_LIMIT, ge=1, le=svc.MAX_LIMIT),
+    db: AsyncSession = Depends(get_db),
+):
+    """这一段经文，历代各家怎么注。
+
+    先在已装载的经里按内容定位（简繁通吃），再把锚点前后合成一「段」——注家
+    把牒文锚在同一段的不同行上，按单行作答会把一段的注切碎。
+    """
+    pkgs = svc.packages()
+    for pkg in pkgs:
+        line = pkg.find(q)
+        if not line:
+            continue
+        span, hits, total = pkg.passage(line, limit)
+        urls = await _reader_urls(db, [h["work"] for h in hits])
+        base_cbeta = svc.to_cbeta_id(pkg.meta["base_work"])
+        base_urls = await _reader_urls(db, [pkg.meta["base_work"]])
+        return PassageCommentaries(
+            query=q,
+            matched=True,
+            base_work=pkg.meta["base_work"],
+            base_title=pkg.meta.get("base_title"),
+            base_urn=build_urn(base_cbeta) if base_cbeta else None,
+            base_reader_url=base_urls.get(pkg.meta["base_work"], (None, None))[1],
+            passage="".join(pkg.text.get(x, "") for x in span),
+            line_from=span[0] if span else None,
+            line_to=span[-1] if span else None,
+            commentaries=[
+                CommentaryHit(
+                    work=h["work"],
+                    title=(pkg.comms.get(h["work"], {}) or {}).get("title"),
+                    tier=(pkg.comms.get(h["work"], {}) or {}).get("tier"),
+                    note=h["text"],
+                    anchor=h["anchor"],
+                    base_line=h["base_line"],
+                    score=h["score"],
+                    same_as=(pkg.comms.get(h["work"], {}) or {}).get("same_as"),
+                    urn=urls.get(h["work"], (None, None))[0],
+                    reader_url=urls.get(h["work"], (None, None))[1],
+                )
+                for h in hits
+            ],
+            total=total,
+            truncated=total > len(hits),
+            caveats=[
+                f"本段共 {total} 家注，返回前 {len(hits)} 家（按质检档次与置信度排序）。"
+                if total > len(hits) else
+                f"本段共 {total} 家注，已全部返回。",
+                "覆盖不完整：一部注疏实际所注，约一半没有被对齐出来——列出的注家"
+                "不等于全部注过这句的人。",
+                "注文截到该注疏的下一处牒文为止，最多 4 行；要读全文请循 anchor 回原书。",
+                "原文出自 CBETA（CC BY-NC-SA 4.0，非营利使用）。",
+            ],
+        )
+    return PassageCommentaries(
+        query=q,
+        matched=False,
+        available_sutras=svc.available(),
+        caveats=[_NO_DATA] if not pkgs else [
+            "已装载的经里没有这一句 —— 见 available_sutras。注意区分两件事："
+            "「这部经还没有经注数据」不等于「这句话没人注过」。",
+            "定位是逐字的（简繁通吃，忽略标点），不做模糊匹配；引文有异文就会找不到。",
+        ],
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -174,6 +174,7 @@ class Settings(BaseSettings):
     # ES phrase search plus full-fascicle source reads — same cost class as
     # /api/search/content (30/min).
     rate_limit_verify_quote: int = 30
+    rate_limit_commentary: int = 60
     # Chat (AI Q&A) — the most expensive endpoint: RAG retrieval always uses the
     # platform embedding key (even for BYOK users) plus a long streaming LLM
     # call and a DB pool slot. 30/min/IP is generous for real use (a stream

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -28,6 +28,9 @@ STRICT_PATHS: dict[str, int] = {
     # Open-world quote verification — ES phrase search + fascicle reads per
     # call; the hosted MCP endpoint fronts it with its own per-client window.
     "/api/verify/quote": settings.rate_limit_verify_quote,
+    # 经注对读：包常驻内存，单次查询只是子串定位——比核验便宜，
+    # 但仍是全文检索，别落进 200/min 的默认桶。
+    "/api/commentary/passage": settings.rate_limit_commentary,
     # Chat / AI Q&A — the most expensive endpoint (platform-key RAG embedding +
     # streaming LLM + a held DB pool slot), previously left at the loose
     # default. Exact-path map (STRICT_PATHS.get(path)), so both routes are

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,6 +65,7 @@ from app.api import (
     bookmarks,
     chat,
     citations,
+    commentary,
     dictionary,
     exports,
     feed,
@@ -494,6 +495,9 @@ app.include_router(urn.router, prefix="/api")
 
 # Quote verification — open-world verbatim check (AI-facing)
 app.include_router(verification.router, prefix="/api")
+
+# Commentary lookup — 一段经文，历代各家怎么注
+app.include_router(commentary.router, prefix="/api")
 
 # Phase 4 routers
 # Off by default — see settings.enable_open_data_exports.

--- a/backend/app/schemas/commentary.py
+++ b/backend/app/schemas/commentary.py
@@ -1,0 +1,54 @@
+"""Schemas for /api/commentary — 一段经文，历代各家怎么注。
+
+Agent-facing like the verification schemas: every claim is either resolvable
+(URNs, reader URLs) or explicitly bounded (``truncated``, ``caveats``). The
+corpus is known to be incomplete — roughly half of what a commentator actually
+wrote is not aligned — so a response that reads as exhaustive would be a lie.
+"""
+
+from pydantic import BaseModel
+
+__all__ = ["CommentaryHit", "CorpusInfo", "PassageCommentaries"]
+
+
+class CommentaryHit(BaseModel):
+    work: str
+    title: str | None = None
+    # A/B/C —— 该部注疏的质检档次（留出法准确率 ≥95% / 85–95% / 70–85%）。
+    tier: str | None = None
+    note: str
+    anchor: str
+    base_line: str
+    score: float
+    # 同一部书的另一版本（牒句分布几乎重合），例如玄宗御注收在两部藏经里。
+    # 只标不合并——藏掉一部 CBETA 书对要按版本查证的人更糟。
+    same_as: str | None = None
+    urn: str | None = None
+    reader_url: str | None = None
+
+
+class PassageCommentaries(BaseModel):
+    query: str
+    matched: bool
+    base_work: str | None = None
+    base_title: str | None = None
+    base_urn: str | None = None
+    base_reader_url: str | None = None
+    passage: str | None = None
+    line_from: str | None = None
+    line_to: str | None = None
+    commentaries: list[CommentaryHit] = []
+    # 本段实际有几家 vs 返回了几家。截断时必须看得出来。
+    total: int = 0
+    truncated: bool = False
+    # 没命中时一并给出可查的经 —— 覆盖面目前很窄，不说清楚调用方只会反复试错，
+    # 而且会把「这部经没数据」误读成「这句话没人注过」。
+    available_sutras: list[dict] = []
+    caveats: list[str] = []
+
+
+class CorpusInfo(BaseModel):
+    """哪些经有经注对读数据 —— 问之前先知道能问什么。"""
+
+    sutras: list[dict] = []
+    caveats: list[str] = []

--- a/backend/app/services/commentary.py
+++ b/backend/app/services/commentary.py
@@ -1,0 +1,140 @@
+"""经注对读：一段经文，历代各家怎么注。
+
+数据是 hanzhu-align 产出的「经注对齐」——把「哪一段疏注哪一句经」从汉传注疏
+里抽出来。CBETA 只为极少数书做了机器可解析的引经标记，古代注疏里基本是 0；
+那份数据把这件事推广开，其中一半（无标记书的自主对齐）此前无人做过。
+
+**数据不在本仓库。** 本仓库是公开的，而对齐数据集尚未公开，所以包以带外方式
+部署到 ``/data/commentary/*.json``（该目录已在 .gitignore 内且挂进容器）。没有
+包时本模块静默降级为「无数据」，接口照常返回 200 并说明原因——线上少一个功能
+好过整个后端起不来。
+
+包里自带经文与注文（CBETA，CC BY-NC-SA 4.0，非营利使用并署名），所以运行时
+不需要另一份 CBETA 语料。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+
+from app.services.quote_verifier import normalise_for_match
+
+logger = logging.getLogger(__name__)
+
+PACKAGE_DIR = Path("/data/commentary")
+
+# 每次最多返回几家。段级中位 13 家、最多 50 家，全吐给模型既挤占上下文又没人
+# 读得完；超出时如实标 truncated，绝不假装这就是全部。
+DEFAULT_LIMIT = 8
+MAX_LIMIT = 50
+
+# CBETA 书号 → fojin 的 cbeta_id：T08n0235 → T0235、X24n0461 → X0461。
+_WORK_ID = re.compile(r"^([A-Z]+)\d*n(\w+)$")
+
+
+def to_cbeta_id(work_id: str) -> str | None:
+    m = _WORK_ID.match(work_id or "")
+    return f"{m.group(1)}{m.group(2)}" if m else None
+
+
+@dataclass
+class Package:
+    """一部经的经注对读包。文本在内存里常驻——单包约 2 MB。"""
+
+    meta: dict
+    lines: list[dict]
+    comms: dict
+    by_line: dict = field(default_factory=dict)
+    ids: list[str] = field(default_factory=list)
+    pos: dict = field(default_factory=dict)
+    text: dict = field(default_factory=dict)
+    _flat: str = ""
+    _owner: list[str] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, path: Path) -> Package:
+        d = json.loads(path.read_text(encoding="utf-8"))
+        pkg = cls(meta=d["meta"], lines=d["base_lines"], comms=d["commentaries"])
+        pkg.ids = [ln["id"] for ln in pkg.lines]
+        pkg.pos = {x: i for i, x in enumerate(pkg.ids)}
+        pkg.text = {ln["id"]: ln["text"] for ln in pkg.lines}
+        pkg.by_line = {}
+        for n in d["notes"]:
+            pkg.by_line.setdefault(n["base_line"], []).append(n)
+        # 全经拼接 + 每个字属于哪一行。CBETA 一行才十来个字，稍长的句子必然
+        # 跨行，逐行匹配是找不到的。归一化用 quote_verifier 那一份 —— 全站
+        # 「同一句经文」只能有一个定义，顺带让简体查询也能命中繁体原文。
+        parts = []
+        for ln in pkg.lines:
+            t = normalise_for_match(ln["text"])
+            parts.append(t)
+            pkg._owner.extend([ln["id"]] * len(t))
+        pkg._flat = "".join(parts)
+        return pkg
+
+    def find(self, quote: str) -> str | None:
+        """含该句的第一行行号。"""
+        needle = normalise_for_match(quote)
+        if not needle:
+            return None
+        p = self._flat.find(needle)
+        return self._owner[p] if p >= 0 else None
+
+    def passage(self, center: str, limit: int) -> tuple[list[str], list[dict], int]:
+        """(段内各行, 去重后的各家注, 本段总家数)。
+
+        同一部注疏常在段内多行都有锚点（牒文分几处引），按行列会让它重复出现，
+        把「有几家注」答成「有几条对齐」。按注疏去重，保留置信度最高的锚点。
+        """
+        i = self.pos.get(center)
+        if i is None:
+            return [], [], 0
+        r = self.meta.get("passage_radius", 3)
+        span = self.ids[max(0, i - r): i + r + 1]
+        best: dict[str, dict] = {}
+        for bl in span:
+            for n in self.by_line.get(bl, ()):
+                if n["work"] not in best or n["score"] > best[n["work"]]["score"]:
+                    best[n["work"]] = n
+        order = {"A": 0, "B": 1, "C": 2}
+        ranked = sorted(
+            best.values(),
+            key=lambda n: (order.get(self.comms.get(n["work"], {}).get("tier"), 9), -n["score"]),
+        )
+        return span, ranked[:limit], len(ranked)
+
+
+@lru_cache(maxsize=1)
+def packages() -> list[Package]:
+    """加载 /data/commentary 下的全部包；缺目录或坏文件都不抛，只记日志。"""
+    if not PACKAGE_DIR.is_dir():
+        logger.info("commentary: no package dir at %s — feature idle", PACKAGE_DIR)
+        return []
+    out = []
+    for p in sorted(PACKAGE_DIR.glob("*.json")):
+        try:
+            out.append(Package.load(p))
+        except Exception:
+            logger.warning("commentary: failed to load %s", p, exc_info=True)
+    logger.info("commentary: loaded %d package(s)", len(out))
+    return out
+
+
+def available() -> list[dict]:
+    return [
+        {
+            "base_work": p.meta["base_work"],
+            "base_title": p.meta.get("base_title"),
+            "commentary_count": p.meta.get("commentary_count"),
+            "line_coverage_pct": (
+                p.meta["lines_with_notes"] * 100 // p.meta["line_count"]
+                if p.meta.get("line_count") else None
+            ),
+        }
+        for p in packages()
+    ]

--- a/backend/tests/test_commentary.py
+++ b/backend/tests/test_commentary.py
@@ -1,0 +1,150 @@
+"""经注对读服务。
+
+数据包不随仓库发布，所以这里用合成包测行为，另外专门守住「没有包时会怎样」——
+线上少一个功能好过整个后端起不来。
+"""
+
+import json
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+if "elasticsearch" not in sys.modules:
+    _es = MagicMock()
+    _es.AsyncElasticsearch = MagicMock
+    sys.modules["elasticsearch"] = _es
+
+from app.services import commentary as svc
+
+# 繁体原文，逐行拆开——CBETA 一行才十来个字，所以查询必然跨行。
+LINES = [
+    {"id": "T08n0235_p0749c19", "text": "薩莊嚴佛土不？」「不也，世尊！"},
+    {"id": "T08n0235_p0749c20", "text": "是故須菩提，諸菩薩摩訶薩應如是生清淨心，"},
+    {"id": "T08n0235_p0749c21", "text": "不應住色生心，不應住聲、香、味、"},
+    {"id": "T08n0235_p0749c22", "text": "觸、法生心，應無所住而生其心。"},
+    {"id": "T08n0235_p0749c23", "text": "「須菩提！譬如有人，身如須彌山王，"},
+]
+
+
+def _pkg(tmp_path, notes):
+    data = {
+        "meta": {
+            "schema": 1, "base_work": "T08n0235", "base_title": "金剛般若波羅蜜經",
+            "commentary_count": 3, "note_count": len(notes), "line_count": len(LINES),
+            "lines_with_notes": 3, "passage_radius": 3,
+        },
+        "base_lines": LINES,
+        "commentaries": {
+            "F03n0100": {"title": "御注並序", "tier": "A", "same_as": None},
+            "ZW10n0081": {"title": "御注金剛般若經", "tier": "A", "same_as": "F03n0100"},
+            "X24n0461": {"title": "金剛經註", "tier": "C", "same_as": None},
+        },
+        "notes": notes,
+    }
+    d = tmp_path / "commentary"
+    d.mkdir(exist_ok=True)
+    (d / "diamond.json").write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    return d
+
+
+def _note(work, base_line, anchor, score, text):
+    return {"work": work, "base_line": base_line, "anchor": anchor,
+            "score": score, "text": text}
+
+
+@pytest.fixture()
+def loaded(tmp_path, monkeypatch):
+    notes = [
+        _note("F03n0100", "T08n0235_p0749c21", "F03n0100_p0334b10", 1.0, "知色相空"),
+        # 同一部书在段内第二处锚点，置信更低——去重后应只留上面那条
+        _note("F03n0100", "T08n0235_p0749c22", "F03n0100_p0334b14", 0.8, "重复锚点"),
+        _note("ZW10n0081", "T08n0235_p0749c21", "ZW10n0081_p0073a07", 1.0, "另一版本"),
+        _note("X24n0461", "T08n0235_p0749c22", "X24n0461_p0546b12", 1.0, "此修行人"),
+    ]
+    d = _pkg(tmp_path, notes)
+    monkeypatch.setattr(svc, "PACKAGE_DIR", d)
+    svc.packages.cache_clear()
+    yield
+    svc.packages.cache_clear()
+
+
+def test_missing_package_dir_is_not_an_error(tmp_path, monkeypatch):
+    """没装数据包时必须静默降级——后端不能因为少一份可选数据起不来。"""
+    monkeypatch.setattr(svc, "PACKAGE_DIR", tmp_path / "nope")
+    svc.packages.cache_clear()
+    assert svc.packages() == []
+    assert svc.available() == []
+    svc.packages.cache_clear()
+
+
+def test_corrupt_package_is_skipped_not_raised(tmp_path, monkeypatch):
+    d = tmp_path / "commentary"
+    d.mkdir()
+    (d / "broken.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(svc, "PACKAGE_DIR", d)
+    svc.packages.cache_clear()
+    assert svc.packages() == []
+    svc.packages.cache_clear()
+
+
+def test_finds_a_quote_that_spans_lines(loaded):
+    """CBETA 一行十来个字，任何完整句子都跨行；逐行匹配一定找不到。"""
+    pkg = svc.packages()[0]
+    assert pkg.find("應無所住而生其心") == "T08n0235_p0749c22"
+
+
+def test_simplified_query_matches_traditional_source(loaded):
+    """读者按简体输入，语料是繁体。归一化用的是 quote_verifier 那一份，
+    全站「同一句经文」只能有一个定义。"""
+    pkg = svc.packages()[0]
+    assert pkg.find("应无所住而生其心") == "T08n0235_p0749c22"
+
+
+def test_passage_merges_neighbouring_lines(loaded):
+    """注家把牒文锚在同一段的不同行上；只看锚点那一行会把一段的注切碎。"""
+    pkg = svc.packages()[0]
+    span, hits, total = pkg.passage("T08n0235_p0749c22", 10)
+    assert len(span) >= 4
+    # c21 上的两家 + c22 上的一家，跨行合并后都在
+    assert {h["work"] for h in hits} == {"F03n0100", "ZW10n0081", "X24n0461"}
+    assert total == 3
+
+
+def test_one_entry_per_commentary_keeping_best_anchor(loaded):
+    """同一部书段内多处锚点只算一家，否则「有几家注」会被答成「有几条对齐」。"""
+    pkg = svc.packages()[0]
+    _, hits, _ = pkg.passage("T08n0235_p0749c22", 10)
+    f = [h for h in hits if h["work"] == "F03n0100"]
+    assert len(f) == 1
+    assert f[0]["score"] == 1.0            # 留置信度高的那个锚点
+    assert f[0]["text"] == "知色相空"
+
+
+def test_limit_reports_the_true_total(loaded):
+    """截断时必须能看出被截断了——列出三家不能让人以为只有三家。"""
+    pkg = svc.packages()[0]
+    _, hits, total = pkg.passage("T08n0235_p0749c22", 2)
+    assert len(hits) == 2
+    assert total == 3
+
+
+def test_tier_orders_before_score(loaded):
+    """A 档在前：质检档次比单条置信度更能说明这部书可不可信。"""
+    pkg = svc.packages()[0]
+    _, hits, _ = pkg.passage("T08n0235_p0749c22", 10)
+    assert hits[-1]["work"] == "X24n0461"   # 唯一的 C 档排最后
+
+
+def test_unknown_quote_returns_nothing_rather_than_guessing(loaded):
+    pkg = svc.packages()[0]
+    assert pkg.find("此句不在本经之中") is None
+
+
+@pytest.mark.parametrize(
+    "work,expected",
+    [("T08n0235", "T0235"), ("X24n0461", "X0461"), ("ZW10n0081", "ZW0081"),
+     ("F03n0100", "F0100"), ("garbage", None)],
+)
+def test_cbeta_id_conversion(work, expected):
+    assert svc.to_cbeta_id(work) == expected

--- a/mcp-server/fojin_mcp/__init__.py
+++ b/mcp-server/fojin_mcp/__init__.py
@@ -1,4 +1,4 @@
 """fojin MCP server package — cross-canon Buddhist corpus tools over stdio or
 streamable HTTP (the hosted endpoint at mcp.fojin.ai)."""
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/mcp-server/fojin_mcp/client.py
+++ b/mcp-server/fojin_mcp/client.py
@@ -210,6 +210,15 @@ class FojinClient:
         # double-encode it into a literal "%23" on the server side.
         return await self._get("/urn/resolve", {"urn": urn})
 
+    async def commentaries(self, quote: str, limit: int = 8) -> dict[str, Any]:
+        """这一段经文，历代各家怎么注。
+
+        服务端返回的结构已经是给 agent 看的（注家/档次/注文/URN/截断标志/
+        覆盖声明），原样透传。"""
+        return await self._get(
+            "/commentary/passage", {"q": quote, "limit": _clamp(limit, 1, 50)}
+        )
+
     async def verify_quote(
         self, quote: str, *, cite: str | None = None, juan: int | None = None
     ) -> dict[str, Any]:

--- a/mcp-server/fojin_mcp/server.py
+++ b/mcp-server/fojin_mcp/server.py
@@ -186,6 +186,27 @@ async def verify_quote(quote: str, cite: str | None = None, juan: int | None = N
     return await _call("verify_quote", lambda c: c.verify_quote(quote, cite=cite, juan=juan))
 
 
+@mcp.tool()
+async def commentaries(quote: str, limit: int = 8) -> dict:
+    """What the historical commentators said about a passage of Buddhist scripture.
+
+    Give a line of a sūtra and get back the classical commentaries that gloss
+    it — each with the commentator's own words, the work it comes from, a
+    quality tier, and a resolvable citation. This is the layer no other tool
+    exposes for the Chinese canon: CBETA marks up almost none of it, and the
+    alignment behind this was derived text by text.
+
+    Two things to read carefully rather than skim. `total` is how many
+    commentators the passage actually has — `truncated` says the list you got
+    is a sample. And coverage is partial: roughly half of what a commentator
+    wrote is not aligned, so an absent commentator means "not in the data",
+    never "he said nothing". When nothing matches, `available_sutras` tells
+    you which sūtras have data at all — do not read a miss as silence from the
+    tradition.
+    """
+    return await _call("commentaries", lambda c: c.commentaries(quote, limit=limit))
+
+
 @mcp.custom_route("/healthz", methods=["GET"])
 async def healthz(_request: Request) -> JSONResponse:
     """Liveness for the hosted endpoint (nginx/compose healthchecks)."""

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fojin-mcp"
-version = "0.3.2"
+version = "0.4.0"
 description = "MCP server exposing fojin's verified cross-canon Buddhist corpus (cited, URN-addressable passages) to AI research tools."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "app.fojin/fojin-mcp",
   "title": "fojin — Buddhist Canon Tools",
   "description": "Buddhist canon tools: search, passages, cross-canon parallels, dictionaries — all URN-cited.",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "websiteUrl": "https://fojin.app",
   "repository": {
     "url": "https://github.com/xr843/fojin",

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -248,6 +248,29 @@ async def test_verify_quote_params_and_passthrough():
 
 
 @pytest.mark.asyncio
+async def test_commentaries_clamps_limit_and_passes_through():
+    """服务端返回的结构已经是给 agent 看的，客户端不该再塑形——尤其是
+    truncated / available_sutras 这类「说明自己不完整」的字段，丢一个都会
+    让调用方把样本当全集。"""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={
+            "matched": True, "total": 50, "truncated": True,
+            "commentaries": [{"work": "F03n0100", "tier": "A"}],
+            "available_sutras": [], "caveats": ["…"]})
+
+    async with _client_with(handler) as c:
+        out = await c.commentaries("應無所住而生其心", limit=999)
+
+    assert seen["path"] == "/api/commentary/passage"
+    assert seen["params"]["limit"] == "50"          # 999 → 上限 50
+    assert out["truncated"] is True and out["total"] == 50
+
+
+@pytest.mark.asyncio
 async def test_cbeta_lookup_cached_across_calls():
     """text_id→cbeta_id is static; a long-lived client must not re-fetch it on
     every get_parallels (the hosted endpoint shares one client process-wide)."""

--- a/mcp-server/tests/test_http.py
+++ b/mcp-server/tests/test_http.py
@@ -72,6 +72,7 @@ def test_tools_list_over_streamable_http():
     assert tools == {
         "search_corpus", "read_passage", "get_parallels",
         "lookup_dictionary", "lookup_entity", "resolve_urn", "verify_quote",
+        "commentaries",
     }
 
 


### PR DESCRIPTION
汉传注疏里「哪一段疏注哪一句经」这层关系，**CBETA 对古代注疏基本没有标记**。这个 PR 把已经做出来的对齐接出来：给一句经文，返回历代注家各自的原话、所属书、质检档次与可点开的引证。

首个数据集是**《金刚经》：52 家注、5,683 条**。段级覆盖 98%，98% 的位置有 10 家以上——随便翻到哪一句都有十几家历代注解，是完整覆盖而不是抽样。

```
「應無所住而生其心」
  [A] F03n0100  金剛般若波羅蜜經（御注並序）   ← 唐玄宗御注
  [A] T33n1700  金剛般若經贊述
  [C] X24n0461  金剛經註
  … 本段共 50 家
```

## 数据不进本仓库 ⚠️

本仓库**公开**，而对齐数据集尚未公开。所以包带外部署到 `/data/commentary/`（已在 `.gitignore` 内、已挂进容器），代码公开、数据私有——与 `verify_quote` 同一个模式：服务提供答案，不发布数据集。

没有包时**静默降级**为「无数据」，接口照常 200 并说明原因。线上少一个功能，好过后端因为缺一份可选数据起不来（有测试守这条）。

包里自带经文与注文（CBETA CC BY-NC-SA 4.0，非营利使用并署名），所以运行时不需要另一份 2.6GB 的 CBETA 语料。

## 几处刻意的设计——都是为了不让调用方把样本当全集

- **`total` 与 `truncated` 分开报**：本段实际几家 vs 返回了几家
- **没命中时一并返回 `available_sutras`**。覆盖面目前只有一部经；不说清楚，调用方会把「这部经还没有数据」误读成**「这句话没人注过」**——对一个学术工具，这是最坏的一种错觉
- **`caveats` 明写覆盖不完整**：一部注疏实际所注，约一半没有被对齐出来（吉藏那部实测召回 ~48%）
- **`same_as` 只标不合并**：藏掉一部 CBETA 书，对要按版本查证的人比重复更糟
- **定位复用 `quote_verifier` 的归一化**：全站「同一句经文」只能有一个定义，顺带让简体查询命中繁体原文

## 测试

后端 14 个新测试（含**没有包 / 包损坏时不得抛异常**、跨行检索、简体命中繁体、段内同书去重留最佳锚点、截断报真实总数、A 档排序优先），MCP 40 个全绿，ruff 干净。

**fojin-mcp 0.4.0** —— 工具说明是模型的使用手册，所以把 `total`/`truncated` 的读法和「缺席不等于没注过」都写进了描述。

## 合并后

1. scp 数据包到 `/home/admin/fojin/data/commentary/`
2. 后端 webhook 自动部署；`docker compose up -d --build mcp`
3. tag `mcp-v0.4.0` → PyPI，registry 更新