### PR TITLE
feat(commentary): 让注疏链接落到卷和行，而不是丢在整本书门口

### DIFF
--- a/backend/app/api/commentary.py
+++ b/backend/app/api/commentary.py
@@ -83,7 +83,7 @@ async def _locate(
     }
     located: dict[tuple[int, str], tuple[int, str]] = {}
     if pairs:
-        tids, refs = zip(*sorted(pairs))
+        tids, refs = zip(*sorted(pairs), strict=True)
         for tid, ref, juan, near in await db.execute(
             _JUAN_OF_LINE, {"tids": list(tids), "refs": list(refs)}
         ):

--- a/backend/app/api/commentary.py
+++ b/backend/app/api/commentary.py
@@ -21,29 +21,90 @@ _NO_DATA = (
 )
 
 
-async def _reader_urls(db: AsyncSession, work_ids: list[str]) -> dict[str, tuple]:
-    """CBETA 书号 → (urn, 绝对阅读链接)。一次查库，查不到的留空。
-
-    注疏多半收在卍续藏、藏外等丛书里，未必都在 fojin 的语料内——查不到就
-    老实留 None，不要拼一个点不开的链接。
+# 行标 → 卷号。不要求精确命中，取同一页上最靠近的那条索引行。
+#
+# 为什么不精确匹配：2026-08-12 拿本包 4,230 条注疏锚点对生产索引量过一次，
+# 精确命中只有 6.6%，而且是双峰的——大正藏那几部 99%，卍續藏几乎全 0%。
+# 原因是 text_line_anchors 里 X 部的 <lb> 混着两个版本存（同一卷里 0448–0455
+# 与 0523–0537 两套页码按字符位置交错），行的切法和对齐时用的那份不是同一套。
+# 只认精确匹配的话，这个功能对 93% 的注疏等于没做。
+#
+# 限定同页，是为了不跨版本乱跳：一行的卷次必定等于同页另一行的卷次，而隔了
+# 几十页的「最近邻」很可能是另一个版本的页码，那种猜法会把人送到错的卷。
+# 同页找不到就退回书级——宁可少给，不给错的。
+_JUAN_OF_LINE = sql_text(
     """
-    want = {w: svc.to_cbeta_id(w) for w in work_ids}
+    SELECT DISTINCT ON (w.tid, w.ref)
+           w.tid, w.ref, a.juan_num, a.line_ref
+      FROM unnest(CAST(:tids AS int[]), CAST(:refs AS text[])) AS w(tid, ref)
+      JOIN text_line_anchors a
+        ON a.text_id = w.tid
+       AND left(a.line_ref, 4) = left(w.ref, 4)
+     ORDER BY w.tid, w.ref,
+              (a.line_ref > w.ref),                                   -- 先取不越过目标的
+              CASE WHEN a.line_ref <= w.ref THEN a.line_ref END DESC,  -- 其中最靠后的
+              a.line_ref ASC                                           -- 都在目标之后就取最早的
+    """
+)
+
+
+async def _locate(
+    db: AsyncSession, targets: list[tuple[str, str | None]]
+) -> dict[tuple[str, str | None], tuple[str | None, str | None]]:
+    """(CBETA 书号, 行标) → (urn, 绝对阅读链接)，能落到行就落到行。
+
+    两次查库，与结果条数无关：先把书号换成 text_id，再一次把所有行标换成卷号。
+
+    退化是分层的，每层都比上一层保守：同页找不到索引行就只给卷级，书不在语料
+    里就连链接都不给。注疏多半收在卍续藏、藏外等丛书里，未必都在 fojin 的语料
+    内——查不到就老实留 None，不要拼一个点不开的链接。
+    """
+    if not targets:
+        return {}
+
+    want = {w: svc.to_cbeta_id(w) for w, _ in targets}
     ids = [c for c in want.values() if c]
     if not ids:
-        return {}
+        return {t: (None, None) for t in targets}
+
     rows = (
         await db.execute(
             sql_text("SELECT cbeta_id, id FROM buddhist_texts WHERE cbeta_id = ANY(:ids)"),
             {"ids": ids},
         )
     ).fetchall()
-    by_cbeta = {r[0]: r[1] for r in rows}
-    out = {}
-    for w, c in want.items():
-        tid = by_cbeta.get(c)
-        out[w] = (
-            build_urn(c) if c else None,
-            absolute_reader_url(reader_path(tid)) if tid else None,
+    text_ids = {r[0]: r[1] for r in rows}
+
+    # 行标 → (卷号, 该卷里最靠近的索引行)，一次问完。
+    pairs = {
+        (text_ids[want[w]], ref)
+        for w, anchor in targets
+        if want.get(w) in text_ids and (ref := svc.line_ref(anchor))
+    }
+    located: dict[tuple[int, str], tuple[int, str]] = {}
+    if pairs:
+        tids, refs = zip(*sorted(pairs))
+        for tid, ref, juan, near in await db.execute(
+            _JUAN_OF_LINE, {"tids": list(tids), "refs": list(refs)}
+        ):
+            located[(tid, ref)] = (juan, near)
+
+    out: dict[tuple[str, str | None], tuple[str | None, str | None]] = {}
+    for work, anchor in targets:
+        cbeta = want.get(work)
+        if not cbeta:
+            out[(work, anchor)] = (None, None)
+            continue
+        tid = text_ids.get(cbeta)
+        ref = svc.line_ref(anchor)
+        juan, near = located.get((tid, ref), (None, None)) if tid and ref else (None, None)
+        # 滚动落点用索引里真有的那一行，不用 anchor 本身——指一行页面上不存在
+        # 的行，阅读器什么也不会做，看起来就像链接坏了。
+        # URN 里的锚点则跟规范走，带 p。
+        at = f"p{near}" if near else None
+        out[(work, anchor)] = (
+            build_urn(cbeta, juan, at),
+            absolute_reader_url(reader_path(tid, juan, at)) if tid else None,
         )
     return out
 
@@ -79,16 +140,20 @@ async def passage(
         if not line:
             continue
         span, hits, total = pkg.passage(line, limit)
-        urls = await _reader_urls(db, [h["work"] for h in hits])
-        base_cbeta = svc.to_cbeta_id(pkg.meta["base_work"])
-        base_urls = await _reader_urls(db, [pkg.meta["base_work"]])
+        base_work = pkg.meta["base_work"]
+        # 经文侧锚到这一段的第一行——读者点过去，落在他问的那句上。
+        base_key = (base_work, span[0] if span else None)
+        located = await _locate(
+            db, [(h["work"], h["anchor"]) for h in hits] + [base_key]
+        )
+        base_urn, base_url = located.get(base_key, (None, None))
         return PassageCommentaries(
             query=q,
             matched=True,
-            base_work=pkg.meta["base_work"],
+            base_work=base_work,
             base_title=pkg.meta.get("base_title"),
-            base_urn=build_urn(base_cbeta) if base_cbeta else None,
-            base_reader_url=base_urls.get(pkg.meta["base_work"], (None, None))[1],
+            base_urn=base_urn,
+            base_reader_url=base_url,
             passage="".join(pkg.text.get(x, "") for x in span),
             line_from=span[0] if span else None,
             line_to=span[-1] if span else None,
@@ -102,8 +167,8 @@ async def passage(
                     base_line=h["base_line"],
                     score=h["score"],
                     same_as=(pkg.comms.get(h["work"], {}) or {}).get("same_as"),
-                    urn=urls.get(h["work"], (None, None))[0],
-                    reader_url=urls.get(h["work"], (None, None))[1],
+                    urn=located.get((h["work"], h["anchor"]), (None, None))[0],
+                    reader_url=located.get((h["work"], h["anchor"]), (None, None))[1],
                 )
                 for h in hits
             ],
@@ -115,7 +180,10 @@ async def passage(
                 f"本段共 {total} 家注，已全部返回。",
                 "覆盖不完整：一部注疏实际所注，约一半没有被对齐出来——列出的注家"
                 "不等于全部注过这句的人。",
-                "注文截到该注疏的下一处牒文为止，最多 4 行；要读全文请循 anchor 回原书。",
+                "注文截到该注疏的下一处牒文为止，最多 4 行；要读全文请点 reader_url，"
+                "它落在这条注所在的那一卷、同页最近的一行上（卍续藏诸书的行号"
+                "索引与对齐所用的不是同一套，落点可能差一两行）。要引用请用 anchor，"
+                "那是这条注真正的出处。",
                 "原文出自 CBETA（CC BY-NC-SA 4.0，非营利使用）。",
             ],
         )

--- a/backend/app/services/commentary.py
+++ b/backend/app/services/commentary.py
@@ -42,6 +42,21 @@ def to_cbeta_id(work_id: str) -> str | None:
     return f"{m.group(1)}{m.group(2)}" if m else None
 
 
+# 行标 X24n0456_p0455c03 → 0455c03，也就是 text_line_anchors.line_ref 的写法。
+# 锚点本身带书号前缀（一段里的注文来自不同的书），而库里按 text_id 分表存，
+# 前缀是冗余的。
+_LINE_REF = re.compile(r"_p([0-9a-z]+)$")
+
+
+def line_ref(anchor: str | None) -> str | None:
+    """CBETA 行标里的页-栏-行部分，用于反查它落在第几卷。
+
+    对不上就返回 None：宁可退回书级链接，也不要拼一个跳不到的锚点。
+    """
+    m = _LINE_REF.search(anchor or "")
+    return m.group(1) if m else None
+
+
 @dataclass
 class Package:
     """一部经的经注对读包。文本在内存里常驻——单包约 2 MB。"""

--- a/backend/app/services/urn.py
+++ b/backend/app/services/urn.py
@@ -100,10 +100,10 @@ def build_urn(
     "no URN" silently rather than break answer assembly.
 
     ``juan``/``anchor`` are emitted only when given; a work-level URN is valid
-    and resolves to the text detail page. Anchors are currently opaque (CBETA
-    line numbers aren't indexed yet — see the module docstring), so callers pass
-    juan-level URNs; the parameter exists so line-level anchoring is a
-    non-breaking add later.
+    and resolves to the text detail page. Anchors stay opaque to this function —
+    it never parses one — but they are no longer hypothetical: ``text_line_anchors``
+    indexes every CBETA ``<lb>`` marker, and the commentary endpoint resolves a
+    line marker to its juan so it can emit ``fojin:cbeta/X0456.3#p0455c03``.
     """
     if not isinstance(cbeta_id, str) or not cbeta_id:
         return None

--- a/backend/tests/test_commentary.py
+++ b/backend/tests/test_commentary.py
@@ -5,6 +5,7 @@
 """
 
 import json
+import os
 import sys
 from unittest.mock import MagicMock
 
@@ -148,3 +149,152 @@ def test_unknown_quote_returns_nothing_rather_than_guessing(loaded):
 )
 def test_cbeta_id_conversion(work, expected):
     assert svc.to_cbeta_id(work) == expected
+
+
+@pytest.mark.parametrize(
+    "anchor,expected",
+    [
+        ("X24n0456_p0455c03", "0455c03"),
+        ("T08n0235_p0749c19", "0749c19"),
+        ("ZW10n0081_p0123a01", "0123a01"),
+        # 行标缺失或不成形——退回书级，别拼一个跳不到的锚点。
+        (None, None),
+        ("", None),
+        ("T08n0235", None),
+        ("T08n0235_p", None),
+    ],
+)
+def test_line_ref_extraction(anchor, expected):
+    assert svc.line_ref(anchor) == expected
+
+
+# --- 链接落到行 -------------------------------------------------------------
+#
+# 真实数据上的形状已经用生产库验过（见 api/commentary 里 _JUAN_OF_LINE 的注释）：
+# 大正藏精确命中，卍续藏落在同页邻行，跨卷的 0467a11 正确解到第 3 卷。下面守的
+# 是把查询结果拼成链接这一段，以及三档退化各自退到哪。
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeDB:
+    """按调用顺序吐预设结果：第一次是书号→text_id，第二次是行标→卷。"""
+
+    def __init__(self, *results):
+        self._results = list(results)
+
+    async def execute(self, _stmt, _params=None):
+        return _Rows(self._results.pop(0) if self._results else [])
+
+
+@pytest.mark.asyncio
+async def test_link_lands_on_the_line_when_the_anchor_resolves():
+    from app.api.commentary import _locate
+
+    db = _FakeDB([("X0456", 12400)], [(12400, "0455c03", 1, "0455c02")])
+    got = await _locate(db, [("X24n0456", "X24n0456_p0455c03")])
+    urn, url = got[("X24n0456", "X24n0456_p0455c03")]
+    # 滚动落点是索引里真有的那一行，不是 anchor 本身——指向页面上不存在的行，
+    # 阅读器什么也不做，看起来就像链接坏了。
+    assert url == "https://fojin.app/reader?text=12400&juan=1&anchor=p0455c02"
+    assert urn == "fojin:cbeta/X0456.1#p0455c02"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_the_book_when_the_page_has_no_indexed_line():
+    from app.api.commentary import _locate
+
+    db = _FakeDB([("X0456", 12400)], [])  # 同页一行都没索引到
+    got = await _locate(db, [("X24n0456", "X24n0456_p0455c03")])
+    urn, url = got[("X24n0456", "X24n0456_p0455c03")]
+    assert url == "https://fojin.app/texts/12400"
+    assert urn == "fojin:cbeta/X0456"
+
+
+@pytest.mark.asyncio
+async def test_no_link_at_all_when_the_work_is_not_in_the_corpus():
+    from app.api.commentary import _locate
+
+    # 注疏多收在藏外丛书里，未必都在语料内。宁可不给，也不给点不开的。
+    db = _FakeDB([], [])
+    got = await _locate(db, [("B07n0023", "B07n0023_p0123a01")])
+    assert got[("B07n0023", "B07n0023_p0123a01")] == ("fojin:cbeta/B0023", None)
+
+
+@pytest.mark.asyncio
+async def test_one_round_trip_regardless_of_how_many_commentaries():
+    from app.api import commentary as api
+
+    calls = []
+
+    class _Counting(_FakeDB):
+        async def execute(self, stmt, params=None):
+            calls.append(params)
+            return await super().execute(stmt, params)
+
+    db = _Counting(
+        [("X0456", 12400), ("X0461", 12403)],
+        [(12400, "0455c03", 1, "0455c02"), (12403, "0455c03", 2, "0455c01")],
+    )
+    await api._locate(db, [
+        ("X24n0456", "X24n0456_p0455c03"),
+        ("X24n0461", "X24n0461_p0455c03"),
+    ])
+    # 两次查库，与注家数量无关——一段常有 50 家，逐条查会打爆数据库。
+    assert len(calls) == 2
+
+
+# 上面几个用的是 DB 替身，守的是「查询结果怎么拼成链接」。_JUAN_OF_LINE 这条
+# SQL 本身它们一行也没执行过——去掉同页约束，它们照样全绿（试过）。而这条查询
+# 用了 unnest / DISTINCT ON / left()，都是 Postgres 专有的，换不成 SQLite。
+#
+# 所以真正守它的是下面这个：给了真库就跑，没给就明确跳过，不拿一个从没执行过
+# 的查询冒充「已覆盖」。案例是 2026-08-12 在生产库上验过的那批。
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("FOJIN_TEST_DATABASE_URL"),
+    reason="需要 FOJIN_TEST_DATABASE_URL 指向一个装了 CBETA 语料的库",
+)
+async def test_juan_lookup_against_a_real_corpus():
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.api.commentary import _JUAN_OF_LINE
+
+    cases = [
+        # (text_id, 目标行标, 期望卷, 期望落点)
+        (7, "0749c19", 1, "0749c19"),      # 经文侧：大正藏，精确命中
+        (7872, "0096c20", 2, "0096c20"),   # 注疏侧：大正藏，精确命中
+        (12400, "0448c02", 1, "0448c01"),  # 卍续藏：同页邻行，差一行
+        (12400, "0455c03", 1, "0455c02"),
+        (12400, "0467a11", 3, "0467a10"),  # 跨卷：同页约束把它正确解到第 3 卷
+    ]
+    engine = create_async_engine(os.environ["FOJIN_TEST_DATABASE_URL"])
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(_JUAN_OF_LINE, {
+                "tids": [c[0] for c in cases],
+                "refs": [c[1] for c in cases],
+            })).all()
+    finally:
+        await engine.dispose()
+
+    got = {(t, r): (j, n) for t, r, j, n in rows}
+    for tid, ref, juan, near in cases:
+        assert got.get((tid, ref)) == (juan, near), f"{tid}/{ref}"
+
+    # 行标不成形时一行都不该返回——调用方据此退回书级。
+    rows = []
+    async with create_async_engine(os.environ["FOJIN_TEST_DATABASE_URL"]).connect() as conn:
+        rows = (await conn.execute(
+            _JUAN_OF_LINE, {"tids": [12400], "refs": ["9999z99"]}
+        )).all()
+    assert rows == []


### PR DESCRIPTION
「每一句都能点回原典」是这个项目全部的说服力，而经注对读的链接一直断在最后一米：注文条目给的是 `/texts/12400` —— 一本三卷六百行的书，读者自己去找。

零件其实都在：锚点一直在返回里（`X24n0456_p0455c03`），阅读器早就认 `?anchor=`（`TextReaderPage.tsx:664` 会滚过去并闪一下），`text_line_anchors` 表存着每一条 CBETA `<lb>`。缺的只是把行标换成卷号这一步。

## 为什么不是精确匹配

**先量了一次**：拿本包 4,230 条注疏锚点对生产索引，精确命中只有 **6.6%**，而且是双峰的：

| | 命中率 |
|---|---|
| T33n1699（大正藏） | 99% |
| X25n0481 | 100% |
| X25n0471 | 51% |
| **其余 30 部（卍续藏为主）** | **0%** |

原因查清了：`text_line_anchors` 里 X 部的 `<lb>` **混着两个版本存**。同一卷里 `0448–0455` 与 `0523–0537` 两套页码按字符位置交错——

```
按 char_offset 顺序: 0523a05, 0448b16, 0523a08, 0448b19, 0448b24, 0523a13 ...
```

行的切法和对齐时用的那份不是同一套。**只认精确匹配的话，这个功能对 93% 的注疏等于没做。**

## 改法

取**同一页上最靠近的那条索引行**。

限定同页，是为了不跨版本乱跳：一行的卷次必定等于同页另一行的卷次，而隔了几十页的「最近邻」很可能是另一个版本的页码，那种猜法会把人送到错的卷。同页找不到就退回书级 —— **宁可少给，不给错的**。

滚动落点用索引里**真有**的那一行，不用 `anchor` 本身：指向页面上不存在的行，阅读器什么也不做，看起来就像链接坏了。`anchor` 字段仍是这条注真正的出处，要引用用它 —— 链接只是导航。

退化是分层的：同页无索引行 → 卷级；书不在语料里 → 连链接都不给（注疏多收在藏外丛书，52 部里 12 部不在 fojin 语料内）。

## 验证

SQL 直接打了生产库：

| tid | ref | juan | near | |
|---|---|---|---|---|
| 7 | 0749c19 | 1 | 0749c19 | 经文侧，大正藏，精确 |
| 7872 | 0096c20 | 2 | 0096c20 | 注疏侧，大正藏，精确 |
| 12400 | 0448c02 | 1 | 0448c01 | 卍续藏，同页邻行 |
| 12400 | 0455c03 | 1 | 0455c02 | |
| 12400 | 0467a11 | **3** | 0467a10 | 跨卷——同页约束正确解到第 3 卷 |

不成形的行标返回零行，调用方据此退回书级。

## 关于测试，说实话

单元测试用 DB 替身，守的是「查询结果怎么拼成链接」和三档退化。**做了变异测试**：把落点改回 `anchor` 本身 → `test_link_lands_on_the_line` 立刻变红 ✅。

但**去掉同页约束它们照样全绿** —— 那条 SQL 一行也没被执行过。所以另加了一个按需连真库的集成测试（`FOJIN_TEST_DATABASE_URL`，没给就明确跳过），把上面五个案例钉住。没写「断言 SQL 字符串里包含那一行」那种同义反复的测试 —— 那只是把代码抄一遍。

## 顺带

`build_urn` 的 docstring 说锚点「尚未建索引」——表早就有了，这次正是它当年预留的那个 non-breaking add。

测试：backend **1643 passed, 1 skipped**。`test_health_check_probe.py` 那 3 个证书失败改动之前就是红的（stash 后复现过）。