### PR TITLE
fix(mcp): 访问日志终于记得下「谁在调哪个工具」

### DIFF
--- a/mcp-server/fojin_mcp/http.py
+++ b/mcp-server/fojin_mcp/http.py
@@ -11,7 +11,8 @@ This module owns everything that only matters when fojin-mcp is *hosted* (at
   underneath.
 - :class:`AccessLogMiddleware` — one structured JSON line per request to the
   ``fojin_mcp.access`` logger: the adoption observability the stdio server
-  never had. Logs the ``Mcp-Name`` header (tool name) when a client sends it.
+  never had. The tool name is read out of the JSON-RPC body as it streams past
+  (see :class:`_ToolSniffer` for why it is not read from a header).
 - :func:`build_http_app` — assembles the Starlette app: MCP streamable HTTP in
   stateless + json_response mode (each call is one plain JSON POST — no long
   SSE streams, so Cloudflare's proxy timeout/buffering never enters the
@@ -128,6 +129,61 @@ class RateLimitMiddleware:
         await self.app(scope, receive, send)
 
 
+class _ToolSniffer:
+    """Pulls the tool name out of a JSON-RPC request body as it streams past.
+
+    Why this exists: until 2026-08-12 the access log read the tool name from an
+    ``Mcp-Name`` request header, which no client sends. Every real call was
+    logged as ``"tool": null`` — the one field the log was built for. The only
+    entries that ever carried a name came from scanners that happen to set that
+    optional header, so the log answered "which tool do bots announce" instead
+    of "which tool is anyone using".
+
+    Reads chunks as they flow rather than buffering the whole body and
+    replaying it: a JSON-RPC call arrives in one chunk in practice, and a
+    middleware that holds every request body in memory is a liability on an
+    endpoint anyone can POST to. Parsing is attempted on each chunk until the
+    JSON is complete, and abandoned past ``LIMIT`` — this is observability, so
+    losing a name costs a log field, never a request.
+    """
+
+    LIMIT = 64 * 1024
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+        self._done = False
+        self.tool: str | None = None
+
+    def feed(self, chunk: bytes) -> None:
+        if self._done or not chunk:
+            return
+        self._buf += chunk
+        if len(self._buf) > self.LIMIT:
+            self._give_up()
+            return
+        try:
+            payload = json.loads(self._buf)
+        except ValueError:
+            return  # 还没收全，等下一块
+        self._done = True
+        self._buf.clear()
+        self.tool = self._name(payload)
+
+    def _give_up(self) -> None:
+        self._done = True
+        self._buf.clear()
+
+    @staticmethod
+    def _name(payload: Any) -> str | None:
+        # 批量请求是一个数组；取第一个真正的工具调用。
+        for one in payload if isinstance(payload, list) else [payload]:
+            if isinstance(one, dict) and one.get("method") == "tools/call":
+                name = (one.get("params") or {}).get("name")
+                if isinstance(name, str) and name:
+                    return name
+        return None
+
+
 class AccessLogMiddleware:
     """One JSON line per request: ts, ip, method, path, status, ms, tool, ua.
 
@@ -145,6 +201,13 @@ class AccessLogMiddleware:
             return
         start = time.monotonic()
         status_holder = {"status": 0}
+        sniffer = _ToolSniffer()
+
+        async def receive_wrapper() -> dict[str, Any]:
+            message = await receive()
+            if message.get("type") == "http.request":
+                sniffer.feed(message.get("body") or b"")
+            return message
 
         async def send_wrapper(message: dict[str, Any]) -> None:
             if message["type"] == "http.response.start":
@@ -152,7 +215,7 @@ class AccessLogMiddleware:
             await send(message)
 
         try:
-            await self.app(scope, receive, send_wrapper)
+            await self.app(scope, receive_wrapper, send_wrapper)
         finally:
             access_logger.info(
                 "%s",
@@ -166,7 +229,8 @@ class AccessLogMiddleware:
                         "path": scope.get("path"),
                         "status": status_holder["status"],
                         "ms": round((time.monotonic() - start) * 1000, 1),
-                        "tool": _header(scope, b"mcp-name"),
+                        # 请求体优先；Mcp-Name 头留作兜底，有客户端会设它。
+                        "tool": sniffer.tool or _header(scope, b"mcp-name"),
                         "ua": _header(scope, b"user-agent"),
                     },
                     ensure_ascii=False,

--- a/mcp-server/tests/test_http.py
+++ b/mcp-server/tests/test_http.py
@@ -8,6 +8,7 @@ concerns (rate limiting, Host validation, healthz) without any network.
 
 from __future__ import annotations
 
+import logging
 import json
 
 import httpx
@@ -133,3 +134,62 @@ def test_host_header_validation_rejects_unknown_host():
     with TestClient(app) as tc:
         resp = tc.post("/mcp", json=_rpc("tools/list"), headers=MCP_HEADERS)
     assert resp.status_code >= 400
+
+
+# --- 访问日志真的记下了工具名 --------------------------------------------
+#
+# 2026-08-12 之前它记的是 Mcp-Name 请求头，而没有客户端发这个头：40 小时生产
+# 日志里每一次真实调用都是 "tool": null，唯一带上名字的反而是碰巧设了这个可选
+# 头的扫描器。日志于是回答了「机器人自称在调什么」，而不是「谁在用什么」。
+
+
+def _access_lines(caplog):
+    return [json.loads(r.message) for r in caplog.records
+            if r.name == "fojin_mcp.access"]
+
+
+def test_access_log_records_the_tool_actually_called(mock_fojin_client, caplog):
+    caplog.set_level(logging.INFO, logger="fojin_mcp.access")
+    with TestClient(_test_app()) as tc:
+        tc.post("/mcp", json=_rpc("tools/call", {
+            "name": "search_corpus", "arguments": {"query": "空", "limit": 3},
+        }), headers=MCP_HEADERS)
+    calls = [ln for ln in _access_lines(caplog) if ln["path"] == "/mcp"]
+    assert calls and calls[-1]["tool"] == "search_corpus"
+
+
+def test_access_log_leaves_tool_null_for_non_tool_traffic(caplog):
+    """别的 MCP 方法也带 params.name —— 只看 name 就会把它们记成工具调用。
+
+    故意用 prompts/get 而不是 tools/list：tools/list 压根没有 params.name，
+    拿它来测「不是工具调用就不记名字」等于没测（把方法判断删掉，那种写法照样
+    全绿——试过）。爬虫打的正是这一类方法，记错了整份采用数据就废了。
+    """
+    caplog.set_level(logging.INFO, logger="fojin_mcp.access")
+    with TestClient(_test_app()) as tc:
+        tc.post("/mcp", json=_rpc("prompts/get", {"name": "not-a-tool"}),
+                headers=MCP_HEADERS)
+    calls = [ln for ln in _access_lines(caplog) if ln["path"] == "/mcp"]
+    assert calls and calls[-1]["tool"] is None
+
+
+def test_sniffer_survives_a_body_split_across_chunks():
+    from fojin_mcp.http import _ToolSniffer
+
+    body = json.dumps(_rpc("tools/call", {"name": "commentaries",
+                                          "arguments": {"quote": "應無所住"}})).encode()
+    s = _ToolSniffer()
+    for i in range(0, len(body), 7):        # 切碎，模拟分块到达
+        s.feed(body[i:i + 7])
+    assert s.tool == "commentaries"
+
+
+def test_sniffer_gives_up_on_an_oversized_body_instead_of_hoarding_it():
+    """可观测性不能变成任何人都能 POST 的内存负担——丢一个日志字段，不丢请求。"""
+    from fojin_mcp.http import _ToolSniffer
+
+    s = _ToolSniffer()
+    s.feed(b'{"method":"tools/call","params":{"name":"x","arguments":{"q":"'
+           + b"\xe7\xa9\xba" * _ToolSniffer.LIMIT)
+    assert s.tool is None
+    assert not s._buf


### PR DESCRIPTION
这份日志的注释写着它存在的理由是回答 *"who is actually calling which tool"* —— **而它答不了**。工具名读的是 `Mcp-Name` **请求头**，没有客户端发这个头。

## 生产实测

40 小时日志里，**每一次真实调用都是 `"tool": null`**。唯一带上名字的 8 条，恰恰来自碰巧会设这个可选头的扫描器（`SaSame-MCP-Audit`、`io.verifymcp` 之类）。

于是这份日志回答的是「机器人自称在调什么」，而不是「谁在用什么」—— 采用数据里最要紧的那一项，一直是空的。

## 改法

从 JSON-RPC 请求体里取 `params.name`（`method == "tools/call"` 时）。

**不缓冲整个 body 再回放**：工具调用实际上就是一个 chunk，而一个把所有请求体攒在内存里的中间件，架在谁都能 POST 的公网端点上是个负担。做法是让 chunk 流过时顺手喂给嗅探器，每来一块试一次 JSON 解析，超过 64 KiB 就放弃 —— 这是可观测性，**丢一个日志字段可以，丢请求不行**。

`Mcp-Name` 头留作兜底。批量请求（数组）取第一个真正的工具调用。

## 变异测试

| 把什么改坏 | 哪个测试变红 |
|---|---|
| 退回只读请求头（原 bug） | `test_access_log_records_the_tool_actually_called` |
| 去掉 64 KiB 上限 | `test_sniffer_gives_up_on_an_oversized_body` |
| 不再区分 `tools/call` | `test_access_log_leaves_tool_null_for_non_tool_traffic` |

⚠️ **最后一个一开始是假绿。** 原本拿 `tools/list` 当反例，而它压根没有 `params.name` —— 把方法判断整个删掉，测试照样全过。换成 `prompts/get`（它带 `params.name`）才真守住。

别的 MCP 方法也用 `name` 这个键，只看 `name` 会把它们全记成工具调用，**而爬虫打的正是这一类方法** —— 记错了整份采用数据就废了。

测试：mcp-server **44 passed**。