### PR TITLE
fix(reader): 让「点回原典」的链接真的能点开

### DIFF
--- a/backend/app/api/urn.py
+++ b/backend/app/api/urn.py
@@ -31,7 +31,7 @@ class URNResolveResponse(BaseModel):
     reader_url: str | None = None
     # The same target as an absolute URL. Added because the relative form is
     # unusable to a consumer with no host: an agent holding
-    # "/reader?text=42&juan=1" cannot render a link, and in practice links to
+    # "/texts/42/read?juan=1" cannot render a link, and in practice links to
     # CBETA instead. Additive, so existing citers that prepend their own host
     # keep working.
     reader_url_absolute: str | None = None

--- a/backend/app/services/urn.py
+++ b/backend/app/services/urn.py
@@ -19,7 +19,7 @@ URN grammar (BNF-ish):
 Examples:
 
     fojin:cbeta/T0001                  → text-level: redirect to /text/{id}
-    fojin:cbeta/T0001.1                → juan-level: redirect to /reader?text=&juan=1
+    fojin:cbeta/T0001.1                → juan-level: redirect to /texts/<id>/read?juan=1
     fojin:cbeta/T0001.1#p0001a01       → line-level: same + ?anchor=p0001a01
 
 The ANCHOR is intentionally opaque: this PR does not index CBETA's
@@ -214,11 +214,19 @@ def reader_path(
     ``text_id``/``juan`` pair — quote verification, search results — do not
     have to fabricate a ``ParsedURN`` just to name a link, and so the route
     shape lives in exactly one place.
+
+    The route is ``/texts/:id/read`` — see ``App.tsx``. It used to be built as
+    ``/reader?text=&juan=``, which no router ever served: the SPA answers 200
+    for any path, so every check that only looked at the status code passed
+    while the browser rendered the 404 page. That shape was in the URN module
+    docstring, in the resolver, in verify_quote, and asserted by three tests —
+    which is how it survived: the tests pinned the broken shape in place.
+    Anything that verifies a reader link has to load it, not curl it.
     """
     if juan is None:
         # Text-level: jump to the detail page so the user picks a juan.
         return f"/texts/{text_id}"
-    base = f"/reader?text={text_id}&juan={juan}"
+    base = f"/texts/{text_id}/read?juan={juan}"
     if anchor:
         base += f"&anchor={anchor}"
     return base
@@ -239,7 +247,7 @@ def absolute_reader_url(relative: str | None) -> str | None:
 
     The relative form is the published contract of ``/api/urn/resolve`` and
     stays that way, but it is useless to the consumers that matter most here:
-    an AI agent holding ``/reader?text=42&juan=1`` has no host to attach it to,
+    an AI agent holding ``/texts/42/read?juan=1`` has no host to attach it to,
     so it either drops the citation or — observed in a real session — invents a
     link to CBETA instead. fojin does the verification and someone else gets
     the click. Callers that serve agents should offer this alongside.

--- a/backend/tests/test_commentary.py
+++ b/backend/tests/test_commentary.py
@@ -205,7 +205,7 @@ async def test_link_lands_on_the_line_when_the_anchor_resolves():
     urn, url = got[("X24n0456", "X24n0456_p0455c03")]
     # 滚动落点是索引里真有的那一行，不是 anchor 本身——指向页面上不存在的行，
     # 阅读器什么也不做，看起来就像链接坏了。
-    assert url == "https://fojin.app/reader?text=12400&juan=1&anchor=p0455c02"
+    assert url == "https://fojin.app/texts/12400/read?juan=1&anchor=p0455c02"
     assert urn == "fojin:cbeta/X0456.1#p0455c02"
 
 

--- a/backend/tests/test_urn.py
+++ b/backend/tests/test_urn.py
@@ -120,14 +120,14 @@ def test_build_url_text_level_goes_to_detail_page() -> None:
 def test_build_url_juan_level_goes_to_reader() -> None:
     assert (
         build_reader_url(_p("cbeta", "T0001", juan=3), text_id=42)
-        == "/reader?text=42&juan=3"
+        == "/texts/42/read?juan=3"
     )
 
 
 def test_build_url_with_anchor_appends_anchor_param() -> None:
     assert (
         build_reader_url(_p("cbeta", "T0001", juan=3, anchor="p0001a01"), text_id=42)
-        == "/reader?text=42&juan=3&anchor=p0001a01"
+        == "/texts/42/read?juan=3&anchor=p0001a01"
     )
 
 

--- a/backend/tests/test_verify_quote.py
+++ b/backend/tests/test_verify_quote.py
@@ -309,7 +309,7 @@ async def test_matches_carry_a_clickable_absolute_url():
     out = await verify_quote(DB, FakeES(), SNOW_VERSE, cite="T0374", juan=13)
     url = out.matches[0].reader_url
     assert url is not None and url.startswith("https://")
-    assert url.endswith("/reader?text=15&juan=13")
+    assert url.endswith("/texts/15/read?juan=13")
 
 
 # ── rate limit registration ──────────────────────────────────────────────

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -662,23 +662,50 @@ export default function TextReaderPage() {
     : null;
 
   // URN deep-link: ?anchor=p0001a09 → scroll to that CBETA line + brief flash.
+  //
+  // Keeps trying for a second instead of looking once. `lineAnchors` being
+  // non-empty means the *data* arrived, not that React has painted the spans
+  // that carry it — a single requestAnimationFrame lands in the gap, finds
+  // nothing, and returns. That is what it did in production: the target line
+  // was in the DOM (verified: 640 anchors rendered, the wanted one 2,940px
+  // down) and scrollIntoView on it worked when called by hand, but the page
+  // sat at the top of the juan. Every URN, verify_quote hit and commentary
+  // link that carried an anchor silently dropped the reader at the top.
   useEffect(() => {
     const anchorParam = searchParams.get("anchor");
     if (!anchorParam || !lineAnchors.length) return;
     const ref = anchorParam.replace(/^p/, "");
-    const raf = requestAnimationFrame(() => {
+    let raf = 0;
+    let flash: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+    let tries = 0;
+
+    const attempt = () => {
+      if (cancelled) return;
       const el = readerContentRef.current?.querySelector<HTMLElement>(
         `.cbeta-line[data-ref="${CSS.escape(ref)}"]`,
       );
-      if (!el) return;
+      if (!el) {
+        // ~1s at 60fps. Give up quietly after that: the anchor may belong to
+        // another juan, and nudging the reader somewhere arbitrary is worse
+        // than leaving it where the reader put it.
+        if (tries++ < 60) raf = requestAnimationFrame(attempt);
+        return;
+      }
       el.scrollIntoView({ block: "center", behavior: "smooth" });
       const p = el.closest("p");
       if (p) {
         p.classList.add("cbeta-line-flash");
-        setTimeout(() => p.classList.remove("cbeta-line-flash"), 2200);
+        flash = setTimeout(() => p.classList.remove("cbeta-line-flash"), 2200);
       }
-    });
-    return () => cancelAnimationFrame(raf);
+    };
+
+    raf = requestAnimationFrame(attempt);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      if (flash) clearTimeout(flash);
+    };
   }, [searchParams, lineAnchors, juanNum]);
 
   const changeFontSize = (delta: number) => {


### PR DESCRIPTION
两个 bug，合起来让 fojin 交给 agent 的**每一个阅读链接都是坏的** —— 而「每一句都能点回原典」正是这个项目的全部说服力。

发现过程：合并 #1170 后去生产验证行级链接，JSON 完美，**点开是 404**。

## 一、路由压根不存在

`reader_path` 造的是 `/reader?text=7&juan=1`。前端路由是 `/texts/:id/read`（`App.tsx:72`）—— **没有 `/reader`**。

它活了这么久，是因为 SPA 对任何路径都回 200：

```
$ curl -o /dev/null -w '%{http_code}' https://fojin.app/reader?text=7&juan=1
200          ← 而浏览器渲染的是 404 页
```

**而且有三个测试断言着这个坏形状**（`test_urn.py` ×2、`test_verify_quote.py` ×1），把它钉死在那里。断言错形状的测试比没有测试更坏。

受影响的是全部三个 agent 出口：`resolve_urn`、`verify_quote`、`commentaries`。

## 二、锚点滚动只试一帧就放弃

`lineAnchors` 有值只说明**数据**到了，不等于 React 已经把带 `data-ref` 的 span 画出来。原来那个 effect 在单个 `requestAnimationFrame` 里查一次，正好落在空档里，查不到就 `return`，**不重试**。

生产实测（在真页面里跑 JS）：

```
总锚点数: 640      目标存在: true      目标位置: 下方 2940px      当前滚动: 44
手动 scrollIntoView → 目标移到 427px    结论: 时序问题，不是容器问题
```

所以所有带锚点的链接 —— URN、`verify_quote`、经注对读 —— 都**静默地把读者丢在卷首**。

改成最多重试约一秒；超时安静放弃（锚点可能属于别的卷，把读者推到一个随便的位置比留在原地更糟）。顺带补上 flash 定时器的清理。

## 教训

**curl 打 200 不能证明链接可用。** 这两个 bug 都只有真的加载页面才看得见，而我上一轮正是只看了 JSON 就准备收工。

## 测试

backend **1643 passed** / frontend **446 passed**，tsc 干净。

锚点重试**没有自动化守卫** —— jsdom 没有布局、`scrollIntoView` 是空实现，硬写只能验「有没有重试查询」。它的权威验证是部署后真浏览器加载，我会做完再报。