### PR TITLE
fix(reader): 锚点跳转改成瞬时——平滑滚动在一卷的距离上根本不完成

### DIFF
--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -692,7 +692,13 @@ export default function TextReaderPage() {
         if (tries++ < 60) raf = requestAnimationFrame(attempt);
         return;
       }
-      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      // Instant, not smooth. Measured on prod: a smooth scrollIntoView to this
+      // line left .reader-container at scrollTop 0 even six seconds later,
+      // while the same call without `behavior` landed it at 23,315 — a juan is
+      // tens of thousands of pixels tall and the smooth path never completes
+      // over that distance in this container. Instant is also what a deep link
+      // wants: arrive at the line, don't animate past everything before it.
+      el.scrollIntoView({ block: "center" });
       const p = el.closest("p");
       if (p) {
         p.classList.add("cbeta-line-flash");


### PR DESCRIPTION
#1172 修好了时序（只试一帧 → 重试一秒）。部署后真浏览器验证，**还是不滚**。继续查，这次量到了原因。

生产实测，同一个元素、同一个容器：

| 调用 | 6 秒后 `.reader-container.scrollTop` |
|---|---|
| `scrollIntoView({block:'center', behavior:'smooth'})` | **0** — 纹丝不动 |
| `scrollIntoView({block:'center'})` | **23315** ✅ |

一卷正文有几万像素高（这条注在容器下方 23,770px），平滑滚动在这个距离上从来走不完。

改成瞬时。对深链来说这本来也更对：读者要的是「到那一行」，不是看着两万像素的内容从眼前滑过去。落点仍然闪一下，让人知道停在哪。

## 记一笔

这个 bug 前后骗了我两次 —— 第一次看 JSON 以为成了；第二次看到「修复已部署、压缩代码里能读出重试循环」以为成了。都不成。**只有量到 scrollTop 的实际数字才算数。**

测试：frontend **446 passed**，tsc 干净。