### PR TITLE
fix(deploy): 音频部署脚本三处实战修补

### DIFF
--- a/deploy/deploy-audio.sh
+++ b/deploy/deploy-audio.sh
@@ -48,7 +48,11 @@ CUES=$(find "$LOCAL_OUT" -name '*.cues.json' | wc -l)
 log "本地产物：$MP3S 个 mp3 / $CUES 份 cues"
 
 log "① 产物 → 生产仓库 backend/out/（gitignored，容器内可见）"
-ssh $SSH_OPTS "$VPS" "mkdir -p $REPO_OUT $STATIC_DIR"
+# ⚠️ /srv 是 root 所有（drwxr-xr-x root:root），直接 mkdir 会 Permission denied。
+#    用 install -d 一次性建好并把属主给部署账号，后续 rsync 才写得进去；
+#    755 保证 nginx 的 worker 进程读得到。
+ssh $SSH_OPTS "$VPS" "mkdir -p $REPO_OUT &&
+  sudo install -d -o \$(id -un) -g \$(id -gn) -m 755 /srv/fojin $STATIC_DIR"
 # 只传 mp3 与 cues.json，**不传 *.parts/**（逐句 WAV 分片，几百个大文件）
 rsync -av $DRY --include='*/' --include='*.mp3' --include='*.cues.json' \
   --exclude='*' --prune-empty-dirs -e "ssh $SSH_OPTS" \
@@ -68,15 +72,34 @@ rsync -av $DRY --include='*/' --include='*.mp3' --exclude='*' --prune-empty-dirs
 
 if [ "$DO_NGINX" = "1" ]; then
   log "④ host nginx 配置同步 + reload"
+  # ⚠️ 生产的 /etc/nginx/conf.d/fojin.conf 历史上被手工改过（那台机器上留着
+  #    fojin.conf.bak-pre-cors / -realip / -bodysize 等一串备份）。仓库副本
+  #    未必是它的超集，**先 diff 再覆盖**，并按同样的命名留一份回滚点。
+  log "   先看差异（无输出 = 完全一致）"
+  ssh $SSH_OPTS "$VPS" "sudo diff -u /etc/nginx/conf.d/fojin.conf \
+    /home/admin/fojin/deploy/host-nginx/fojin.conf" || true
   [ -z "$DRY" ] && ssh $SSH_OPTS "$VPS" "
+    sudo cp -a /etc/nginx/conf.d/fojin.conf \
+      /etc/nginx/conf.d/fojin.conf.bak-audio-\$(date +%s) &&
     sudo cp /home/admin/fojin/deploy/host-nginx/fojin.conf /etc/nginx/conf.d/fojin.conf &&
     sudo nginx -t && sudo systemctl reload nginx"
 fi
 
+# ⚠️ 验证必须看 Content-Type，不能只看状态码：/audio/ 段没生效时
+#    SPA 回退会返回 **200 + index.html**，<audio> 静默不播、无任何报错。
+#    实测踩过一次（2026-08-12）。
+
 log "验证"
 FIRST_MP3=$(find "$LOCAL_OUT" -name '*.mp3' | head -1 | sed "s|^$LOCAL_OUT||")
 echo "  音频:"
-curl -sI "https://fojin.app/audio/$FIRST_MP3" | head -3 | sed 's/^/    /'
+CT=$(curl -sI "https://fojin.app/audio/$FIRST_MP3" \
+  | tr -d '\r' | awk -F': ' 'tolower($1)=="content-type"{print $2}' | tail -1)
+echo "    Content-Type: ${CT:-（无）}"
+case "$CT" in
+  audio/*) echo "    ✅ 真音频" ;;
+  *)       echo "    ❌ 不是音频 —— /audio/ 段没生效，SPA 回退成 index.html 了。"
+           echo "       补跑：./deploy/deploy-audio.sh --nginx" ;;
+esac
 echo "  API:"
 TID=$(echo "$FIRST_MP3" | cut -d/ -f1)
 curl -s "https://fojin.app/api/texts/$TID/juans/1/audio" | head -c 180 | sed 's/^/    /'


### PR DESCRIPTION
首次真机部署心经音频（text_id=9）时暴露的三个问题，已在生产验证。

## 1. `/srv` 是 root 所有，步骤①直接中断

```
mkdir: cannot create directory ‘/srv/fojin’: Permission denied
```

改用 `sudo install -d -o $(id -un) -g $(id -gn) -m 755`，一次性建目录并把属主给部署账号，后续 rsync 才写得进去；755 保证 nginx worker 读得到。

## 2. nginx 步骤覆盖生产配置前既不备份也不看差异

那台机器上留着 `fojin.conf.bak-pre-cors` / `-realip` / `-bodysize` 一串手工改动的痕迹 —— 仓库副本未必是它的超集。改成**先 diff 再覆盖**，并按同样命名留一份回滚点。

（这次实测 diff 只有新增的 `/audio/` 段，无漂移；备份 `fojin.conf.bak-audio-1786544140` 已留在机器上。）

## 3. 验证只看状态码 —— 而失败形态恰好是 200

`/audio/` 段没生效时，SPA 回退返回 **200 + index.html**，`<audio>` 静默不播且无任何报错。今天正是靠人工查 Content-Type 才发现的：

```
content-type: text/html
前 8 字节: 3c21 444f 4354 5950   <!DOCTYP
```

改判 `Content-Type` 前缀，非 `audio/*` 直接报错并提示补跑 `--nginx`。

## 生产验证

| 项 | 结果 |
|---|---|
| Content-Type | `audio/mpeg` |
| 前 8 字节 | `4944 3304` = ID3 |
| Content-Length | 1623213（与本地字节数一致）|
| Range 请求 | 206 + `content-range: bytes 100000-100100/1623213` |
| 缺失文件 | 404（未回退 SPA）|
| cue 坐标 | 13 个，覆盖 0–380，与生产 `text_contents` 长度逐字对上 |

仅改 `deploy/deploy-audio.sh`，不触及应用代码。