### PR TITLE
feat(audio): 读诵埋点 + 64k 码率 + 索引页

### DIFF
--- a/backend/app/api/audio.py
+++ b/backend/app/api/audio.py
@@ -1,0 +1,55 @@
+"""读诵目录。
+
+⚠️ 与宿主机 nginx 的 ``location /audio/``（静态 mp3 直出）**不冲突** ——
+本路由挂在 ``/api`` 前缀下，路径是 ``/api/audio/available``，不以
+``/audio/`` 开头，nginx 的前缀匹配落不到那条上。
+
+单卷音频与时间戳在 ``texts.py`` 的 ``/texts/{id}/juans/{n}/audio``；
+这里只回「哪些经能听」，供索引页与经典详情页共用。
+"""
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.services.audio import list_available_audio
+
+router = APIRouter(tags=["audio"])
+
+
+class AudioJuanItem(BaseModel):
+    juan_num: int
+    duration_ms: int
+    url: str
+
+
+class AudioCatalogItem(BaseModel):
+    text_id: int
+    title_zh: str
+    translator: str | None = None
+    dynasty: str | None = None
+    taisho_id: str | None = None
+    # 合成引擎。前端据此标注「AI 合成朗读」——将来拿到授权的真人读诵是 "human"，
+    # 那时标注必须跟着变，不能让人以为机器读的是法师读的。
+    engine: str
+    juan_count: int
+    total_duration_ms: int
+    juans: list[AudioJuanItem] = []
+
+
+class AudioCatalogResponse(BaseModel):
+    total: int
+    items: list[AudioCatalogItem] = []
+
+
+@router.get("/audio/available", response_model=AudioCatalogResponse)
+async def read_available_audio(
+    lang: str = Query("zh", description="正文语言"),
+    db: AsyncSession = Depends(get_db),
+):
+    """有在线读诵音频的经，按经聚合、按总时长升序。
+
+    列出目前可收听的经典。音频总量按设计就很小（第一期一部），故不分页。"""
+    items = await list_available_audio(db, lang)
+    return AudioCatalogResponse(total=len(items), items=items)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,6 +61,7 @@ from app.api import (
     alignment,
     alignment_review,
     annotations,
+    audio,
     auth,
     bookmarks,
     chat,
@@ -472,6 +473,7 @@ app.include_router(relations.router, prefix="/api")
 app.include_router(knowledge_graph.router, prefix="/api")
 app.include_router(iiif.router, prefix="/api")
 app.include_router(alignment.router, prefix="/api")
+app.include_router(audio.router, prefix="/api")
 
 # Phase 3 routers
 app.include_router(chat.router, prefix="/api")

--- a/backend/app/services/audio.py
+++ b/backend/app/services/audio.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.audio import TextAudio
+from app.models.text import BuddhistText
 
 
 def build_audio_payload(audio: TextAudio) -> dict:
@@ -51,3 +52,57 @@ async def get_juan_audio(
     )
     audio = (await session.execute(stmt)).scalar_one_or_none()
     return build_audio_payload(audio) if audio else None
+
+
+def group_audio_by_text(rows: list[tuple]) -> list[dict]:
+    """``[(TextAudio, BuddhistText), …]`` → 按经聚合的目录项。
+
+    音频按**卷**存，索引页按**经**列 —— 使用者找的是「哪部经能听」。
+    排序用总时长升序而非 text_id：短经先上是这个功能的现实
+    （心經 1.7 分钟 vs 壇經一卷 134 分钟），让人一眼看到能听完的那几部。
+    """
+    by_text: dict[int, dict] = {}
+    for audio, text in rows:
+        item = by_text.setdefault(
+            audio.text_id,
+            {
+                "text_id": audio.text_id,
+                "title_zh": text.title_zh,
+                "translator": text.translator,
+                "dynasty": text.dynasty,
+                "taisho_id": text.taisho_id,
+                "engine": audio.engine,
+                "juans": [],
+            },
+        )
+        item["juans"].append(
+            {
+                "juan_num": audio.juan_num,
+                "duration_ms": audio.duration_ms,
+                "url": f"/audio/{audio.audio_path}",
+            }
+        )
+
+    items = []
+    for item in by_text.values():
+        item["juans"].sort(key=lambda j: j["juan_num"])
+        item["juan_count"] = len(item["juans"])
+        item["total_duration_ms"] = sum(j["duration_ms"] for j in item["juans"])
+        items.append(item)
+    items.sort(key=lambda it: (it["total_duration_ms"], it["text_id"]))
+    return items
+
+
+async def list_available_audio(session: AsyncSession, lang: str = "zh") -> list[dict]:
+    """有读诵音频的经的完整目录。
+
+    音频总量按设计就很小（第一期一部，扩到十部也不过十行），所以不分页 ——
+    前端一次取回，索引页与经典详情页共用同一份缓存。
+    """
+    stmt = (
+        select(TextAudio, BuddhistText)
+        .join(BuddhistText, BuddhistText.id == TextAudio.text_id)
+        .where(TextAudio.lang == lang)
+        .order_by(TextAudio.text_id, TextAudio.juan_num)
+    )
+    return group_audio_by_text(list((await session.execute(stmt)).all()))

--- a/backend/scripts/audio/build_audio.py
+++ b/backend/scripts/audio/build_audio.py
@@ -48,6 +48,10 @@ DEFAULT_API = "https://fojin.app/api"
 #    且报错里看不出是被挡的。
 _UA = {"User-Agent": "fojin-audio-pipeline/1.0"}
 
+# mono 32 kHz 的口语，64k 与 128k 听感无差，体积减半（心經 1.6 MB → 793 KB）。
+# 长经差别更要命：壇經一卷 134 分钟，128k 要 63 MB。
+DEFAULT_BITRATE = "64k"
+
 
 def log(*a: object) -> None:
     print(f"[{time.strftime('%H:%M:%S')}]", *a, flush=True)
@@ -64,7 +68,7 @@ def wav_ms(path: Path) -> int:
         return int(w.getnframes() / w.getframerate() * 1000)
 
 
-def concat_to_mp3(parts: list[Path], out_path: Path) -> None:
+def concat_to_mp3(parts: list[Path], out_path: Path, bitrate: str = DEFAULT_BITRATE) -> None:
     """WAV 分片无损拼接后一次性编码为 MP3。"""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False, encoding="utf-8") as fh:
@@ -74,31 +78,23 @@ def concat_to_mp3(parts: list[Path], out_path: Path) -> None:
     try:
         subprocess.run(
             ["ffmpeg", "-y", "-v", "error", "-f", "concat", "-safe", "0", "-i", lst,
-             "-c:a", "libmp3lame", "-b:a", "128k", "-ar", "32000", "-ac", "1", str(out_path)],
+             "-c:a", "libmp3lame", "-b:a", bitrate, "-ar", "32000", "-ac", "1", str(out_path)],
             check=True, capture_output=True,
         )
     finally:
         Path(lst).unlink(missing_ok=True)
 
 
-def build_juan(cfg: dict, text_id: int, juan: int, api_base: str, out_root: Path, key: str) -> dict:
-    raw = fetch_juan(api_base, text_id, juan)
-    if not raw:
-        raise RuntimeError(f"text_id={text_id} juan={juan} 无正文")
+def synth_hash_of(cfg: dict, raw: str, pron: list[str]) -> str:
+    """**合成身份** —— 只由影响波形的参数决定，给 ``.parts`` 目录命名。
 
-    segs = split_content(raw)
-    pron = to_minimax_dict(text=raw.replace("\n", ""))
+    ⚠️ 字段名与取值必须与 2026-08-12 之前的单层 fingerprint **逐字节一致**。
+    动一个字，已合成的 WAV 分片就会失联、断点续传落空、重新调 API ——
+    而 MiniMax 是非确定性的（实测同句同参数三次 8.01/8.82/9.30 秒，
+    极差 14.8%），重合成等于把使用者逐轮听审通过的版本扔掉重赌。
 
-    # ⚠️ hash 必须覆盖**正文 + 所有影响成品的配置**，不能只 hash 正文。
-    #
-    # 文件名带 hash 前 8 位是为了「重生成 = 新 URL」，从而绕开 Cloudflare
-    # 边缘缓存跨部署存活。但若只 hash 正文，那么「改了词典重新合成」这种
-    # 最常见的重生成场景 URL 不变 —— 边缘缓存会一直供旧音频，而 max-age
-    # 是一年。实测就发生过：补了「般羅/罣礙」重新合成，hash 纹丝不动。
-    #
-    # 另外 MiniMax 合成是**非确定性**的（实测同句同参数 3 次：8.01/8.82/9.30 秒，
-    # 极差 14.8%），所以就算配置全同，重跑也会得到不同音频 —— 这更需要
-    # 「配置变了就换 URL」，而不是指望音频本身可复现。
+    刻意**不含任何编码参数**：换码率不该让人重新付费合成。
+    """
     fingerprint = json.dumps(
         {
             "text": raw,
@@ -110,11 +106,47 @@ def build_juan(cfg: dict, text_id: int, juan: int, api_base: str, out_root: Path
         },
         ensure_ascii=False, sort_keys=True,
     )
-    content_hash = hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()
-    hash8 = content_hash[:8]
-    log(f"[{text_id}/{juan}] {len(raw)} 字 → {len(segs)} 段，词典 {len(pron)} 条，hash={hash8}")
+    return hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()
 
-    work = out_root / str(text_id) / f"{juan}-{hash8}.parts"
+
+def content_hash_of(synth_hash: str, cfg: dict) -> str:
+    """**成品身份** —— 合成身份叠上编码参数，给 mp3 命名，也是入库的 content_hash。
+
+    文件名带它的前 8 位，是为了「重生成 = 新 URL」。``/audio/`` 段发的是
+    ``Cache-Control: immutable, max-age=31536000``，同名文件在 Cloudflare
+    边缘能活一年 —— 编码参数变了却不换名，等于改了个寂寞。
+    """
+    fingerprint = json.dumps(
+        {
+            "synth": synth_hash,
+            "bitrate": cfg.get("bitrate", DEFAULT_BITRATE),
+            "format": cfg.get("audio_format", "mp3"),
+        },
+        ensure_ascii=False, sort_keys=True,
+    )
+    return hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()
+
+
+def build_juan(
+    cfg: dict, text_id: int, juan: int, api_base: str, out_root: Path,
+    key: str | None, no_synth: bool = False,
+) -> dict:
+    raw = fetch_juan(api_base, text_id, juan)
+    if not raw:
+        raise RuntimeError(f"text_id={text_id} juan={juan} 无正文")
+
+    segs = split_content(raw)
+    pron = to_minimax_dict(text=raw.replace("\n", ""))
+
+    # 两层哈希，各管一件事，理由见 synth_hash_of / content_hash_of 的文档串。
+    synth_hash = synth_hash_of(cfg, raw, pron)
+    content_hash = content_hash_of(synth_hash, cfg)
+    hash8 = content_hash[:8]
+    bitrate = cfg.get("bitrate", DEFAULT_BITRATE)
+    log(f"[{text_id}/{juan}] {len(raw)} 字 → {len(segs)} 段，词典 {len(pron)} 条，"
+        f"synth={synth_hash[:8]} content={hash8} @{bitrate}")
+
+    work = out_root / str(text_id) / f"{juan}-{synth_hash[:8]}.parts"
     work.mkdir(parents=True, exist_ok=True)
 
     parts: list[Path] = []
@@ -124,6 +156,15 @@ def build_juan(cfg: dict, text_id: int, juan: int, api_base: str, out_root: Path
     for i, seg in enumerate(segs):
         part = work / f"{i:04d}.wav"
         if not part.exists():          # 断点续传：重跑不重复付费
+            if no_synth:
+                # 保险丝。只想换编码却触发了合成，说明 synth_hash 算错了 ——
+                # 放任下去会用一份新赌出来的音频顶掉已听审通过的版本。
+                raise RuntimeError(
+                    f"--no-synth 模式下缺分片 {part}；synth_hash 可能变了，"
+                    f"检查 synth_hash_of 的字段是否被改动"
+                )
+            if not key:
+                raise RuntimeError("需要 API key 才能合成；只重编码请加 --no-synth")
             info = synthesize(
                 normalize_for_tts(seg.text),
                 part,
@@ -143,7 +184,7 @@ def build_juan(cfg: dict, text_id: int, juan: int, api_base: str, out_root: Path
             log(f"  …{i + 1}/{len(segs)} 段，累计 {elapsed / 1000:.0f}s")
 
     audio_path = out_root / str(text_id) / f"{juan}-{hash8}.mp3"
-    concat_to_mp3(parts, audio_path)
+    concat_to_mp3(parts, audio_path, bitrate)
 
     meta = {
         "text_id": text_id,
@@ -155,8 +196,10 @@ def build_juan(cfg: dict, text_id: int, juan: int, api_base: str, out_root: Path
         "duration_ms": elapsed,
         "byte_size": audio_path.stat().st_size,
         "audio_format": "mp3",
+        "bitrate": bitrate,
         "char_count": len(raw),
         "content_hash": content_hash,
+        "synth_hash": synth_hash,
         "cues": cues,
     }
     (out_root / str(text_id) / f"{juan}-{hash8}.cues.json").write_text(
@@ -167,14 +210,14 @@ def build_juan(cfg: dict, text_id: int, juan: int, api_base: str, out_root: Path
     return meta
 
 
-def load_key(key_file: str | None) -> str:
+def load_key(key_file: str | None, required: bool = True) -> str | None:
     if key_file:
         for line in Path(key_file).read_text(encoding="utf-8-sig").splitlines():
             line = line.strip()
             if line:
                 return (line.split("=", 1)[1] if "=" in line else line).strip("\"'")
     key = os.environ.get("MINIMAX_API_KEY")
-    if not key:
+    if not key and required:
         sys.exit("需要 MINIMAX_API_KEY 环境变量，或 --key-file 指向密钥文件")
     return key
 
@@ -185,16 +228,22 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--out", default="out/audio")
     ap.add_argument("--api-base", default=DEFAULT_API)
     ap.add_argument("--key-file", help="密钥文件（每行 KEY 或 NAME=KEY）；不给则读环境变量")
+    ap.add_argument(
+        "--no-synth", action="store_true",
+        help="只用已有 WAV 分片重新编码，缺任何一片就报错。换码率时用它 —— "
+             "既省掉 API key，也防止哈希算错时静默重新合成顶掉已听审的版本。",
+    )
     args = ap.parse_args(argv)
 
     cfg = yaml.safe_load(Path(args.manifest).read_text(encoding="utf-8"))
-    key = load_key(args.key_file)
+    key = load_key(args.key_file, required=not args.no_synth)
     out_root = Path(args.out)
     done = 0
     for entry in cfg["texts"]:
         for juan in entry["juans"]:
             try:
-                build_juan(cfg, entry["text_id"], juan, args.api_base, out_root, key)
+                build_juan(cfg, entry["text_id"], juan, args.api_base, out_root,
+                           key, no_synth=args.no_synth)
                 done += 1
             except Exception as exc:
                 log(f"✗ text_id={entry['text_id']} juan={juan}: {type(exc).__name__}: {exc}")

--- a/backend/scripts/audio/import_audio.py
+++ b/backend/scripts/audio/import_audio.py
@@ -26,8 +26,17 @@ from app.database import async_session
 from app.models.audio import TextAudio, TextAudioCue
 
 
+def audio_key(meta: dict) -> tuple[int, int, str, str]:
+    """``text_audio`` 的唯一键 ``(text_id, juan_num, lang, voice_id)``。
+
+    ⚠️ 重复检测与实际入库**必须共用这一个推导**。两边各写一遍，只要默认值
+    有一点出入，就会出现「检查放行、入库照撞」——那种 bug 只会在生产上露头。
+    """
+    return (meta["text_id"], meta["juan_num"], meta["lang"], meta["voice_id"])
+
+
 async def import_one(meta: dict, dry_run: bool) -> str:
-    key = (meta["text_id"], meta["juan_num"], meta["lang"], meta["voice_id"])
+    key = audio_key(meta)
     async with async_session() as session:
         existing = (
             await session.execute(
@@ -81,13 +90,38 @@ async def import_one(meta: dict, dry_run: bool) -> str:
         return f"{action} text_id={key[0]} juan={key[1]} cue={len(meta['cues'])}"
 
 
+def find_duplicate_keys(metas: list[dict]) -> dict[tuple, list[str]]:
+    """同一次运行里指向同一把唯一键的产物 —— 返回 {键: [audio_path…]}。
+
+    ``import_one`` 对已存在的行是先删后插，所以重复键意味着**后处理的赢**，
+    而顺序由 ``sorted()`` 的字典序决定、与新旧无关。实测形态见
+    ``tests/test_audio_import.py`` 的文档串：重编码后新旧两份并存，
+    字典序让旧的赢，线上静默回退且日志显示"成功"。
+    """
+    seen: dict[tuple, list[str]] = {}
+    for m in metas:
+        seen.setdefault(audio_key(m), []).append(m.get("audio_path", "?"))
+    return {k: v for k, v in seen.items() if len(v) > 1}
+
+
 async def run(directory: Path, dry_run: bool) -> int:
-    metas = sorted(directory.rglob("*.cues.json"))
-    if not metas:
+    paths = sorted(directory.rglob("*.cues.json"))
+    if not paths:
         print(f"{directory} 下没有 *.cues.json —— 先跑 build_audio.py")
         return 1
-    for path in metas:
-        meta = json.loads(path.read_text(encoding="utf-8"))
+    metas = [json.loads(p.read_text(encoding="utf-8")) for p in paths]
+
+    dupes = find_duplicate_keys(metas)
+    if dupes:
+        print("✗ 同一卷有多份产物，入库会互相顶掉（谁赢取决于文件名字典序，不是新旧）：")
+        for (tid, juan, lang, voice), files in dupes.items():
+            print(f"   text_id={tid} juan={juan} lang={lang} voice={voice}")
+            for f in files:
+                print(f"     - {f}")
+        print("   删掉过时的 *.mp3 与 *.cues.json 后重跑（.parts 目录留着，重编码要用）")
+        return 2
+
+    for meta in metas:
         print("✓", await import_one(meta, dry_run))
     print(f"\n共处理 {len(metas)} 卷")
     if not dry_run:

--- a/backend/scripts/audio/manifest.yml
+++ b/backend/scripts/audio/manifest.yml
@@ -8,6 +8,10 @@ model: speech-2.8-hd
 voice_id: Chinese (Mandarin)_Lyrical_Voice   # 抒情男声，使用者从 4 个候选中选定
 lang: zh
 speed: 1.0
+# mono 32 kHz 的口语，64k 与 128k 听感无差、体积减半（心經 1.6 MB → 793 KB）。
+# 改这里会换 content_hash 即换 URL（绕开 Cloudflare 一年期边缘缓存），
+# 但**不会**换 synth_hash —— 已合成的 WAV 分片照用，不重新付费。
+bitrate: 64k
 
 texts:
   - text_id: 9

--- a/backend/tests/test_audio_api.py
+++ b/backend/tests/test_audio_api.py
@@ -72,6 +72,51 @@ async def test_endpoint_404_when_no_audio(client) -> None:
         texts_api.get_juan_audio = original
 
 
+async def test_catalog_endpoint_returns_grouped_items(client) -> None:
+    """索引页与经典详情页共用这一个端点，形状必须稳定。"""
+    from app.api import audio as audio_api
+
+    original = audio_api.list_available_audio
+    audio_api.list_available_audio = AsyncMock(
+        return_value=[
+            {
+                "text_id": 9,
+                "title_zh": "般若波羅蜜多心經",
+                "translator": "玄奘",
+                "dynasty": "唐",
+                "taisho_id": "T0251",
+                "engine": "minimax",
+                "juan_count": 1,
+                "total_duration_ms": 101_363,
+                "juans": [{"juan_num": 1, "duration_ms": 101_363, "url": "/audio/9/1-7891dd17.mp3"}],
+            }
+        ]
+    )
+    try:
+        resp = await client.get("/api/audio/available")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["items"][0]["title_zh"] == "般若波羅蜜多心經"
+        assert body["items"][0]["juans"][0]["url"] == "/audio/9/1-7891dd17.mp3"
+    finally:
+        audio_api.list_available_audio = original
+
+
+async def test_catalog_endpoint_is_empty_not_404_when_nothing_available(client) -> None:
+    """空目录回 200 + 空数组。404 会让索引页显示成「页面不存在」。"""
+    from app.api import audio as audio_api
+
+    original = audio_api.list_available_audio
+    audio_api.list_available_audio = AsyncMock(return_value=[])
+    try:
+        resp = await client.get("/api/audio/available")
+        assert resp.status_code == 200
+        assert resp.json() == {"total": 0, "items": []}
+    finally:
+        audio_api.list_available_audio = original
+
+
 async def test_endpoint_returns_payload_when_audio_exists(client) -> None:
     """有音频时回 200，且 text_id/juan_num 由路径参数带回。"""
     from app.api import texts as texts_api

--- a/backend/tests/test_audio_build.py
+++ b/backend/tests/test_audio_build.py
@@ -1,0 +1,77 @@
+"""合成编排的哈希分层。
+
+一个文件名要同时满足两个互相冲突的要求：
+
+* **换编码参数必须换 URL** —— `/audio/` 段发的是
+  `Cache-Control: immutable, max-age=31536000`，同名文件在 Cloudflare 边缘
+  能活一年。不换名就等于改了个寂寞。
+* **换编码参数绝不能重新合成** —— MiniMax 是非确定性的（实测同句同参数
+  三次：8.01 / 8.82 / 9.30 秒，极差 14.8%）。心經 H 版是使用者逐轮听审
+  才通过的，重合成就是把它扔了重赌一次。
+
+所以哈希必须分两层：``synth_hash`` 只由合成参数决定、给 ``.parts`` 目录命名，
+保证断点续传能命中已有 WAV；``content_hash`` 再叠上编码参数、给 mp3 命名。
+两者混成一个，二选一必然失败其中之一。
+"""
+
+from scripts.audio.build_audio import content_hash_of, synth_hash_of
+
+CFG = {
+    "voice_id": "Chinese (Mandarin)_Lyrical_Voice",
+    "model": "speech-2.8-hd",
+    "speed": 1.0,
+    "bitrate": "64k",
+}
+RAW = "般若波羅蜜多心經\n唐三藏法師玄奘譯\n觀自在菩薩行深般若波羅蜜多時"
+PRON = ["般若/(bo1)(re3)", "波羅蜜/(bo1)(luo2)(mi4)"]
+
+
+def test_bitrate_does_not_change_synth_hash() -> None:
+    """⭐ 换码率不能动 synth_hash —— 动了 .parts 目录就找不到，会重新调 API。"""
+    a = synth_hash_of(CFG, RAW, PRON)
+    b = synth_hash_of({**CFG, "bitrate": "128k"}, RAW, PRON)
+    assert a == b
+
+
+def test_bitrate_does_change_content_hash() -> None:
+    """⭐ 换码率必须换 content_hash —— 不换名 Cloudflare 会供一年旧文件。"""
+    a = content_hash_of(synth_hash_of(CFG, RAW, PRON), CFG)
+    b = content_hash_of(synth_hash_of(CFG, RAW, PRON), {**CFG, "bitrate": "128k"})
+    assert a != b
+
+
+def test_synth_hash_is_blind_to_encoding_only_keys() -> None:
+    """合成层不该看见任何编码参数，否则以后加一个就断一次续传。"""
+    base = synth_hash_of(CFG, RAW, PRON)
+    for extra in ({"bitrate": "48k"}, {"sample_rate": 44100}, {"channels": 2}):
+        assert synth_hash_of({**CFG, **extra}, RAW, PRON) == base
+
+
+def test_text_change_moves_both_hashes() -> None:
+    """经文改了，音频就过期了 —— 两层都必须变。"""
+    s1, s2 = synth_hash_of(CFG, RAW, PRON), synth_hash_of(CFG, RAW + "，照見五蘊皆空", PRON)
+    assert s1 != s2
+    assert content_hash_of(s1, CFG) != content_hash_of(s2, CFG)
+
+
+def test_pronunciation_change_moves_both_hashes() -> None:
+    """补词典是最常见的重生成场景 —— 早期版本只 hash 正文，hash 纹丝不动。"""
+    s1 = synth_hash_of(CFG, RAW, PRON)
+    s2 = synth_hash_of(CFG, RAW, [*PRON, "罣礙/(gua4)(ai4)"])
+    assert s1 != s2
+    assert content_hash_of(s1, CFG) != content_hash_of(s2, CFG)
+
+
+def test_voice_and_speed_move_both_hashes() -> None:
+    for change in ({"voice_id": "other"}, {"speed": 0.9}, {"model": "speech-2.6"}):
+        s = synth_hash_of({**CFG, **change}, RAW, PRON)
+        assert s != synth_hash_of(CFG, RAW, PRON)
+
+
+def test_hashes_are_hex_sha256() -> None:
+    """入库字段是 String(64)，非 64 位十六进制会被截断或报错。"""
+    s = synth_hash_of(CFG, RAW, PRON)
+    c = content_hash_of(s, CFG)
+    for h in (s, c):
+        assert len(h) == 64
+        assert all(ch in "0123456789abcdef" for ch in h)

--- a/backend/tests/test_audio_catalog.py
+++ b/backend/tests/test_audio_catalog.py
@@ -1,0 +1,84 @@
+"""读诵目录的聚合形状。
+
+音频按**卷**存（``text_audio`` 的键含 juan_num），但索引页要按**经**列：
+使用者找的是「哪部经能听」，不是「哪一卷能听」。中间这层聚合没有 DB
+参与也能测 —— 把 ORM 行拼成列表项的规则本身就是逻辑。
+
+⚠️ 排序刻意用「总时长升序」而非 text_id：短经先上是这个功能的现实
+（心經 1.7 分钟 vs 壇經 134 分钟），让人一眼看到能听完的那几部。
+"""
+
+from unittest.mock import MagicMock
+
+from app.services.audio import group_audio_by_text
+
+
+def _row(text_id: int, juan: int, ms: int, title: str, translator: str | None = "玄奘",
+         dynasty: str | None = "唐", taisho: str | None = "T0251") -> tuple:
+    audio = MagicMock()
+    audio.text_id, audio.juan_num, audio.duration_ms = text_id, juan, ms
+    audio.engine, audio.voice_id = "minimax", "Lyrical"
+    audio.audio_path = f"{text_id}/{juan}-abcd1234.mp3"
+    text = MagicMock()
+    text.id, text.title_zh, text.translator = text_id, title, translator
+    text.dynasty, text.taisho_id = dynasty, taisho
+    return (audio, text)
+
+
+def test_one_juan_one_item() -> None:
+    items = group_audio_by_text([_row(9, 1, 101_363, "般若波羅蜜多心經")])
+    assert len(items) == 1
+    it = items[0]
+    assert it["text_id"] == 9
+    assert it["title_zh"] == "般若波羅蜜多心經"
+    assert it["translator"] == "玄奘"
+    assert it["dynasty"] == "唐"
+    assert it["taisho_id"] == "T0251"
+    assert it["juan_count"] == 1
+    assert it["total_duration_ms"] == 101_363
+    assert it["juans"] == [{"juan_num": 1, "duration_ms": 101_363, "url": "/audio/9/1-abcd1234.mp3"}]
+
+
+def test_multiple_juans_collapse_into_one_item() -> None:
+    """一经多卷只出一行，时长求和 —— 否则地藏經会占满整页。"""
+    items = group_audio_by_text([
+        _row(24, 1, 300_000, "地藏菩薩本願經"),
+        _row(24, 2, 200_000, "地藏菩薩本願經"),
+    ])
+    assert len(items) == 1
+    assert items[0]["juan_count"] == 2
+    assert items[0]["total_duration_ms"] == 500_000
+    assert [j["juan_num"] for j in items[0]["juans"]] == [1, 2]
+
+
+def test_juans_are_sorted_even_if_rows_are_not() -> None:
+    """卷次必须升序 —— 列表里「第2卷」排在「第1卷」前面是明显的错。"""
+    items = group_audio_by_text([
+        _row(24, 3, 100, "地藏菩薩本願經"),
+        _row(24, 1, 100, "地藏菩薩本願經"),
+        _row(24, 2, 100, "地藏菩薩本願經"),
+    ])
+    assert [j["juan_num"] for j in items[0]["juans"]] == [1, 2, 3]
+
+
+def test_items_sorted_by_total_duration_ascending() -> None:
+    """短的排前面 —— 能一次听完的那几部才是这个功能的现实入口。"""
+    items = group_audio_by_text([
+        _row(24, 1, 500_000, "地藏菩薩本願經"),
+        _row(9, 1, 101_363, "般若波羅蜜多心經"),
+        _row(7, 1, 300_000, "金剛般若波羅蜜經"),
+    ])
+    assert [it["text_id"] for it in items] == [9, 7, 24]
+
+
+def test_missing_translator_and_dynasty_do_not_crash() -> None:
+    """CBETA 里有相当一批经没有译者著录，不能因此让整页 500。"""
+    items = group_audio_by_text([_row(6562, 1, 1000, "普門品經", translator=None,
+                                      dynasty=None, taisho=None)])
+    assert items[0]["translator"] is None
+    assert items[0]["dynasty"] is None
+    assert items[0]["taisho_id"] is None
+
+
+def test_empty_input_gives_empty_list() -> None:
+    assert group_audio_by_text([]) == []

--- a/backend/tests/test_audio_import.py
+++ b/backend/tests/test_audio_import.py
@@ -1,0 +1,73 @@
+"""入库前的重复键检测。
+
+``text_audio`` 的唯一键是 ``(text_id, juan_num, lang, voice_id)``，而
+``import_one`` 遇到已存在的行是**先删后插**。所以同一次运行里若出现两份
+指向同一把键的 cues.json，后处理的那份会静默顶掉前一份 —— 而顺序由
+``sorted()`` 的**字典序**决定，跟新旧无关。
+
+实测踩过：心經从 128k 重编码到 64k 后，产物目录里同时躺着
+``1-7891dd17.cues.json``（新，64k）和 ``1-ba9307ad.cues.json``（旧，128k）。
+字典序 ``7`` < ``b``，于是**旧的最后处理、赢了**，线上会回退到 128k
+而全程没有任何报错。
+
+宁可让它当场报错，也不要让人对着一份"部署成功"的日志找为什么没生效。
+"""
+
+import pytest
+from scripts.audio.import_audio import audio_key, find_duplicate_keys
+
+
+def _meta(text_id: int, juan: int, path: str, voice: str = "V", lang: str = "zh") -> dict:
+    return {
+        "text_id": text_id, "juan_num": juan, "lang": lang,
+        "voice_id": voice, "audio_path": path,
+    }
+
+
+def test_no_duplicates_returns_empty() -> None:
+    metas = [_meta(9, 1, "9/1-a.mp3"), _meta(9, 2, "9/2-b.mp3"), _meta(7, 1, "7/1-c.mp3")]
+    assert find_duplicate_keys(metas) == {}
+
+
+def test_same_juan_twice_is_flagged() -> None:
+    """⭐ 就是重编码那次的形态：同经同卷同音色，两个不同的 hash 文件名。"""
+    metas = [_meta(9, 1, "9/1-7891dd17.mp3"), _meta(9, 1, "9/1-ba9307ad.mp3")]
+    dupes = find_duplicate_keys(metas)
+    assert list(dupes) == [(9, 1, "zh", "V")]
+    assert sorted(dupes[(9, 1, "zh", "V")]) == ["9/1-7891dd17.mp3", "9/1-ba9307ad.mp3"]
+
+
+def test_different_voice_is_not_a_duplicate() -> None:
+    """同一卷并存多个音色是**设计允许**的（表的唯一键含 voice_id）。"""
+    metas = [_meta(9, 1, "9/1-a.mp3", voice="Lyrical"), _meta(9, 1, "9/1-b.mp3", voice="Calm")]
+    assert find_duplicate_keys(metas) == {}
+
+
+def test_different_lang_is_not_a_duplicate() -> None:
+    metas = [_meta(9, 1, "9/1-a.mp3", lang="zh"), _meta(9, 1, "9/1-b.mp3", lang="en")]
+    assert find_duplicate_keys(metas) == {}
+
+
+def test_three_way_collision_lists_all() -> None:
+    metas = [_meta(9, 1, f"9/1-{h}.mp3") for h in ("aa", "bb", "cc")]
+    assert len(find_duplicate_keys(metas)[(9, 1, "zh", "V")]) == 3
+
+
+@pytest.mark.parametrize("missing", ["text_id", "juan_num", "lang", "voice_id"])
+def test_key_fields_are_all_required(missing: str) -> None:
+    """四个字段一个都不能缺 —— 缺了就当场 KeyError，不要用默认值蒙混。
+
+    早先这里给 lang/voice_id 配了默认值，结果检测与 ``import_one`` 各推导
+    一次键：检测放行、入库照撞。共用 ``audio_key`` 是为了根除这种漂移，
+    所以本用例钉的是「两边同样地严」。
+    """
+    m = _meta(9, 1, "9/1-a.mp3")
+    del m[missing]
+    with pytest.raises(KeyError):
+        find_duplicate_keys([m])
+
+
+def test_duplicate_check_uses_the_same_key_as_import() -> None:
+    """检测用的键必须与入库用的键逐字段相同。"""
+    m = _meta(9, 1, "9/1-a.mp3")
+    assert audio_key(m) == (9, 1, "zh", "V")

--- a/deploy/deploy-audio.sh
+++ b/deploy/deploy-audio.sh
@@ -54,7 +54,15 @@ log "① 产物 → 生产仓库 backend/out/（gitignored，容器内可见）"
 ssh $SSH_OPTS "$VPS" "mkdir -p $REPO_OUT &&
   sudo install -d -o \$(id -un) -g \$(id -gn) -m 755 /srv/fojin $STATIC_DIR"
 # 只传 mp3 与 cues.json，**不传 *.parts/**（逐句 WAV 分片，几百个大文件）
-rsync -av $DRY --include='*/' --include='*.mp3' --include='*.cues.json' \
+#
+# ⚠️ 这一步必须 --delete，第③步必须**不** --delete —— 两个目录的性质相反：
+#   * 这里（仓库 out/）是**入库暂存区**，必须与本地一模一样。留着过时的
+#     cues.json 会让同一卷进来两份，import 先删后插、谁赢取决于文件名
+#     字典序。实测踩过：重编码到 64k 后 `1-7891dd17` 与 `1-ba9307ad` 并存，
+#     字典序 7<b，**旧的最后处理反而赢**，线上静默退回 128k 且日志显示成功。
+#   * /srv/fojin/audio/（第③步）是**对外静态目录**，旧文件要留着 ——
+#     已经打开页面的用户手里还攥着旧 URL，删了他们正在听的就断了。
+rsync -av --delete $DRY --include='*/' --include='*.mp3' --include='*.cues.json' \
   --exclude='*' --prune-empty-dirs -e "ssh $SSH_OPTS" \
   "$LOCAL_OUT" "$VPS:$REPO_OUT"
 

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1547,5 +1547,14 @@
   "xiaojin.menu_quit": "Quit XiaoJin",
   "xiaojin.speaking_as": "Speaking as {{name}}",
   "xiaojin.recall": "Bring back XiaoJin",
-  "admin_dashboard.trends.series.anonymous_messages": "Guest messages"
+  "admin_dashboard.trends.series.anonymous_messages": "Guest messages",
+  "nav.readaloud": "Listen",
+  "readaloud.title": "Listen to Sutras",
+  "readaloud.subtitle": "Follow along as you read — the current line highlights, and playback continues on a locked screen.",
+  "readaloud.seo_title": "Listen to Sutras — line-synced Buddhist audio | FoJin",
+  "readaloud.seo_desc": "Listen to Buddhist scriptures with audio aligned to the text line by line, and keep listening with the screen locked. Currently AI-synthesised speech, not a human recording.",
+  "readaloud.synthetic_notice": "All audio here is AI-synthesised speech (MiniMax Speech), not a monastic's recitation. Texts follow the CBETA digital canon.",
+  "readaloud.empty": "No recordings available yet",
+  "readaloud.juan_count": "{{n}} fascicle(s)",
+  "readaloud.juan": "Fascicle {{n}}"
 }

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1547,5 +1547,14 @@
   "xiaojin.menu_quit": "退出小津",
   "xiaojin.speaking_as": "正以 {{name}} 的口吻作答",
   "xiaojin.recall": "喚回小津",
-  "admin_dashboard.trends.series.anonymous_messages": "訪客訊息數"
+  "admin_dashboard.trends.series.anonymous_messages": "訪客訊息數",
+  "nav.readaloud": "讀誦",
+  "readaloud.title": "線上讀誦",
+  "readaloud.subtitle": "邊看經文邊聽，逐句高亮跟隨，可鎖屏收聽。",
+  "readaloud.seo_title": "線上讀誦 — 佛經音頻逐句跟隨 | 佛津 FoJin",
+  "readaloud.seo_desc": "線上收聽佛經，音頻與經文逐句對齊、讀到哪高亮到哪，手機可鎖屏收聽。目前為 AI 語音合成，非真人錄音。",
+  "readaloud.synthetic_notice": "以下音頻均由 AI 語音合成（MiniMax Speech），非法師真人讀誦。經文文本依 CBETA 電子佛典。",
+  "readaloud.empty": "暫無可收聽的經典",
+  "readaloud.juan_count": "{{n}} 卷",
+  "readaloud.juan": "第 {{n}} 卷"
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1547,5 +1547,14 @@
   "xiaojin.menu_quit": "退出小津",
   "xiaojin.speaking_as": "正以 {{name}} 的口吻作答",
   "xiaojin.recall": "唤回小津",
-  "admin_dashboard.trends.series.anonymous_messages": "游客消息数"
+  "admin_dashboard.trends.series.anonymous_messages": "游客消息数",
+  "nav.readaloud": "读诵",
+  "readaloud.title": "在线读诵",
+  "readaloud.subtitle": "边看经文边听，逐句高亮跟随，可锁屏收听。",
+  "readaloud.seo_title": "在线读诵 — 佛经音频逐句跟随 | 佛津 FoJin",
+  "readaloud.seo_desc": "在线收听佛经，音频与经文逐句对齐、读到哪高亮到哪，手机可锁屏收听。目前为 AI 语音合成，非真人录音。",
+  "readaloud.synthetic_notice": "以下音频均由 AI 语音合成（MiniMax Speech），非法师真人读诵。经文文本依 CBETA 电子佛典。",
+  "readaloud.empty": "暂无可收听的经典",
+  "readaloud.juan_count": "{{n}} 卷",
+  "readaloud.juan": "第 {{n}} 卷"
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ const DictionaryPage = lazy(() => import("./pages/DictionaryPage"));
 const SutraLandingPage = lazy(() => import("./pages/SutraLandingPage"));
 const WorkDetailPage = lazy(() => import("./pages/WorkDetailPage"));
 const CollectionsPage = lazy(() => import("./pages/CollectionsPage"));
+const ReadAloudPage = lazy(() => import("./pages/ReadAloudPage"));
 const CrossCanonPage = lazy(() => import("./pages/CrossCanonPage"));
 const TopicsPage = lazy(() => import("./pages/TopicsPage"));
 const AdminDashboardPage = lazy(() => import("./pages/AdminDashboardPage"));
@@ -71,6 +72,7 @@ function App() {
             <Route path="/texts/:id" element={<TextDetailPage />} />
             <Route path="/texts/:id/read" element={<TextReaderPage />} />
             <Route path="/sources" element={<SourcesPage />} />
+            <Route path="/read-aloud" element={<ReadAloudPage />} />
             <Route path="/collections" element={<CollectionsPage />} />
             <Route path="/collections/:collectionId" element={<CollectionsPage />} />
             <Route path="/cross-canon" element={<CrossCanonPage />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -655,6 +655,36 @@ export interface AudioCue {
   kind: string;
 }
 
+export interface AudioCatalogJuan {
+  juan_num: number;
+  duration_ms: number;
+  url: string;
+}
+
+export interface AudioCatalogItem {
+  text_id: number;
+  title_zh: string;
+  translator: string | null;
+  dynasty: string | null;
+  taisho_id: string | null;
+  /** "minimax" | "human" —— 标注必须跟着变，不能让人以为机器读的是法师读的 */
+  engine: string;
+  juan_count: number;
+  total_duration_ms: number;
+  juans: AudioCatalogJuan[];
+}
+
+export interface AudioCatalogResponse {
+  total: number;
+  items: AudioCatalogItem[];
+}
+
+/** 有读诵音频的经。总量按设计就很小，索引页与经典详情页共用同一份缓存。 */
+export async function getAvailableAudio(): Promise<AudioCatalogResponse> {
+  const { data } = await api.get<AudioCatalogResponse>("/audio/available");
+  return data;
+}
+
 export interface TextAudioResponse {
   text_id: number;
   juan_num: number;

--- a/frontend/src/audio/AudioPlayerProvider.test.tsx
+++ b/frontend/src/audio/AudioPlayerProvider.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import AudioPlayerProvider from "./AudioPlayerProvider";
+import { useAudioPlayer, type AudioTrack } from "./useAudioPlayback";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const TRACK: AudioTrack = {
+  textId: 9,
+  juanNum: 1,
+  title: "般若波羅蜜多心經 第1卷",
+  audio: {
+    text_id: 9,
+    juan_num: 1,
+    url: "/audio/9/1-ba9307ad.mp3",
+    voice_id: "Chinese (Mandarin)_Lyrical_Voice",
+    engine: "minimax",
+    duration_ms: 101_412,
+    cues: [],
+  },
+};
+
+/** Provider 内部用 `new Audio()`，元素不在 DOM 里，只能从构造处截获。 */
+let created: HTMLAudioElement[] = [];
+let track: ReturnType<typeof vi.fn>;
+
+function Harness() {
+  const p = useAudioPlayer();
+  return (
+    <>
+      <button onClick={() => p.play(TRACK)}>go</button>
+      <button onClick={() => p.seek(30_000)}>jump</button>
+    </>
+  );
+}
+
+beforeEach(() => {
+  created = [];
+  track = vi.fn();
+  vi.stubGlobal("umami", { track });
+  const Orig = window.Audio;
+  vi.stubGlobal(
+    "Audio",
+    class extends Orig {
+      constructor(src?: string) {
+        super(src);
+        created.push(this as unknown as HTMLAudioElement);
+      }
+    },
+  );
+  // jsdom 不实现 HTMLMediaElement.play()，不打桩会抛 "Not implemented"
+  vi.spyOn(window.HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function start() {
+  render(
+    <AudioPlayerProvider>
+      <Harness />
+    </AudioPlayerProvider>,
+  );
+  await userEvent.click(screen.getByText("go"));
+  return created[0];
+}
+
+describe("AudioPlayerProvider 埋点", () => {
+  it("开播记 audio_play", async () => {
+    const el = await start();
+    act(() => void el.dispatchEvent(new Event("play")));
+    expect(track).toHaveBeenCalledWith("audio_play", { text_id: 9, juan_num: 1 });
+  });
+
+  it("同一卷内暂停再播不重复记 audio_play —— 否则「有多少人开始听」会被续播灌水", async () => {
+    const el = await start();
+    act(() => void el.dispatchEvent(new Event("play")));
+    act(() => void el.dispatchEvent(new Event("pause")));
+    act(() => void el.dispatchEvent(new Event("play")));
+    expect(track.mock.calls.filter((c) => c[0] === "audio_play")).toHaveLength(1);
+  });
+
+  it("播完记 audio_complete —— 这是「真的在听」的唯一硬信号", async () => {
+    const el = await start();
+    act(() => void el.dispatchEvent(new Event("ended")));
+    expect(track).toHaveBeenCalledWith("audio_complete", { text_id: 9, juan_num: 1 });
+  });
+
+  it("拖动进度条记 audio_seek", async () => {
+    await start();
+    await userEvent.click(screen.getByText("jump"));
+    expect(track).toHaveBeenCalledWith("audio_seek", { text_id: 9, juan_num: 1 });
+  });
+
+  it("没有曲目时 seek 不记事件", async () => {
+    render(
+      <AudioPlayerProvider>
+        <Harness />
+      </AudioPlayerProvider>,
+    );
+    await userEvent.click(screen.getByText("jump"));
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/audio/AudioPlayerProvider.tsx
+++ b/frontend/src/audio/AudioPlayerProvider.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } fro
 import { useTranslation } from "react-i18next";
 
 import { findCueIndex } from "./cues";
+import { trackAudio } from "./telemetry";
 import { AudioPlayerContext, type AudioPlayerState, type AudioTrack } from "./useAudioPlayback";
 
 /**
@@ -16,6 +17,9 @@ import { AudioPlayerContext, type AudioPlayerState, type AudioTrack } from "./us
 export default function AudioPlayerProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation();
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  // 已记过 audio_play 的曲目键。暂停后续播会再次触发 play 事件，
+  // 不去重的话「有多少人开始听」会被续播灌水。
+  const playedRef = useRef<string | null>(null);
   const [track, setTrack] = useState<AudioTrack | null>(null);
   const [playing, setPlaying] = useState(false);
   const [cueIndex, setCueIndex] = useState(-1);
@@ -56,10 +60,14 @@ export default function AudioPlayerProvider({ children }: { children: ReactNode 
     else el.pause();
   }, [track]);
 
-  const seek = useCallback((ms: number) => {
-    const el = audioRef.current;
-    if (el) el.currentTime = ms / 1000;
-  }, []);
+  const seek = useCallback(
+    (ms: number) => {
+      const el = audioRef.current;
+      if (el) el.currentTime = ms / 1000;
+      if (track) trackAudio("audio_seek", track.textId, track.juanNum);
+    },
+    [track],
+  );
 
   const setRate = useCallback((r: number) => {
     const el = audioRef.current;
@@ -79,15 +87,27 @@ export default function AudioPlayerProvider({ children }: { children: ReactNode 
     setPlaying(false);
     setCueIndex(-1);
     setPositionMs(0);
+    // 关掉播放器再重开同一卷算一次新的收听
+    playedRef.current = null;
   }, []);
 
   // 播放状态与 cue 跟随
   useEffect(() => {
     const el = audioRef.current;
     if (!el) return;
-    const onPlay = () => setPlaying(true);
+    const onPlay = () => {
+      setPlaying(true);
+      if (!track) return;
+      const key = `${track.textId}/${track.juanNum}`;
+      if (playedRef.current === key) return;   // 续播不重复记
+      playedRef.current = key;
+      trackAudio("audio_play", track.textId, track.juanNum);
+    };
     const onPause = () => setPlaying(false);
-    const onEnded = () => setPlaying(false);
+    const onEnded = () => {
+      setPlaying(false);
+      if (track) trackAudio("audio_complete", track.textId, track.juanNum);
+    };
     const onTime = () => {
       const ms = Math.round(el.currentTime * 1000);
       setPositionMs(ms);

--- a/frontend/src/audio/format.ts
+++ b/frontend/src/audio/format.ts
@@ -1,0 +1,10 @@
+/** 毫秒 → `1:41` / `2:14:00`。语言中立，不进 i18n。 */
+export function formatDuration(ms: number): string {
+  const total = Math.round(ms / 1000);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  // 一小时以上必须补上小时位 —— 壇經一卷 134 分钟，写成「134:00」没人看得懂。
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}

--- a/frontend/src/audio/telemetry.test.ts
+++ b/frontend/src/audio/telemetry.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { trackAudio } from "./telemetry";
+
+function withUmami(fn: (track: ReturnType<typeof vi.fn>) => void) {
+  const track = vi.fn();
+  vi.stubGlobal("umami", { track });
+  fn(track);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("trackAudio", () => {
+  it("带上 text_id 与 juan_num —— 否则只知道「有人听」，不知道听的是哪部经", () => {
+    withUmami((track) => {
+      trackAudio("audio_play", 9, 1);
+      expect(track).toHaveBeenCalledWith("audio_play", { text_id: 9, juan_num: 1 });
+    });
+  });
+
+  it("umami 未加载时静默跳过，不抛异常", () => {
+    // 自托管者不配 VITE_UMAMI_* 就不会注入脚本（见 src/umami.ts），
+    // 埋点不能因此让播放器崩掉。
+    vi.stubGlobal("umami", undefined);
+    expect(() => trackAudio("audio_play", 9, 1)).not.toThrow();
+  });
+
+  it("事件名原样透传", () => {
+    withUmami((track) => {
+      trackAudio("audio_complete", 7, 2);
+      expect(track).toHaveBeenCalledWith("audio_complete", { text_id: 7, juan_num: 2 });
+    });
+  });
+});

--- a/frontend/src/audio/telemetry.ts
+++ b/frontend/src/audio/telemetry.ts
@@ -1,0 +1,21 @@
+/**
+ * 读诵埋点。
+ *
+ * ⚠️ **只能在客户端埋。** `/audio/*.mp3` 带 `immutable, max-age=31536000`，
+ * 绝大多数请求由 Cloudflare 边缘直接供给、永远到不了源站；宿主机 nginx 里
+ * 那条 `access_log off` 就算打开，得到的也是严重低估的数字。
+ *
+ * 四个事件回答四个问题：
+ * * `audio_open`     —— 有多少人**想**听（点了「读诵」）
+ * * `audio_play`     —— 有多少人**开始**听（每卷只记一次，续播不灌水）
+ * * `audio_complete` —— 有多少人**听完**了 ← 这是「真的在听」的唯一硬信号
+ * * `audio_seek`     —— 有没有人在跳着听
+ */
+export type AudioEvent = "audio_open" | "audio_play" | "audio_complete" | "audio_seek";
+
+export function trackAudio(event: AudioEvent, textId: number, juanNum: number): void {
+  // 自托管者不配 VITE_UMAMI_* 就不会注入脚本（见 src/umami.ts）——
+  // 埋点绝不能因此让播放器崩掉。
+  if (typeof umami === "undefined") return;
+  umami.track(event, { text_id: textId, juan_num: juanNum });
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -12,6 +12,7 @@ import {
   ApartmentOutlined,
   DatabaseOutlined,
   BookOutlined,
+  SoundOutlined,
   FileTextOutlined,
   MenuOutlined,
   DashboardOutlined,
@@ -99,6 +100,11 @@ export default function Layout() {
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
     { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
+    // 在线读诵(/read-aloud)。**刻意放进导航，也刻意可随时撤下** ——
+    // 此前它只有阅读页工具栏一个入口，触达接近零；不给曝光，三个月后
+    // 收到的数据只会证明"没人找得到"，而那件事我们已经知道了。
+    // 若三个月后播放数仍 <50/月，先撤这一行，再决定后续。
+    { icon: <SoundOutlined />, label: t("nav.readaloud"), path: "/read-aloud" },
     // 开放数据(/exports)暂不对外公开：后端路由由 ENABLE_OPEN_DATA_EXPORTS 控制，
     // 默认关闭（未鉴权、无限流，单次 kg.json 达 50MB/60s）。前端入口与路由一并撤下，
     // 重新放出时需同时打开后端开关并恢复 App.tsx 里的 /exports 路由。

--- a/frontend/src/pages/ReadAloudPage.test.tsx
+++ b/frontend/src/pages/ReadAloudPage.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HelmetProvider } from "react-helmet-async";
+
+import ReadAloudPage from "./ReadAloudPage";
+import { formatDuration } from "../audio/format";
+import * as client from "../api/client";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    // 把插值也带出来，否则「{{n}} 卷」这类键测不出数字是否传对
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts && "n" in opts ? `${key}:${opts.n}` : key,
+    i18n: { language: "zh" },
+  }),
+}));
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>
+          <ReadAloudPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+}
+
+const XINJING = {
+  text_id: 9,
+  title_zh: "般若波羅蜜多心經",
+  translator: "玄奘",
+  dynasty: "唐",
+  taisho_id: "T0251",
+  engine: "minimax",
+  juan_count: 1,
+  total_duration_ms: 101_363,
+  juans: [{ juan_num: 1, duration_ms: 101_363, url: "/audio/9/1-7891dd17.mp3" }],
+};
+
+const DIZANG = {
+  text_id: 24,
+  title_zh: "地藏菩薩本願經",
+  translator: "實叉難陀",
+  dynasty: "唐",
+  taisho_id: "T0412",
+  engine: "minimax",
+  juan_count: 2,
+  total_duration_ms: 5_940_000,
+  juans: [
+    { juan_num: 1, duration_ms: 3_000_000, url: "/audio/24/1-aaaa.mp3" },
+    { juan_num: 2, duration_ms: 2_940_000, url: "/audio/24/2-bbbb.mp3" },
+  ],
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("formatDuration", () => {
+  it("不足一小时用 m:ss", () => {
+    expect(formatDuration(101_363)).toBe("1:41");
+    expect(formatDuration(9_000)).toBe("0:09");
+  });
+
+  it("超过一小时用 h:mm:ss —— 壇經一卷 134 分钟，写成「134:00」没人看得懂", () => {
+    expect(formatDuration(5_940_000)).toBe("1:39:00");
+    expect(formatDuration(8_040_000)).toBe("2:14:00");
+  });
+
+  it("四舍五入到秒，不出现小数", () => {
+    expect(formatDuration(1_600)).toBe("0:02");
+  });
+});
+
+describe("ReadAloudPage", () => {
+  it("列出可听的经，链接落到阅读页（播放器与逐句高亮都在那里）", async () => {
+    vi.spyOn(client, "getAvailableAudio").mockResolvedValue({ total: 1, items: [XINJING] });
+    renderPage();
+    // ⚠️ 库里存的是繁体，简体语境下 localizeHan 会转 —— 断言必须写转换后的形态，
+    //    否则这条用例只是在测「我记不记得数据库是繁体的」。
+    const link = await screen.findByText("般若波罗蜜多心经");
+    expect(link.closest("a")).toHaveAttribute("href", "/texts/9/read?juan=1");
+    expect(screen.getByText("1:41")).toBeInTheDocument();
+  });
+
+  it("繁体经名按当前语境转写 —— 简体用户不该看到「般若波羅蜜多心經」", async () => {
+    vi.spyOn(client, "getAvailableAudio").mockResolvedValue({ total: 1, items: [XINJING] });
+    renderPage();
+    await screen.findByText("般若波罗蜜多心经");
+    expect(screen.queryByText("般若波羅蜜多心經")).not.toBeInTheDocument();
+  });
+
+  it("译者与朝代一并显示 —— 同一部经常有多个译本，不写清楚点不对", async () => {
+    vi.spyOn(client, "getAvailableAudio").mockResolvedValue({ total: 1, items: [XINJING] });
+    renderPage();
+    expect(await screen.findByText(/唐 玄奘/)).toBeInTheDocument();
+    expect(screen.getByText(/T0251/)).toBeInTheDocument();
+  });
+
+  it("多卷时给出逐卷直达", async () => {
+    vi.spyOn(client, "getAvailableAudio").mockResolvedValue({ total: 1, items: [DIZANG] });
+    renderPage();
+    expect(await screen.findByText("readaloud.juan:1")).toBeInTheDocument();
+    const j2 = screen.getByText("readaloud.juan:2");
+    expect(j2.closest("a")).toHaveAttribute("href", "/texts/24/read?juan=2");
+  });
+
+  it("单卷不渲染卷次直达 —— 只有一颗按钮的空行是噪音", async () => {
+    vi.spyOn(client, "getAvailableAudio").mockResolvedValue({ total: 1, items: [XINJING] });
+    renderPage();
+    await screen.findByText("般若波罗蜜多心经");
+    expect(screen.queryByText("readaloud.juan:1")).not.toBeInTheDocument();
+  });
+
+  it("诚信标注必须在页首出现，而不是只藏在播放条里", async () => {
+    vi.spyOn(client, "getAvailableAudio").mockResolvedValue({ total: 1, items: [XINJING] });
+    renderPage();
+    expect(await screen.findByText("readaloud.synthetic_notice")).toBeInTheDocument();
+  });
+
+  it("空目录显示空态而不是崩掉", async () => {
+    vi.spyOn(client, "getAvailableAudio").mockResolvedValue({ total: 0, items: [] });
+    renderPage();
+    expect(await screen.findByText("readaloud.empty")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ReadAloudPage.tsx
+++ b/frontend/src/pages/ReadAloudPage.tsx
@@ -1,0 +1,90 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+import { Empty, Spin, Tag, Alert } from "antd";
+import { SoundOutlined } from "@ant-design/icons";
+
+import { getAvailableAudio, type AudioCatalogItem } from "../api/client";
+import { formatDuration } from "../audio/format";
+import { localizeHan } from "../utils/hanScript";
+import "../styles/sources.css";
+
+/**
+ * 读诵索引页。
+ *
+ * 这个功能此前**只有一个入口** —— 阅读页工具栏那个按钮，且只在该卷恰好
+ * 有音频时才出现。也就是说：你得先打开心經的阅读页，才可能发现它存在。
+ * 没有这一页，再加十部经触达仍然接近零。
+ *
+ * 刻意**不做自动播放**：从这里跳过去会中断用户手势链，iOS 会静默拦下
+ * `play()`，用户只会以为坏了。落到阅读页、按那个高亮的按钮，一次点击而已。
+ */
+export default function ReadAloudPage() {
+  const { t, i18n } = useTranslation();
+  const { data, isLoading } = useQuery({
+    queryKey: ["audioCatalog"],
+    queryFn: getAvailableAudio,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const items: AudioCatalogItem[] = data?.items ?? [];
+
+  return (
+    <div className="sources-page">
+      <Helmet>
+        <title>{t("readaloud.seo_title")}</title>
+        <meta name="description" content={t("readaloud.seo_desc")} />
+      </Helmet>
+
+      <header className="sources-header">
+        <h1>
+          <SoundOutlined /> {t("readaloud.title")}
+        </h1>
+        <p>{t("readaloud.subtitle")}</p>
+      </header>
+
+      {/* 诚信标注放在页首，而不是只藏在播放条里 —— 用户在点进去之前就该知道。 */}
+      <Alert type="info" showIcon message={t("readaloud.synthetic_notice")} style={{ marginBottom: 20 }} />
+
+      {isLoading && <Spin />}
+
+      {!isLoading && items.length === 0 && (
+        <Empty description={t("readaloud.empty")} />
+      )}
+
+      <ul className="readaloud-list">
+        {items.map((it) => (
+          <li key={it.text_id} className="readaloud-item">
+            <div className="readaloud-item-main">
+              <Link to={`/texts/${it.text_id}/read?juan=${it.juans[0]?.juan_num ?? 1}`}>
+                {localizeHan(it.title_zh, i18n.language)}
+              </Link>
+              <span className="readaloud-meta">
+                {[it.dynasty, it.translator]
+                  .filter(Boolean)
+                  .map((s) => localizeHan(String(s), i18n.language))
+                  .join(" ")}
+                {it.taisho_id ? ` · ${it.taisho_id}` : ""}
+              </span>
+            </div>
+            <div className="readaloud-item-side">
+              <Tag>{t("readaloud.juan_count", { n: it.juan_count })}</Tag>
+              <Tag color="blue">{formatDuration(it.total_duration_ms)}</Tag>
+            </div>
+            {it.juan_count > 1 && (
+              <div className="readaloud-juans">
+                {it.juans.map((j) => (
+                  <Link key={j.juan_num} to={`/texts/${it.text_id}/read?juan=${j.juan_num}`}>
+                    {t("readaloud.juan", { n: j.juan_num })}
+                    <span className="readaloud-juan-dur"> {formatDuration(j.duration_ms)}</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -17,8 +17,9 @@ import {
   HomeOutlined,
   BookOutlined,
   ExportOutlined,
+  SoundOutlined,
 } from "@ant-design/icons";
-import { getTextDetail } from "../api/client";
+import { getTextDetail, getAvailableAudio } from "../api/client";
 import { useTranslation } from "react-i18next";
 import { buildCbetaReadUrl } from "../utils/sourceUrls";
 import { getLastPosition } from "../utils/readingHistory";
@@ -45,6 +46,16 @@ export default function TextDetailPage() {
     queryFn: () => getTextDetail(Number(id)),
     enabled: !!id,
   });
+
+  // 与 /read-aloud 索引页共用同一份缓存（目录很小，第一期只有一部经），
+  // 所以这里不是额外一次请求。详情页访客比阅读页还多（90 天 1,355 vs 1,132），
+  // 有音频却不在这里露出，等于白丢两成触达。
+  const { data: audioCatalog } = useQuery({
+    queryKey: ["audioCatalog"],
+    queryFn: getAvailableAudio,
+    staleTime: 5 * 60 * 1000,
+  });
+  const audioItem = audioCatalog?.items.find((it) => it.text_id === Number(id));
 
   useEffect(() => {
     if (text && id) {
@@ -218,6 +229,16 @@ export default function TextDetailPage() {
               style={{ background: "var(--fj-accent)", borderColor: "var(--fj-accent)", color: "var(--fj-on-accent)" }}
             >
               {t("textDetail.readOnCbeta")}
+            </Button>
+          )}
+          {audioItem && (
+            <Button
+              icon={<SoundOutlined />}
+              onClick={() =>
+                navigate(`/texts/${text.id}/read?juan=${audioItem.juans[0]?.juan_num ?? 1}`)
+              }
+            >
+              {t("reader.audio.button")}
             </Button>
           )}
           <BookmarkButton textId={text.id} />

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -21,6 +21,7 @@ import {
   DownloadOutlined,
   SoundOutlined,
 } from "@ant-design/icons";
+import { trackAudio } from "../audio/telemetry";
 import { useAudioPlayer } from "../audio/useAudioPlayback";
 import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, getJuanLineAnchors, getJuanAudio, type ApparatusEntryItem } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
@@ -956,7 +957,9 @@ export default function TextReaderPage() {
                     : "default"
                 }
                 icon={<SoundOutlined />}
-                onClick={() =>
+                onClick={() => {
+                  // 意图信号：点了按钮 ≠ 听完，两个数的比值才是转化率
+                  trackAudio("audio_open", Number(textId), juanNum);
                   audioPlayer.play({
                     textId: Number(textId),
                     juanNum,
@@ -965,8 +968,8 @@ export default function TextReaderPage() {
                       n: juanNum,
                     }),
                     audio: audioData,
-                  })
-                }
+                  });
+                }}
               >
                 {t("reader.audio.button")}
               </Button>

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -653,3 +653,48 @@
 :root[data-theme="dark"] .sources-cap-chip-remote { border-left-color: #5cdbd3; }
 :root[data-theme="dark"] .sources-cap-chip-iiif   { border-left-color: #b37feb; }
 :root[data-theme="dark"] .sources-cap-chip-api    { border-left-color: #ffb266; }
+
+/* ── 读诵索引页 ───────────────────────────────────────────────── */
+.readaloud-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.readaloud-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--fj-border, rgba(0, 0, 0, 0.08));
+}
+.readaloud-item-main {
+  flex: 1 1 260px;
+  min-width: 0;
+}
+.readaloud-item-main a {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+.readaloud-meta {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.85rem;
+  color: var(--fj-ink-muted, #8a8078);
+}
+.readaloud-item-side {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+/* 多卷时的卷次直达。单卷不渲染，避免只有一颗按钮的空行。 */
+.readaloud-juans {
+  flex: 1 1 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin-top: 4px;
+  font-size: 0.88rem;
+}
+.readaloud-juan-dur {
+  color: var(--fj-ink-muted, #8a8078);
+}


### PR DESCRIPTION
按「收敛成一小批 + 补埋点 + 停三个月看数据，不做成产品线」的决定，做掉三件不需要新合成的事。

## 为什么是这三件

Umami 实数（90 天，真人流量）：

| | 访客 |
|---|---|
| 阅读页全站 | 1,132（432 部经，其中 379 部 <5 访客）|
| **心經玄奘譯阅读页** | **17**（阅读排行第 15）|
| 经典详情页全站 | 1,355 |

我们做的那部经，每月 5.7 个人打开。而读诵此前**只有一个入口** —— 阅读页工具栏那颗按钮，且只在该卷恰好有音频时才出现。再加十部经，触达仍然接近零。

## 1. 埋点（`feat(reader): 读诵埋点`）

读诵是全站唯一没有埋点的功能。而 `/audio/*.mp3` 带 `immutable, max-age=1y`，绝大多数请求由 Cloudflare 边缘直供、到不了源站 —— 宿主机 nginx 那条 `access_log off` 就算打开也只会得到严重低估的数字。**只能在客户端埋。**

`audio_open` / `audio_play` / `audio_complete` / `audio_seek`，都带 `text_id` 与 `juan_num`。`audio_play` 每卷只记一次（续播不灌水），`audio_complete` 是「真的在听」的唯一硬信号，两者与 `audio_open` 的比值就是转化率。

## 2. 码率 128k → 64k（`fix(audio): 码率降到 64k`）

心經 1.6 MB → 793 KB。mono 32 kHz 的口语听感无差；长经差别更要命 —— 壇經一卷 134 分钟，128k 要 63 MB。

要同时满足两个互相冲突的要求，哈希必须分层：

- **换编码必须换 URL**，否则同名文件在 CF 边缘活一年，等于改了个寂寞
- **换编码绝不能重新合成**，MiniMax 非确定性（同句同参数三次 8.01/8.82/9.30 秒，极差 14.8%），心經 H 版是逐轮听审通过的

于是 `synth_hash`（只含合成参数，给 `.parts` 命名，与旧 fingerprint 逐字节一致）+ `content_hash`（叠加码率，给 mp3 命名）。实测重编码 `synth=ba9307ad` 纹丝不动、**计费 0 字符**、时长与 13 个 cue 一字未变。另加 `--no-synth` 保险丝。

**两个部署期实测踩出来的坑：**

1. `import_audio` 用 `sorted()` 遍历，同卷多产物时**字典序**决定谁赢。`1-7891dd17` < `1-ba9307ad`，旧的 128k 最后处理反而赢 —— **生产上真实发生了一次**，日志还显示"成功"。加 `find_duplicate_keys` 当场拒绝，并把键推导抽成 `audio_key` 供检测与入库共用。
2. deploy 第①步（仓库 `out/` 暂存区）必须 `--delete`，第③步（`/srv` 对外目录）必须**不** `--delete`。性质相反：暂存区留旧文件会造成上面那个撞车；对外目录删旧文件会掐断已打开页面手里的旧 URL。

## 3. 索引页（`feat(audio): 读诵索引页与列表端点`）

`GET /api/audio/available`（按经聚合、总时长升序，短经先上）+ `/read-aloud` 页 + 详情页露出 + 导航一项。

**刻意不做的两件：**
- 不自动播放 —— 跳转会中断用户手势链，iOS 静默拦下 `play()`，用户只会以为坏了
- 不进 `staticPages.json` —— 会在 dist 生成同名目录、撞 `try_files` 多一次 301，且 Baiduspider 30 天真实抓取为 0，此刻 SEO 收益约等于零。已核实 `dist/read-aloud` 不存在

## 验证

- 后端 1,679 passed（3 个 `test_health_check_probe` 失败是本机 cryptography 版本偏旧，master 同样失败，CI 绿）
- 前端 476 passed / eslint `--max-warnings 0` / tsc / i18n ratchet / vite build 全过
- 变异检验：把 `audio_play` 去重和 `find_duplicate_keys` 分别改坏，对应用例都会红
- 64k 音频已部署，生产实测 `content-length: 811629`、`audio/mpeg`、ID3 头、cue 未变

## 三个月后的处置

若播放数 <50/月：先撤导航那一行，不做品级切分、不做法華楞嚴、不再加经。