### PR TITLE
fix(audio): audio_seek 节流

### DIFF
--- a/frontend/src/audio/AudioPlayerProvider.test.tsx
+++ b/frontend/src/audio/AudioPlayerProvider.test.tsx
@@ -98,6 +98,27 @@ describe("AudioPlayerProvider 埋点", () => {
     expect(track).toHaveBeenCalledWith("audio_seek", { text_id: 9, juan_num: 1 });
   });
 
+  it("一次拖动只记一条 —— antd Slider 的 onChange 连发，不节流会淹没其他事件", async () => {
+    // 生产实测：仅仅 mousedown→mousemove→mouseup 就发了 2 条；
+    // 真人横拖整条进度条会发几十条，audio_seek 会把 open/play/complete 全压下去。
+    await start();
+    const jump = screen.getByText("jump");
+    await userEvent.click(jump);
+    await userEvent.click(jump);
+    await userEvent.click(jump);
+    expect(track.mock.calls.filter((c) => c[0] === "audio_seek")).toHaveLength(1);
+  });
+
+  it("隔开足够久的两次拖动记两条 —— 节流不能把真实的第二次跳播吃掉", async () => {
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(1_000_000);
+    await start();
+    await userEvent.click(screen.getByText("jump"));
+    now.mockReturnValue(1_000_000 + 5_000);
+    await userEvent.click(screen.getByText("jump"));
+    expect(track.mock.calls.filter((c) => c[0] === "audio_seek")).toHaveLength(2);
+  });
+
   it("没有曲目时 seek 不记事件", async () => {
     render(
       <AudioPlayerProvider>

--- a/frontend/src/audio/AudioPlayerProvider.tsx
+++ b/frontend/src/audio/AudioPlayerProvider.tsx
@@ -5,6 +5,9 @@ import { findCueIndex } from "./cues";
 import { trackAudio } from "./telemetry";
 import { AudioPlayerContext, type AudioPlayerState, type AudioTrack } from "./useAudioPlayback";
 
+/** 同一次拖动内 audio_seek 的最小间隔。见 seek() 里的说明。 */
+const SEEK_TRACK_GAP_MS = 2000;
+
 /**
  * 读诵播放器。挂在 Layout 层，持有全站唯一的 <audio>。
  *
@@ -20,6 +23,7 @@ export default function AudioPlayerProvider({ children }: { children: ReactNode 
   // 已记过 audio_play 的曲目键。暂停后续播会再次触发 play 事件，
   // 不去重的话「有多少人开始听」会被续播灌水。
   const playedRef = useRef<string | null>(null);
+  const lastSeekTrackedRef = useRef(0);
   const [track, setTrack] = useState<AudioTrack | null>(null);
   const [playing, setPlaying] = useState(false);
   const [cueIndex, setCueIndex] = useState(-1);
@@ -64,7 +68,15 @@ export default function AudioPlayerProvider({ children }: { children: ReactNode 
     (ms: number) => {
       const el = audioRef.current;
       if (el) el.currentTime = ms / 1000;
-      if (track) trackAudio("audio_seek", track.textId, track.juanNum);
+      if (!track) return;
+      // ⚠️ antd Slider 的 onChange 在拖动过程中连发 —— 生产实测一次
+      //    mousedown→mousemove→mouseup 就发了 2 条，真人横拖整条进度条会发
+      //    几十条。不节流的话 audio_seek 会把 open/play/complete 全淹没，
+      //    Umami 面板上看起来像"用户主要在拖进度条"。
+      const now = Date.now();
+      if (now - lastSeekTrackedRef.current < SEEK_TRACK_GAP_MS) return;
+      lastSeekTrackedRef.current = now;
+      trackAudio("audio_seek", track.textId, track.juanNum);
     },
     [track],
   );


### PR DESCRIPTION
真机验证 #1179 的埋点时发现的。

## 问题

antd `Slider` 的 `onChange` 在拖动过程中连发。生产实测，仅仅

```js
rail.dispatchEvent(new MouseEvent("mousedown", ...))
document.dispatchEvent(new MouseEvent("mousemove", ...))
document.dispatchEvent(new MouseEvent("mouseup", ...))
```

就发出了 **2 条** `audio_seek`。真人横拖整条进度条会发几十条 —— Umami 面板上会显示成「用户主要在拖进度条」，把 `audio_open` / `audio_play` / `audio_complete` 这三个真正要看的数压下去。

## 修法

节流 2 秒：同一次拖动只记一条，隔开的第二次跳播仍会记。

两条用例把上下界都钉住了，双向变异都验过：

| 变异 | 会红的用例 |
|---|---|
| 去掉节流判断 | 「一次拖动只记一条」 |
| 窗口调到 999999 | 「隔开足够久的两次拖动记两条」 |

## 这轮真机验证的其他结论

生产上四个事件**全部触发**，payload 正确：

```
audio_open, audio_play, audio_open, audio_complete, audio_seek, audio_seek
                                    ↑ 音频播完时自然触发，最重要的指标端到端通了
```

`audio_play` 的去重也在生产成立：连点两次「读诵」得到 `opens: 2, plays: 1`。

⚠️ 另确认一条：**antd 的 ref/坐标点击对 Slider 不生效**（点了滑块位置没动，我一度误判成埋点没触发），必须派发真实 MouseEvent。

前端 478 passed / eslint `--max-warnings 0` / tsc 全过。