### PR TITLE
fix(chat): 思考档位从来没下发过——顺手修掉两处会静默吞掉真相的地方

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -44,6 +44,15 @@ class Settings(BaseSettings):
     llm_api_key: str = ""
     llm_model: str = "gpt-4o-mini"
 
+    # 思考档位（只对 DeepSeek V4 生效，见 llm_client.thinking_params）。
+    # 空 = 不下发任何字段 = 上游默认（官方默认 high），与配置它之前的线上行为
+    # 逐字节相同。可选 off / low / high / max。
+    # ⚠️ 改这个值等于改答案：换默认档前必须跑 `python -m eval.run_eval
+    # --temperature 0` 比引用准确性与逐字保真度，见 answer-fidelity-is-the-bar。
+    # 它存在的直接原因是这个开关此前根本不存在 —— 2026-08-13 实测，默认档下同一
+    # 个问题的首个正文字在 77-188 秒之间，而 low 档 16-29 秒、关闭 1 秒。
+    chat_reasoning_effort: str = ""
+
     # LLM fallback — platform secondary model used when the primary provider
     # fails before any tokens have been streamed. Leave empty to disable.
     llm_fallback_api_url: str = ""

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -74,6 +74,9 @@ from app.services.llm_client import (  # noqa: F401
     _resolve_llm_config,
     _resolve_with_model_override,
     _with_reasoning_headroom,
+    configured_thinking_params,
+    read_error_body,
+    thinking_params,
 )
 from app.services.llm_cost import record_llm_cost
 from app.services.master_profiles import get_master
@@ -274,7 +277,13 @@ async def _generate_session_title(
                 resp = await client.post(
                     f"{api_url}/chat/completions",
                     headers={"Authorization": f"Bearer {api_key}"},
-                    json={"model": model, "messages": messages, "temperature": 0.3, "max_tokens": _with_reasoning_headroom(model, 64)},
+                    json={"model": model, "messages": messages, "temperature": 0.3,
+                          "max_tokens": _with_reasoning_headroom(model, 64),
+                          # 标题一律关思考：给一个 5-10 字的标题跑上游默认的最高档
+                          # 推理是纯等待（实测同档位在正式问答上要 77-188 秒），而
+                          # 标题不进答案，关掉没有质量风险。留着 max_tokens 的推理
+                          # 额度是因为「关不掉的模型」仍要防 #1095 那种推理饿死正文。
+                          **thinking_params(model, "off")},
                 )
                 resp.raise_for_status()
                 title = resp.json()["choices"][0]["message"]["content"].strip().strip("\"'《》")
@@ -551,7 +560,9 @@ async def send_message(
             resp = await client.post(
                 f"{u}/chat/completions",
                 headers={"Authorization": f"Bearer {k}"},
-                json={"model": m, "messages": llm_messages, "temperature": 0.7, "max_tokens": _with_reasoning_headroom(m, 8000 if page_content else 2000)},
+                json={"model": m, "messages": llm_messages, "temperature": 0.7,
+                      "max_tokens": _with_reasoning_headroom(m, 8000 if page_content else 2000),
+                      **configured_thinking_params(m)},
             )
             resp.raise_for_status()
             return resp.json()["choices"][0]["message"]["content"]
@@ -949,7 +960,8 @@ async def send_message_stream(
                 "POST", f"{u}/chat/completions",
                 headers={"Authorization": f"Bearer {k}"},
                 json={"model": m, "messages": llm_messages, "temperature": 0.7,
-                      "max_tokens": _with_reasoning_headroom(m, 8000 if page_content else 2000), "stream": True},
+                      "max_tokens": _with_reasoning_headroom(m, 8000 if page_content else 2000), "stream": True,
+                      **configured_thinking_params(m)},
             ) as resp:
                 resp.raise_for_status()
                 async for line in resp.aiter_lines():
@@ -1097,7 +1109,11 @@ async def send_message_stream(
                     continue
                 # Final attempt failed — surface the error
                 if is_byok and status in (400, 401, 403, 404, 422, 429):
-                    resp_body = exc.response.text[:500] if isinstance(exc, httpx.HTTPStatusError) and exc.response else "N/A"
+                    # ⚠️ 必须先 aread 再读 body：这里的响应是流式且未读的，直接取
+                    # .text 会抛 ResponseNotRead —— 那样**错误处理器自己崩掉**，
+                    # 掉进最外层 except，用户拿到通用的「AI 服务暂时不可用」，
+                    # 归因码也退化成 internal。2026-08-13 生产实证。
+                    resp_body = await read_error_body(exc)
                     logger.warning("BYOK LLM stream HTTP %s: %s | url=%s model=%s", status, resp_body, att_url, att_model)
                     error_msg = _byok_error_message(exc, status)
                     error_code = "byok_config"
@@ -1106,7 +1122,7 @@ async def send_message_stream(
                     error_msg = "抱歉，AI 服务响应超时，请稍后重试。"
                     error_code = "upstream_timeout"
                 elif isinstance(exc, httpx.HTTPStatusError):
-                    resp_body = exc.response.text[:500] if exc.response else "N/A"
+                    resp_body = await read_error_body(exc)  # 同上：流式 body 要先 aread
                     logger.warning("LLM stream returned HTTP %s: %s | url=%s model=%s", status, resp_body, att_url, att_model)
                     error_msg = f"抱歉，AI 服务返回错误（HTTP {status}），请稍后重试。"
                     # status 进 code：上游 429（限流）和 5xx（挂了）要分开看，

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -138,6 +138,58 @@ def _with_reasoning_headroom(model: str | None, max_tokens: int) -> int:
     return max_tokens + _REASONING_HEADROOM_TOKENS if _is_reasoning_model(model) else max_tokens
 
 
+# 思考档位。**与 _is_reasoning_model 是两个不同的名单，不要合并**：那个名单管
+# 「要不要留推理额度」，宁可多算（o1/o3/*-thinking 都算上，多留额度无害）；这个
+# 名单管「往请求体里塞私有字段」，只能少算 —— 除 Anthropic 外的七家共用同一个
+# OpenAI 兼容 body builder，把 DeepSeek 的字段发给 OpenAI / Gemini 会被 400 拒掉，
+# 那位自带 Key 的用户直接问不出话。所以这里只列**官方文档写明支持**的型号。
+# 见 api-docs.deepseek.com/guides/thinking_mode/
+_THINKING_CAPABLE_MARKERS = ("deepseek-v4",)
+
+# 官方接受的档位。"off" 是我们这侧的叫法，映射到 thinking.type=disabled；
+# 不要用 Anthropic 格式的 reasoning.effort=none，DeepSeek 的兼容端点不认。
+_THINKING_EFFORTS = ("low", "high", "max")
+
+
+def thinking_params(model: str | None, effort: str | None) -> dict:
+    """DeepSeek V4 思考档位对应的请求体字段；不适用时返回空 dict。
+
+    ``effort`` 取值：``None``/``""`` 不发任何字段（= 上游默认，官方默认是 high）、
+    ``"off"`` 关闭思考、``"low"``/``"high"``/``"max"`` 显式指定档位。
+
+    为什么默认是「什么都不发」而不是显式 high：默认必须与配置这个开关之前的线上
+    行为逐字节相同，否则开关本身就成了一次未经 eval 的答案改动。
+
+    2026-08-13 生产实测，同一条真实提示词、同一模型 deepseek-v4-pro，各跑两次 ——
+    首个正文字：不带参数 77.1s / 187.9s，low 档 29.3s / 15.7s，关闭 1.0s / 1.2s。
+    等待时间几乎全是隐藏推理（正文要等推理吐完才开始流）。
+    """
+    if not effort:
+        return {}
+    m = (model or "").lower()
+    if not any(k in m for k in _THINKING_CAPABLE_MARKERS):
+        return {}
+    e = effort.strip().lower()
+    if e == "off":
+        return {"thinking": {"type": "disabled"}}
+    if e in _THINKING_EFFORTS:
+        return {"thinking": {"type": "enabled"}, "reasoning_effort": e}
+    # 非法值当作没配：.env 里一个笔误不该让全站每一次问答都吃 400。
+    logger.warning(
+        "未知的思考档位 %r，已忽略（可选：off / %s）", effort, " / ".join(_THINKING_EFFORTS)
+    )
+    return {}
+
+
+def configured_thinking_params(model: str | None) -> dict:
+    """正式问答用的档位 —— 取自 ``settings.chat_reasoning_effort``。
+
+    单独一个函数而不是让 chat.py 直接读 settings：调用点有三处（流式、非流式、
+    eval），读配置的口径必须只有一份，否则迟早会有一处忘了跟着改。
+    """
+    return thinking_params(model, settings.chat_reasoning_effort)
+
+
 def _build_anthropic_body(model: str, messages: list[dict], *, temperature: float = 0.7,
                           max_tokens: int = 2000, stream: bool = False) -> dict:
     system, user_messages = _convert_messages_for_anthropic(messages)
@@ -147,6 +199,29 @@ def _build_anthropic_body(model: str, messages: list[dict], *, temperature: floa
     if stream:
         body["stream"] = True
     return body
+
+
+async def read_error_body(exc: Exception, limit: int = 500) -> str:
+    """取上游错误响应的正文；**流式响应必须先 aread**，否则 .text 抛 ResponseNotRead。
+
+    2026-08-13：流式路径的 except 块直接取 ``exc.response.text``，于是错误处理器
+    自己崩了，401 / 429 / 5xx 一律掉进最外层 ``except Exception``，用户永远只看到
+    「抱歉，AI 服务暂时不可用」，归因码也全成了 internal。
+
+    读完 body 还有第二个好处：``_byok_error_message`` 靠 body 里的关键词分辨
+    「模型 ID 不存在」「余额不足」「Key 无效」—— 读不到 body 时它只能一律回落到
+    「Key 无效」，等于把三种配置错误说成同一种。
+
+    ⚠️ 非流式响应（``client.post``）本来就已读，aread 是幂等的空操作，安全。
+    """
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return "N/A"
+    try:
+        await resp.aread()
+        return resp.text[:limit]
+    except Exception:
+        return "N/A"
 
 
 def _byok_error_message(exc: Exception, status: int | None) -> str:

--- a/backend/eval/run_eval.py
+++ b/backend/eval/run_eval.py
@@ -31,6 +31,7 @@ from app.config import settings
 from app.database import async_session
 from app.services.chat import _build_llm_messages
 from app.services.citation_guard import _norm_title
+from app.services.llm_client import _with_reasoning_headroom, configured_thinking_params
 from app.services.quote_verifier import iter_quote_citations
 from app.services.rag_retrieval import retrieve_rag_context
 from eval.faithfulness import (
@@ -55,6 +56,33 @@ logger = logging.getLogger(__name__)
 EVAL_DIR = Path(__file__).parent
 TEST_SET_PATH = EVAL_DIR / "test_set.json"
 REPORTS_DIR = EVAL_DIR / "reports"
+
+# 重推理模型（deepseek-v4*）单题实测总耗时 91.9s / 197.8s，60 秒会让整份报告
+# 变成 90 条 [ERROR]。300 秒留足余量，反正 eval 是离线跑的，慢不要紧、错才要紧。
+EVAL_LLM_TIMEOUT_S = 300
+
+# eval 的答案预算与生产同口径（生产是 2000，reader 模式 8000）。
+_EVAL_ANSWER_TOKENS = 2000
+
+
+def build_eval_llm_body(model: str, messages: list[dict], temperature: float) -> dict:
+    """eval 调用 LLM 的请求体 —— 独立成函数是为了能被单测钉住。
+
+    2026-08-13 在生产机上照抄改动前的参数实跑（真实提示词、deepseek-v4-pro）：
+    ``timeout=60, max_tokens=2000`` → 30.2 秒后拿到 **正文 0 字**、推理 2,686 字、
+    ``finish=length``。推理与可见答案共用同一个 max_tokens，2000 全被推理吃掉，
+    与 #1095 修的生产故障同源，只是这次躲在 eval 里 —— 而 eval 不会报错，它会
+    安静地产出一份「90 道题全空」的报告，然后我们拿它去比较档位。
+    """
+    return {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": _with_reasoning_headroom(model, _EVAL_ANSWER_TOKENS),
+        # 让 eval 能按 CHAT_REASONING_EFFORT 跑不同档位，否则 high / low 的
+        # 引用准确性没法对比 —— 而那正是换默认档的唯一依据。
+        **configured_thinking_params(model),
+    }
 
 
 def load_test_set() -> dict:
@@ -172,11 +200,11 @@ async def run_single_question(
 
     t1 = time.monotonic()
     try:
-        async with httpx.AsyncClient(timeout=60) as client:
+        async with httpx.AsyncClient(timeout=EVAL_LLM_TIMEOUT_S) as client:
             resp = await client.post(
                 f"{api_url}/chat/completions",
                 headers={"Authorization": f"Bearer {api_key}"},
-                json={"model": model, "messages": llm_messages, "temperature": temperature, "max_tokens": 2000},
+                json=build_eval_llm_body(model, llm_messages, temperature),
             )
             resp.raise_for_status()
             answer = resp.json()["choices"][0]["message"]["content"]

--- a/backend/tests/test_eval_llm_call_config.py
+++ b/backend/tests/test_eval_llm_call_config.py
@@ -1,0 +1,66 @@
+"""eval 的 LLM 调用参数必须能撑住重推理模型，否则它量的是空答案。
+
+2026-08-13 在生产机上照抄 run_eval.py 当时的调用参数实跑（真实提示词、
+deepseek-v4-pro、temperature 0）：
+
+    timeout=60, max_tokens=2000  →  耗时 30.2s，**正文 0 字**，推理 2,686 字，
+                                    finish=length
+
+推理把 2000 token 的预算整个吃光，正文一个 token 都没轮到 —— 与 #1095 修掉的
+生产故障是同一回事，只是这次躲在 eval 里。放宽后同一条提示词能正常出 1,000+ 字。
+
+后果比一次线上故障更隐蔽：eval 不会报错，它会**给出一份 90 道题全是空答案的
+报告**，引用准确性、幻觉率全归零，而我们会拿它去比较档位。
+
+两条硬约束：
+
+1. 预算要装得下「实测推理量 + 完整答案」，不能只按答案长度拍。
+2. 超时要覆盖高档推理的实测总耗时（91.9s / 197.8s 两次），60 秒必然全军覆没。
+"""
+
+from eval.run_eval import EVAL_LLM_TIMEOUT_S, build_eval_llm_body
+
+# 2026-08-13 生产实测的推理长度，取最大的那次当下限，不拍好看的数字。
+MEASURED_REASONING_CHARS = 13908
+# run_eval 与 chat 共用 _estimate_tokens 的 2/3 口径
+MEASURED_REASONING_TOKENS = MEASURED_REASONING_CHARS * 2 // 3
+
+
+def test_budget_survives_a_real_reasoning_trace():
+    body = build_eval_llm_body("deepseek-v4-pro", [{"role": "user", "content": "x"}], 0.0)
+    budget = body["max_tokens"]
+    assert budget >= MEASURED_REASONING_TOKENS + 2000, (
+        f"预算 {budget} 装不下实测的 {MEASURED_REASONING_TOKENS} token 推理 + 2000 token 答案；"
+        "eval 会得到一份全是空答案的报告"
+    )
+
+
+def test_timeout_covers_measured_high_effort_latency():
+    """高档推理实测总耗时 91.9s / 197.8s —— 60 秒会让 90 道题全部 [ERROR]。"""
+    assert EVAL_LLM_TIMEOUT_S >= 240, (
+        f"超时 {EVAL_LLM_TIMEOUT_S}s 低于实测的 197.8s 总耗时"
+    )
+
+
+def test_non_reasoning_model_budget_is_untouched():
+    """非推理模型不该被顺手抬高预算 —— 那会改变既有基线的可比性。"""
+    body = build_eval_llm_body("glm-5.2", [{"role": "user", "content": "x"}], 0.0)
+    assert body["max_tokens"] == 2000
+
+
+def test_thinking_effort_flows_into_the_eval_body(monkeypatch):
+    """eval 必须能按档位跑，否则没法比较 high 与 low 的引用准确性。"""
+    from app.services import llm_client
+
+    monkeypatch.setattr(llm_client.settings, "chat_reasoning_effort", "low")
+    body = build_eval_llm_body("deepseek-v4-pro", [{"role": "user", "content": "x"}], 0.0)
+    assert body["reasoning_effort"] == "low"
+    assert body["thinking"] == {"type": "enabled"}
+
+
+def test_default_eval_body_sends_no_thinking_fields(monkeypatch):
+    from app.services import llm_client
+
+    monkeypatch.setattr(llm_client.settings, "chat_reasoning_effort", "")
+    body = build_eval_llm_body("deepseek-v4-pro", [{"role": "user", "content": "x"}], 0.0)
+    assert "thinking" not in body and "reasoning_effort" not in body

--- a/backend/tests/test_stream_upstream_error_surfacing.py
+++ b/backend/tests/test_stream_upstream_error_surfacing.py
@@ -1,0 +1,141 @@
+"""流式路径的上游 HTTP 错误必须原样浮出来，别被自己的错误处理吞掉。
+
+2026-08-13 生产实测：某位自带 Key 的用户连吃 8 次 401，每次 0.4 秒拿到同一句
+「抱歉，AI 服务暂时不可用，请稍后重试。」（正好 20 字）。日志里是
+``ERROR app.services.chat: LLM stream failed`` 带 traceback，而 traceback 的最后
+一行正是错误处理器自己那句 ``resp_body = exc.response.text[...]``。
+
+成因：``exc.response`` 是一个**流式且从未 read 过**的响应，取 ``.text`` 抛
+``httpx.ResponseNotRead``，于是处理 401 的分支自己崩了，掉进最外层
+``except Exception``，``_byok_error_message()`` 与 ``byok_config`` 归因码根本没机会执行。
+
+后果有两层：那位用户以为是佛津坏了而不是自己的 Key 无效；#1119 那套断流归因
+（byok_config / upstream_http_429 …）在整条流式路径上是瞎的。
+
+⚠️ 写这类替身时必须让响应**真的**处于未读状态（用异步生成器当 content）。
+传 bytes 的话响应已读，``.text`` 正常，测试会假绿 —— 见 fixture-shells-hide-real-bugs。
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.schemas.chat import ChatSource
+
+
+def _unread_401() -> httpx.HTTPStatusError:
+    """造一个与生产同构的异常：401，且 body 尚未读取。"""
+    req = httpx.Request("POST", "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions")
+
+    async def _body():
+        yield b'{"error":{"message":"Invalid API-key provided.","code":"invalid_api_key"}}'
+
+    resp = httpx.Response(401, content=_body(), request=req)
+    # 自证：此刻取 .text 必须抛 ResponseNotRead，否则这个替身没有复现真实条件。
+    with pytest.raises(httpx.ResponseNotRead):
+        _ = resp.text
+    return httpx.HTTPStatusError("Client error '401 Unauthorized'", request=req, response=resp)
+
+
+def _client_raising(exc: Exception):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock(side_effect=exc)
+
+    async def aiter_lines():
+        if False:  # pragma: no cover - 永远到不了，raise_for_status 先抛
+            yield ""
+
+    mock_resp.aiter_lines = aiter_lines
+
+    class _StreamCM:
+        async def __aenter__(self): return mock_resp
+        async def __aexit__(self, *_): return False
+
+    class _ClientInstance:
+        def stream(self, *a, **kw): return _StreamCM()
+
+    class _ClientCM:
+        async def __aenter__(self): return _ClientInstance()
+        async def __aexit__(self, *_): return False
+
+    return MagicMock(return_value=_ClientCM())
+
+
+class _FakeSessionmaker:
+    def __call__(self):
+        class _SessCM:
+            async def __aenter__(self_inner): return AsyncMock()
+            async def __aexit__(self_inner, *_): return False
+
+        return _SessCM()
+
+
+def _prepare_chat_return(is_byok: bool):
+    fake_session = MagicMock()
+    fake_session.id = 42
+    return (
+        fake_session, "https://dashscope.aliyuncs.com/compatible-mode/v1", "bad-key",
+        "qwen3.7-plus", is_byok, "dashscope",
+        [ChatSource(text_id=1, juan_num=1, chunk_text="色不異空", score=0.9, title_zh="心經")],
+        [{"role": "user", "content": "測試"}], [],
+    )
+
+
+async def _collect_events(is_byok: bool, exc: Exception) -> list[dict]:
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock,
+               return_value=_prepare_chat_return(is_byok)), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
+         patch("app.services.chat._mark_attachments_consumed", new_callable=AsyncMock), \
+         patch("app.services.chat.httpx.AsyncClient", _client_raising(exc)):
+        from app.services.chat import send_message_stream
+
+        out: list[dict] = []
+        async for chunk in send_message_stream(
+            user_id=1, message="測試", sessionmaker=_FakeSessionmaker(),
+        ):
+            for line in chunk.splitlines():
+                if line.startswith("data: "):
+                    try:
+                        out.append(json.loads(line[len("data: "):]))
+                    except json.JSONDecodeError:
+                        pass
+        return out
+
+
+@pytest.mark.asyncio
+async def test_byok_401_surfaces_key_error_not_generic_outage():
+    events = await _collect_events(is_byok=True, exc=_unread_401())
+    errors = [e for e in events if e.get("type") == "error"]
+    assert errors, f"没有 error 事件，收到的是 {events!r:.300}"
+    err = errors[-1]
+
+    assert err.get("code") == "byok_config", (
+        f"归因码丢了（断流统计会把 Key 配错记成服务故障）：{err!r}"
+    )
+    assert err["message"] != "抱歉，AI 服务暂时不可用，请稍后重试。", (
+        "用户又拿到了那句通用文案 —— 错误处理器很可能仍在读未 read 的流式 body"
+    )
+    assert "Key" in err["message"] or "模型" in err["message"] or "余额" in err["message"], (
+        f"提示没有说清到底哪里配错了：{err['message']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_platform_upstream_http_error_keeps_its_status_code():
+    """平台侧（非 BYOK）的上游错误同样不能被吞：归因码要带上状态码。"""
+    req = httpx.Request("POST", "https://api.deepseek.com/v1/chat/completions")
+
+    async def _body():
+        yield b'{"error":{"message":"Rate limit reached."}}'
+
+    resp = httpx.Response(429, content=_body(), request=req)
+    exc = httpx.HTTPStatusError("Client error '429'", request=req, response=resp)
+
+    events = await _collect_events(is_byok=False, exc=exc)
+    errors = [e for e in events if e.get("type") == "error"]
+    assert errors, f"没有 error 事件，收到的是 {events!r:.300}"
+    assert errors[-1].get("code") == "upstream_http_429", (
+        f"429 被归因成了别的东西：{errors[-1]!r}"
+    )

--- a/backend/tests/test_thinking_mode_params.py
+++ b/backend/tests/test_thinking_mode_params.py
@@ -1,0 +1,191 @@
+"""思考档位参数：一个只对 DeepSeek V4 生效的开关，默认什么都不发。
+
+2026-08-13 生产实测（同一条真实提示词、同一模型，各跑两次）：
+
+    不带思考参数（= 上游默认 high）  首个正文字 77.1s / 187.9s，推理 5,268 / 13,908 字
+    reasoning_effort=low            首个正文字 29.3s / 15.7s，推理 1,888 / 1,327 字
+    thinking=disabled               首个正文字  1.0s /  1.2s，推理 0 字
+
+等待时间几乎全是隐藏推理（正文要等推理吐完才开始），而我们的请求体里一个档位
+参数都没有 —— 每道题都跑上游默认的最高档，连 max_tokens=64 的会话标题也是。
+
+这里锁四条：
+
+1. **不配置就什么都不发**。默认必须与今天的线上行为逐字节相同，否则这个开关
+   本身就成了一次未经 eval 的答案改动。见 answer-fidelity-is-the-bar。
+2. **只对 deepseek-v4* 下发**。除 Anthropic 外的七家共用同一个 OpenAI 兼容
+   body builder，把 DeepSeek 私有字段发给 OpenAI / Gemini 会被 400 拒掉 ——
+   那位自带 Key 的用户会直接问不出话来。
+3. **非法档位当作没配**。.env 里一个笔误不能让全站每一次问答都 400。
+4. **会话标题一律关思考**。给一个 5-10 字的标题跑最高档推理是纯浪费，且它
+   不进答案，没有质量风险。
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.llm_client import thinking_params
+
+
+class TestThinkingParams:
+    def test_no_effort_sends_nothing(self):
+        """默认（未配置）必须与今天的线上行为完全一致 —— 一个字段都不加。"""
+        assert thinking_params("deepseek-v4-pro", None) == {}
+        assert thinking_params("deepseek-v4-pro", "") == {}
+
+    def test_low_effort_enables_thinking(self):
+        assert thinking_params("deepseek-v4-pro", "low") == {
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "low",
+        }
+
+    def test_high_and_max_pass_through(self):
+        for effort in ("high", "max"):
+            assert thinking_params("deepseek-v4-flash", effort) == {
+                "thinking": {"type": "enabled"},
+                "reasoning_effort": effort,
+            }
+
+    def test_off_disables_thinking(self):
+        """关闭用的是 thinking.type=disabled，不是 reasoning_effort=none —— 后者
+        是 Anthropic 格式，DeepSeek 的 OpenAI 兼容端点不认。"""
+        assert thinking_params("deepseek-v4-pro", "off") == {"thinking": {"type": "disabled"}}
+
+    @pytest.mark.parametrize("model", [
+        "qwen3.7-plus", "kimi-k3", "glm-5.2", "gpt-5.6-sol",
+        "gemini-3.6-flash", "doubao-seed-2-1-pro-260628", "deepseek-chat",
+    ])
+    def test_other_providers_get_nothing(self, model):
+        """⭐ 本文件最重要的一条：thinking / reasoning_effort 是 DeepSeek V4 的私有
+        字段。七家共用一个 body builder，漏给别人就是把那位用户的问答打成 400。"""
+        for effort in ("low", "high", "max", "off"):
+            assert thinking_params(model, effort) == {}
+
+    def test_invalid_effort_is_ignored(self):
+        """.env 笔误不能让全站问答 400 —— 当作没配，退回上游默认。"""
+        assert thinking_params("deepseek-v4-pro", "lowest") == {}
+        assert thinking_params("deepseek-v4-pro", "none") == {}
+
+    def test_model_none_is_safe(self):
+        assert thinking_params(None, "low") == {}
+
+
+class TestTitleGenerationDisablesThinking:
+    """会话标题：max_tokens=64 却在跑最高档推理，纯浪费，且不进答案。"""
+
+    @pytest.mark.asyncio
+    async def test_title_request_body_disables_thinking(self):
+        from app.services.chat import _generate_session_title
+
+        captured = {}
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(
+            return_value={"choices": [{"message": {"content": "般若与智慧"}}]}
+        )
+
+        class _Client:
+            async def __aenter__(self): return self
+            async def __aexit__(self, *_): return False
+
+            async def post(self, url, headers=None, json=None):
+                captured.update(json or {})
+                return mock_resp
+
+        with patch("app.services.chat._build_llm_http_client",
+                   new=AsyncMock(return_value=_Client())):
+            title = await _generate_session_title(
+                "https://api.deepseek.com/v1", "k", "deepseek-v4-pro",
+                "「般若」和智慧有什么不同？", "般若体绝名字……", provider="deepseek",
+            )
+
+        assert title == "般若与智慧"
+        assert captured.get("thinking") == {"type": "disabled"}, (
+            f"标题生成仍在跑思考模式，请求体={json.dumps(captured, ensure_ascii=False)[:200]}"
+        )
+
+
+def _capture_stream_client(captured: dict):
+    """替身 httpx.AsyncClient：记下流式请求体，回一个只有一块正文的流。"""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+
+    async def aiter_lines():
+        yield "data: " + json.dumps({"choices": [{"delta": {"content": "色不異空"}}]})
+        yield "data: [DONE]"
+
+    mock_resp.aiter_lines = aiter_lines
+
+    class _StreamCM:
+        async def __aenter__(self): return mock_resp
+        async def __aexit__(self, *_): return False
+
+    class _ClientInstance:
+        def stream(self, *args, **kwargs):
+            captured.update(kwargs.get("json") or {})
+            return _StreamCM()
+
+    class _ClientCM:
+        async def __aenter__(self): return _ClientInstance()
+        async def __aexit__(self, *_): return False
+
+    return MagicMock(return_value=_ClientCM())
+
+
+class _FakeSessionmaker:
+    def __call__(self):
+        class _SessCM:
+            async def __aenter__(self_inner): return AsyncMock()
+            async def __aexit__(self_inner, *_): return False
+
+        return _SessCM()
+
+
+def _prepare_chat_return():
+    from app.schemas.chat import ChatSource
+
+    fake_session = MagicMock()
+    fake_session.id = 42
+    return (
+        fake_session, "https://api.deepseek.com/v1", "fake-key", "deepseek-v4-pro",
+        False, "deepseek",
+        [ChatSource(text_id=1, juan_num=1, chunk_text="色不異空", score=0.9, title_zh="心經")],
+        [{"role": "user", "content": "測試"}], [],
+    )
+
+
+async def _run_stream_capturing_body(effort: str) -> dict:
+    captured: dict = {}
+    with patch("app.services.chat._prepare_chat", new_callable=AsyncMock,
+               return_value=_prepare_chat_return()), \
+         patch("app.services.chat._save_messages", new_callable=AsyncMock, return_value=99), \
+         patch("app.services.chat._mark_attachments_consumed", new_callable=AsyncMock), \
+         patch("app.services.llm_client.settings.chat_reasoning_effort", effort), \
+         patch("app.services.chat.httpx.AsyncClient", _capture_stream_client(captured)):
+        from app.services.chat import send_message_stream
+
+        async for _ in send_message_stream(
+            user_id=1, message="測試", sessionmaker=_FakeSessionmaker(),
+        ):
+            pass
+    return captured
+
+
+class TestAnswerPathHonoursSetting:
+    """正式问答走配置项；**默认必须与今天的线上行为逐字节相同**。"""
+
+    @pytest.mark.asyncio
+    async def test_default_sends_no_thinking_fields(self):
+        body = await _run_stream_capturing_body("")
+        assert "thinking" not in body and "reasoning_effort" not in body, (
+            f"未配置档位时不应改变请求体，实际={json.dumps(body, ensure_ascii=False)[:200]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_configured_effort_reaches_the_request(self):
+        body = await _run_stream_capturing_body("low")
+        assert body.get("thinking") == {"type": "enabled"}
+        assert body.get("reasoning_effort") == "low"


### PR DESCRIPTION
用户报「AI 问答响应变慢」。核查结论：不是站点慢，是 DeepSeek V4 在**上游默认的
最高思考档**下把 5,000–14,000 字的隐藏推理跑完才吐第一个正文字，而我们的请求体
里一个档位参数都没有。

## 定位（生产实测，非推断）

检索侧健康：12 小时 29 次采样，RAG 总计 0.64–3.02s；建连+prefill 0.9s。
LLM 侧：同期 29 次调用中位 50.2s、p90 ≈154s、最长 223.6s，推理量 569–11,201 字。

在生产机上用**真实提示词**（5 来源 / 3,189 字上下文 / 提示词合计 5,893 字）跑同
一个问题，只改档位，各两次：

    不带思考参数（= 上游默认 high）  首个正文字 77.1s / 187.9s   推理  5,268 / 13,908 字
    reasoning_effort=low            首个正文字 29.3s / 15.7s    推理  1,888 /  1,327 字
    thinking=disabled               首个正文字  1.0s /  1.2s    推理      0 /      0 字

⛔ 顺带证伪一条我自己的怀疑：**不是 #1095 把 max_tokens 抬到 26000 造成的**。
退回 6000 一样慢（首字 77.8s / 82.1s），而且其中一次直接 finish=length —— 答案被
截断在半句「一方便門、二實」上，正是 #1095 当初修的故障。那个额度不能回退。

## 改动

1. `thinking_params(model, effort)`：只对 deepseek-v4* 下发 thinking /
   reasoning_effort，其余一律返回空 dict。**这个门控是本 PR 最要紧的一行** ——
   除 Anthropic 外的七家共用同一个 OpenAI 兼容 body builder，漏给 OpenAI /
   Gemini 就是把那位自带 Key 的用户打成 400。它与 `_is_reasoning_model` 是两个
   名单，故意不合并：那个宁可多算（多留额度无害），这个只能少算。
2. 新增 `CHAT_REASONING_EFFORT`，**默认空 = 一个字段都不发 = 与今天的线上行为
   逐字节相同**。改这个值等于改答案，换默认档前必须跑 eval。
3. 会话标题（max_tokens=64）一律关思考 —— 给一个 5-10 字的标题跑最高档推理是纯
   等待，且它不进答案，零质量风险。
4. 修 `chat.py` 流式路径两处 `exc.response.text`：那是**流式且未 read** 的响应，
   取 .text 抛 ResponseNotRead，于是**错误处理器自己崩掉**，401/429/5xx 全部掉进
   最外层 except。生产实证：某位 BYOK 用户连吃 8 次 401，每次 0.4 秒只拿到通用的
   「抱歉，AI 服务暂时不可用」（正好 20 字），日志是 LLM stream failed 带
   traceback，而 traceback 最后一行正是那句 resp_body = exc.response.text[...]。
   后果两层：他以为是佛津坏了而不是自己 Key 无效；#1119 那套断流归因在整条流式
   路径上是瞎的（全记成 internal）。`:566` / `:588` 走非流式 post，本来就已读，
   不动。
5. 修 eval harness 两处硬伤，否则第二步的档位对比量不出任何东西：timeout 60→300
   （高档单题实测 91.9s / 197.8s，60 秒会让 90 题全部 [ERROR]），max_tokens 2000
   加上推理额度。照抄改动前参数在生产实跑：30.2 秒拿到**正文 0 字**、推理 2,686
   字、finish=length —— eval 不会报错，它会安静地产出一份「90 题全空」的报告。

## 验证

· 三个新用例文件先红后绿，且红在正确的地方：档位用例红在「请求体里没有
  reasoning_effort」而不是 patch 目标写错（第一版正是patch 错了 settings 所在模块，
  两条一起红，已修正为只红该红的那条）；错误处理用例红在
  `code='internal' + 20 字通用文案`，与生产日志逐字对上。
· 错误处理的替身用**异步生成器**当 content，让响应真的处于未读状态；传 bytes
  的话响应已读、.text 正常，测试会假绿（fixture-shells-hide-real-bugs）。
· 「默认不发任何字段」单独一条用例守着，防止这个开关本身变成一次未经 eval 的
  答案改动。
· ruff（改动文件）+ pytest 1710 通过；test_health_check_probe 的 3 个失败在
  master 上同样红（已 stash 复核），与本改动无关。

## 未解决

默认档仍是上游的 high，本 PR **不动默认**。是否切到 low 要看 90 题 eval 的引用
准确性与逐字保真度差值 —— 现有 nightly 是 --no-llm 只测检索，没有答案质量基线，
必须先跑一轮。