### PR TITLE
chore(nav): 读诵不占导航位——它是读经时的一个动作，不是一个板块

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -12,7 +12,6 @@ import {
   ApartmentOutlined,
   DatabaseOutlined,
   BookOutlined,
-  SoundOutlined,
   FileTextOutlined,
   MenuOutlined,
   DashboardOutlined,
@@ -100,11 +99,12 @@ export default function Layout() {
     { icon: <ApartmentOutlined />, label: t("nav.kg"), path: "/kg" },
     { icon: <GlobalOutlined />, label: t("nav.geo"), path: "/map" },
     { icon: <BookOutlined />, label: t("nav.collections"), path: "/collections" },
-    // 在线读诵(/read-aloud)。**刻意放进导航，也刻意可随时撤下** ——
-    // 此前它只有阅读页工具栏一个入口，触达接近零；不给曝光，三个月后
-    // 收到的数据只会证明"没人找得到"，而那件事我们已经知道了。
-    // 若三个月后播放数仍 <50/月，先撤这一行，再决定后续。
-    { icon: <SoundOutlined />, label: t("nav.readaloud"), path: "/read-aloud" },
+    // 在线读诵(/read-aloud)不占导航位：读诵是**读一部经时的一个动作**，不是与
+    // 辞典/知识图谱并列的一个板块 —— 它的入口已经在阅读页工具栏上，和跨藏对照、
+    // 高麗藏、校勘排在同一排（那正是这类"就地展开"功能该待的地方，见上面
+    // cross_canon 那行同样的处置）。放进导航等于把同一个入口做两遍。
+    // 路由仍可直达 /read-aloud（索引页留着，供分享与直达）。
+    // { icon: <SoundOutlined />, label: t("nav.readaloud"), path: "/read-aloud" },
     // 开放数据(/exports)暂不对外公开：后端路由由 ENABLE_OPEN_DATA_EXPORTS 控制，
     // 默认关闭（未鉴权、无限流，单次 kg.json 达 50MB/60s）。前端入口与路由一并撤下，
     // 重新放出时需同时打开后端开关并恢复 App.tsx 里的 /exports 路由。


### PR DESCRIPTION
导航里的「读诵」撤下。理由不是数据不好，是**位置放错了**：读诵是读一部经时的
一个动作，不是与佛学辞典、知识图谱并列的板块。它的入口本来就在阅读页工具栏上，
和「跨藏对照」「高麗藏」「校勘」排在同一排 —— 那正是这类"就地展开"功能该待的
地方。放进导航等于把同一个入口做两遍，还让首页看起来多了一条并不存在的产品线。

跨藏对照走的正是同一条路（本文件上方那行早已注释掉，功能活在阅读器面板与文本
详情的段级入口里），这次只是照抄那个处置。

- 路由 `/read-aloud` 保留，索引页仍可直达与分享；阅读页工具栏的「读诵」按钮、
  播放器、埋点全部不动。
- 一并删掉因此不再被引用的 `SoundOutlined` import（CI 的 eslint 跑
  `--max-warnings 0`，留着会直接挂）。
- `nav.readaloud` 的翻译键保留，与其余几行注释掉的导航项一致。

验证：tsc + eslint + i18n ratchet 全过；vitest 22 文件 171 用例通过。
未加"断言导航里没有读诵"的用例 —— 本文件另有五处同样注释掉的导航项，都没有这
类反向断言，不为这一行单开先例。