### PR TITLE
feat(chat): 等待期显示思考过程片段——90% 的等待砍不掉，那就让它可见

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -106,8 +106,19 @@ logger = logging.getLogger(__name__)
 LLM_STREAM_HEARTBEAT_INTERVAL_S = 25.0
 
 # 推理进度事件的最小间隔。推理模型可产出数千 token 的 reasoning_content，逐块
-# 转发等于把 SSE 流量放大数倍，而前端只用它显示一个「已思考 N 秒」的活性信号。
+# 转发等于把 SSE 流量放大数倍；按秒聚合后一帧带一段文本，量级与正文相当。
 REASONING_EMIT_INTERVAL_S = 1.0
+
+# 单个 reasoning 帧携带文本的上限，超出时**保尾弃头**。上游可能在一次网络读里
+# 灌进上千字（重推理模型的常态），不封顶等于把单帧放大几十倍；而显示端要的是
+# 「正在想什么」的活窗 —— 最新的想法在尾部。
+#
+# 为什么现在发文本了（2026-08-13，推翻同日更早「只发字数」的决定）：削推理档位
+# 换速度已被 90 题 eval 证否（low 档逐字保真度 −12.9pp），等待的 30-180 秒是买
+# 质量的钱、砍不掉，能改的只有等待的感受。护栏不变：文本只进前端**等待区**并
+# 带「非回答」标签，正文一到整块销毁；此处它绝不写进 full_answer（见下方消费
+# 循环的白名单注释），所以答案真实性的不变式原样成立。
+REASONING_TEXT_FRAME_MAX_CHARS = 2000
 
 # Fixed backoff before a single same-provider retry of a transient
 # pre-first-token stream failure (see _stream_attempt). Kept short: the goal
@@ -816,6 +827,7 @@ async def send_message_stream(
     # detached ORM attribute is read after the session closes.
     chat_session_id = 0
     pending_attachment_ids: list[int] = []
+    _prep_t0 = _time.monotonic()
     async with sessionmaker() as db_prep:
         try:
             # Production SSE path: resolve the user from the raw token inside
@@ -889,6 +901,15 @@ async def send_message_stream(
         )
         yield f"data: {json.dumps({'type': 'done'})}\n\n"
         return
+
+    # 流式路径此前没有 prep 计时（send_message 的 "TIMING: _prepare_chat" 只在
+    # 非流式路径打）—— 2026-08-13 排查延迟时这一环量不到，只能拿 rag_retrieval
+    # 的 TIMING 当代理。reader 标记同理：page_content 决定 max_tokens 2000/8000，
+    # 但日志里此前无从分辨 reader 模式占比。
+    logger.info(
+        "TIMING: stream prep took %.2fs (reader=%s)",
+        _time.monotonic() - _prep_t0, bool(page_content),
+    )
 
     (
         _chat_session, api_url, api_key, model, is_byok, provider,
@@ -1041,6 +1062,10 @@ async def send_message_stream(
     received_first_token = False
     reasoning_chars = 0
     last_reasoning_emit = 0.0
+    # 本秒尚未发出的推理文本。fallback 切换时**不清空**（与 reasoning_chars 同一
+    # 口径）—— 两个模型的推理在显示端可能相邻，但显示的是滚动活窗且答案一到就
+    # 整块销毁，混排无害；清了反而让切换那一秒的窗口空白。
+    pending_reasoning = ""
     phase2_start = _time.monotonic()
     try:
         for idx, (att_url, att_key, att_model, att_provider, is_fb) in enumerate(attempts):
@@ -1061,14 +1086,19 @@ async def send_message_stream(
                         # 也绝不置 received_first_token（否则下方的空回复兜底失效，
                         # 用户会永远卡在假的「正在检索…」上且没有重试按钮）。
                         reasoning_chars += len(content)
+                        pending_reasoning += content
                         now = _time.monotonic()
-                        # 节流：推理可达 4000 token，逐块转发等于把 SSE 流量放大
-                        # 数倍，而前端只显示一个数字。
+                        # 节流：按秒聚合成一帧。帧里带上这一秒的推理文本（保尾
+                        # 封顶），给前端等待区当「思考过程片段」显示 —— 它只进
+                        # 独立的 reasoning 帧，绝不进 full_answer / token。
                         if now - last_reasoning_emit >= REASONING_EMIT_INTERVAL_S:
                             last_reasoning_emit = now
+                            frame_text = pending_reasoning[-REASONING_TEXT_FRAME_MAX_CHARS:]
+                            pending_reasoning = ""
                             yield (
                                 "data: "
-                                + json.dumps({"type": "reasoning", "chars": reasoning_chars},
+                                + json.dumps({"type": "reasoning", "chars": reasoning_chars,
+                                              "text": frame_text},
                                              ensure_ascii=False)
                                 + "\n\n"
                             )
@@ -1147,13 +1177,14 @@ async def send_message_stream(
     # 2026-08-01 那次排查因此得先去翻 Prometheus 的 model 标签才知道用的是哪个。
     logger.info(
         "chat/stream phase-2 LLM done in %.2fs (%d chars, reasoning=%d chars, "
-        "session_id=%s, provider=%s, model=%s)",
+        "session_id=%s, provider=%s, model=%s, reader=%s)",
         _time.monotonic() - phase2_start,
         len(full_answer),
         reasoning_chars,
         chat_session_id,
         provider,
         model,
+        bool(page_content),
     )
 
     # Empty-completion guard: the stream finished without ever producing an

--- a/backend/tests/test_chat_stream_reasoning_event.py
+++ b/backend/tests/test_chat_stream_reasoning_event.py
@@ -169,6 +169,57 @@ async def test_reasoning_events_are_throttled():
 
 
 @pytest.mark.anyio
+async def test_reasoning_frames_carry_the_text_excerpt():
+    """推理帧要带上文本增量 —— 等待期「思考过程片段」的原料。
+
+    2026-08-13 定案：削推理档位换速度已被 90 题 eval 证否（逐字保真度 −12.9pp），
+    等待的 30-180 秒砍不掉，能改的只有等待的感受。推理文本是现成的可读中文，
+    此前整条丢掉、只发一个字数 —— 现在随帧带出去，但只准进等待区，绝不进正文。
+    """
+    events = await _run([
+        {"reasoning_content": "先看《心經》這一段，"},
+        {"reasoning_content": "但也可能該引《大般若經》。"},
+        {"content": "「色不異空」出自《心經》。"},
+    ])
+
+    reasoning_frames = [e for e in events if e.get("type") == "reasoning"]
+    assert reasoning_frames, "没有 reasoning 事件"
+    for f in reasoning_frames:
+        assert isinstance(f.get("text"), str) and f["text"], (
+            f"推理帧缺少 text 字段（前端等待区没有原料可显示）: {f!r}"
+        )
+    joined = "".join(f["text"] for f in reasoning_frames)
+    assert "先看《心經》這一段，" in joined, f"推理文本没有透传: {joined!r}"
+
+    # 承重不变式：文本走 reasoning 帧，绝不混进 token 正文
+    tokens = "".join(e["content"] for e in events if e.get("type") == "token")
+    assert tokens == "「色不異空」出自《心經》。", f"答案正文被污染: {tokens!r}"
+
+
+@pytest.mark.anyio
+async def test_reasoning_text_frame_is_capped_keeping_the_tail():
+    """单帧文本要封顶且保尾部 —— 显示的是「正在想什么」的活窗，不是完整记录。
+
+    上游可能在一次网络读里灌进上千字（重推理模型的常态），不封顶等于把 SSE 帧
+    放大几十倍；封头不封尾则显示的永远是最旧的想法。
+    """
+    from app.services.chat import REASONING_TEXT_FRAME_MAX_CHARS
+
+    big = "前面的推理。" * 800 + "最新落点在《心經》"
+    events = await _run([{"reasoning_content": big}, {"content": "答案。"}])
+
+    frames = [e for e in events if e.get("type") == "reasoning"]
+    assert frames, "没有 reasoning 事件"
+    for f in frames:
+        assert len(f["text"]) <= REASONING_TEXT_FRAME_MAX_CHARS, (
+            f"单帧 {len(f['text'])} 字，超出 {REASONING_TEXT_FRAME_MAX_CHARS} 封顶"
+        )
+    assert frames[0]["text"].endswith("最新落点在《心經》"), (
+        f"封顶截掉了尾部（最新的想法）: ...{frames[0]['text'][-40:]!r}"
+    )
+
+
+@pytest.mark.anyio
 async def test_phase2_log_records_reasoning_volume_and_model(caplog):
     """phase-2 日志必须带上推理字符数与模型名。
 
@@ -188,3 +239,11 @@ async def test_phase2_log_records_reasoning_volume_and_model(caplog):
     assert line is not None, "phase-2 计时日志没打出来"
     assert "reasoning=10 chars" in line, f"日志缺少推理字符数: {line}"
     assert "model=deepseek-v4-pro" in line, f"日志缺少模型名: {line}"
+    # reader 标记：page_content 决定 max_tokens 2000/8000，没有它日志里量不出
+    # reader 模式占比（2026-08-13 排查延迟时的观测缺口）。
+    assert "reader=False" in line, f"日志缺少 reader 标记: {line}"
+
+    # 流式路径的 prep 计时同为该次排查的缺口 —— 此前只有非流式的
+    # "TIMING: _prepare_chat"，/chat/stream 的 prep 一直量不到。
+    assert any("TIMING: stream prep took" in r.getMessage() for r in caplog.records), \
+        "流式路径缺少 prep 计时日志"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -969,6 +969,7 @@
   "chat.generating": "Generating answer",
   "chat.reasoning_hint": "Working through the scriptures",
   "chat.thinking_seconds": " (thinking for {{n}}s)",
+  "chat.reasoning_excerpt_label": "Reasoning excerpt · not the final answer",
   "chat.request_failed": "Request failed, please retry",
   "chat.reference_sources": "Sources",
   "chat.export_empty": "No conversation to export",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -969,6 +969,7 @@
   "chat.generating": "正在生成回答",
   "chat.reasoning_hint": "正在推敲經文",
   "chat.thinking_seconds": "（已思考 {{n}} 秒）",
+  "chat.reasoning_excerpt_label": "思考過程片段 · 非最終回答",
   "chat.request_failed": "請求失敗，請重試",
   "chat.reference_sources": "參考經文",
   "chat.export_empty": "暫無對話內容可匯出",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -969,6 +969,7 @@
   "chat.generating": "正在生成回答",
   "chat.reasoning_hint": "正在推敲经文",
   "chat.thinking_seconds": "（已思考 {{n}} 秒）",
+  "chat.reasoning_excerpt_label": "思考过程片段 · 非最终回答",
   "chat.request_failed": "请求失败，请重试",
   "chat.reference_sources": "参考经文",
   "chat.export_empty": "暂无对话内容可导出",

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -264,6 +264,28 @@ describe("sendChatMessageStream", () => {
     expect(callbacks.onDone).toHaveBeenCalledTimes(1);
   });
 
+  it("reasoning 帧的 text 要透传给 onReasoning —— 等待区「思考过程片段」的原料", async () => {
+    // ⚠️ 这是全站唯一走真实 processChunk 的 reasoning 用例：页面级测试全部
+    // mock 掉 sendChatMessageStream，测不到这一层。此前这里重建对象只取
+    // chars，text 在此处被静默丢弃的话，上层测试照样全绿。
+    const { sendChatMessageStream } = await import("./client");
+    const onReasoning = vi.fn();
+    const callbacks = {
+      onToken: vi.fn(), onSources: vi.fn(), onSessionId: vi.fn(),
+      onError: vi.fn(), onDone: vi.fn(), onReasoning,
+    };
+
+    const promise = sendChatMessageStream("hello", undefined, null, callbacks);
+    const xhr = MockStreamXHR.instances[0];
+    xhr.responseText =
+      'data: {"type": "reasoning", "chars": 12, "text": "先看《心經》這一段"}\n\n' +
+      'data: {"type": "done"}\n\n';
+    xhr.onprogress?.();
+    await promise;
+
+    expect(onReasoning).toHaveBeenCalledWith({ chars: 12, text: "先看《心經》這一段" });
+  });
+
   it("流上收到 401：清身份 + 报出原因，但不硬跳登录页丢掉整段对话", async () => {
     // 承重条。这里曾经是 window.location.href = "/login" 且 return（连 onDone
     // 都不调，Promise 永不 settle —— 因为反正整页要重载）。代价是用户刚打完的

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1815,13 +1815,21 @@ export interface ChatRetrieval {
   titles: string[];
 }
 
-/** 推理模型思考阶段的活性信号（后端按约 1 次/秒节流）。不含推理原文：那里面
- *  全是会被模型自己推翻的中间结论，摆在答案位置上是拿答案真实性冒险。
+/** 推理模型思考阶段的进度帧（后端按约 1 次/秒节流聚合）。
+ *
+ *  `text` 是这一帧聚合的推理文本片段（后端单帧封顶、保尾弃头）。
+ *  2026-08-13 决定发文本（推翻本文件更早「只发字数」的注释）：削推理档位换
+ *  速度已被 90 题 eval 证否（low 档逐字保真度 −12.9pp），等待的 30-180 秒砍
+ *  不掉，能改的只有等待的感受。原注释担心的「中间结论摆在答案位置」由三条
+ *  护栏顶住：只渲染进等待区、带「非回答」标签、首个 token 一到整块销毁 ——
+ *  **绝不写进 content**（空转兜底按哨兵身份判断，这条有承重测试）。
  *
  *  `chars` **仅作活性信号，不要当字数显示** —— 它跨 fallback 累加（主模型失败
- *  切备用模型时不重置），所以不等于「本次推理的字数」。目前无消费者。 */
+ *  切备用模型时不重置），所以不等于「本次推理的字数」。text 同理跨 fallback
+ *  相邻，但显示端是滚动活窗且随答案销毁，混排无害。 */
 export interface ChatReasoning {
   chars: number;
+  text?: string;
 }
 
 export interface ChatMessageItem {
@@ -1836,6 +1844,9 @@ export interface ChatMessageItem {
   retrieval?: ChatRetrieval | null;
   /** 首个推理信号到达的时刻（epoch ms），用于渲染「已思考 N 秒」。同样不持久化。 */
   reasoningSince?: number | null;
+  /** 等待期「思考过程片段」活窗的内容（保尾截断）。只在 content 仍是哨兵时
+   *  渲染，首个 token 一到即清空 —— 绝不持久化、绝不混进 content。 */
+  reasoningText?: string | null;
 }
 
 export interface SharedQA {
@@ -2077,7 +2088,12 @@ export function sendChatMessageStream(
               callbacks.onSources(event.sources);
               break;
             case "reasoning":
-              callbacks?.onReasoning?.({ chars: event.chars });
+              // 显式重建对象（不透传整个 event）：字段白名单在这里。text 旧后端
+              // 没有 —— 滚动部署期间保持可选。
+              callbacks?.onReasoning?.({
+                chars: event.chars,
+                text: typeof event.text === "string" ? event.text : undefined,
+              });
               break;
             case "retrieved":
               callbacks?.onRetrieved?.({

--- a/frontend/src/components/ReaderAIPanel.test.tsx
+++ b/frontend/src/components/ReaderAIPanel.test.tsx
@@ -88,6 +88,22 @@ describe("ReaderAIPanel", () => {
     expect(await screen.findByText(/正在推敲经文/)).toBeInTheDocument();
   });
 
+  it("b: reasoning.text 显示为思考片段活窗，token 一到整块销毁", async () => {
+    // 阅读页是全站等待最长的一条路（300s 超时、常态 90-180s）——
+    // 思考片段在这里的价值最大。约束与 ChatPage 相同：只进等待区，不碰 content。
+    const { container } = renderPanel();
+    await ask(container);
+    cb!.onReasoning?.({ chars: 9, text: "先定位這一卷的科判，" });
+    cb!.onReasoning?.({ chars: 18, text: "再看窺基怎麼說。" });
+    await screen.findByText(/先定位這一卷的科判，再看窺基怎麼說。/);
+    expect(container.querySelector(".chat-reasoning-excerpt")).not.toBeNull();
+
+    cb!.onToken("此卷明五識身相應地。");
+    await screen.findByText(/此卷明五識身相應地/);
+    expect(container.querySelector(".chat-reasoning-excerpt")).toBeNull();
+    expect(container.textContent).not.toContain("科判");
+  });
+
   // 承重点：进度事件绝不能写进 content —— 一旦写进去，下面那条空转兜底就失效了
   // （它按哨兵的身份判断）。这正是 ChatPage 当初立的同一条约束。
   it("b 承重点: 进度事件之后仍能落到失败兜底", async () => {

--- a/frontend/src/components/ReaderAIPanel.tsx
+++ b/frontend/src/components/ReaderAIPanel.tsx
@@ -124,25 +124,37 @@ function ReaderThinking({ m, t }: { m: ChatMessageItem; t: TFunction }) {
   }, [reasoningSince]);
 
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 8, color: "#8b7355", flexWrap: "wrap" }}>
-      <Spin size="small" />
-      <span>
-        {m.retrieval && (
-          <>
-            {t("chat.retrieved_hint", { n: m.retrieval.count })}
-            {m.retrieval.titles.map((title) => (
-              <span key={title} className="chat-retrieved-title">{t("chat.retrieved_title", { title })}</span>
-            ))}
-            <span className="chat-retrieved-sep">·</span>
-          </>
-        )}
-        {reasoningSince
-          ? `${t("chat.reasoning_hint")}${t("chat.thinking_seconds", { n: seconds })}`
-          : m.retrieval
-            ? t("chat.generating")
-            : t("reader.ai.thinking")}
-      </span>
-    </div>
+    <>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, color: "#8b7355", flexWrap: "wrap" }}>
+        <Spin size="small" />
+        <span>
+          {m.retrieval && (
+            <>
+              {t("chat.retrieved_hint", { n: m.retrieval.count })}
+              {m.retrieval.titles.map((title) => (
+                <span key={title} className="chat-retrieved-title">{t("chat.retrieved_title", { title })}</span>
+              ))}
+              <span className="chat-retrieved-sep">·</span>
+            </>
+          )}
+          {reasoningSince
+            ? `${t("chat.reasoning_hint")}${t("chat.thinking_seconds", { n: seconds })}`
+            : m.retrieval
+              ? t("chat.generating")
+              : t("reader.ai.thinking")}
+        </span>
+      </div>
+      {/* 思考片段活窗：本组件只在 content===THINKING_SENTINEL 时被挂载，
+          正文一到整个组件卸载 —— 销毁时机与 ChatPage 同一套。 */}
+      {m.reasoningText ? (
+        <div className="chat-reasoning-excerpt" aria-hidden="true">
+          <span className="chat-reasoning-excerpt-label">{t("chat.reasoning_excerpt_label")}</span>
+          <div className="chat-reasoning-excerpt-clip">
+            <div className="chat-reasoning-excerpt-text">{m.reasoningText}</div>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 }
 
@@ -241,7 +253,8 @@ export default function ReaderAIPanel({
           prev.map((m) => {
             if (m.id !== assistantId) return m;
             const current = m.content === THINKING_SENTINEL ? "" : m.content;
-            return { ...m, content: current + content };
+            // 思考片段随首个 token 销毁（渲染层另有哨兵分支这道保险）。
+            return { ...m, content: current + content, reasoningText: null };
           }),
         );
         scrollToBottom();
@@ -279,14 +292,22 @@ export default function ReaderAIPanel({
           prev.map((m) => (m.id === assistantId ? { ...m, retrieval: info } : m)),
         );
       },
-      onReasoning: () => {
+      onReasoning: (r) => {
         setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantId && !m.reasoningSince
-              ? { ...m, reasoningSince: Date.now() }
-              : m,
-          ),
+          prev.map((m) => {
+            if (m.id !== assistantId) return m;
+            const next = { ...m };
+            if (!next.reasoningSince) next.reasoningSince = Date.now();
+            if (r.text) {
+              // 思考片段活窗（保尾截断），与 ChatPage 同一套约束与销毁时机。
+              next.reasoningText = ((next.reasoningText ?? "") + r.text).slice(-1200);
+            }
+            return next;
+          }),
         );
+        // 与 ChatPage 同一条修补：活窗撑高气泡，不跟滚就整段等待期不可见
+        // （.reader-ai-messages 是小滚动盒，第一轮问答后必然可滚）。
+        scrollToBottom();
       },
       onSessionId: (newSessionId: number) => {
         if (!sessionId) setSessionId(newSessionId);

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -300,6 +300,55 @@ describe("ChatPage 首屏结构", () => {
     expect(container.querySelector(".chat-thinking")).not.toBeNull();
   });
 
+  // 思考过程片段：等待期显示推理文本活窗。两条承重不变式：
+  //   1. 文本只进等待区（.chat-reasoning-excerpt），content 仍是哨兵；
+  //   2. 首个 token 一到，整块销毁 —— 被模型自己推翻的中间结论不能留在屏幕上，
+  //      更不能混进答案正文。
+  it("思考片段: reasoning.text 显示在等待区，首个 token 到达后整块销毁", async () => {
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks) => { cb = callbacks; },
+    );
+    const { container } = await renderEmpty();
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+
+    // 放掉发送时 scrollToBottom(true) 的 100ms 定时器，再清零计数 —— 下面要
+    // 单独断言「reasoning 事件本身触发跟滚」。
+    await new Promise((r) => setTimeout(r, 150));
+    const scrollSpy = vi.spyOn(Element.prototype, "scrollIntoView");
+    scrollSpy.mockClear();
+
+    cb!.onReasoning?.({ chars: 9, text: "先查《心經》的出處，" });
+    cb!.onReasoning?.({ chars: 21, text: "再對比《大般若經》。" });
+
+    await waitFor(() => {
+      expect(container.querySelector(".chat-reasoning-excerpt")).not.toBeNull();
+    });
+    // 活窗把气泡撑高 ~100px，而钉底发生在发送时 —— reasoning 必须自己跟滚，
+    // 否则已可滚动的对话里活窗整段等待期落在折叠线以下（对抗审查实锤）。
+    // jsdom 测不到布局，这里锁的是「跟滚被触发」这个行为本身。
+    await waitFor(() => expect(scrollSpy).toHaveBeenCalled());
+    scrollSpy.mockRestore();
+    // 两帧文本按序拼接显示（活窗）
+    expect(container.querySelector(".chat-reasoning-excerpt")!.textContent)
+      .toContain("先查《心經》的出處，再對比《大般若經》。");
+    // content 仍是哨兵（等待 UI 还在）
+    expect(container.querySelector(".chat-thinking")).not.toBeNull();
+
+    cb!.onToken?.("「色不異空」出自《心經》。");
+
+    await waitFor(() => {
+      // 正文一到，思考片段整块销毁
+      expect(container.querySelector(".chat-reasoning-excerpt")).toBeNull();
+    });
+    // 推理文本绝不在答案正文里
+    const bubbles = container.querySelectorAll(".chat-markdown, .markdown-body");
+    const answerText = Array.from(bubbles).map((b) => b.textContent).join("");
+    expect(answerText).not.toContain("先查《心經》");
+    expect(screen.getByText(/色不異空/)).toBeInTheDocument();
+  });
+
   // P0 的核心不变式，也是本轮唯一能自动挡住「存量定时器把用户拽回底部」的断言。
   // 守卫在「调用时」判过一次，但真正的 scrollIntoView 在 100ms 后才执行；若不在
   // 触发时复判，用户在流式中途上滚后，存量定时器仍会把视口拽回底部，而那次程序化

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -435,36 +435,52 @@ function MessageBubbleInner({
         }}>
           {m.role === "assistant" ? (
             m.content === THINKING_SENTINEL ? (
-              <div className="chat-thinking">
-                {/* 收进单个 span：.chat-thinking 是 inline-flex，为「一句短文案 +
-                    三个点」设计的；多段内容直接铺进去会各自变成 flex 项，被挤成
-                    竖排窄列。包一层后它仍只有两个 flex 项，内部按正常文本流换行。 */}
-                {/* 三段独立组合，不要把推理嵌进检索分支里 —— 生产上 retrieved
-                    确实总先于 reasoning 到达，但那是时序巧合而非契约，任一方缺席
-                    时另一方都应照常显示。 */}
-                <span className="chat-thinking-text">
-                  {m.retrieval && (
-                    <>
-                      {t("chat.retrieved_hint", { n: m.retrieval.count })}
-                      {m.retrieval.titles.map((tt) => (
-                        <span key={tt} className="chat-retrieved-title">
-                          {t("chat.retrieved_title", { title: tt })}
-                        </span>
-                      ))}
-                      <span className="chat-retrieved-sep">·</span>
-                    </>
-                  )}
-                  {/* 括号并在翻译值里，不写死在这里 —— 全角（）是 U+FF08/FF09，
-                      落在半宽全宽形式区，i18n 扫描器的 CJK 正则结构上扫不到它，
-                      门禁绿灯不能当作「英文界面没问题」的证据。英文值自带半角括号。 */}
-                  {reasoningSince
-                    ? `${t("chat.reasoning_hint")}${t("chat.thinking_seconds", { n: thinkingSeconds })}`
-                    : m.retrieval
-                      ? t("chat.generating")
-                      : t("chat.thinking")}
-                </span>
-                <span className="chat-thinking-dots"><span /><span /><span /></span>
-              </div>
+              <>
+                <div className="chat-thinking">
+                  {/* 收进单个 span：.chat-thinking 是 inline-flex，为「一句短文案 +
+                      三个点」设计的；多段内容直接铺进去会各自变成 flex 项，被挤成
+                      竖排窄列。包一层后它仍只有两个 flex 项，内部按正常文本流换行。 */}
+                  {/* 三段独立组合，不要把推理嵌进检索分支里 —— 生产上 retrieved
+                      确实总先于 reasoning 到达，但那是时序巧合而非契约，任一方缺席
+                      时另一方都应照常显示。 */}
+                  <span className="chat-thinking-text">
+                    {m.retrieval && (
+                      <>
+                        {t("chat.retrieved_hint", { n: m.retrieval.count })}
+                        {m.retrieval.titles.map((tt) => (
+                          <span key={tt} className="chat-retrieved-title">
+                            {t("chat.retrieved_title", { title: tt })}
+                          </span>
+                        ))}
+                        <span className="chat-retrieved-sep">·</span>
+                      </>
+                    )}
+                    {/* 括号并在翻译值里，不写死在这里 —— 全角（）是 U+FF08/FF09，
+                        落在半宽全宽形式区，i18n 扫描器的 CJK 正则结构上扫不到它，
+                        门禁绿灯不能当作「英文界面没问题」的证据。英文值自带半角括号。 */}
+                    {reasoningSince
+                      ? `${t("chat.reasoning_hint")}${t("chat.thinking_seconds", { n: thinkingSeconds })}`
+                      : m.retrieval
+                        ? t("chat.generating")
+                        : t("chat.thinking")}
+                  </span>
+                  <span className="chat-thinking-dots"><span /><span /><span /></span>
+                </div>
+                {/* 思考过程片段活窗。只在哨兵分支里渲染 —— 正文一到（content 被
+                    换掉）整块随分支消失，这是渲染层的保险；onToken 另清
+                    reasoningText，两道各自独立。aria-hidden：读屏用户听
+                    「已思考 N 秒」就够了，逐秒变动的中间结论只会淹没读屏。 */}
+                {m.reasoningText ? (
+                  <div className="chat-reasoning-excerpt" aria-hidden="true">
+                    <span className="chat-reasoning-excerpt-label">
+                      {t("chat.reasoning_excerpt_label")}
+                    </span>
+                    <div className="chat-reasoning-excerpt-clip">
+                      <div className="chat-reasoning-excerpt-text">{m.reasoningText}</div>
+                    </div>
+                  </div>
+                ) : null}
+              </>
             ) : m.content === REQUEST_FAILED_SENTINEL ? (
               t("chat.request_failed")
             ) : (
@@ -1261,7 +1277,9 @@ export default function ChatPage() {
           prev.map((m) => {
             if (m.id !== assistantId) return m;
             const current = m.content === THINKING_SENTINEL ? "" : m.content;
-            return { ...m, content: current + content };
+            // reasoningText 随首个 token 销毁：被模型自己推翻的中间结论
+            // 不能留在屏幕上（渲染层另有一道保险，两道各自独立）。
+            return { ...m, content: current + content, reasoningText: null };
           }),
         );
         scrollToBottom();
@@ -1304,18 +1322,29 @@ export default function ChatPage() {
       onSearching: (_searchMsg: string) => {
         // 搜索状态由初始占位符 "正在检索经文并生成回答..." 显示，不覆盖 content
       },
-      onReasoning: () => {
-        // 只当作活性信号：把等待期文案换成「正在推敲经文…（已思考 N 秒）」。
-        // 秒数由前端自己计时，后端只负责证明「还在推进」——静态文案在 7-13 秒里
-        // 读起来像卡死，一个在动的计数器才说明系统活着。
+      onReasoning: (r) => {
+        // 计时（已思考 N 秒）+ 思考片段活窗。等待的 30-180 秒是买质量的钱
+        // （削档已被 90 题 eval 证否），能改的只有等待的感受 —— 推理文本是
+        // 现成的可读中文，此前整条丢掉。
         // 与 onRetrieved 同一条承重约束：只写独立字段，绝不碰 content。
         setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantId && m.reasoningSince == null
-              ? { ...m, reasoningSince: Date.now() }
-              : m,
-          ),
+          prev.map((m) => {
+            if (m.id !== assistantId) return m;
+            const next = { ...m };
+            if (next.reasoningSince == null) next.reasoningSince = Date.now();
+            if (r.text) {
+              // 保尾截断：显示的是「正在想什么」的活窗，不是完整思考记录。
+              // 截尾同时消解跨 fallback 拼接 —— 旧模型的推理很快滚出窗口。
+              next.reasoningText = ((next.reasoningText ?? "") + r.text).slice(-1200);
+            }
+            return next;
+          }),
         );
+        // 活窗把气泡向下撑高 ~100px，而钉底发生在发送时 —— 不跟滚的话，已可
+        // 滚动的对话里活窗整段等待期落在折叠线以下，token 一到又被销毁，用户
+        // 从头到尾看不见它（对抗审查实锤的失效场景）。scrollToBottom 非 force
+        // 自带「贴底才跟随 + 触发时复判」，用户上滚重读时不会被拽回。
+        scrollToBottom();
       },
       onRetrieved: (retrieval) => {
         // 只写独立字段。绝不能写进 content —— THINKING_SENTINEL 是按身份比较的

--- a/frontend/src/pages/MessageBubble.test.tsx
+++ b/frontend/src/pages/MessageBubble.test.tsx
@@ -99,6 +99,29 @@ describe("MessageBubble", () => {
     expect(document.querySelector(".chat-thinking")).not.toBeNull();
   });
 
+  it("哨兵 + reasoningText → 渲染思考片段活窗（带非回答标签）", () => {
+    renderBubble({
+      m: msg({
+        content: "正在检索经文并生成回答...",
+        reasoningText: "先查《心經》的出處",
+      }),
+    });
+    const excerpt = document.querySelector(".chat-reasoning-excerpt");
+    expect(excerpt).not.toBeNull();
+    expect(excerpt!.textContent).toContain("先查《心經》的出處");
+    // 必须带「非回答」标签 —— 中间结论不能被当成答案读
+    expect(document.querySelector(".chat-reasoning-excerpt-label")).not.toBeNull();
+  });
+
+  it("正文已开始时，残留的 reasoningText 绝不渲染", () => {
+    // onToken 会清 reasoningText，但渲染层不能依赖那个清理 —— 两道保险各自独立。
+    renderBubble({
+      m: msg({ content: "「色不異空」出自《心經》。", reasoningText: "殘留的推理" }),
+    });
+    expect(document.querySelector(".chat-reasoning-excerpt")).toBeNull();
+    expect(document.body.textContent).not.toContain("殘留的推理");
+  });
+
   it("renders follow-up suggestions and fires onSuggestionClick", () => {
     const { onSuggestionClick } = renderBubble({
       m: msg({ content: "答案正文\n[追问] 什么是阿赖耶识" }),

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -418,6 +418,35 @@ em {
   opacity: 0.5;
 }
 
+/* 思考过程片段活窗（等待期专用，正文一到整块销毁）。
+   clip 层的 column-reverse 是「贴住最新内容」的关键：单个子元素比容器高时，
+   flex 从底边开始排，溢出被裁掉的是**头部** —— 无 JS 即得「始终显示尾部」。 */
+.chat-reasoning-excerpt {
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-left: 2px solid var(--fj-border);
+  color: var(--fj-ink-muted);
+  font-size: 12px;
+  line-height: 1.7;
+}
+.chat-reasoning-excerpt-label {
+  display: block;
+  font-size: 11px;
+  opacity: 0.75;
+  letter-spacing: 0.4px;
+  margin-bottom: 2px;
+}
+.chat-reasoning-excerpt-clip {
+  max-height: 5.1em; /* ≈3 行 */
+  overflow: hidden;
+  display: flex;
+  flex-direction: column-reverse;
+}
+.chat-reasoning-excerpt-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* 「回到底部」悬浮按钮。锚点 sticky 在滚动视口下沿、height:0 不占布局空间；
    按钮相对锚点绝对定位向上撑出，所以不需要给滚动容器加 position:relative 的
    外层包裹（那会扰动空状态的撑高块 flex 链）。 */


### PR DESCRIPTION
用户报 /chat 响应要一分钟。全面核算延迟结构后的结论：等待的 ~90% 是 DeepSeek
的隐藏推理，它是买质量的钱、砍不掉 —— 削档换速度已被 90 题 eval 证否（low 档
逐字保真度 −12.9pp，配对 15:6，方向一致无一反弹）。检索 0.6-3.0s、建连+prefill
~0.9s，都不是瓶颈；重复提问率仅 2.6%（30 天 1,959 条），预生成缓存路线数据上
不成立。**能优化的是等待的感受**：推理文本是现成的可读中文，此前收到后整条
丢掉、只发一个字数计数器。

## 改动

后端（chat.py）：
1. reasoning 帧带上按秒聚合的推理文本（REASONING_TEXT_FRAME_MAX_CHARS=2000
   封顶、保尾弃头 —— 活窗要的是最新的想法）。chars 语义不变。
2. 补两个本次排查暴露的观测缺口：流式路径此前没有 prep 计时（只有非流式的
   TIMING: _prepare_chat）；phase-2 日志加 reader= 标记（page_content 决定
   max_tokens 2000/8000，此前日志无从分辨 reader 模式占比）。

前端（ChatPage + ReaderAIPanel，后者是全站等待最长的一条路，300s 超时常态
90-180s）：
3. 等待区新增「思考过程片段」活窗：CSS column-reverse 裁剪保证无 JS 贴住最新
   内容，≈3 行高，带「非最终回答」标签，aria-hidden（读屏听「已思考 N 秒」
   即可，逐秒变动的中间结论只会淹没读屏）。
4. onReasoning 跟滚（非 force，自带贴底判定与触发时复判）—— 对抗审查实锤：
   不跟滚的话活窗把气泡撑高 ~100px 而钉底发生在发送时，已可滚动的对话里它
   整段等待期落在折叠线以下，token 一到又被销毁，用户从头到尾看不见。

## 答案真实性护栏（这次是有意推翻 client.ts 里「不发推理原文」的旧决定）

旧注释担心「中间结论摆在答案位置」。护栏三条，每条有承重测试：
- 文本只进独立的 reasoning 帧与 reasoningText 字段，**绝不碰 full_answer /
  token / content**（空转兜底按哨兵身份判断，动 content 即失效）；
- 只在等待区渲染、带「非回答」标签；
- 首个 token 一到整块销毁，且有两道独立保险（onToken 清字段 + 渲染层哨兵
  分支），MessageBubble 另有「正文已开始时残留 reasoningText 绝不渲染」用例。

## 验证

· 后端 2 条新用例先红后绿（帧带 text / 单帧封顶保尾）；前端 4 条先红后绿
  （client 透传【全站唯一走真实 processChunk 的 reasoning 用例，页面级测试
  全部 mock 掉 client，测不到这层】/ ChatPage 行为 / MessageBubble 渲染 /
  ReaderAIPanel）；跟滚断言单独验证过红（注释掉修复行 → 红）。
· 三镜头对抗审查（真实性不变式 / 前端状态 / SSE 协议）：唯一确认缺陷即上述
  跟滚问题，已修；「推理文本含换行会撕裂 SSE 帧」被怀疑者驳倒（json.dumps
  对控制字符一律转义，序列化后必为单行）。
· 滚动部署四种新旧组合均安全：旧前端只取 chars（text 被丢弃）、新前端对无
  text 的旧帧按 undefined 处理。
· 后端 pytest 1712 通过（test_health_check_probe 3 个失败为 master 存量）；
  前端 tsc + eslint + i18n ratchet + vitest 483 全绿。