### PR TITLE
feat(chat): 思考片段改打字机逐字流——不再一秒一跳

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -106,8 +106,11 @@ logger = logging.getLogger(__name__)
 LLM_STREAM_HEARTBEAT_INTERVAL_S = 25.0
 
 # 推理进度事件的最小间隔。推理模型可产出数千 token 的 reasoning_content，逐块
-# 转发等于把 SSE 流量放大数倍；按秒聚合后一帧带一段文本，量级与正文相当。
-REASONING_EMIT_INTERVAL_S = 1.0
+# 转发等于把 SSE 流量放大数倍；聚合后一帧带一段文本，量级与正文相当。
+# 0.25s（原 1.0s）：前端打字机以帧为节拍吐字，1 秒一帧的输入让追赶步进忽快
+# 忽慢；0.25s 一帧约 10-20 字，吐字近匀速。帧头开销 ~70 B × 4 帧/秒，三分钟
+# 的重推理也只多 ~50 KB，相对正文可忽略。
+REASONING_EMIT_INTERVAL_S = 0.25
 
 # 单个 reasoning 帧携带文本的上限，超出时**保尾弃头**。上游可能在一次网络读里
 # 灌进上千字（重推理模型的常态），不封顶等于把单帧放大几十倍；而显示端要的是

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1815,7 +1815,8 @@ export interface ChatRetrieval {
   titles: string[];
 }
 
-/** 推理模型思考阶段的进度帧（后端按约 1 次/秒节流聚合）。
+/** 推理模型思考阶段的进度帧（后端按约 4 帧/秒节流聚合，见
+ *  REASONING_EMIT_INTERVAL_S；前端 ReasoningExcerpt 打字机再平滑成逐字流）。
  *
  *  `text` 是这一帧聚合的推理文本片段（后端单帧封顶、保尾弃头）。
  *  2026-08-13 决定发文本（推翻本文件更早「只发字数」的注释）：削推理档位换

--- a/frontend/src/components/ReaderAIPanel.test.tsx
+++ b/frontend/src/components/ReaderAIPanel.test.tsx
@@ -95,7 +95,8 @@ describe("ReaderAIPanel", () => {
     await ask(container);
     cb!.onReasoning?.({ chars: 9, text: "先定位這一卷的科判，" });
     cb!.onReasoning?.({ chars: 18, text: "再看窺基怎麼說。" });
-    await screen.findByText(/先定位這一卷的科判，再看窺基怎麼說。/);
+    // 打字机逐字吐出（约 33ms/字，18 字 ≈ 0.6s），放宽默认 1s 超时
+    await screen.findByText(/先定位這一卷的科判，再看窺基怎麼說。/, undefined, { timeout: 3000 });
     expect(container.querySelector(".chat-reasoning-excerpt")).not.toBeNull();
 
     cb!.onToken("此卷明五識身相應地。");

--- a/frontend/src/components/ReaderAIPanel.tsx
+++ b/frontend/src/components/ReaderAIPanel.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { isNearBottom } from "../utils/scrollBottom";
+import ReasoningExcerpt from "./ReasoningExcerpt";
 import { Input, Button, message, Spin, Tooltip } from "antd";
 import {
   SendOutlined,
@@ -144,16 +145,9 @@ function ReaderThinking({ m, t }: { m: ChatMessageItem; t: TFunction }) {
               : t("reader.ai.thinking")}
         </span>
       </div>
-      {/* 思考片段活窗：本组件只在 content===THINKING_SENTINEL 时被挂载，
-          正文一到整个组件卸载 —— 销毁时机与 ChatPage 同一套。 */}
-      {m.reasoningText ? (
-        <div className="chat-reasoning-excerpt" aria-hidden="true">
-          <span className="chat-reasoning-excerpt-label">{t("chat.reasoning_excerpt_label")}</span>
-          <div className="chat-reasoning-excerpt-clip">
-            <div className="chat-reasoning-excerpt-text">{m.reasoningText}</div>
-          </div>
-        </div>
-      ) : null}
+      {/* 思考片段活窗（打字机组件）：本组件只在 content===THINKING_SENTINEL
+          时被挂载，正文一到整个组件卸载 —— 销毁时机与 ChatPage 同一套。 */}
+      {m.reasoningText ? <ReasoningExcerpt text={m.reasoningText} /> : null}
     </>
   );
 }
@@ -299,8 +293,9 @@ export default function ReaderAIPanel({
             const next = { ...m };
             if (!next.reasoningSince) next.reasoningSince = Date.now();
             if (r.text) {
-              // 思考片段活窗（保尾截断），与 ChatPage 同一套约束与销毁时机。
-              next.reasoningText = ((next.reasoningText ?? "") + r.text).slice(-1200);
+              // 全量累加、不截尾（打字机按前缀吐字，截尾会让前缀失配），
+              // 与 ChatPage 同一套约束与销毁时机。
+              next.reasoningText = (next.reasoningText ?? "") + r.text;
             }
             return next;
           }),

--- a/frontend/src/components/ReasoningExcerpt.test.tsx
+++ b/frontend/src/components/ReasoningExcerpt.test.tsx
@@ -1,0 +1,73 @@
+/** 思考过程片段的打字机行为。
+ *
+ * 使用者反馈（2026-08-13）：整块渲染的活窗「一段段文本不断地跳动」——后端按
+ * 秒聚合发帧，一帧几十字整块上屏就是一跳。这里锁的是主流 LLM 界面那种效果：
+ * 新到的文本进缓冲，匀速逐字吐出。
+ *
+ * 三条行为，第一条是本组件存在的理由：
+ *   1. **不整块上屏**：一帧文本到达后的第一个 tick 只显示一部分；
+ *   2. 最终追平：缓冲会被吐完，不弄丢内容；
+ *   3. 文本增长（下一帧追加）时接着吐，不从头重来。
+ */
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ReasoningExcerpt from "./ReasoningExcerpt";
+
+const FRAME = "先查《心經》的出處，再對比《大般若經》的譯例，然後決定引哪一段。";
+
+describe("ReasoningExcerpt", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function textOf(container: HTMLElement): string {
+    return container.querySelector(".chat-reasoning-excerpt-text")?.textContent ?? "";
+  }
+
+  it("一帧文本不整块上屏 —— 首个 tick 只显示一部分", () => {
+    const { container } = render(<ReasoningExcerpt text={FRAME} />);
+    act(() => {
+      vi.advanceTimersByTime(40); // 一个 tick
+    });
+    const shown = textOf(container).replace("▌", "");
+    expect(shown.length).toBeGreaterThan(0);
+    expect(shown.length).toBeLessThan(FRAME.length);
+    expect(FRAME.startsWith(shown)).toBe(true);
+  });
+
+  it("缓冲最终被吐完，内容一字不丢", () => {
+    const { container } = render(<ReasoningExcerpt text={FRAME} />);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(textOf(container)).toContain(FRAME);
+  });
+
+  it("下一帧追加文本时接着吐，不从头重来", () => {
+    const { container, rerender } = render(<ReasoningExcerpt text={FRAME} />);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(textOf(container)).toContain(FRAME);
+
+    rerender(<ReasoningExcerpt text={FRAME + "另外還要核對卷號。"} />);
+    act(() => {
+      vi.advanceTimersByTime(40);
+    });
+    // 旧内容还在（没有清零重来），新内容开始逐字出现
+    expect(textOf(container)).toContain(FRAME);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(textOf(container)).toContain("另外還要核對卷號。");
+  });
+
+  it("带「非最终回答」标签", () => {
+    render(<ReasoningExcerpt text={FRAME} />);
+    expect(screen.getByText(/非最终回答|非最終回答|not the final answer/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ReasoningExcerpt.tsx
+++ b/frontend/src/components/ReasoningExcerpt.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+/** 思考过程片段活窗 —— 打字机式匀速吐字。
+ *
+ * 后端按 REASONING_EMIT_INTERVAL_S 聚合发帧，一帧几十字；直接整块渲染就是
+ * 使用者反馈的「一段段文本不断地跳动」。这里把新到的文本先进缓冲，以 ~30Hz
+ * 步进追赶：步长与积压成正比（积压越多走得越快，追平后逐字），视觉上与主流
+ * LLM 界面的思考流一致，且缓冲永不丢字。
+ *
+ * 护栏与母组件相同：只在等待期挂载（content 仍是哨兵），正文一到整块卸载；
+ * aria-hidden —— 读屏听「已思考 N 秒」即可，逐字变动的中间结论只会淹没读屏。
+ */
+const TICK_MS = 33;
+// 追赶分母：每 tick 吐出 backlog/40（至少 1 字）。等效吐字速率 ≈
+// backlog×0.75/s + 30 字/s 下限，对上游 40-70 字/s 的推理吞吐，稳态积压
+// 约几十字（不到一秒的滞后），看起来是「实时在写」。
+const CATCHUP_DIVISOR = 40;
+
+export default function ReasoningExcerpt({ text }: { text: string }) {
+  const { t } = useTranslation();
+  // 减动效偏好：整段直出，不做打字机（放 useState 初始化器：渲染期不读环境）。
+  const [reduceMotion] = useState(
+    () =>
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  const [shown, setShown] = useState(0);
+  // interval 回调要读最新的 text，但不能因 text 变化重建 interval（重建会打乱
+  // 节拍）—— 经典的 latest-ref 模式，写入放 effect 里过 React Compiler 的
+  // 「渲染期不写 ref」检查。
+  const textRef = useRef(text);
+  useEffect(() => {
+    textRef.current = text;
+  }, [text]);
+
+  useEffect(() => {
+    if (reduceMotion) return;
+    const id = setInterval(() => {
+      setShown((s) => {
+        const len = textRef.current.length;
+        if (s >= len) return s;
+        return Math.min(len, s + Math.max(1, Math.ceil((len - s) / CATCHUP_DIVISOR)));
+      });
+    }, TICK_MS);
+    return () => clearInterval(id);
+  }, [reduceMotion]);
+
+  const visible = reduceMotion ? text : text.slice(0, shown);
+  return (
+    <div className="chat-reasoning-excerpt" aria-hidden="true">
+      <span className="chat-reasoning-excerpt-label">{t("chat.reasoning_excerpt_label")}</span>
+      <div className="chat-reasoning-excerpt-clip">
+        <div className="chat-reasoning-excerpt-text">
+          {visible}
+          <span className="chat-reasoning-caret">▌</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -330,9 +330,13 @@ describe("ChatPage 首屏结构", () => {
     // jsdom 测不到布局，这里锁的是「跟滚被触发」这个行为本身。
     await waitFor(() => expect(scrollSpy).toHaveBeenCalled());
     scrollSpy.mockRestore();
-    // 两帧文本按序拼接显示（活窗）
-    expect(container.querySelector(".chat-reasoning-excerpt")!.textContent)
-      .toContain("先查《心經》的出處，再對比《大般若經》。");
+    // 两帧文本按序拼接、由打字机逐字吐出（约 33ms/字，20 字 ≈ 0.7s，放宽超时）
+    await waitFor(
+      () =>
+        expect(container.querySelector(".chat-reasoning-excerpt")!.textContent)
+          .toContain("先查《心經》的出處，再對比《大般若經》。"),
+      { timeout: 3000 },
+    );
     // content 仍是哨兵（等待 UI 还在）
     expect(container.querySelector(".chat-thinking")).not.toBeNull();
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -47,6 +47,7 @@ import {
   RailSettingsIcon,
 } from "../components/RailIcons";
 import DraggableModal from "../components/DraggableModal";
+import ReasoningExcerpt from "../components/ReasoningExcerpt";
 import { getMasters } from "../api/client";
 import type { CitationTarget } from "../components/CitationDrawer";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -466,20 +467,10 @@ function MessageBubbleInner({
                   </span>
                   <span className="chat-thinking-dots"><span /><span /><span /></span>
                 </div>
-                {/* 思考过程片段活窗。只在哨兵分支里渲染 —— 正文一到（content 被
-                    换掉）整块随分支消失，这是渲染层的保险；onToken 另清
-                    reasoningText，两道各自独立。aria-hidden：读屏用户听
-                    「已思考 N 秒」就够了，逐秒变动的中间结论只会淹没读屏。 */}
-                {m.reasoningText ? (
-                  <div className="chat-reasoning-excerpt" aria-hidden="true">
-                    <span className="chat-reasoning-excerpt-label">
-                      {t("chat.reasoning_excerpt_label")}
-                    </span>
-                    <div className="chat-reasoning-excerpt-clip">
-                      <div className="chat-reasoning-excerpt-text">{m.reasoningText}</div>
-                    </div>
-                  </div>
-                ) : null}
+                {/* 思考过程片段活窗（打字机组件）。只在哨兵分支里渲染 —— 正文
+                    一到（content 被换掉）整块随分支消失，这是渲染层的保险；
+                    onToken 另清 reasoningText，两道各自独立。 */}
+                {m.reasoningText ? <ReasoningExcerpt text={m.reasoningText} /> : null}
               </>
             ) : m.content === REQUEST_FAILED_SENTINEL ? (
               t("chat.request_failed")
@@ -1333,9 +1324,10 @@ export default function ChatPage() {
             const next = { ...m };
             if (next.reasoningSince == null) next.reasoningSince = Date.now();
             if (r.text) {
-              // 保尾截断：显示的是「正在想什么」的活窗，不是完整思考记录。
-              // 截尾同时消解跨 fallback 拼接 —— 旧模型的推理很快滚出窗口。
-              next.reasoningText = ((next.reasoningText ?? "") + r.text).slice(-1200);
+              // 全量累加、不截尾：打字机组件按前缀吐字，截尾会让前缀失配、
+              // 整窗重排跳动。上限由推理预算天然封顶（≤ 数万字，流结束即清），
+              // 显示端的活窗高度由 CSS clip 管。
+              next.reasoningText = (next.reasoningText ?? "") + r.text;
             }
             return next;
           }),

--- a/frontend/src/pages/MessageBubble.test.tsx
+++ b/frontend/src/pages/MessageBubble.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { Components } from "react-markdown";
 import i18n from "../i18n";
 import zhHantTranslation from "../../public/locales/zh-Hant/translation.json";
@@ -99,7 +99,7 @@ describe("MessageBubble", () => {
     expect(document.querySelector(".chat-thinking")).not.toBeNull();
   });
 
-  it("哨兵 + reasoningText → 渲染思考片段活窗（带非回答标签）", () => {
+  it("哨兵 + reasoningText → 渲染思考片段活窗（带非回答标签）", async () => {
     renderBubble({
       m: msg({
         content: "正在检索经文并生成回答...",
@@ -108,7 +108,11 @@ describe("MessageBubble", () => {
     });
     const excerpt = document.querySelector(".chat-reasoning-excerpt");
     expect(excerpt).not.toBeNull();
-    expect(excerpt!.textContent).toContain("先查《心經》的出處");
+    // 打字机逐字吐出（约 33ms/字），等它追平
+    await waitFor(
+      () => expect(excerpt!.textContent).toContain("先查《心經》的出處"),
+      { timeout: 3000 },
+    );
     // 必须带「非回答」标签 —— 中间结论不能被当成答案读
     expect(document.querySelector(".chat-reasoning-excerpt-label")).not.toBeNull();
   });

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -446,6 +446,15 @@ em {
   white-space: pre-wrap;
   word-break: break-word;
 }
+.chat-reasoning-caret {
+  display: inline-block;
+  margin-left: 1px;
+  opacity: 0.6;
+  animation: chat-caret-blink 1s steps(1) infinite;
+}
+@keyframes chat-caret-blink {
+  50% { opacity: 0; }
+}
 
 /* 「回到底部」悬浮按钮。锚点 sticky 在滚动视口下沿、height:0 不占布局空间；
    按钮相对锚点绝对定位向上撑出，所以不需要给滚动容器加 position:relative 的


### PR DESCRIPTION
使用者反馈：#1183 的活窗「一段段文本不断地跳动」——后端按秒聚合发帧，一帧
几十字整块上屏就是一跳。目标是主流 LLM 对话界面那种匀速吐字的思考流。

两层配合：

1. 后端 REASONING_EMIT_INTERVAL_S 1.0 → 0.25：一帧约 10-20 字，给前端一个
   近匀速的输入节拍。帧头开销 ~70B × 4/s，三分钟重推理只多 ~50KB。
2. 前端新组件 ReasoningExcerpt（ChatPage 与 ReaderAIPanel 共用，替换两处
   内联 JSX）：新到文本先进缓冲，~30Hz 步进吐字，步长与积压成正比 ——
   积压越多走得越快、追平后逐字，稳态滞后不到一秒，缓冲永不丢字。
   附闪烁光标；prefers-reduced-motion 时整段直出不做打字机。

配套改动：reasoningText 改为全量累加、去掉 slice(-1200) 保尾截断 —— 打字机
按前缀吐字，截尾会让前缀失配、整窗重排跳动（上限由推理预算天然封顶且流结束
即清，活窗高度由 CSS clip 管）。

护栏不变：只在等待期挂载、正文一到整块销毁、绝不碰 content —— 全部承重测试
原样通过。

验证：新组件 4 条用例先红后绿，第一条锁的就是「一帧不整块上屏」；三处既有
用例适配渐进显示（waitFor 放宽超时）；前端 tsc + eslint + i18n + vitest 487
全绿；后端 reasoning/heartbeat 10 条全绿。