### PR TITLE
perf(chat): meta 问题关思考——一句自我介绍不需要几十秒推理

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -268,6 +268,22 @@ async def _save_messages(
     return assistant_msg.id
 
 
+def _thinking_params_for_request(
+    model: str, *, message: str, master_id: str | None, text_id: int | None,
+) -> dict:
+    """按请求形态选思考档：meta 问题直接关，其余走配置档。
+
+    meta 问题（你是谁 / 你好 / hello …，判定与 _prepare_chat 的跳过 RAG 分支
+    完全同一条）不检索、META_INTRO_PROMPT 明令禁止引用 —— 没有任何引文保真度
+    可损失，而上游默认档会为一句自我介绍跑几十秒推理。生产会话列表里这类
+    问题占比可观（游客首次试探几乎都是它），关掉思考等于把这批请求从
+    30-180s 拉回几秒，且质量无从受损。
+    """
+    if _is_meta_question(message) and not master_id and not text_id:
+        return thinking_params(model, "off")
+    return configured_thinking_params(model)
+
+
 async def _generate_session_title(
     api_url: str, api_key: str, model: str, message: str, answer: str,
     *, provider: str | None = None,
@@ -576,7 +592,7 @@ async def send_message(
                 headers={"Authorization": f"Bearer {k}"},
                 json={"model": m, "messages": llm_messages, "temperature": 0.7,
                       "max_tokens": _with_reasoning_headroom(m, 8000 if page_content else 2000),
-                      **configured_thinking_params(m)},
+                      **_thinking_params_for_request(m, message=message, master_id=master_id, text_id=text_id)},
             )
             resp.raise_for_status()
             return resp.json()["choices"][0]["message"]["content"]
@@ -985,7 +1001,7 @@ async def send_message_stream(
                 headers={"Authorization": f"Bearer {k}"},
                 json={"model": m, "messages": llm_messages, "temperature": 0.7,
                       "max_tokens": _with_reasoning_headroom(m, 8000 if page_content else 2000), "stream": True,
-                      **configured_thinking_params(m)},
+                      **_thinking_params_for_request(m, message=message, master_id=master_id, text_id=text_id)},
             ) as resp:
                 resp.raise_for_status()
                 async for line in resp.aiter_lines():

--- a/backend/tests/test_thinking_mode_params.py
+++ b/backend/tests/test_thinking_mode_params.py
@@ -157,7 +157,7 @@ def _prepare_chat_return():
     )
 
 
-async def _run_stream_capturing_body(effort: str) -> dict:
+async def _run_stream_capturing_body(effort: str, message: str = "測試") -> dict:
     captured: dict = {}
     with patch("app.services.chat._prepare_chat", new_callable=AsyncMock,
                return_value=_prepare_chat_return()), \
@@ -168,7 +168,7 @@ async def _run_stream_capturing_body(effort: str) -> dict:
         from app.services.chat import send_message_stream
 
         async for _ in send_message_stream(
-            user_id=1, message="測試", sessionmaker=_FakeSessionmaker(),
+            user_id=1, message=message, sessionmaker=_FakeSessionmaker(),
         ):
             pass
     return captured
@@ -189,3 +189,35 @@ class TestAnswerPathHonoursSetting:
         body = await _run_stream_capturing_body("low")
         assert body.get("thinking") == {"type": "enabled"}
         assert body.get("reasoning_effort") == "low"
+
+
+class TestMetaQuestionDisablesThinking:
+    """meta 问题（你是谁/你好，不走 RAG、禁止引用）一律关思考。
+
+    这批请求没有任何引文保真度可损失（META_INTRO_PROMPT 明令不引经文），
+    而上游默认档会为一句自我介绍跑几十秒推理 —— 生产会话列表里游客首次
+    试探几乎全是这类问题。判定必须与 _prepare_chat 跳过 RAG 的分支同一条
+    （_is_meta_question + 无 master + 无 text_id），不能各写一份。
+    """
+
+    @pytest.mark.asyncio
+    async def test_meta_question_gets_thinking_disabled(self):
+        body = await _run_stream_capturing_body("", message="你是谁")
+        assert body.get("thinking") == {"type": "disabled"}, (
+            f"meta 问题仍在跑默认档推理，请求体={json.dumps(body, ensure_ascii=False)[:200]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_configured_effort_does_not_override_meta_off(self):
+        """就算配置了档位，meta 问题也保持关闭 —— off 比 low 更快且同样无损。
+
+        注意「你好 / hello」**不是** meta 问题（不在 _META_KEYWORDS 里，走完整
+        RAG 路径）—— 要不要把问候也归进来是改答案行为的另一个决定，不在这里做。
+        """
+        body = await _run_stream_capturing_body("low", message="介绍你自己")
+        assert body.get("thinking") == {"type": "disabled"}
+
+    @pytest.mark.asyncio
+    async def test_normal_question_is_unaffected(self):
+        body = await _run_stream_capturing_body("", message="「般若」和智慧有什么不同？")
+        assert "thinking" not in body and "reasoning_effort" not in body


### PR DESCRIPTION
「你是谁 / 介绍你自己 / 你能做什么」这类 meta 问题在生产会话列表里占比可观
（游客首次试探几乎全是它），此前也在跑上游默认的最高档推理。而这批请求：

- 不走 RAG（_prepare_chat 直接跳过检索）；
- META_INTRO_PROMPT 明令**不引用任何经文** ——

即没有任何引文保真度可损失。关掉思考把它们从 30-180s 拉回几秒，质量无从受损。

实现：_thinking_params_for_request(m, message, master_id, text_id) —— 判定与
_prepare_chat 跳过 RAG 的分支**同一条**（_is_meta_question + 无 master + 无
text_id），不另写一份口径。流式与非流式两个正式问答路径都走它；就算配置了
CHAT_REASONING_EFFORT 档位，meta 问题也保持 off（更快且同样无损）。

明确不做的：「你好 / hello」不是 meta 问题（不在 _META_KEYWORDS，走完整 RAG
路径）——要不要把问候归进来是改答案行为的另一个决定，需要单独评审，测试里
写明了这一点。

验证：3 条新用例先红后绿；pytest 1715 通过（health_check_probe 3 失败为
master 存量）；ruff 过。