### PR TITLE
feat(prompt): 引文纪律收尾重申——引得更克制、错得更少，延迟不变

### DIFF
--- a/backend/app/services/prompt_builder.py
+++ b/backend/app/services/prompt_builder.py
@@ -75,6 +75,17 @@ SYSTEM_PROMPT = (
 )
 
 
+# 与 backend 2026-08-13 四臂 eval 的 D 臂逐字相同 —— 改这段文字等于作废那次
+# eval 的结论，改前必须重跑（工具在 /data/eval-effort 的方法论，见 memory
+# reasoning-effort-eval-verdict）。
+CITATION_DISCIPLINE_SUFFIX = (
+    "\n\n## 引文纪律（最高优先级重申）\n"
+    "- 引号「」与【《经名》第N卷】只用于能从检索片段中**逐字复制**的内容；"
+    "记不清逐字原文就转述，不加引号、不标【】。\n"
+    "- 宁可少引、不可错引：每个要点最多引 1 条最贴切的原文。\n"
+    "- 不确定时选择不引用——转述并说明依据即可。"
+)
+
 META_INTRO_PROMPT = (
     "你是小津（XiaoJin）——佛津（FoJin）平台内置的佛教古籍研习 AI 助手。\n\n"
     "当用户询问你是谁、你能做什么、请你自我介绍时，严格按以下格式回复，"
@@ -291,6 +302,16 @@ def _build_llm_messages(
         enhanced_prompt = master.system_prompt
     else:
         enhanced_prompt = _classify_and_enhance_prompt(message)
+        # 引文纪律收尾重申 —— 只加在与 2026-08-13 四臂 eval（90 题 × 4）完全相同
+        # 的路径上：普通 RAG 问答（无祖师、无 meta、无阅读页上下文）。那次 D 臂
+        # （默认档 + 本后缀）三个忠实度指标齐升：逐字 90.2%→94.7%、卷号
+        # 94.4%→98.0%、全验证 80.6%→84.4%，配对 1:4，延迟同量级；代价是引文
+        # 总数 −30%（355→250）—— 按「答案不得有错误信息」的最高准则，引得更
+        # 克制但更准是正确的方向。祖师/阅读页路径未测过，不扩散。
+        # 放在**系统提示词末尾**是有意的：与 eval 的注入位置一致，且离生成
+        # 最近的指令服从率最高（规则 4b/4c 讲过同样的事，但排在 2,000 字外）。
+        if not _is_meta_question(message) and not reading_context:
+            enhanced_prompt += CITATION_DISCIPLINE_SUFFIX
 
     # Enhance with reading context when user is asking from the reader page.
     # Only the reading-mode *instructions* go into the system prompt; the

--- a/backend/tests/test_citation_discipline_suffix.py
+++ b/backend/tests/test_citation_discipline_suffix.py
@@ -1,0 +1,59 @@
+"""引文纪律后缀：只加在被 eval 验证过的那条路径上。
+
+2026-08-13 四臂 eval（90 题 × 4 臂、temperature 0、同时段并行）的 D 臂结论：
+默认档 + 本后缀，三个忠实度指标齐升（逐字 90.2%→94.7%、卷号 94.4%→98.0%、
+全验证 80.6%→84.4%，配对 1:4），延迟同量级，代价是引文总数 −30%。
+
+三条边界与一条钉死：
+  1. 普通 RAG 问答必须带后缀，且在系统提示词**末尾**（eval 的注入位置）；
+  2. 祖师 / meta / 阅读页三条路径不带 —— 它们没测过，不扩散；
+  3. 后缀文字与 eval 逐字相同 —— 改文字等于作废 eval 结论。
+"""
+
+from app.services.prompt_builder import (
+    CITATION_DISCIPLINE_SUFFIX,
+    _build_llm_messages,
+)
+
+
+def _system_of(msgs: list[dict]) -> str:
+    assert msgs[0]["role"] == "system"
+    return msgs[0]["content"]
+
+
+def test_plain_rag_question_gets_the_suffix_at_the_end():
+    msgs = _build_llm_messages([], "【系统自动检索】……", "「般若」和智慧有什么不同？")
+    system = _system_of(msgs)
+    assert system.endswith(CITATION_DISCIPLINE_SUFFIX), (
+        "后缀必须在系统提示词末尾（与 eval 注入位置一致，且离生成最近的指令"
+        f"服从率最高）；实际结尾: …{system[-80:]!r}"
+    )
+
+
+def test_suffix_text_is_pinned_to_the_evaled_wording():
+    """改这段文字等于作废 2026-08-13 的四臂 eval，改前必须重跑。"""
+    assert "逐字复制" in CITATION_DISCIPLINE_SUFFIX
+    assert "宁可少引、不可错引" in CITATION_DISCIPLINE_SUFFIX
+    assert "最多引 1 条" in CITATION_DISCIPLINE_SUFFIX
+
+
+def test_meta_question_does_not_get_the_suffix():
+    """meta 路径本来就禁止引用，再加引文纪律是自相矛盾的噪音。"""
+    msgs = _build_llm_messages([], "", "你是谁")
+    assert CITATION_DISCIPLINE_SUFFIX not in _system_of(msgs)
+
+
+def test_master_path_does_not_get_the_suffix():
+    """祖师问答是另一套提示词家族，D 臂没测过它 —— 不扩散。"""
+    msgs = _build_llm_messages([], "【系统自动检索】……", "如何修行？", master_id="huineng")
+    assert CITATION_DISCIPLINE_SUFFIX not in _system_of(msgs)
+
+
+def test_reader_path_does_not_get_the_suffix():
+    """阅读页要求围绕页面原文解读引用，与「宁可少引」的取向相反，且未测过。"""
+    msgs = _build_llm_messages(
+        [], "", "这一段什么意思？",
+        reading_context={"title": "般若波羅蜜多心經", "juan_num": 1,
+                         "selected_text": None, "page_content": "觀自在菩薩……"},
+    )
+    assert CITATION_DISCIPLINE_SUFFIX not in _system_of(msgs)


### PR DESCRIPTION
为「缩短响应时间」跑的四臂 eval（90 题 × 4 臂、temperature 0、同时段并行，
方法论同 #1181 那轮）出了两个结论，这个 PR 落地其中的意外收获：

    臂                     LLM中位   逐字保真度        卷号准确率      配对vs A
    A 默认档               45.0s    55/61 = 90.2%    186/197=94.4%      —
    B low                  27.6s    38/56 = 67.9%    180/206=87.4%    15:4 (p=0.019)
    C low+纪律             25.3s    46/58 = 79.3%    177/192=92.2%     9:5
    D 默认档+纪律          50.7s    54/57 = 94.7%    148/151=98.0%     1:4

1. ⛔ 降档提速正式判死：A vs B 配对 15:4，McNemar p=0.019 —— 下午那轮的
   -12.9pp 这次拿到显著性。纪律后缀能把 low 档拉回一半（B 67.9% → C 79.3%）
   但离 A 仍差 11pp —— 速度的下限就是质量的价格，默认档不动。
2. ✅ D 臂顺手赢了：同样的纪律后缀加在**默认档**上，三个忠实度指标齐升
   （逐字 +4.5pp、卷号 +3.6pp、全验证 +3.8pp，配对 1:4），p90 延迟反而略低
   （90.0s vs 102.8s）。代价是引文总数 −30%（355→250，每答约 3.9→2.8 条）——
   按「答案不得有错误信息」的最高准则，引得更克制但更准是正确的方向。

## 改动

SYSTEM 提示词末尾追加「引文纪律（最高优先级重申）」三条 —— 内容与既有规则
4b/4c 同义，但放在**离生成最近**的位置（原规则排在 2,000 字外）。文字与 eval
的 D 臂**逐字相同**，有用例钉死：改文字等于作废 eval 结论，改前必须重跑。

只加在被 eval 覆盖的那条路径上：普通 RAG 问答。祖师 / meta / 阅读页三条路径
**不加**（没测过，不扩散；meta 本来就禁止引用，阅读页要求围绕页面原文引用，
与「宁可少引」取向相反）。

## 验证

5 条用例（末尾位置 / 文字钉死 / 三条路径不扩散）；pytest 1720 通过
（health_check_probe 3 失败为 master 存量）；ruff 过。

原始数据在生产 /home/admin/fojin/data/eval-effort/ev-*.jsonl（360 行）。