### PR TITLE
chore(seo): 首页标题改说全站，不再只说 AI 问答

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -47,7 +47,7 @@
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
     <!-- Umami Analytics is opt-in at build time via VITE_UMAMI_URL + VITE_UMAMI_WEBSITE_ID;
          see src/umami.ts. Self-hosters who don't set both envs get no tracking script. -->
-    <title>佛津 FoJin — 佛经 AI 问答，每句引用可点开核对原文</title>
+    <title>佛津 FoJin — 全球佛教古籍聚合平台，AI问答引文可核对原文</title>
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -58,7 +58,7 @@
           "@type": "WebSite",
           "name": "佛津 FoJin",
           "url": "https://fojin.app/",
-          "description": "佛经 AI 问答平台——从大藏经原文作答，每条引用标注经名卷号并可点开核对原典",
+          "description": "全球佛教古籍聚合平台——AI 问答从大藏经原文作答，每条引用标注经名卷号并可点开核对原典",
           "inLanguage": "zh-CN",
           "potentialAction": {
             "@type": "SearchAction",
@@ -97,7 +97,7 @@
     <div id="root"></div>
     <noscript>
       <div style="max-width:800px;margin:40px auto;padding:0 24px;font-family:serif;color:#2b2318">
-        <h1>佛津 FoJin — 佛经 AI 问答，每句引用可点开核对原文</h1>
+        <h1>佛津 FoJin — 全球佛教古籍聚合平台，AI问答引文可核对原文</h1>
         <p>用大白话向大藏经提问，佛学助手「小津」从典籍原文作答。答案里的每条引用都标注经名与卷号，点开即可比对原典——这是佛津与一般 AI 问答最不同的地方：<strong>你不必相信它，你可以去查它</strong>。</p>
         <h2>核心功能</h2>
         <ul>

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3,7 +3,7 @@
   "home.title_accent": "Fo",
   "home.title_rest": "Jin",
   "app.tagline": "Global Buddhist Classics Digital Resource Platform",
-  "app.title": "FoJin — Buddhist canon Q&A, every citation opens to its source",
+  "app.title": "FoJin — Global Buddhist classics platform, citations you can check",
   "nav.home": "Home",
   "nav.search": "Search",
   "nav.sources": "Sources",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -3,7 +3,7 @@
   "home.title_accent": "佛",
   "home.title_rest": "津",
   "app.tagline": "全球佛教古籍數字資源聚合平臺",
-  "app.title": "佛津 FoJin — 佛經 AI 問答，每句引用可點開核對原文",
+  "app.title": "佛津 FoJin — 全球佛教古籍聚合平臺，AI問答引文可核對原文",
   "nav.home": "首頁",
   "nav.search": "搜尋",
   "nav.sources": "資料來源",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -3,7 +3,7 @@
   "home.title_accent": "佛",
   "home.title_rest": "津",
   "app.tagline": "全球佛教古籍数字资源聚合平台",
-  "app.title": "佛津 FoJin — 佛经 AI 问答，每句引用可点开核对原文",
+  "app.title": "佛津 FoJin — 全球佛教古籍聚合平台，AI问答引文可核对原文",
   "nav.home": "首页",
   "nav.search": "搜索",
   "nav.sources": "数据源",


### PR DESCRIPTION
浏览器 tab 与搜索结果此前是「佛津 FoJin — 佛经 AI 问答，每句引用可点开核对
原文」，而首页 hero 上写的是「全球佛教古籍数字资源聚合平台」—— 同一个首页，
站外读到的和站内看到的是两个产品。使用数据也不支持只说问答：8-05 的板块真实
使用量是 问答 715 / 辞典 428 / 知识图谱 219 / 跨藏对读 17，辞典是问答的六成，
标题里一个字都没有。

改为：佛津 FoJin — 全球佛教古籍聚合平台，AI问答引文可核对原文

前半句覆盖全站（数据源 / 阅读器 / 辞典 / 图谱 / 地理 / 专题），与 hero 定位
一致；后半句保住那句别人抄不走的承诺 —— 「引文可核对原文」是本站唯一在转的
差异化，任何改法都不能把它挤掉。约 28 全角，在 Google 的截断线内。

同步四处（此前三处文案就不完全一致）：
- index.html 的 <title>
- index.html 的 noscript <h1>（无脚本环境下的首屏标题，与 title 同文）
- index.html 的 JSON-LD WebSite.description —— 它此前自称「佛经 AI 问答平台」，
  与新标题的定位直接矛盾，改为「全球佛教古籍聚合平台——AI 问答从大藏经原文
  作答……」，信息不减
- 三语 app.title（HomePage 的 Helmet 读它覆盖 index.html）

**不动**的两处，理由写在这里免得下次误改：
- staticPages.json 里那条「佛经 AI 问答 — 每句引用可点开核对原文」是 /chat 页
  的标题，那一页确实就是 AI 问答，本来就该这么写；
- og:title / og:description 是分享卡片文案（「问佛经，得到能核对原文的答案」），
  是另一套钩子文案，要不要跟着调整是单独的产品决定。

验证：tsc + eslint + i18n ratchet + vitest 487 全绿；三个 locale 文件改后
仍是合法 JSON（脚本内 json.load 校验，且逐行替换保留原有键序与格式）。