### PR TITLE
chore(seo): 首页标题与 hero 标语对齐，AI 问答补空格

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -47,7 +47,7 @@
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
     <!-- Umami Analytics is opt-in at build time via VITE_UMAMI_URL + VITE_UMAMI_WEBSITE_ID;
          see src/umami.ts. Self-hosters who don't set both envs get no tracking script. -->
-    <title>佛津 FoJin — 全球佛教古籍聚合平台，AI问答引文可核对原文</title>
+    <title>佛津 FoJin — 全球佛教古籍数字资源聚合平台，AI 问答引文可核对原文</title>
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -58,7 +58,7 @@
           "@type": "WebSite",
           "name": "佛津 FoJin",
           "url": "https://fojin.app/",
-          "description": "全球佛教古籍聚合平台——AI 问答从大藏经原文作答，每条引用标注经名卷号并可点开核对原典",
+          "description": "全球佛教古籍数字资源聚合平台——AI 问答从大藏经原文作答，每条引用标注经名卷号并可点开核对原典",
           "inLanguage": "zh-CN",
           "potentialAction": {
             "@type": "SearchAction",
@@ -97,7 +97,7 @@
     <div id="root"></div>
     <noscript>
       <div style="max-width:800px;margin:40px auto;padding:0 24px;font-family:serif;color:#2b2318">
-        <h1>佛津 FoJin — 全球佛教古籍聚合平台，AI问答引文可核对原文</h1>
+        <h1>佛津 FoJin — 全球佛教古籍数字资源聚合平台，AI 问答引文可核对原文</h1>
         <p>用大白话向大藏经提问，佛学助手「小津」从典籍原文作答。答案里的每条引用都标注经名与卷号，点开即可比对原典——这是佛津与一般 AI 问答最不同的地方：<strong>你不必相信它，你可以去查它</strong>。</p>
         <h2>核心功能</h2>
         <ul>

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -3,7 +3,7 @@
   "home.title_accent": "佛",
   "home.title_rest": "津",
   "app.tagline": "全球佛教古籍數字資源聚合平臺",
-  "app.title": "佛津 FoJin — 全球佛教古籍聚合平臺，AI問答引文可核對原文",
+  "app.title": "佛津 FoJin — 全球佛教古籍數字資源聚合平臺，AI 問答引文可核對原文",
   "nav.home": "首頁",
   "nav.search": "搜尋",
   "nav.sources": "資料來源",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -3,7 +3,7 @@
   "home.title_accent": "佛",
   "home.title_rest": "津",
   "app.tagline": "全球佛教古籍数字资源聚合平台",
-  "app.title": "佛津 FoJin — 全球佛教古籍聚合平台，AI问答引文可核对原文",
+  "app.title": "佛津 FoJin — 全球佛教古籍数字资源聚合平台，AI 问答引文可核对原文",
   "nav.home": "首页",
   "nav.search": "搜索",
   "nav.sources": "数据源",

--- a/frontend/src/homeTitleConsistency.test.ts
+++ b/frontend/src/homeTitleConsistency.test.ts
@@ -1,0 +1,62 @@
+/** 首页标题的两条一致性 —— 都是已经真实发生过漂移的地方。
+ *
+ * 首页标题有两个源：`index.html` 的 <title>（爬虫首屏、首次加载的 tab）与
+ * locale 的 `app.title`（HomePage 的 Helmet 读它覆盖）。2026-08-13 核对时发现
+ * 两处文案、以及 JSON-LD 里的站点定位，历史上各写各的。
+ *
+ * 更要紧的是第二条：标题说的和首页 hero 上写的曾经是两个产品 —— tab 说
+ * 「佛经 AI 问答」，hero 说「全球佛教古籍数字资源聚合平台」。用户从搜索结果
+ * 点进来，读到的定位对不上。修法是让标题**逐字包含** hero 标语，这条用例
+ * 就是钉住它。
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import zhHantTranslation from "../public/locales/zh-Hant/translation.json";
+import zhTranslation from "../public/locales/zh/translation.json";
+
+/** locale 包里并非每个值都是字符串（如 home.hot_tags 是数组），所以放宽索引
+ *  签名，取值时再收窄 —— 直接 `as Record<string, string>` 会被 tsc 拒绝。 */
+type Bundle = Record<string, string | string[]>;
+
+const LOCALES: Record<"zh" | "zh-Hant", Bundle> = {
+  zh: zhTranslation as Bundle,
+  "zh-Hant": zhHantTranslation as Bundle,
+};
+
+const text = (loc: "zh" | "zh-Hant", key: string): string => String(LOCALES[loc][key]);
+
+const readIndexHtml = () => readFileSync(resolve(process.cwd(), "index.html"), "utf-8");
+
+describe("首页标题一致性", () => {
+  it("index.html 的 <title> 与简体 app.title 逐字相同", () => {
+    const title = /<title>([^<]*)<\/title>/.exec(readIndexHtml())?.[1];
+    expect(title).toBe(text("zh", "app.title"));
+  });
+
+  it("noscript 的 <h1> 也是同一句（无脚本环境的首屏标题）", () => {
+    expect(readIndexHtml()).toContain(`<h1>${text("zh", "app.title")}</h1>`);
+  });
+
+  it.each(["zh", "zh-Hant"] as const)(
+    "%s: 标题包含 hero 标语 —— 站外读到的与站内看到的必须是同一个定位",
+    (loc) => {
+      expect(text(loc, "app.title")).toContain(text(loc, "app.tagline"));
+    },
+  );
+
+  it("标题宽度在搜索结果的截断线附近仍可读（CJK 记 1、半角记 0.5）", () => {
+    // Google 中文标题约显示 600px ≈ 30 全角。超一点只会截掉尾部，不是硬错误，
+    // 所以这里卡的是「别再长下去」的护栏值，不是精确阈值。
+    // 用码位转义而非字面字符：字符类里那个表意空格（U+3000）会被 eslint 的
+    // no-irregular-whitespace 判为错误，而 CI 跑 --max-warnings 0。
+    const CJK = /[\u2E80-\u9FFF\u3000-\u303F\uFF00-\uFFEF]/;
+    const width = [...text("zh", "app.title")].reduce(
+      (n, ch) => n + (CJK.test(ch) ? 1 : 0.5),
+      0,
+    );
+    expect(width).toBeLessThanOrEqual(34);
+  });
+});


### PR DESCRIPTION
两处按使用者指定调整：

1. 「AI问答」→「AI 问答」—— 与全站排版一致（导航项本来就写「AI 问答」）。
2. 「全球佛教古籍聚合平台」→「全球佛教古籍数字资源聚合平台」—— 与首页 hero
   的 app.tagline **逐字相同**，站外读到的标题与站内看到的标语从此是同一句。

最终：佛津 FoJin — 全球佛教古籍数字资源聚合平台，AI 问答引文可核对原文

同步 index.html 的 <title> / noscript <h1> / JSON-LD description 与简繁两个
app.title（英文不动：en 标题里没有 AI 空格问题，而把 "Digital Resource" 塞进去
会顶穿英文标题的显示宽度）。

## 顺带把这条不变式钉成用例（新增 homeTitleConsistency.test.ts）

首页标题有两个源 —— index.html 的 <title>（爬虫首屏 + 首次加载的 tab）与
locale 的 app.title（HomePage 的 Helmet 覆盖）。核对时发现它们连同 JSON-LD 的
站点定位，历史上各写各的；而标题与 hero 更是长期说着两个产品（tab 说「佛经
AI 问答」、hero 说「聚合平台」），用户从搜索结果点进来读到的定位对不上。

四条用例：<title> 与 app.title 逐字相同、noscript <h1> 同文、简繁标题都必须
**包含** hero 标语、标题宽度不越过截断护栏值。

验证：先证红 —— 把 app.title 退回上一版，四条里该红的三条全红（宽度那条本就
不该红）；改回即绿。tsc + eslint + i18n ratchet + vitest 492 全绿。
⚠️ 宽度用例的 CJK 字符类必须写码位转义：字面表意空格（U+3000）会被 eslint 的
no-irregular-whitespace 判错，而 CI 跑 --max-warnings 0。