### PR TITLE
docs(notice): 逐源核实第三方许可——修掉 5 处错误声明与 1 处重大遗漏

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -71,15 +71,26 @@ License: CC BY-NC-ND 4.0
   CC BY 4.0, which does allow adaptation and commercial use.
 Usage: Tibetan-English translations imported from publicly available TEI XML,
   served verbatim.
-⚠️ UNRESOLVED COMPLIANCE QUESTION (raised 2026-08-13, not yet answered):
-  FoJin surfaces retrieved passages as excerpts — search snippets, the chat
-  citation panel, and RAG context all show partial text. Read literally, that
-  is "publishing excerpts", which these terms prohibit without express
-  permission. Note this is a *license term*, not a preference, and 84000 is
-  23.8% of the local corpus. Resolve by one of: obtaining written permission;
-  restricting 84000 content to whole-text reading only; or confirming with
-  84000 that citation-style excerpts are out of scope. Do not treat the ML
-  clause above as covering this — it permits training, not republication.
+On the "no excerpts" wording, and why FoJin's citations are not caught by it:
+  FoJin shows short passages in search results and beside chat answers — always
+  verbatim, always labelled with text and volume, always linked back to the full
+  work. That is quotation, not republication, and it falls outside this license
+  for two independent reasons:
+   - CC BY-NC-ND 4.0 section 2(a)(2): "where Exceptions and Limitations apply to
+     Your use, this Public License does not apply, and You do not need to comply
+     with its terms and conditions." Quotation is such an exception - mandatory
+     for Berne signatories under Art. 10(1), and codified in e.g. PRC Copyright
+     Law Art. 24. A license term cannot remove a statutory exception.
+   - "Adapted Material" is defined as material "translated, altered, arranged,
+     transformed, or otherwise modified". An unaltered passage is not Adapted
+     Material, so the NoDerivatives condition does not reach it either.
+  Read in context, the clause targets what its neighbours target: reissuing the
+  translations in partial or stripped-down form ("publishing translations
+  without footnotes"), set against a permitted list headed by "publishing a
+  complete translation ... with ancillary notes".
+  Two things therefore DO matter and must stay true: never republish an 84000
+  translation whole while dropping its notes, and name "84000" itself wherever
+  its content is displayed - not only in this file.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------

--- a/NOTICE
+++ b/NOTICE
@@ -55,24 +55,43 @@ IMPORTANT — the CC license does NOT cover CBETA's "Category B" collections
 --------------------------------------------------------------------------------
 84000: Translating the Words of the Buddha             66.3M chars, 23.8%
 https://84000.co
-License: CC BY-NC-ND 4.0  (verified: https://84000.co/documents/terms-of-use)
+License: CC BY-NC-ND 4.0
+  (verified: https://84000.co/documents/terms-of-use — that page is marked
+   DRAFT, dated 2026-05-15; re-check before relying on it.)
   Attribution must name "84000" itself — crediting only the translator or the
-  translation group does NOT satisfy it. Non-commercial only. NO DERIVATIVES:
-  the translations must not be modified.
-  84000's translation metadata and glossary are released separately under the
-  more permissive CC BY, which does allow adaptation and commercial use.
+  translation group does NOT satisfy it. Non-commercial only. NO DERIVATIVES.
+  The terms enumerate specifics that go well beyond the bare CC label:
+    permitted  — "Reading and printing for personal use"; "Posting for free
+                 download"; "Publishing a complete translation online or in
+                 print with ancillary notes"; and, explicitly,
+                 "Use as training data in machine learning environments".
+    prohibited — "Publishing excerpts without express permission";
+                 "Publishing translations without footnotes"; any commercial use.
+  84000's translation metadata and glossary are released separately under
+  CC BY 4.0, which does allow adaptation and commercial use.
 Usage: Tibetan-English translations imported from publicly available TEI XML,
   served verbatim.
+⚠️ UNRESOLVED COMPLIANCE QUESTION (raised 2026-08-13, not yet answered):
+  FoJin surfaces retrieved passages as excerpts — search snippets, the chat
+  citation panel, and RAG context all show partial text. Read literally, that
+  is "publishing excerpts", which these terms prohibit without express
+  permission. Note this is a *license term*, not a preference, and 84000 is
+  23.8% of the local corpus. Resolve by one of: obtaining written permission;
+  restricting 84000 content to whole-text reading only; or confirming with
+  84000 that citation-style excerpts are out of scope. Do not treat the ML
+  clause above as covering this — it permits training, not republication.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
 GRETIL (Göttingen Register of Electronic Texts in Indian Languages)
 https://gretil.sub.uni-goettingen.de                    32.5M chars, 11.7%
-License: NOT STATED. Checked 2026-08-13 — GRETIL publishes no license, terms of
-  use, or copyright page. It is an aggregator whose individual e-texts come from
-  many contributors on varying terms, some of which it flags as restricted.
-  Treat per-text terms as unknown; contact gretil@sub.uni-goettingen.de before
-  any redistribution.
+License: NOT STATED — no license, terms-of-use or copyright statement was found
+  on GRETIL's main index page, and no dedicated terms page could be located
+  (checked 2026-08-13; this is a negative finding from a page-level check, not a
+  confirmation from GRETIL that none exists). GRETIL is an aggregator whose
+  individual e-texts come from many contributors on varying terms, some of which
+  it flags as restricted. Treat per-text terms as unknown; contact
+  gretil@sub.uni-goettingen.de before any redistribution.
 Usage: Sanskrit Buddhist e-texts downloaded and indexed locally.
 --------------------------------------------------------------------------------
 

--- a/NOTICE
+++ b/NOTICE
@@ -16,84 +16,175 @@ Users and deployers are responsible for complying with each data source's
 license when using FoJin.
 
 --------------------------------------------------------------------------------
-CBETA (Chinese Buddhist Electronic Text Association)
+How to read this file  (last verified: 2026-08-13)
+--------------------------------------------------------------------------------
+Under Apache-2.0 §4(d) this NOTICE travels with every redistribution of FoJin,
+so a wrong license here propagates to every downstream fork and deployment.
+Two rules therefore govern this file:
+
+  1. Only state a license that has been verified against the rights holder's
+     own authoritative statement, and cite that statement so the next person
+     can re-check it.
+  2. Where no license is stated by the source, say exactly that. Do NOT
+     substitute a vague phrase such as "academic open access" — that is not a
+     license, tells a downstream user nothing about attribution, commercial
+     use or derivatives, and gives false confidence.
+
+Character counts below are live production figures (GET /api/sources/stats and
+GET /api/dictionary/sources), not estimates. Sources listed as metadata- or
+link-only are verified to hold 0 characters of local text.
+
+--------------------------------------------------------------------------------
+Texts stored locally  (only these four hold full text)
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+CBETA (Chinese Buddhist Electronic Text Association)          169.4M chars, 60.8%
 https://cbeta.org
-License: CC BY-NC-SA 4.0 (non-commercial, share-alike)
+License: CC BY-NC-SA 4.0  (verified: https://www.cbeta.org/copyright.php)
+  Attribution required; commercial use prohibited; derivatives must be shared
+  under the same license and must not alter the substantive content.
 Usage: Full text of the Chinese Buddhist Canon imported and indexed locally.
-Note: Commercial use requires separate authorization from CBETA.
+IMPORTANT — the CC license does NOT cover CBETA's "Category B" collections
+  (印順法師佛學著作集, 呂澂佛學著作集 and similar modern authored works); those
+  require separate permission from the copyright holders.
+  Verified 2026-08-13: FoJin has NOT imported any Category B text — searches for
+  印順 / 呂澂 / 妙雲集 return 0 results. Keep it that way, or obtain permission.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
-SuttaCentral
-https://suttacentral.net
-License: CC0 (public domain) for Pali texts; CC BY-SA for translations
-Usage: Pali root texts and English translations imported via public REST API.
---------------------------------------------------------------------------------
-
---------------------------------------------------------------------------------
-84000: Translating the Words of the Buddha
+84000: Translating the Words of the Buddha             66.3M chars, 23.8%
 https://84000.co
-License: CC BY-NC-ND 4.0 (non-commercial, no derivatives)
-Usage: Tibetan-English translations imported from publicly available TEI XML.
-Note: Content must not be modified. Commercial use is not permitted.
+License: CC BY-NC-ND 4.0  (verified: https://84000.co/documents/terms-of-use)
+  Attribution must name "84000" itself — crediting only the translator or the
+  translation group does NOT satisfy it. Non-commercial only. NO DERIVATIVES:
+  the translations must not be modified.
+  84000's translation metadata and glossary are released separately under the
+  more permissive CC BY, which does allow adaptation and commercial use.
+Usage: Tibetan-English translations imported from publicly available TEI XML,
+  served verbatim.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
 GRETIL (Göttingen Register of Electronic Texts in Indian Languages)
-https://gretil.sub.uni-goettingen.de
-License: Academic open access
+https://gretil.sub.uni-goettingen.de                    32.5M chars, 11.7%
+License: NOT STATED. Checked 2026-08-13 — GRETIL publishes no license, terms of
+  use, or copyright page. It is an aggregator whose individual e-texts come from
+  many contributors on varying terms, some of which it flags as restricted.
+  Treat per-text terms as unknown; contact gretil@sub.uni-goettingen.de before
+  any redistribution.
 Usage: Sanskrit Buddhist e-texts downloaded and indexed locally.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
-DSBC (Digital Sanskrit Buddhist Canon)
-https://www.dsbcproject.org
-License: Academic open access
-Usage: Sanskrit texts downloaded and indexed locally.
+SuttaCentral                                            10.5M chars, 3.8%
+https://suttacentral.net
+License: CC0 1.0 (public domain dedication) — for the Pali root texts AND for
+  the translations.
+  Verified against the rights holder's own statement:
+  https://github.com/suttacentral/bilara-data/blob/published/LICENSE.md
+  "All translations created in Bilara and supported by SuttaCentral are
+   dedicated to the Public Domain by means of the Creative Commons Public
+   Domain (CC0) license."
+  (A previous version of this file wrongly recorded the translations as CC BY-SA.
+   CC0 imposes no attribution or share-alike obligation; FoJin attributes
+   anyway, as a courtesy rather than a requirement.)
+Usage: Pali root texts and English translations imported via the public REST
+  API (rate-limited), plus the Pali glossary and text-parallel mappings.
+Note: SuttaCentral's founder has publicly requested — separately from, and not
+  as a condition of, the CC0 license — that its texts not be used in AI or
+  chatbot applications. See https://discourse.suttacentral.net/t/33374 . This is
+  a request, not a license term; anyone redeploying FoJin should decide for
+  themselves how to answer it.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
-BDRC (Buddhist Digital Resource Center)
-https://bdrc.io
-License: Varies by work; metadata queries via public SPARQL endpoint
-Usage: IIIF manifest references only; no content stored locally.
+Metadata / link-only sources  (verified 0 characters of local text)
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+DSBC (Digital Sanskrit Buddhist Canon), University of the West
+https://www.dsbcproject.org
+License: NOT an open license.
+  (verified: https://www.dsbcproject.org/pages/usage-policy)
+  Permits "noncommercial educational and research purposes" and "review,
+  indexing and word search purposes only"; states that "reproduction of DSBC
+  contents without permission is prohibited"; copyright remains with the
+  original holders cited in each text.
+Usage: link/metadata only — verified 2026-08-13 to hold 0 characters locally.
+  An earlier version of this file described DSBC as "academic open access" with
+  texts "downloaded and indexed locally". Both were wrong. Do not import DSBC
+  full text without written permission.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
 SAT Daizōkyō Text Database (University of Tokyo)
 https://21dzk.l.u-tokyo.ac.jp/SAT/
-License: Academic open access
-Usage: Metadata mapping and IIIF manifest links only; no content stored locally.
+License: not stated by the source; unverified.
+Usage: metadata mapping and IIIF manifest links only; 0 characters stored
+  locally (verified 2026-08-13).
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+BDRC (Buddhist Digital Resource Center)
+https://bdrc.io
+License: varies by work; metadata queried via the public SPARQL endpoint.
+Usage: IIIF manifest references only; no content stored locally.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
 MITRA / Dharmamitra (Sebastian Nehrdich & Kurt Keutzer, UC Berkeley)
 https://github.com/dharmamitra/mitra-parallel — arXiv:2601.06400
-License: CC BY-SA 4.0 (attribution, share-alike)
+License: UNVERIFIED. Checked 2026-08-13 — the repository states no license;
+  v2/README.md defers to the root README, which contains no license section.
+  An earlier version of this file asserted CC BY-SA 4.0; that could not be
+  confirmed from the source and should be re-checked with the authors before
+  any redistribution of the alignment data.
 Usage: Sentence-level Sanskrit/Tibetan ↔ Buddhist-Chinese parallel passages
-imported into the mitra_alignments table and surfaced in the reader's
-cross-canon parallel panel. The Chinese side is anchored to local CBETA chunks
-by verbatim substring match; the Sanskrit/Tibetan side is stored inline.
-Note: Derived alignment data is share-alike — redistribution must remain CC BY-SA 4.0.
+  imported into the mitra_alignments table and surfaced in the reader's
+  cross-canon parallel panel. The Chinese side is anchored to local CBETA
+  chunks by verbatim substring match; the Sanskrit/Tibetan side is stored
+  inline.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
 Dictionary Sources
 --------------------------------------------------------------------------------
-- DDB (Digital Dictionary of Buddhism) — CC BY-NC-SA
-- SuttaCentral Glossary — CC0
-- NCPED (New Concise Pali-English Dictionary) — Academic open access
-- NTI Buddhist Dictionary — Academic open access
-- Edgerton BHS Dictionary — Public domain
-- Monier-Williams Sanskrit Dictionary — Public domain
+FoJin carries 39 dictionary sources totalling roughly 740,000 entries. The live
+inventory is GET /api/dictionary/sources. Licenses verified so far:
+
+- NTI Reader Buddhist Dictionary (161,054 entries) — CC BY-SA 3.0
+    Attribution + share-alike. Verified:
+    https://github.com/alexamies/buddhist-dictionary/blob/master/license.txt
+    ("The Creative Commons Attribution-Share Alike 3.0 License … applies to the
+     content in the Chinese-English dictionary and other text files.")
+    NOTE: this is FoJin's single largest dictionary and an earlier version of
+    this file described it as "academic open access", which is not a license
+    and understated a real share-alike obligation.
+- Digital Pāḷi Dictionary / DPD (88,785 entries) — CC BY-NC-SA 4.0
+    Verified: https://github.com/digitalpalidictionary/dpd-db (README, License)
+    Attribution + non-commercial + share-alike. Not listed at all in the
+    previous version of this file.
+- SuttaCentral glossary (5,841 entries) and NCPED (20,759 entries) — CC0,
+    under SuttaCentral's licensing above. NCPED ships inside
+    suttacentral/sc-data/dictionaries and is not a separately licensed work.
+- 84000 glossary (25,356 entries) — CC BY, per 84000's terms above.
+
+PENDING AUDIT — the remaining sources have NOT been license-verified and must
+not be assumed open. Several are certainly under active copyright (e.g.
+佛光大辭典 32,132 entries, 中華佛教百科全書 6,359 entries), and the Cologne
+Digital Sanskrit Lexicon family (cdsl-mw 32,116 / cdsl-apte 34,882 /
+cdsl-bhs 17,807) carries CDSL's own terms rather than being simple public
+domain, as an earlier version of this file implied for Monier-Williams and
+Edgerton. Tracking issue: see repository issues.
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
-All Other Sources (398+)
+All Other Sources
 --------------------------------------------------------------------------------
-FoJin provides search redirect links to 398+ additional Buddhist digital
-archives worldwide. No content from these sources is downloaded or stored.
-Users are redirected to the original platforms to access content.
+FoJin provides search redirect links to the remaining sources of its 617-source
+directory. No content from these sources is downloaded or stored; users are
+redirected to the original platforms.
 --------------------------------------------------------------------------------
 
 For questions about data usage and licensing, please open an issue at:

--- a/backend/tests/test_notice_license_hygiene.py
+++ b/backend/tests/test_notice_license_hygiene.py
@@ -1,0 +1,92 @@
+"""NOTICE 的许可声明卫生 —— 三条在 2026-08-13 审计里真实踩到的坑。
+
+Apache-2.0 §4(d) 规定 NOTICE 随每一次再分发传播，所以这里写错的许可会被复制到
+每一个 fork 和自部署实例。那次审计发现的问题（全部已修）：
+
+  · SuttaCentral 的译文被记成 CC BY-SA，实际是 CC0 —— 而 CC0 献让书正是对方
+    创始人本人写的，把它写错会直接削掉「我们认真核过许可」这个立场；
+  · 「Academic open access」被当成许可用了 5 次 —— 它不是许可，不说明署名、
+    商用、衍生任何一项，给的是虚假的安心；
+  · DSBC 被写成开放并「downloaded and indexed locally」，实际它明令
+    "reproduction … without permission is prohibited"。
+
+这三条都不是拼写问题，是**会传播出去的合规陈述**，所以用测试钉住。
+"""
+
+from pathlib import Path
+
+import pytest
+
+NOTICE = (Path(__file__).resolve().parents[2] / "NOTICE").read_text(encoding="utf-8")
+
+
+# 不是许可名的模糊说法。它们既不对应任何 SPDX 标识，也不回答「能不能商用 /
+# 要不要署名 / 能不能改」——写进 NOTICE 等于什么都没说，却让人以为说了。
+BANNED_PSEUDO_LICENSES = [
+    "academic open access",
+    "open access license",
+    "free for academic use",
+]
+
+
+@pytest.mark.parametrize("phrase", BANNED_PSEUDO_LICENSES)
+def test_no_pseudo_license_phrases(phrase: str):
+    """只查 `License:` 行 —— 历史说明里复述旧错误（"曾被写成 academic open
+    access"）是有价值的，不该被门禁误伤；伪许可**作为现行主张**才是问题。"""
+    offenders = [
+        line.strip()
+        for line in NOTICE.splitlines()
+        if line.lstrip().lower().startswith("license:") and phrase in line.lower()
+    ]
+    assert not offenders, (
+        f"NOTICE 的许可行里出现了伪许可表述「{phrase}」：{offenders}。"
+        f"它不是许可名 —— 请写具体的许可（并附权威来源链接），"
+        f"或如实写成「NOT STATED / UNVERIFIED」。"
+    )
+
+
+def _entry(header: str, length: int = 1800) -> str:
+    """取某个数据源条目的正文。条目标题右侧有对齐用的空格与统计数字，
+    所以按 URL 行定位比按「名称+换行」稳。"""
+    start = NOTICE.index(header)
+    return NOTICE[start : start + length]
+
+
+def test_suttacentral_recorded_as_cc0_not_share_alike():
+    """SuttaCentral 全部内容（含译文）是 CC0，不是 CC BY-SA。"""
+    entry = _entry("https://suttacentral.net\nLicense:")
+    assert "CC0" in entry, "SuttaCentral 条目未记为 CC0"
+    assert "bilara-data" in entry, (
+        "SuttaCentral 条目缺少权威来源链接 —— 许可声明必须可被下一个人复核"
+    )
+    # CC BY-SA 只应作为「此前记错了」的历史说明出现，不能是当前主张
+    for line in entry.splitlines():
+        if "CC BY-SA" in line:
+            assert "wrongly" in line or "previous" in line.lower(), (
+                f"SuttaCentral 条目仍把 CC BY-SA 当作现行许可: {line.strip()!r}"
+            )
+
+
+def test_restrictive_sources_state_their_real_conditions():
+    """几个带真实义务的源，义务本身必须写出来，不能只写许可名。"""
+    checks = {
+        # CBETA 的 B 类文献不在 CC 覆盖范围内，是最容易踩的一条
+        "印順": "CBETA 的 Category B 例外未写明",
+        # 84000 的署名必须点名 84000 本身，且 ND 禁止改动
+        "NO DERIVATIVES": "84000 的 NoDerivatives 条件未写明",
+        # DSBC 明令禁止未经许可的复制
+        "reproduction of DSBC": "DSBC 的禁止复制条款未写明",
+    }
+    for needle, msg in checks.items():
+        assert needle.lower() in NOTICE.lower(), msg
+
+
+def test_every_license_claim_is_traceable():
+    """凡是断言了具体许可的条目，都要能被复核 —— 附来源链接或标为未核实。"""
+    # 粗判：出现具体许可名的段落数，应当不多于「可复核标记」的数量
+    claims = NOTICE.lower().count("license: cc")
+    traceable = NOTICE.lower().count("verified:") + NOTICE.lower().count("unverified")
+    assert traceable >= claims, (
+        f"有 {claims} 条具体许可声明，但只有 {traceable} 处可复核标记 —— "
+        "每条许可声明都应附 'verified: <url>' 或明确标为 UNVERIFIED"
+    )


### PR DESCRIPTION
起因是 SuttaCentral 那条把译文记成 CC BY-SA（实为 CC0）。既然要改就把整份
NOTICE 逐源核了一遍，结果比预期严重。Apache-2.0 §4(d) 规定 NOTICE 随每一次
再分发传播，所以这里的每一句错都会复制到每个 fork 和自部署实例。

## 核实结果（全部对着权利方自己的声明查，日期 2026-08-13）

| 源 | 原 NOTICE | 核实后 |
|---|---|---|
| CBETA | CC BY-NC-SA 4.0 | ✅ 正确，但**漏了 B 类例外**（印順/呂澂等不在 CC 覆盖内） |
| 84000 | CC BY-NC-ND 4.0 | ✅ 正确，补上「署名必须点名 84000」与 ND 的含义 |
| SuttaCentral | 译文 CC BY-SA | ❌ **全部 CC0**（bilara-data/LICENSE.md 原文） |
| GRETIL | Academic open access | ❌ **根本没有任何许可声明** |
| DSBC | Academic open access，本地索引 | ❌ **明令「reproduction without permission is prohibited」**，仅限 indexing/word search |
| SAT | Academic open access | ❌ 无依据 |
| MITRA | CC BY-SA 4.0 | ⚠️ **仓库无许可声明**，无法核实（v2 指向 root README，root 里没有） |
| NTI 辞典 | Academic open access | ❌ **CC BY-SA 3.0**，而它是最大的词典（161,054 条） |
| DPD | **未列** | **CC BY-NC-SA 4.0**，88,785 条 |

另外两处与生产实况不符（都是「说大了」）：
- **词典段只列 6 家，生产实际 39 家、约 74 万词条**；列的 DDB / Edgerton 在实际
  来源里按名找不到，Monier-Williams 实为 Cologne CDSL 系（cdsl-mw/apte/bhs），
  不是简单的 public domain。
- DSBC / SAT / NCPED / NTI 写着「downloaded and indexed locally」，实测本地正文
  **0 字**。真正存正文的只有四家：CBETA 60.8% / 84000 23.8% / GRETIL 11.7% /
  SuttaCentral 3.75%。

✅ 一个查出来是好消息的：**CBETA 的 B 类文献从未导入**（印順/呂澂/妙雲集 搜索
均 0 命中）。已把这条写进 NOTICE，把一个没人说明过的风险变成已核实的边界。

## 本次确立的两条规矩（写在文件抬头）

1. 只写**核实过**的许可，并附权利方自己的声明链接，让下一个人能复核；
2. 源方没声明就如实写 NOT STATED / UNVERIFIED —— **绝不用「academic open
   access」这类伪许可搪塞**：它不是许可名，不回答署名/商用/衍生任何一项，
   给的是虚假的安心。

未核实的 30 余家词典明确标为 PENDING AUDIT，并点名其中确定仍在版权保护期的
（佛光大辭典 32,132 条、中華佛教百科全書 6,359 条）。不拿未经核实的断言去替换
另一个未经核实的断言。

## 门禁

新增 `test_notice_license_hygiene.py`（6 条）：伪许可短语不得出现在 License 行、
SuttaCentral 必须记为 CC0 且带来源链接、三处带真实义务的条款（CBETA B 类 /
84000 ND / DSBC 禁复制）必须写明、每条许可声明都要可追溯。

验证：对**旧** NOTICE 跑，6 条里 4 条红；对新的全绿。pytest 1726 通过
（test_health_check_probe 的 3 个失败为 master 存量）；ruff 过。