### PR TITLE
fix(sources): CBETA 大陆镜像站已被官方关闭——改指官方下载页

### DIFF
--- a/backend/alembic/versions/0177_fix_offline_source_urls_20260815.py
+++ b/backend/alembic/versions/0177_fix_offline_source_urls_20260815.py
@@ -1,0 +1,135 @@
+"""Repoint two sources whose sites are gone from the URL we listed.
+
+Both were flagged by the health cron but neither could be auto-corrected: the
+probe reports *reachability*, and only an editor can decide what a dead URL
+should become.
+
+* ``cbeta-archive`` — "CBETA大藏经下载(大陆档案站)",
+  ``https://archive.cbetaonline.cn/``. CBETA has **officially closed the whole
+  mainland mirror**: "CBETA Online 中國大陸鏡像站 (cbetaonline.cn) ... 已於近期
+  停止服務，相關資料下載與更新服務亦同步停止" — "為因應當地相關規範與要求"
+  (https://cbeta.org/post/30973). The announcement points readers at CBETA
+  Online and cbeta.org instead. Verified dead from two independent vantages
+  (connection reset / ECONNRESET); the cron only ever saw ``dns_unresolved``,
+  which it correctly rates ``low`` confidence, so the row was never badged and
+  never dropped — it just kept being served to readers as a live download link.
+
+  This entry is the catalog's only *bulk download* pointer for CBETA (the other
+  six CBETA rows are online reading, API, multi-version browsing, concordance,
+  catalog and a RAG demo), so it is repointed rather than deactivated:
+  ``https://cbeta.org/ebooks`` is CBETA's own 下載電子書 page and offers the same
+  function (TXT / ePub / PDF / DOCX / ODT full-canon packages). Region moves
+  中国大陆 → 中国台湾, because no mainland-hosted mirror exists any more and
+  claiming one would send mainland readers at a host that is gone for
+  regulatory reasons. Licence metadata is unchanged: same publisher, same
+  CC-BY-NC-SA-3.0-TW terms with the same three excluded collections.
+
+* ``tejaniya`` — ``https://tejaniyasayadaw.space/`` redirects to
+  ``https://www.sayadawutejaniya.com/`` (200). The cron already recorded the
+  redirect target in ``health_detail`` and classified the row ``moved``; this
+  just follows it. The target was checked to be the real teaching archive
+  (transcribed talks, guided meditations, four free books, and a pointer to the
+  official ashintejaniya.org), not a parked domain.
+
+Health fields are cleared for both rows the way 0166 did, so a stale red verdict
+does not outlive the URL that caused it. The next cron pass re-derives them.
+
+Revision ID: 0177
+Revises: 0176
+Create Date: 2026-08-15
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text as sa_text
+
+revision: str = "0177"
+down_revision: str | None = "0176"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+CBETA_ARCHIVE_NEW = {
+    "base_url": "https://cbeta.org/ebooks",
+    "name_zh": "CBETA 大藏经电子书下载(官方)",
+    "name_en": "CBETA Official E-Book Downloads",
+    "region": "中国台湾",
+    "description": (
+        "CBETA 官方「下載電子書」页，提供全套大藏经的 TXT/ePub/PDF/DOCX/ODT "
+        "离线数据包（TXT 分含注、不含注两种），每年随经文更新三至四次。"
+        "原大陆镜像站 archive.cbetaonline.cn 已于 2026 年 8 月由 CBETA 公告关闭，"
+        "此处改指官方下载页；XML 原始数据见 CBETA 主站与其 GitHub 仓库。"
+    ),
+}
+
+CBETA_ARCHIVE_OLD = {
+    "base_url": "https://archive.cbetaonline.cn/",
+    "name_zh": "CBETA大藏经下载(大陆档案站)",
+    "name_en": "CBETA Tripitaka Archive (Mainland Mirror)",
+    "region": "中国大陆",
+    "description": "CBETA大陆镜像离线下载站，提供多种格式（EPUB/PDF/HTML/XML）的大藏经数据包下载。",
+}
+
+TEJANIYA_NEW_URL = "https://www.sayadawutejaniya.com/"
+TEJANIYA_OLD_URL = "https://tejaniyasayadaw.space/"
+
+
+def _update_cbeta_archive(values: dict[str, str]) -> None:
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET base_url = :base_url,
+                   name_zh = :name_zh,
+                   name_en = :name_en,
+                   region = :region,
+                   description = :description
+             WHERE code = 'cbeta-archive'
+            """
+        ).bindparams(**values)
+    )
+
+
+def _set_tejaniya_url(url: str) -> None:
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET base_url = :url
+             WHERE code = 'tejaniya'
+            """
+        ).bindparams(url=url)
+    )
+
+
+def _clear_stale_health() -> None:
+    """Drop the verdict that belonged to the previous URL.
+
+    ``health_confidence`` goes back to its 'high' default alongside the cleared
+    status so the pair stays coherent; nothing is badged until the cron writes a
+    real verdict against the new URL."""
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET health_status = 'ok',
+                   health_checked_at = NULL,
+                   health_detail = NULL,
+                   health_confidence = 'high',
+                   unreachable_since = NULL
+             WHERE code IN ('cbeta-archive', 'tejaniya')
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    _update_cbeta_archive(CBETA_ARCHIVE_NEW)
+    _set_tejaniya_url(TEJANIYA_NEW_URL)
+    _clear_stale_health()
+
+
+def downgrade() -> None:
+    _update_cbeta_archive(CBETA_ARCHIVE_OLD)
+    _set_tejaniya_url(TEJANIYA_OLD_URL)

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -66,7 +66,7 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
   const distributions = (s.distributions || []).filter((d) => d.is_active).slice(0, 5);
   // Only offer the "搜索" button when we have a registered direct-search template
   // for this source. The previous Google site: fallback produced empty results
-  // for download mirrors and un-indexed sites (e.g. archive.cbetaonline.cn),
+  // for download mirrors and un-indexed sites (e.g. cbeta.org/ebooks),
   // misleading users. If a source lacks a template, the button is hidden.
   const searchUrl = searchQuery ? buildSearchUrl(s.code, searchQuery) : null;
 


### PR DESCRIPTION
用户报 `/sources` 上的「CBETA大藏经下载(大陆档案站)」已下线。核实后发现比「链接坏了」更硬。

## 核实

CBETA 官方公告 [cbeta.org/post/30973](https://cbeta.org/post/30973)：大陆镜像站 `cbetaonline.cn`「已於近期停止服務，相關資料下載與更新服務亦同步停止」，理由「為因應當地相關規範與要求」。**是永久关站，不是临时故障，且不会再有大陆镜像。** 两个独立点位实测均为连接重置。

## 巡检为什么没拦住

cron 昨天(08-14)探到了，探测结果是 `dns_unresolved` → 按 0172 的设计判为 `low` 置信度（单台 VPS 的 DNS 失败通常说的是探针自己，不是站点）。**启发式没判错**——它只负责可达性，「一个死掉的 URL 应该变成什么」只能由人定。结果这条死链既没打红标也没下架，继续当可用下载链接发给读者。

这是个结构性缺口，不止这一条：目前另有 12 条高置信度判死的源同样只是挂着红标，没有下架也没有人跟进。

## 改法

跟 0166 的先例，**重指而非停用**：

| | 之前 | 之后 |
|---|---|---|
| base_url | `archive.cbetaonline.cn/` | `cbeta.org/ebooks` |
| region | 中国大陆 | 中国台湾 |
| 名称 | CBETA大藏经下载(大陆档案站) | CBETA 大藏经电子书下载(官方) |

这是全站 7 个 CBETA 条目里**唯一的批量下载入口**（其余是在线阅读/API/多版本/词汇检索/经录/RAG demo），停用会丢掉一个真实功能。`cbeta.org/ebooks` 是 CBETA 自家的「下載電子書」页，提供同样的 TXT/ePub/PDF/DOCX/ODT 全藏数据包。region 改动是因为大陆镜像既已因监管原因消失，再挂大陆名头就是把大陆读者指向一个确定打不开的主机。许可元数据不动（同发布方、同 CC-BY-NC-SA-3.0-TW、同样排除那三部著作集）。

顺带修 `tejaniya`：`tejaniyasayadaw.space` 301 到 `sayadawutejaniya.com`(200)，巡检早把重定向目标记在 `health_detail` 并判为 `moved`，这里只是跟上去。已确认目标是真的教法库（讲记文字稿、引导禅修、四本免费书，并指回官方 ashintejaniya.org），不是抢注停放页。

两行的健康字段照 0166 清掉，免得旧判定活得比造成它的 URL 还久；下一轮 cron 会对新 URL 重新判。

## 验证

本机 Docker 不可用、Postgres 无可用角色，所以用 ORM metadata 建表做了真库往返——CI 的 `alembic-dry-run` 只跑 upgrade/downgrade，**从不 SELECT**，看不出 UPDATE 有没有匹配到行、列名有没有写错。

- 18 项断言全绿，含 downgrade 还原 + 一个不该被波及的对照行
- **反向对照**：不打补丁时 9 项实质断言全红，证明断言不是恒真
- `ruff check` / `ruff format --check` 通过；迁移链单 head（0177），无重复 down_revision
- 前端仅改一处失效注释举例；eslint + SourceCard/SourcesPage 测试 5 项通过
