### PR TITLE
fix(sources): 全量巡检后清掉 5 个主机名已不存在的源，跟一条搬家的

### DIFF
--- a/backend/alembic/versions/0178_retire_dead_sources_20260815.py
+++ b/backend/alembic/versions/0178_retire_dead_sources_20260815.py
@@ -1,0 +1,148 @@
+"""Retire five sources whose hostnames no longer exist; repoint a sixth.
+
+Follow-up to 0177. That one fixed the source a reader reported; this one clears
+what a full probe from the cron's own vantage turned up (601 probed, 556 ok,
+45 needing attention).
+
+**Only the DNS failures are acted on here, deliberately.** Of the 45, 33 are
+``unreachable`` and 11 ``cert_invalid``, but most of those are timeouts and
+cert rejections that say more about the prober than the site — 0172 already
+established that, and it holds: ``buddhism.lib.ntu.edu.tw`` (recorded as a
+timeout for both ``ccbs-ntu`` and ``ntu-buddhism``) resolves and serves fine
+from a second vantage. DNS is the one signal that can be settled independently
+of any vantage, so each hostname below was re-resolved through a public DoH
+resolver rather than trusted from the probe:
+
+  www.tripitaka.or.kr          NXDOMAIN
+  femc.huma-num.fr             NXDOMAIN
+  budsir.ict.mahidol.ac.th     NXDOMAIN
+  voice.suttacentral.net       NXDOMAIN
+  orientnet.jp                 SERVFAIL (the domain's own nameservers)
+  taiwanbuddhism.dila.edu.tw   NOERROR but no A/AAAA/CNAME — the host record was
+                               removed from a zone that is otherwise alive
+                               (``cbetaonline.dila.edu.tw`` resolves normally)
+
+Repointed (1)
+-------------
+``suttacentral-voice`` — the project moved to its own domain. ``sc-voice.net``
+serves 200 and redirects to ``www.sc-voice.net``; the sc-voice GitHub org lists
+it as the primary site with voice.suttacentral.net as the legacy address. Same
+project, so the row follows it.
+
+Deactivated (5)
+---------------
+``is_active = FALSE`` is editorial removal (the model's own wording), which is
+the right verb here: these are not mis-typed URLs to correct but sites that no
+longer exist. It also stops the cron re-probing them every night. Three of the
+five lose nothing, because a live row already covers the same material:
+
+* ``dongguk-hangul-tripitaka`` — 한글대장경 is served by ``abc-tripitaka``
+  (kabc.dongguk.edu) and ``ktk`` (its 통합대장경 list), both ``ok``. Repointing
+  would have made a third row for one site.
+* ``femc-khmer`` — the FEMC digitisation itself is served by ``bdrc-khmer``
+  (khmer-manuscripts.bdrc.io, ``ok``), the BDRC×FEMC Khmer Manuscript Heritage
+  Project.
+* ``mahidol-tipitaka`` — BUDSIR is broken at the source, not just at our URL:
+  the surviving entry host ``budsir.mahidol.ac.th`` resolves but redirects into
+  the NXDOMAIN ``budsir.ict.mahidol.ac.th``; ``budsir.org`` is a parked domain.
+  No live successor found, so nothing to repoint to.
+* ``orientnet-buddhism`` — a link directory; domain SERVFAIL on both apex and
+  www, no successor found.
+* ``taiwan-buddhism-dila`` — no successor found. ``taiwan-fojiao-dila`` (the
+  《台湾佛教》journal archive) is a different resource and stays.
+
+Nothing is deleted: ``downgrade`` restores every row, and the license/metadata
+columns are untouched throughout.
+
+Revision ID: 0178
+Revises: 0177
+Create Date: 2026-08-15
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text as sa_text
+
+revision: str = "0178"
+down_revision: str | None = "0177"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+SC_VOICE_NEW_URL = "https://www.sc-voice.net/"
+SC_VOICE_OLD_URL = "https://voice.suttacentral.net/"
+
+SC_VOICE_NEW_DESC = (
+    "SuttaCentral 经文语音朗读项目，辅助视障用户与听读场景。"
+    "已迁出 suttacentral.net，现址 sc-voice.net（旧域名 voice.suttacentral.net 已停止解析）。"
+)
+SC_VOICE_OLD_DESC = "SuttaCentral 经文语音朗读项目，辅助视障用户阅读"
+
+# Hostname no longer resolves; verified through a public resolver, not the probe.
+RETIRED_CODES = (
+    "dongguk-hangul-tripitaka",
+    "femc-khmer",
+    "mahidol-tipitaka",
+    "orientnet-buddhism",
+    "taiwan-buddhism-dila",
+)
+
+
+def _set_sc_voice(url: str, description: str) -> None:
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET base_url = :url,
+                   description = :description
+             WHERE code = 'suttacentral-voice'
+            """
+        ).bindparams(url=url, description=description)
+    )
+
+
+def _set_active(active: bool) -> None:
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET is_active = :active
+             WHERE code IN (
+                 'dongguk-hangul-tripitaka',
+                 'femc-khmer',
+                 'mahidol-tipitaka',
+                 'orientnet-buddhism',
+                 'taiwan-buddhism-dila'
+             )
+            """
+        ).bindparams(active=active)
+    )
+
+
+def _clear_sc_voice_health() -> None:
+    """Drop the verdict earned by the old hostname, as 0166/0177 did."""
+    op.execute(
+        sa_text(
+            """
+            UPDATE data_sources
+               SET health_status = 'ok',
+                   health_checked_at = NULL,
+                   health_detail = NULL,
+                   health_confidence = 'high',
+                   unreachable_since = NULL
+             WHERE code = 'suttacentral-voice'
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    _set_sc_voice(SC_VOICE_NEW_URL, SC_VOICE_NEW_DESC)
+    _clear_sc_voice_health()
+    _set_active(False)
+
+
+def downgrade() -> None:
+    _set_active(True)
+    _set_sc_voice(SC_VOICE_OLD_URL, SC_VOICE_OLD_DESC)


### PR DESCRIPTION
0177 修的是用户报的那条；这条清的是**从 cron 自己的点位跑一遍全量探测**（`--dry-run`，601 探测 / 556 ok / 45 需处理）之后查实的。

## 只动 DNS 这一类，是故意的

45 条里 33 条 `unreachable`、11 条 `cert_invalid`，但多数是超时和证书判死 —— 0172 早说清这类更多反映探针而非站点，这次再次坐实：`ccbs-ntu` 和 `ntu-buddhism` 都被判 timeout，而 `buddhism.lib.ntu.edu.tw` 在公共解析器和第二个点位上都正常。

**DNS 是唯一能脱离点位独立裁决的信号**，所以每个主机名都用公共 DoH 重新解析过，没采信探针结论：

| 主机 | 独立解析结果 |
|---|---|
| `www.tripitaka.or.kr` | NXDOMAIN |
| `femc.huma-num.fr` | NXDOMAIN |
| `budsir.ict.mahidol.ac.th` | NXDOMAIN |
| `voice.suttacentral.net` | NXDOMAIN |
| `orientnet.jp` | SERVFAIL（域名自己的 NS 坏了） |
| `taiwanbuddhism.dila.edu.tw` | NOERROR 但 A/AAAA/CNAME 全无 —— 父域活着（`cbetaonline.dila.edu.tw` 正常），是这条主机记录被撤了 |

## 重指 1 条

`suttacentral-voice` 迁到了自己的域名：`sc-voice.net` 返回 200 并跳 `www.sc-voice.net`，sc-voice 的 GitHub org 把它列为主站、`voice.suttacentral.net` 标为旧址。同一个项目，跟过去。

## 下架 5 条

用 `is_active=FALSE`（模型注释里写明这就是 editorial removal）—— 这些不是写错的 URL，是站点没了；顺带让 cron 不再每晚白探。**其中三条下架不丢任何东西，已有活条目覆盖同样材料**：

- `dongguk-hangul-tripitaka` → 한글대장경 已由 `abc-tripitaka`（kabc.dongguk.edu）和 `ktk` 承担，都是 ok。重指过去只会造出同一站点的**第三个**重复条目。
- `femc-khmer` → FEMC 的数字化成果本身由 `bdrc-khmer`（khmer-manuscripts.bdrc.io，ok）提供，正是 BDRC×FEMC 高棉写本项目。
- `mahidol-tipitaka` → BUDSIR 是**服务本身坏了**：尚存入口 `budsir.mahidol.ac.th` 解析正常，但它自己跳进已 NXDOMAIN 的 `budsir.ict.mahidol.ac.th`；`budsir.org` 是停放页。无可验证继任。
- `orientnet-buddhism` → 链接导航站，apex 和 www 都 SERVFAIL，未找到继任。
- `taiwan-buddhism-dila` → 未找到继任。`taiwan-fojiao-dila`（《台湾佛教》期刊典藏）是另一回事，保留。

**不删任何行**：`downgrade` 全部还原，许可与元数据列自始至终没碰。

## 验证

同 0177：ORM metadata 建表做真库往返（CI 的 dry-run 从不 SELECT）。

- 28 项断言全绿，含 downgrade 还原
- **4 个对照行**特意选了 `abc-tripitaka` / `bdrc-khmer` / `taiwan-fojiao-dila` —— 正因为它们活着才决定下架而非重指，确认没被误伤
- 负向对照：不打补丁时 9 项实质断言全红
- `ruff check` / `ruff format --check` 通过；单 head（0178），无重复 down_revision
