### PR TITLE
fix(deploy): 迁移改完数据源，读者要等 30 分钟才看得见——补上清缓存这一步

### DIFF
--- a/backend/app/api/sources.py
+++ b/backend/app/api/sources.py
@@ -25,7 +25,13 @@ from app.services.source import (
 router = APIRouter(prefix="/sources", tags=["sources"])
 
 SOURCES_LIST_CACHE_KEY = "sources:list:v3"  # v3: + health_detail (0136)
-SOURCES_LIST_CACHE_TTL = 1800  # 30 min; data only changes on manual admin edits
+# 30 min. Two writers change these rows and BOTH must invalidate the key, or a
+# change stays invisible for up to a full TTL: scripts/health_check_sources.py
+# busts it after each run, and deploy.sh runs scripts/bust_sources_cache.py
+# after `alembic upgrade head` — migrations, not an admin UI, are how data
+# sources are edited here (CLAUDE.md). Bumping the key version counts as a third
+# writer: update both scripts if this constant changes.
+SOURCES_LIST_CACHE_TTL = 1800
 
 _sources_list_adapter = TypeAdapter(list[DataSourceResponse])
 

--- a/backend/scripts/bust_sources_cache.py
+++ b/backend/scripts/bust_sources_cache.py
@@ -1,0 +1,61 @@
+"""Invalidate the cached /api/sources payload.
+
+失效 /api/sources 的列表缓存。
+
+``GET /api/sources`` serves a Redis-cached payload with a 30-minute TTL. Two
+writers change the underlying rows and only one of them used to clear the
+cache: ``health_check_sources.py`` busts it after every run, but an **alembic
+migration** — which is how data sources are actually added and edited in this
+repo (see CLAUDE.md) — had no way to. The result was a source change landing in
+Postgres and staying invisible to readers for up to 30 minutes, looking exactly
+like a migration that silently failed to match any row.
+
+``deploy.sh`` calls this right after ``alembic upgrade head``. Run it by hand
+after any manual edit to ``data_sources``:
+
+    cd backend
+    python scripts/bust_sources_cache.py
+
+Best-effort by design: a cache that cannot be reached is not a reason to fail a
+deploy, since the TTL still expires on its own. Exit code is 0 unless the key
+could not be deleted for an unexpected reason, in which case the caller may
+ignore it — deploy.sh does.
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import redis.asyncio as aioredis
+
+from app.api.sources import SOURCES_LIST_CACHE_KEY
+from app.config import settings
+
+
+async def bust() -> int:
+    """Delete the sources list cache key. Returns the number of keys removed."""
+    client = aioredis.from_url(settings.redis_url)
+    try:
+        return await client.delete(SOURCES_LIST_CACHE_KEY)
+    finally:
+        await client.aclose()
+
+
+def main() -> int:
+    try:
+        removed = asyncio.run(bust())
+    except Exception as exc:  # best-effort; a dead cache must never break a deploy
+        print(f"WARNING: could not invalidate '{SOURCES_LIST_CACHE_KEY}': {exc}")
+        return 1
+    if removed:
+        print(f"Invalidated cache key '{SOURCES_LIST_CACHE_KEY}'.")
+    else:
+        # Nothing cached — the next reader rebuilds from Postgres either way.
+        print(f"Cache key '{SOURCES_LIST_CACHE_KEY}' was not set; nothing to do.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy.sh
+++ b/deploy.sh
@@ -182,6 +182,10 @@ frontend_changed=false
 backend_changed=false
 mcp_changed=false
 backend_image_changed=false
+# Set by either alembic path (the no-restart `upgrade head` below, or a migration
+# riding along with app code that entrypoint.sh applies on restart). Drives the
+# sources-cache bust — see the call after the backend section.
+migrations_applied=false
 
 # Frontend
 if [ -z "$FE_BASE" ]; then
@@ -252,6 +256,11 @@ elif [ "$BE_BASE" != "$NEW_REV" ]; then
       log "backend 依赖/Dockerfile 改动 — 升级为 rebuild image。"
       backend_image_changed=true
     fi
+    # A migration riding along with app code is applied by entrypoint.sh when the
+    # replica restarts below — still a migration, so the cache bust must fire too.
+    if echo "$BE_DIFF" | grep -q '^backend/alembic/'; then
+      migrations_applied=true
+    fi
   elif echo "$BE_DIFF" | grep -q '^backend/'; then
     # Pure scripts/tests/eval/alembic change — log but don't restart.
     log "backend/ 仅有 scripts/tests/eval/alembic 改动 — 跳过 restart（不影响 uvicorn，也不杀正在跑的脚本）。"
@@ -266,6 +275,7 @@ elif [ "$BE_BASE" != "$NEW_REV" ]; then
       log "检测到 alembic 迁移改动 — 运行 alembic upgrade head（容器不重启）。"
       docker compose exec -T backend alembic upgrade head \
         || fail "alembic upgrade head 失败 — 迁移未应用，请人工处理。"
+      migrations_applied=true
     fi
     # Still bump the marker so we don't keep re-evaluating the same untouched
     # diff every cron tick — otherwise the next deploy.sh run will see the same
@@ -341,6 +351,21 @@ if $backend_changed; then
   echo "$NEW_REV" > "$BACKEND_RESTART_MARKER"
 else
   log "Backend unchanged — skip."
+fi
+
+# --- 4b. 迁移改了数据但 /api/sources 走 30 分钟 Redis 缓存 -------------------
+# GET /api/sources serves a cached payload (sources:list:v3, TTL 1800s). The
+# health-check cron busts that key after every run, but a migration had no way
+# to — so a data-source change (which in this repo IS a migration, not an admin
+# edit) landed in Postgres and stayed invisible to readers for up to 30 minutes,
+# looking exactly like a migration that matched zero rows. Observed on 0178:
+# `alembic current` said 0178, psql showed the new values, and /api/sources kept
+# serving the old list. Best-effort — the TTL still expires on its own, so a
+# failure here must not fail the deploy.
+if $migrations_applied; then
+  log "迁移已应用 — 失效 /api/sources 列表缓存。"
+  docker compose exec -T backend python scripts/bust_sources_cache.py \
+    || log "WARNING: 清缓存失败（非致命，最迟 30 分钟后 TTL 自然过期）。"
 fi
 
 # --- 5. 健康检查 -------------------------------------------------------------


### PR DESCRIPTION
0178 合并后实测撞出来的。

## 症状

`alembic current` 已是 0178、psql 里 5 行 `is_active` 确实是 `f`、`suttacentral-voice` 也已是新域名 —— 而 `/api/sources` 依旧返回旧列表（617 条，一条没少）。**看起来完全像「迁移匹配到 0 行」。**

## 真因

`GET /api/sources` 走 Redis 缓存 `sources:list:v3`，TTL 1800 秒。这个 key 有两个写入方，只有一个会清它：

| 写入方 | 会清缓存吗 |
|---|---|
| `scripts/health_check_sources.py` | ✅ 每轮跑完都清 |
| **alembic 迁移** | ❌ 没有任何东西清 |

0177 那次看着「12 分钟后自己生效」，其实是 TTL 到期，不是迁移触发的 —— 纯属运气，下次可能要等满 30 分钟。

根子在这行注释的前提是错的：

```python
SOURCES_LIST_CACHE_TTL = 1800  # 30 min; data only changes on manual admin edits
```

CLAUDE.md 写得很清楚：新数据源**经 alembic 迁移添加，不走后台 UI**。

## 改动

1. 新增 `backend/scripts/bust_sources_cache.py` —— 从 `app.api.sources` 导入 `SOURCES_LIST_CACHE_KEY`（和 `health_check_sources.py` 同一来源，不硬编码字面量，避免 key 版本漂移）。best-effort：清不掉只告警不失败，TTL 兜底。
2. `deploy.sh` 加 `migrations_applied` 旗标，**两条迁移路径都置位** —— 免重启分支（deploy.sh 自己跑 `upgrade head`）和随应用代码同行的分支（重启后由 `entrypoint.sh` 跑）—— 在两条路径汇合之后调用清缓存。
3. 修正那行误导性注释，并写明「谁改了这些行就必须清这个 key」。

## 验证

- **旗标逻辑**用合成 `BE_DIFF` 打了 5 个用例：两条迁移路径都 `true`；「只改应用代码 / 只改测试脚本 / 只改前端」三个负向用例都 `false`。
- **清缓存脚本在生产真实容器里跑通两条分支**：key 存在 → `Invalidated cache key 'sources:list:v3'.`；不存在 → `was not set; nothing to do.`，exit=0。（用 `PYTHONPATH` 跑的，**没有 docker cp 进 `/app`** —— 那是生产仓库的 bind-mount。）
- `bash -n` / `ruff check` / `ruff format --check` 均通过。
- 四个 `noqa` 被本机新版 ruff 的 RUF100 抓出是多余的（`E402` 本就在项目 ignore 列表里），已删 —— CI 钉的 0.9.7 同样启用 `RUF`，不删会红。
