### PR TITLE
feat(texts): 文本页显示数据来源并回链——署名此前只在 NOTICE 里，页面上没有

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -519,6 +519,7 @@
   "sutra_landing.data_provided_by": "Scripture data provided by",
   "sutra_landing.provided": "",
   "textDetail.notFound": "Text not found",
+  "text.source_label": "Source: ",
   "textDetail.pageTitle": "{{title}} — FoJin",
   "textDetail.metaTranslator": "translated by {{translator}}",
   "textDetail.seoDescription": "{{details}} — FoJin Buddhist Classics Digital Resource Platform",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -519,6 +519,7 @@
   "sutra_landing.data_provided_by": "經文資料由",
   "sutra_landing.provided": "提供",
   "textDetail.notFound": "經典未找到",
+  "text.source_label": "來源：",
   "textDetail.pageTitle": "{{title}} — 佛津",
   "textDetail.metaTranslator": "{{translator}}譯",
   "textDetail.seoDescription": "{{details}} — 佛津佛教古籍數字資源平臺",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -519,6 +519,7 @@
   "sutra_landing.data_provided_by": "经文数据由",
   "sutra_landing.provided": "提供",
   "textDetail.notFound": "经典未找到",
+  "text.source_label": "来源：",
   "textDetail.pageTitle": "{{title}} — 佛津",
   "textDetail.metaTranslator": "{{translator}}译",
   "textDetail.seoDescription": "{{details}} — 佛津佛教古籍数字资源平台",

--- a/frontend/src/components/SourceAttribution.test.tsx
+++ b/frontend/src/components/SourceAttribution.test.tsx
@@ -1,0 +1,105 @@
+/** 文本页的来源署名。
+ *
+ * 2026-08-15 审计发现的缺口：`source_url`（如 https://suttacentral.net/{uid}）
+ * 一直存在库里、API 也返回，但 `getTextIdentifiers()` 在前端**一处都没有被调用** ——
+ * 读者在页面上看不到任何来源信息，只有一个藏经名徽章（大正藏 / 甘珠尔 / 巴利三藏），
+ * 那是**藏经**不是**数据源**。
+ *
+ * 为什么这不只是体验问题：
+ *   · CBETA 是 CC BY-NC-SA —— 署名是许可条件，而「大正藏」并不等于署名 CBETA；
+ *   · 84000 的条款白纸黑字写明，只写译者或译经团体、不写「84000」本身，
+ *     **不满足**其署名要求，而页面只显示「甘珠尔」。
+ * 反倒是 SuttaCentral（CC0）根本不要求署名。真正有义务的两家此前没被署名。
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SourceAttribution from "./SourceAttribution";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return { ...actual, getTextIdentifiers: vi.fn() };
+});
+
+import { getTextIdentifiers } from "../api/client";
+import type { SourceId } from "../types/branded";
+
+function renderWith(textId = 1) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <SourceAttribution textId={textId} />
+    </QueryClientProvider>,
+  );
+}
+
+const SC = {
+  id: 196,
+  source_id: 161 as SourceId,
+  source_code: "suttacentral",
+  source_name: "SuttaCentral 巴利经藏",
+  source_uid: "pli-tv-ab",
+  source_url: "https://suttacentral.net/pli-tv-ab",
+};
+
+describe("SourceAttribution", () => {
+  beforeEach(() => vi.mocked(getTextIdentifiers).mockReset());
+
+  it("显示数据源名，并链回该源的原始页面", async () => {
+    vi.mocked(getTextIdentifiers).mockResolvedValue([SC]);
+    const { container } = renderWith();
+
+    const link = await waitFor(() => {
+      const a = container.querySelector<HTMLAnchorElement>(".source-attribution a");
+      expect(a).not.toBeNull();
+      return a!;
+    });
+    expect(link.textContent).toContain("SuttaCentral 巴利经藏");
+    expect(link.href).toBe("https://suttacentral.net/pli-tv-ab");
+  });
+
+  it("外链必须带 noopener noreferrer —— 站外链接的既定安全约束", async () => {
+    vi.mocked(getTextIdentifiers).mockResolvedValue([SC]);
+    const { container } = renderWith();
+    const link = await waitFor(() => {
+      const a = container.querySelector<HTMLAnchorElement>(".source-attribution a");
+      expect(a).not.toBeNull();
+      return a!;
+    });
+    expect(link.rel).toContain("noopener");
+    expect(link.rel).toContain("noreferrer");
+    expect(link.target).toBe("_blank");
+  });
+
+  it("一个文本有多个来源时全部署名", async () => {
+    vi.mocked(getTextIdentifiers).mockResolvedValue([
+      SC,
+      { ...SC, id: 197, source_code: "cbeta", source_name: "CBETA", source_url: "https://cbeta.org/T0001" },
+    ]);
+    const { container } = renderWith();
+    await waitFor(() =>
+      expect(container.querySelectorAll(".source-attribution a")).toHaveLength(2),
+    );
+  });
+
+  it("没有来源时不渲染任何东西（不留空壳）", async () => {
+    vi.mocked(getTextIdentifiers).mockResolvedValue([]);
+    const { container } = renderWith();
+    await waitFor(() => expect(getTextIdentifiers).toHaveBeenCalled());
+    expect(container.querySelector(".source-attribution")).toBeNull();
+  });
+
+  it("来源没有 URL 时仍然署名，只是不做成链接", async () => {
+    vi.mocked(getTextIdentifiers).mockResolvedValue([{ ...SC, source_url: null }]);
+    const { container } = renderWith();
+    await screen.findByText(/SuttaCentral 巴利经藏/);
+    expect(container.querySelector(".source-attribution a")).toBeNull();
+  });
+
+  // 「接口失败时不渲染」没有单独的用例，是有意的：出错时 useQuery 的 data 是
+  // undefined，走的正是上面那条空数组用例已经覆盖的 `!data?.length` 分支 ——
+  // 组件里不存在第二条错误路径可测。而本仓库的 vitest 刻意把未处理错误一律判红
+  // （vite.config.ts 的 onUnhandledError 只白名单了一个 React teardown 竞态），
+  // 为一条零增量的用例去绕过那条策略并不值得。
+});

--- a/frontend/src/components/SourceAttribution.tsx
+++ b/frontend/src/components/SourceAttribution.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+
+import { getTextIdentifiers } from "../api/client";
+
+/** 文本来自哪个数据源 —— 署名 + 回链。
+ *
+ * 这些数据（`text_identifiers.source_url`）一直存在库里、API 也返回，但在
+ * 2026-08-15 之前前端从未调用过 —— 读者只看得到一个藏经名徽章（大正藏 /
+ * 甘珠尔 / 巴利三藏），那是**藏经**，不是**数据源**。
+ *
+ * 为什么补它是义务而非锦上添花：CBETA 用 CC BY-NC-SA，署名是许可条件；
+ * 84000 的条款更明确 —— 只写译者或译经团体而不写「84000」本身，不满足其署名
+ * 要求。反倒是 SuttaCentral（CC0）根本不要求署名，我们照样署，作为礼节。
+ *
+ * 失败静默：署名取不到不该把整个文本页拖垮，所以查询失败时什么都不渲染。
+ */
+export default function SourceAttribution({ textId }: { textId: number }) {
+  const { t } = useTranslation();
+  const { data } = useQuery({
+    queryKey: ["text-identifiers", textId],
+    queryFn: () => getTextIdentifiers(textId),
+    staleTime: 60 * 60 * 1000, // 来源不会变，缓存一小时
+    retry: false,
+  });
+
+  if (!data?.length) return null;
+
+  return (
+    <div className="source-attribution">
+      <span className="source-attribution-label">{t("text.source_label")}</span>
+      {data.map((id, i) => (
+        <span key={id.id}>
+          {i > 0 && <span className="source-attribution-sep">·</span>}
+          {id.source_url ? (
+            <a href={id.source_url} target="_blank" rel="noopener noreferrer">
+              {id.source_name}
+            </a>
+          ) : (
+            <span>{id.source_name}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/TextDetailPage.tsx
+++ b/frontend/src/pages/TextDetailPage.tsx
@@ -27,6 +27,7 @@ import BookmarkButton from "../components/BookmarkButton";
 import { RelatedTextsStandalone as RelatedTexts } from "../components/RelatedTexts";
 import OtherVersions from "../components/OtherVersions";
 import CrossCanonEntry from "../components/CrossCanonEntry";
+import SourceAttribution from "../components/SourceAttribution";
 import CitationGenerator from "../components/CitationGenerator";
 import { addViewHistory } from "../utils/history";
 
@@ -151,13 +152,16 @@ export default function TextDetailPage() {
           <Title level={3} style={{ marginBottom: 4 }}>
             {text.title_zh}
           </Title>
-          <Space style={{ marginBottom: 16 }}>
+          <Space style={{ marginBottom: 8 }}>
             <Tag color="blue">{text.cbeta_id}</Tag>
             {text.taisho_id && text.taisho_id !== text.cbeta_id && (
               <Tag>{text.taisho_id}</Tag>
             )}
             {text.category && <Tag color="geekblue">{text.category}</Tag>}
           </Space>
+          {/* 数据源署名。上面那些标签是**藏经**与分类，不是来源 ——
+              CBETA(CC BY-NC-SA) 与 84000 都把署名列为许可条件。 */}
+          <SourceAttribution textId={text.id} />
 
           <Descriptions column={1} bordered size="small">
             {text.translator && (

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -26,6 +26,7 @@ import { useAudioPlayer } from "../audio/useAudioPlayback";
 import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, getJuanLineAnchors, getJuanAudio, type ApparatusEntryItem } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
 import CitationGenerator from "../components/CitationGenerator";
+import SourceAttribution from "../components/SourceAttribution";
 import AnnotationPanel from "../components/AnnotationPanel";
 import { ReaderDictPopover } from "../components/ReaderDictPopover";
 import { DICT_POPOVER_INIT, MAX_WORD_LEN, type DictPopoverState } from "../components/ReaderDictPopover.types";
@@ -858,6 +859,11 @@ export default function TextReaderPage() {
             </Tooltip>
           )}
         </Typography.Title>
+
+        {/* 数据源署名。上面的徽章是**藏经名**（大正藏 / 甘珠尔 / 巴利三藏），
+            不是来源 —— CBETA(CC BY-NC-SA) 与 84000 都把署名列为许可条件，
+            而 84000 的条款明确「只写译者不写 84000 本身不算数」。 */}
+        <SourceAttribution textId={textId} />
 
         <div className="reader-nav">
           <Select

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -446,6 +446,29 @@ em {
   white-space: pre-wrap;
   word-break: break-word;
 }
+/* 数据源署名 —— 文本页上「这段文字从哪来」。CBETA 与 84000 把署名列为许可
+   条件，所以它必须可见；但它是出处信息不是正文，所以排版上刻意收敛。 */
+.source-attribution {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: var(--fj-ink-muted);
+}
+.source-attribution-label {
+  opacity: 0.8;
+}
+.source-attribution a {
+  color: var(--fj-ink-muted);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.source-attribution a:hover {
+  color: var(--fj-highlight);
+}
+.source-attribution-sep {
+  margin: 0 6px;
+  opacity: 0.5;
+}
+
 .chat-reasoning-caret {
   display: inline-block;
   margin-left: 1px;


### PR DESCRIPTION
2026-08-15 许可审计发现的缺口：`text_identifiers.source_url`（如
https://suttacentral.net/{uid}）一直存在库里、`/api/sources/texts/{id}/identifiers`
也返回，但 `getTextIdentifiers()` 在前端**一处都没有被调用**。读者在文本页上
看不到任何来源信息，只有一个藏经名徽章（大正藏 / 甘珠尔 / 巴利三藏）——
那是**藏经**，不是**数据源**。

## 为什么这是义务而不是锦上添花

- **CBETA** 用 CC BY-NC-SA，署名是**许可条件**，而「大正藏」并不等于署名 CBETA；
- **84000** 的条款写得更死：只写译者或译经团体、不写「84000」本身，**不满足**
  其署名要求 —— 而页面只显示「甘珠尔」。

讽刺的是，唯一在跟我们要数据的 SuttaCentral 用的是 CC0，**根本不要求署名**。
真正有署名义务的两家此前一直没被署名。

## 改动

新增 `SourceAttribution` 组件，接在文本详情页与阅读页的标题区下方：
「来源：<数据源名> ↗」，链回该源的原始页面（`target=_blank` +
`rel=noopener noreferrer`）。一个文本有多个来源时全部列出；没有 URL 的仍然
署名、只是不做成链接；取不到就什么都不渲染 —— 署名缺失不该把文本页拖垮。
排版刻意收敛（12px、muted 色）：它是出处信息，不是正文。

## 验证

5 条用例先红后绿（组件不存在 → 红）：署名+回链、`noopener noreferrer`、
多来源全列、无来源不留空壳、无 URL 时不做成链接。
tsc + eslint + i18n ratchet + vitest 497 全绿。

未写「接口失败」的用例并说明了原因：出错时 `data` 是 undefined，走的正是空数组
用例已覆盖的同一条 `!data?.length` 分支，组件里没有第二条错误路径；而本仓库的
vitest 刻意把未处理错误一律判红（vite.config.ts 的 onUnhandledError 只白名单了
一个 React teardown 竞态），为一条零增量的用例去绕过那条策略不值得。