### PR TITLE
fix(sources): 证书判词只在探测点成立，不该拿去给活着的机构打红标

### DIFF
--- a/backend/app/services/source_health.py
+++ b/backend/app/services/source_health.py
@@ -163,10 +163,16 @@ def classify_cert(
     the world sees — interception, a stale trust store, a geo-routed edge — and
     the source is fine.
 
-    Expiry is checked before hostname because it is the harder, wholly
-    vantage-independent fact. ``CERT_UNKNOWN`` means the leaf could not be read
-    at all (e.g. the server aborts the handshake before sending one), so nothing
-    was re-verified and nothing may be claimed.
+    Expiry is checked before hostname because it is the harder fact *about the
+    leaf in hand* — but it is **not** vantage-independent, as this docstring
+    once claimed. Which leaf you are handed depends on where you dial from (see
+    the CDN-default-cert cases in :func:`probe_confidence`), so this verdict
+    describes one edge, never the source — which is why no cert verdict is
+    allowed to reach ``high`` confidence.
+
+    ``CERT_UNKNOWN`` means the leaf could not be read at all (e.g. the server
+    aborts the handshake before sending one), so nothing was re-verified and
+    nothing may be claimed.
     """
     if not_after is None:
         return CERT_UNKNOWN
@@ -190,18 +196,39 @@ def probe_confidence(*, status: str, error: str | None, cert: str | None) -> str
     ``low`` ones are recorded for operators but say as much about the probe
     environment as about the site.
 
-    high — the server answered with an HTTP status (same everywhere), the leaf
-    cert was independently re-checked and is genuinely expired or genuinely
-    issued for another name, or the host resolves into non-public space.
+    high — the server answered with an HTTP status (the origin spoke, and a code
+    it chose to return is the same everywhere), or the host resolves into
+    non-public space (a fact the prober establishes from DNS alone).
 
-    low — timeouts, dropped connections and DNS failures (all routinely caused
-    by a datacenter IP being blocked or by the VPS's resolver), plus any cert
-    rejection the re-check could not corroborate.
+    low — everything the prober cannot separate from its own vantage: timeouts,
+    dropped connections, DNS failures (all routinely caused by a datacenter IP
+    being blocked or by the VPS's resolver), **and every TLS rejection**.
+
+    On certs this deliberately reverses 0172, which promoted a cert fault to
+    ``high`` once a re-read of the leaf corroborated it. The re-read dials the
+    same host from the same machine, so it can only confirm what *this* vantage
+    is served — never that the fault exists anywhere else. A 2026-08-15 audit
+    found the gap is not theoretical; from the Singapore VPS, with SNI sent and
+    a valid chain:
+
+        www.cnki.net      -> CN = *.cdn.myqcloud.com   (Tencent CDN default)
+        www.palitext.com  -> CN = *.stackcp.com        (host's default)
+        cbc.dila.edu.tw   -> CN = dazangthings.nz
+
+    while a second vantage is served each site's own, in-date certificate. Both
+    cert families are affected — youfun.litphil.sinica.edu.tw was recorded
+    "expired" against a leaf valid to 2026-10-28 elsewhere — so neither
+    CERT_EXPIRED nor CERT_HOSTNAME_MISMATCH survives as evidence about the
+    *source*. A CDN edge answering for a name it holds no certificate for is a
+    fact about that edge; badging it tells a reader in another region that a
+    live institution is broken.
+
+    ``cert`` is therefore no longer consulted here. It is still recorded in
+    ``health_detail`` — an operator wants to know which cert fault was seen —
+    and stays in the signature so callers and the detail line are unchanged.
     """
     if error is None:
         return CONFIDENCE_HIGH
-    if error == SSL_ERROR:
-        return CONFIDENCE_HIGH if cert in (CERT_EXPIRED, CERT_HOSTNAME_MISMATCH) else CONFIDENCE_LOW
     if error == HOST_NON_PUBLIC:
         return CONFIDENCE_HIGH
     return CONFIDENCE_LOW

--- a/backend/tests/test_health_check_probe.py
+++ b/backend/tests/test_health_check_probe.py
@@ -211,13 +211,23 @@ async def test_cert_failure_with_healthy_leaf_is_low_confidence(monkeypatch):
     assert "looks_valid" in v["detail"]
 
 
-async def test_cert_failure_with_expired_leaf_is_high_confidence(monkeypatch):
-    # 台大的情形：叶证书确实已过期，全网一致，可以放心报出去。
+async def test_cert_failure_with_expired_leaf_is_still_low_confidence(monkeypatch):
+    """叶证书确实过期，也不能提升为 high——「全网一致」这个前提是错的。
+
+    2026-08-15 实测：拿到哪张叶证书取决于从哪里拨号。新加坡 VPS 上
+    www.cnki.net 收到的是 *.cdn.myqcloud.com、www.palitext.com 是
+    *.stackcp.com，而 youfun.litphil.sinica.edu.tw 被判「已过期」时，别处
+    的 leaf 有效期到 2026-10-28。复读 leaf 走的是同一个点位，所以它证明的
+    是「这个边缘节点喂了什么」，不是站点有问题。
+
+    status 和 detail 不变——运维仍要知道看到的是哪种证书问题，变的只是
+    「敢不敢拿去给读者打红标」。
+    """
     monkeypatch.setattr(hc, "_read_leaf_facts", lambda host, port: (PAST, ["www.example.org"]))
     client = FakeClient(httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate has expired"))
     v = await hc.probe(client, FakeClient(), "src", URL)
     assert v["status"] == "cert_invalid"
-    assert v["confidence"] == "high"
+    assert v["confidence"] == "low"
     assert "expired" in v["detail"]
 
 

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -19,6 +19,7 @@ from app.services.source_health import (
     HOST_DNS_UNRESOLVED,
     HOST_NON_PUBLIC,
     HOST_PUBLIC,
+    SSL_CHAIN_INCOMPLETE,
     SSL_ERROR,
     _ip_is_blocked,
     classify_cert,
@@ -444,18 +445,33 @@ def test_confidence_high_for_http_status_verdicts():
     assert probe_confidence(status="unreachable", error=None, cert=None) == CONFIDENCE_HIGH
 
 
-def test_confidence_high_for_independently_confirmed_cert_faults():
-    assert probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=CERT_EXPIRED) == CONFIDENCE_HIGH
-    assert probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=CERT_HOSTNAME_MISMATCH) == CONFIDENCE_HIGH
+def test_confidence_low_for_every_cert_verdict_however_well_corroborated():
+    """证书判词一律不可外推——复读 leaf 和探测走的是同一个点位。
+
+    这条推翻了 0172 的设计。2026-08-15 实测：从新加坡 VPS 正确发送 SNI、链
+    校验通过的前提下，www.cnki.net 收到的是 *.cdn.myqcloud.com、
+    www.palitext.com 是 *.stackcp.com、cbc.dila.edu.tw 是 dazangthings.nz，
+    而换一个点位拿到的都是各站自己的有效证书。「过期」一类同样中招：
+    youfun.litphil.sinica.edu.tw 被判过期，别处 leaf 有效期到 2026-10-28。
+    所以 leaf 复读只能证明「这个点位被喂了什么」，不能证明站点有问题。
+    """
+    for cert in (CERT_EXPIRED, CERT_HOSTNAME_MISMATCH, CERT_LOOKS_VALID, CERT_UNKNOWN):
+        verdict = probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=cert)
+        assert verdict == CONFIDENCE_LOW, f"cert={cert} 不该被当作跨点位证据"
 
 
-def test_confidence_low_when_cert_looks_fine_but_handshake_failed():
-    # CNKI / 遊方：OpenSSL 拒了，但独立复核证书是好的 → 是探测点的问题。
-    assert probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=CERT_LOOKS_VALID) == CONFIDENCE_LOW
+def test_confidence_high_survives_only_for_origin_answered_and_non_public():
+    """收窄之后 high 只剩两类，别让谁不小心把证书类再加回来。
 
-
-def test_confidence_low_for_cert_we_could_not_recheck():
-    assert probe_confidence(status="cert_invalid", error=SSL_ERROR, cert=CERT_UNKNOWN) == CONFIDENCE_LOW
+    这两类的共同点是「不依赖探测点」：源站自己回了一个状态码，或主机名解析
+    进非公网地址（探测机自己就能定的事实，也正是 SSRF 该拦的）。
+    """
+    for status in ("ok", "degraded", "unreachable"):
+        assert probe_confidence(status=status, error=None, cert=None) == CONFIDENCE_HIGH
+    assert probe_confidence(status="unreachable", error=HOST_NON_PUBLIC, cert=None) == CONFIDENCE_HIGH
+    # 其余一律 low —— 含 0172 曾放行的两种证书判词。
+    for err in (SSL_ERROR, SSL_CHAIN_INCOMPLETE, HOST_DNS_UNRESOLVED, "timeout", "connect", "read"):
+        assert probe_confidence(status="unreachable", error=err, cert=CERT_EXPIRED) == CONFIDENCE_LOW, err
 
 
 def test_confidence_low_for_timeout_and_dns():

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -293,6 +293,14 @@ export interface DataSource {
   health_checked_at: string | null;
   /** Latest-probe context: redirect target for `moved`, failure reason otherwise, null when ok. */
   health_detail: string | null;
+  /**
+   * Whether the verdict holds beyond the prober's own vantage. The cron runs
+   * from one VPS, where a timeout, a DNS miss or a CDN edge serving its default
+   * certificate says more about the probe than about the site — so only `high`
+   * may be shown to a reader as a fault of the source. See
+   * `app/services/source_health.probe_confidence`.
+   */
+  health_confidence: "high" | "low";
   distributions: SourceDistribution[];
 }
 

--- a/frontend/src/pages/SourcesPage.test.tsx
+++ b/frontend/src/pages/SourcesPage.test.tsx
@@ -57,6 +57,7 @@ function source(o: Partial<DataSource> = {}): DataSource {
     health_status: "ok",
     health_checked_at: null,
     health_detail: null,
+    health_confidence: "high",
     distributions: [],
     ...o,
   };

--- a/frontend/src/pages/sources/SourceCard.test.tsx
+++ b/frontend/src/pages/sources/SourceCard.test.tsx
@@ -30,6 +30,8 @@ function makeSource(overrides: Partial<DataSource> = {}): DataSource {
     health_status: "ok",
     health_checked_at: null,
     health_detail: null,
+    // 与库里的 server_default 一致，别让 fixture 编造一个生产里不存在的初值。
+    health_confidence: "high",
     distributions: [],
     ...overrides,
   };
@@ -89,5 +91,41 @@ describe("SourceCard 健康徽章 tooltip", () => {
     // 若日后某 tip 引入该词，需改为对 tooltip 容器作用域断言。
     expect(await screen.findByText(/浏览器通常仍可正常访问/)).toBeInTheDocument();
     expect(screen.queryByText(/详情：/)).not.toBeInTheDocument();
+  });
+});
+
+describe("SourceCard 只对跨点位成立的判词打徽章", () => {
+  // 巡检跑在单台新加坡 VPS 上：超时、DNS 失败，以及 CDN 边缘节点回自己的
+  // 默认证书，说的都是探测点而非站点。0172 为此加了 health_confidence，但
+  // 徽章从没接上去，于是牛津博德利、普林斯顿、CNKI 这些实测活着的站一直被
+  // 标成坏的。
+  const LOW_CONFIDENCE_CASES = [
+    { status: "unreachable" as const, label: "巡检未达", why: "VPS 连不上但别处 200（牛津/普林斯顿）" },
+    { status: "cert_invalid" as const, label: "证书异常", why: "CDN 边缘回默认证书（CNKI）" },
+  ];
+
+  it.each(LOW_CONFIDENCE_CASES)(
+    "$status 且 confidence=low 时不打徽章（$why）",
+    ({ status, label }) => {
+      renderCard(
+        makeSource({
+          health_status: status,
+          health_confidence: "low",
+          health_detail: "timeout",
+        }),
+      );
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    },
+  );
+
+  it("同样的状态在 confidence=high 时照常打徽章", () => {
+    renderCard(
+      makeSource({
+        health_status: "unreachable",
+        health_confidence: "high",
+        health_detail: "HTTP 522",
+      }),
+    );
+    expect(screen.getByText("巡检未达")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/sources/SourceCard.tsx
+++ b/frontend/src/pages/sources/SourceCard.tsx
@@ -70,8 +70,16 @@ export default function SourceCard({ source: s, searchQuery }: SourceCardProps) 
   // misleading users. If a source lacks a template, the button is hidden.
   const searchUrl = searchQuery ? buildSearchUrl(s.code, searchQuery) : null;
 
+  // Badge only on verdicts that hold outside the prober's own vantage. The cron
+  // runs from a single VPS: a timeout there, a DNS miss, or a CDN edge handing
+  // back its own default certificate are facts about the probe, not the site —
+  // 0172 added health_confidence for exactly this and the badge was never wired
+  // to it, so every low-confidence verdict has been telling readers that live
+  // institutions (Bodleian, Princeton, CNKI …) are broken.
   const health =
-    s.health_status && s.health_status !== "ok" ? HEALTH_BADGE[s.health_status] : null;
+    s.health_status && s.health_status !== "ok" && s.health_confidence === "high"
+      ? HEALTH_BADGE[s.health_status]
+      : null;
   const healthCheckedAt = s.health_checked_at
     ? new Date(s.health_checked_at).toLocaleDateString("zh-CN")
     : null;


### PR DESCRIPTION
## 0172 的推理有个洞

它的设计是：证书出错时复读一遍 leaf，若确认「确实过期」或「确实签给别的名字」，就把 `health_confidence` 提升为 `high`、可以展示给读者。

问题是**复读用的是同一台机器、同一条路径** —— 它只能确认「这个点位被喂了什么证书」，证明不了别处也一样。

## 实测把洞捅穿了

从新加坡 VPS，正确发送 SNI、链校验通过：

| 请求的主机 | VPS 实际收到的证书 |
|---|---|
| `www.cnki.net` | `CN = *.cdn.myqcloud.com`（腾讯云 CDN 默认证书） |
| `www.palitext.com` | `CN = *.stackcp.com`（主机商默认证书） |
| `cbc.dila.edu.tw` | `CN = dazangthings.nz` |

换一个点位拿到的都是各站自己的、在有效期内的证书。**「过期」一类同样中招**：`youfun.litphil.sinica.edu.tw` 被判过期，别处 leaf 有效期到 2026-10-28。

所以这不是拦截、不是信任库过期，而是 **CDN 边缘节点没配上该主机名、回了自己的默认证书** —— 一个关于那个边缘节点的事实。拿它打红标，等于告诉另一个地区的读者「这家活着的机构坏了」。考虑到 70% 的读者在大陆而探测点在新加坡，方向本身就是错的。

## 改法

收窄 `high` 的定义，只剩两类 —— 共同点是**不依赖探测点**：

- 源站自己回了一个 HTTP 状态码
- 主机名解析进非公网地址（探测机自己就能定的事实，也正是 SSRF 该拦的）

证书类（含 0172 放行的两种）与超时、连接失败、DNS 失败一并降为 `low` —— 不打标，但仍记录，运维照样看得到。`cert` 参数保留在签名里：`health_detail` 仍要写明看到的是哪种证书问题，调用点无需改动。

**影响**：11 条 `cert_invalid` 从「红标」变成「不打标」，其中至少 cnki 和 youfun 已实证是活的。留在 `high` 的只剩源站真报错那几条（522/500/508/404），条条可行动。

## 验证

- 74 项单测通过；两个新用例分别覆盖「四种 cert 判词一律 low」和「high 只剩两类」。
- **反向对照**：把逻辑退回 0172 旧版，正是这两个新用例变红（`AssertionError: ssl` / `assert 'high' == 'low'`），证明不是恒真断言。
- 用 **CI 钉的 ruff==0.9.7** 跑 `ruff check app/ eval/` 通过。
- **未动格式**：这两个文件在 0.9.7 的 formatter 下本来就是「待重排」状态（HEAD 原版同样如此），重排会产生上百行无关 diff，而 CI 并不跑格式检查。
