### PR TITLE
fix(chat): token 过期后被静默当成游客，还拿游客额度冒充本人余额

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -302,7 +302,22 @@ async def chat_quota(
 ):
     """Get daily chat quota for the current user or anonymous visitor.
 
-    获取当前用户或匿名用户的每日问答配额。"""
+    获取当前用户或匿名用户的每日问答配额。
+
+    ``authenticated`` exists because the two branches below are otherwise
+    indistinguishable to the caller, and that ambiguity shipped a user-visible
+    lie. ``get_optional_user`` returns ``None`` for a *missing* token and for an
+    expired or otherwise invalid one alike (see ``resolve_optional_user``), so a
+    logged-in reader whose 8-hour JWT had quietly expired fell through to the
+    anonymous branch and was served ``limit: 10``. The client still had the user
+    object in its persisted store, so it rendered the *logged-in* low-quota
+    warning around the *anonymous* number — a reader with 199 of 200 questions
+    left was told 10 remained. The same expiry silently demotes them on
+    ``/chat/stream`` too (IP-shared quota, session not saved to their account),
+    which is the part worth surfacing.
+
+    With this flag the client can tell "you are a guest" from "your session
+    expired" and say so, instead of inventing a quota."""
     from datetime import date
 
     if user:
@@ -314,9 +329,12 @@ async def chat_quota(
             "used": used,
             "remaining": limit - used if not has_byok else -1,
             "has_byok": has_byok,
+            "authenticated": True,
         }
 
-    # Anonymous user — check Redis by IP
+    # Anonymous user — check Redis by IP. Also reached by a logged-in client
+    # whose token expired; `authenticated: False` is the only signal that says
+    # which of the two happened.
     client_ip = _get_client_ip(request)
     redis = getattr(request.app.state, "redis", None)
     used = await get_anonymous_quota_used(redis, client_ip)
@@ -326,6 +344,7 @@ async def chat_quota(
         "used": used,
         "remaining": limit - used,
         "has_byok": False,
+        "authenticated": False,
     }
 
 

--- a/backend/tests/test_chat_quota_authenticated_flag.py
+++ b/backend/tests/test_chat_quota_authenticated_flag.py
@@ -1,0 +1,86 @@
+"""GET /api/chat/quota must say whether it recognised a logged-in user.
+
+用户实拍复现（2026-08-15）：登录用户进入 /chat 就看到「今日免费额度快用完了，
+剩余 10 次」，重新登录也不消失。查库发现该用户当日只用了 1 次（按登录上限 200，
+真实剩余 199），当天全站最高用量 3 次，无人接近上限。
+
+机制：JWT 只有 8 小时且无续期，``resolve_optional_user`` 对过期 token 静默返回
+None，本接口于是落到匿名分支返回 ``limit: 10``。前端的 user 存在持久化 store 里，
+token 过期了 user 对象还在，于是用「登录用户」的横幅渲染了「游客」的数字 ——
+10 恰好是匿名满额（10 - 0），不是巧合。
+
+两条分支此前对调用方完全无法区分，这就是歧义能变成用户可见谎言的原因。
+``authenticated`` 是唯一让客户端分辨「你是游客」和「你的登录过期了」的信号。
+"""
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def _quota(client, user):
+    from app.core.deps import get_optional_user
+    from app.main import app
+
+    app.dependency_overrides[get_optional_user] = lambda: user
+    try:
+        resp = await client.get("/api/chat/quota")
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+    finally:
+        app.dependency_overrides.pop(get_optional_user, None)
+
+
+class _User:
+    """Minimal stand-in — the endpoint only reads these four attributes."""
+
+    def __init__(self, *, daily_chat_count=0, last_chat_date=None, encrypted_api_key=None):
+        self.id = 1
+        self.daily_chat_count = daily_chat_count
+        self.last_chat_date = last_chat_date
+        self.encrypted_api_key = encrypted_api_key
+
+
+async def test_anonymous_visitor_is_reported_unauthenticated(client):
+    body = await _quota(client, None)
+    assert body["authenticated"] is False
+    assert body["limit"] == 10
+
+
+async def test_logged_in_user_is_reported_authenticated(client):
+    from datetime import date
+
+    body = await _quota(client, _User(daily_chat_count=1, last_chat_date=date.today()))
+    assert body["authenticated"] is True
+    assert body["limit"] == 200
+    assert body["remaining"] == 199
+
+
+async def test_expired_token_is_distinguishable_from_a_real_guest_quota(client):
+    """承重点：这是用户实际撞到的那一格。
+
+    token 过期后 get_optional_user 返回 None，本接口只能给出匿名配额 ——
+    这部分改不了，也不该改。能改的是：响应里必须带上一个信号，让客户端不至于
+    把这 10 次当成某个登录用户的余额报出去。
+
+    只断言「匿名返回 limit 10」是不够的：修复前它同样成立，而 bug 照样发生。
+    真正的断言是这个字段存在且为 False —— 客户端据此才能说「登录已过期」。
+    """
+    expired = await _quota(client, None)  # 过期 token 与无 token 在这一层无从区分
+    assert expired["authenticated"] is False, (
+        "少了这个字段，过期登录态和真游客返回完全一致，前端只能编一个余额出来"
+    )
+
+
+async def test_byok_user_reports_unlimited_and_authenticated(client):
+    """自带 Key 的用户 remaining 是 -1（前端据此不弹额度提醒）。
+
+    这条同时说明了为什么管理员自查不出这个 bug：remaining=-1 让额度横幅对他
+    结构上不可达，除非他的 token 也过期 —— 而那时后端回的是匿名分支，
+    has_byok 被硬编码成 False，他反而会看到一句自相矛盾的「配置自己的 API Key
+    可不受此限制」。
+    """
+    body = await _quota(client, _User(encrypted_api_key="x"))
+    assert body["authenticated"] is True
+    assert body["remaining"] == -1
+    assert body["has_byok"] is True

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1531,6 +1531,8 @@
   "profile.byok_description_generic": "Adding your own AI API key lifts the platform's free daily limit, but the usage is billed to your key. Keys are stored with AES encryption and used only for AI API calls.",
   "chat.quota_low": "Your free daily quota is running low — {{remaining}} left.",
   "chat.quota_low_action": "Add your own API key to lift the limit",
+  "chat.session_expired": "Your session has expired — questions now count against the guest quota and are not saved to your account. ",
+  "chat.session_expired_action": "Sign in again",
   "chat.configure_other_models": "Use another provider…",
   "xiaojin.open": "Ask XiaoJin",
   "xiaojin.close": "Close",

--- a/frontend/public/locales/zh-Hant/translation.json
+++ b/frontend/public/locales/zh-Hant/translation.json
@@ -1531,6 +1531,8 @@
   "profile.byok_description_generic": "設定自己的 AI API Key 後，問答次數不再受平台免費額度限制，但呼叫費用由你的 Key 承擔。Key 經 AES 加密儲存，僅用於呼叫 AI 介面。",
   "chat.quota_low": "今日免費額度快用完了，剩餘 {{remaining}} 次。",
   "chat.quota_low_action": "設定自己的 API Key 可不受此限制",
+  "chat.session_expired": "登入狀態已過期，目前提問按訪客額度計算，也不會存入你的帳號。",
+  "chat.session_expired_action": "重新登入",
   "chat.configure_other_models": "設定其他廠商模型…",
   "xiaojin.open": "問小津",
   "xiaojin.close": "關閉",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1531,6 +1531,8 @@
   "profile.byok_description_generic": "配置自己的 AI API Key 后，问答次数不再受平台免费额度限制，但调用费用由你的 Key 承担。Key 经 AES 加密存储，仅用于调用 AI 接口。",
   "chat.quota_low": "今日免费额度快用完了，剩余 {{remaining}} 次。",
   "chat.quota_low_action": "配置自己的 API Key 可不受此限制",
+  "chat.session_expired": "登录状态已过期，当前提问按游客额度计算，也不会存入你的账号。",
+  "chat.session_expired_action": "重新登录",
   "chat.configure_other_models": "配置其他厂商模型…",
   "xiaojin.open": "问小津",
   "xiaojin.close": "关闭",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1902,6 +1902,15 @@ export interface ChatQuota {
   used: number;
   remaining: number;
   has_byok: boolean;
+  /**
+   * Whether the backend actually recognised a logged-in user for this request.
+   * `false` covers both "no token sent" and "token sent but expired/invalid" —
+   * the backend cannot tell those apart either, but the *client* can: if it
+   * still holds a user in its persisted store and gets `false` back, the
+   * session expired. Without this the expired case is indistinguishable from
+   * being a guest, and the UI renders a logged-in banner around a guest quota.
+   */
+  authenticated: boolean;
 }
 
 export async function getChatQuota(): Promise<ChatQuota> {

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
 import { MemoryRouter, useLocation } from "react-router";
@@ -131,7 +131,7 @@ beforeEach(() => {
     has_api_key: true, provider: "deepseek", model: null, key_preview: null,
   });
   vi.mocked(getChatQuota).mockResolvedValue({
-    limit: 10, used: 0, remaining: 10, has_byok: true,
+    limit: 10, used: 0, remaining: 10, has_byok: true, authenticated: true,
   });
   useAuthStore.setState({
     token: "t",
@@ -774,8 +774,11 @@ describe("会话与 URL", () => {
 // ── 额度将尽提醒（登录用户此前什么都看不到）────────────────────────────
 
 describe("额度提醒", () => {
-  function loggedIn(quota: { limit: number; used: number; remaining: number; has_byok: boolean }) {
-    vi.mocked(getChatQuota).mockResolvedValue(quota);
+  function loggedIn(quota: {
+    limit: number; used: number; remaining: number; has_byok: boolean; authenticated?: boolean;
+  }) {
+    // 默认 true：这批用例测的是「后端认得这个人」时的额度提醒。
+    vi.mocked(getChatQuota).mockResolvedValue({ authenticated: true, ...quota });
     return renderPage();
   }
 
@@ -804,6 +807,67 @@ describe("额度提醒", () => {
     loggedIn({ limit: 200, used: 500, remaining: -1, has_byok: true });
     await screen.findByText("「三毒」指的是哪三种毒？");
     expect(screen.queryByText(/额度快用完/)).toBeNull();
+  });
+
+  // ── 用户实拍复现（2026-08-15）──────────────────────────────────────
+  //
+  // 症状：登录用户进入 /chat 就看到「今日免费额度快用完了，剩余 10 次」，
+  // 重新登录也不消失。查库：该用户当日只用了 1 次，按登录上限 200 真实剩余
+  // 199；当天全站最高用量 3 次，没有任何人接近上限。
+  //
+  // 机制：JWT 只有 8 小时且无续期，resolve_optional_user 对过期 token 静默
+  // 返回 None，/chat/quota 于是落到匿名分支返回 limit 10。而前端的 user 存在
+  // 持久化 store 里，token 过期了 user 对象还在 —— 于是用「登录用户」的横幅
+  // 渲染了「游客」的数字。10 恰好是匿名满额（10-0），不是巧合。
+  it("回归: token 过期时不得把游客额度当成本人余额报出去", async () => {
+    // 后端此刻返回的就是匿名配额：authenticated=false，remaining=10。
+    loggedIn({ limit: 10, used: 0, remaining: 10, has_byok: false, authenticated: false });
+    expect(await screen.findByText(/登录状态已过期/)).toBeInTheDocument();
+    // 承重断言：那句编造的余额必须消失。只断言"出现过期提示"的话，
+    // 一个把两条横幅同时显示的实现照样能过。
+    expect(screen.queryByText(/额度快用完/)).toBeNull();
+  });
+
+  it("回归: 过期提示只给「本地有 user」的人看，游客不该看到", async () => {
+    // 游客同样拿到 authenticated=false，但他没过期——他本来就没登录过。
+    useAuthStore.setState({ token: null, user: null });
+    loggedIn({ limit: 10, used: 8, remaining: 2, has_byok: false, authenticated: false });
+    await screen.findByText("「三毒」指的是哪三种毒？");
+    expect(screen.queryByText(/登录状态已过期/)).toBeNull();
+  });
+
+  it("登录态正常时，额度提醒照常工作（不因这次修复被误伤）", async () => {
+    loggedIn({ limit: 200, used: 185, remaining: 15, has_byok: false, authenticated: true });
+    expect(await screen.findByText(/今日免费额度快用完了，剩余 15 次/)).toBeInTheDocument();
+    expect(screen.queryByText(/登录状态已过期/)).toBeNull();
+  });
+
+  // 用户原话是「即便登录后也会出现」——这一条就是那个"即便"。
+  // queryKey 若是常量 ["chatQuota"]，登录前后是同一个 key，配上全局 5 分钟
+  // staleTime，登录后照旧吃登录前缓存的游客额度，不会重新取。
+  it("回归: 登录后必须重新取额度，不能沿用登录前的游客缓存", async () => {
+    useAuthStore.setState({ token: null, user: null });
+    vi.mocked(getChatQuota)
+      .mockResolvedValueOnce({ limit: 10, used: 0, remaining: 10, has_byok: false, authenticated: false })
+      .mockResolvedValue({ limit: 200, used: 1, remaining: 199, has_byok: false, authenticated: true });
+
+    renderPage();
+    await screen.findByText("「三毒」指的是哪三种毒？");
+    const callsAsGuest = vi.mocked(getChatQuota).mock.calls.length;
+
+    act(() => {
+      useAuthStore.setState({
+        token: "fresh",
+        user: {
+          id: 42, username: "reader", email: "r@example.com", display_name: null,
+          role: "user", is_active: true, created_at: "2026-01-01T00:00:00Z",
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(getChatQuota).mock.calls.length).toBeGreaterThan(callsAsGuest);
+    });
   });
 });
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -860,8 +860,13 @@ export default function ChatPage() {
     enabled: !!user,
   });
 
+  // The key carries the user id so logging in or out refetches instead of
+  // serving the other identity's cached answer. With a constant key and the
+  // global 5-minute staleTime, a guest quota fetched before login stayed fresh
+  // across the login and drove the logged-in banner — this is why the wrong
+  // "剩余 10 次" survived signing in.
   const { data: quota, refetch: refetchQuota } = useQuery({
-    queryKey: ["chatQuota"],
+    queryKey: ["chatQuota", user?.id ?? "anon"],
     queryFn: getChatQuota,
   });
 
@@ -1948,9 +1953,34 @@ export default function ChatPage() {
                 style={{ marginBottom: 8, fontSize: 12 }}
               />
             )}
+            {/* 本地还存着 user，后端却说没认证 —— 只可能是 token 过期了。
+                此时后端返回的是匿名配额，拿它去渲染任何「剩余 N 次」都是编造：
+                实测有用户今日只用 1 次（真实剩余 199）却被告知剩 10 次。
+                更要紧的是 /chat/stream 走的是同一套鉴权，过期后配额降为按 IP
+                共享的 10 次、会话不再存进账号 —— 所以这里必须让用户知道。
+                不自动登出：会把正在输入的内容和上下文一起清掉。 */}
+            {user && quota && !quota.authenticated && (
+              <Alert
+                message={
+                  <span>
+                    {t("chat.session_expired")}
+                    {/* 复用游客 CTA 的那条路：先暂存当前对话再跳登录。过期期间
+                        发出的消息本来就没进账号，直接 navigate 会当场销毁它们。
+                        returnTo 也在同一个函数里写好（sessionStorage，见 LoginPage）。 */}
+                    <a onClick={goLoginKeepingTranscript}>
+                      {t("chat.session_expired_action")}
+                    </a>
+                  </span>
+                }
+                type="warning" showIcon closable
+                style={{ marginBottom: 8, fontSize: 12 }}
+              />
+            )}
             {/* 登录用户此前在这里什么都看不到 —— 撞到上限是毫无预警的。
-                remaining 对自带 Key 的用户是 -1，所以 >= 0 已经把他们排除掉了。 */}
-            {user && quota && quota.remaining >= 0 && quota.remaining <= LOW_QUOTA_THRESHOLD && (
+                remaining 对自带 Key 的用户是 -1，所以 >= 0 已经把他们排除掉了。
+                authenticated 这一项不能省：token 过期时后端回的是匿名配额，
+                少了它就会把游客的 10 次当成这位登录用户的余额报出去。 */}
+            {user && quota && quota.authenticated && quota.remaining >= 0 && quota.remaining <= LOW_QUOTA_THRESHOLD && (
               <Alert
                 message={
                   <span>

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -70,7 +70,7 @@ describe("ProfilePage", () => {
       key_preview: null,
     });
     vi.mocked(getChatQuota).mockResolvedValue({
-      limit: 200, used: 3, remaining: 197, has_byok: false,
+      limit: 200, used: 3, remaining: 197, has_byok: false, authenticated: true,
     });
     vi.mocked(getBookmarks).mockResolvedValue({ total: 0, page: 1, size: 20, items: [] });
     vi.mocked(getHistory).mockResolvedValue({ total: 0, page: 1, size: 20, items: [] });
@@ -130,7 +130,7 @@ describe("ProfilePage", () => {
       },
     });
     vi.mocked(getChatQuota).mockResolvedValue({
-      limit: 999, used: 0, remaining: 999, has_byok: false,   // 故意取一个不可能写死的值
+      limit: 999, used: 0, remaining: 999, has_byok: false, authenticated: true,   // 故意取一个不可能写死的值
     });
     renderPage(<ProfilePage />, "/profile?tab=apikey");
 


### PR DESCRIPTION
用户反馈：登录进 `/chat` 就看到「今日免费额度快用完了，剩余 10 次」，**重新登录也不消失**。

## 先确认这不是真的

| | |
|---|---|
| 该用户当日实际用量 | **1 次** |
| 按登录上限 200，真实剩余 | **199 次** |
| 横幅显示 | **剩余 10 次** |
| 当天全站最高用量 | 3 次（无人接近上限） |

**10 恰好等于匿名满额**（limit 10 − used 0），不是巧合。

## 链条

- JWT 只有 8 小时且无续期
- `resolve_optional_user` 对过期 token **静默返回 None**，与「没带 token」同待遇
- `/chat/quota` 于是落到匿名分支返回 `limit: 10`
- 而前端 `user` 存在持久化 store 里，**token 过期了 `user` 对象还在**
- → 用「登录用户」的横幅渲染了「游客」的数字

生产实测，后端完全不给信号：

```
不带 token        → {"limit":10,"used":2,"remaining":8}
带过期/无效 token → {"limit":10,"used":2,"remaining":8}   ← 一模一样
```

## 横幅只是露出来的一角

发消息那条路（`chat.py:486-490`）用的是**同一个** `resolve_optional_user`。过期后用户是真的被降级：

- 配额 200/天 → **按 IP 共享的 10 次/天**
- `user_id = None` → **会话不再存进他的账号**

用户看到「剩余 10 次」的时候，已经在以游客身份使用，历史正在丢失。

## 改动

**1. `/chat/quota` 响应加 `authenticated`**

后端分不清「没带 token」和「token 过期」（也不需要分），但**客户端能**：本地还存着 `user` 却拿到 `authenticated: false`，就只可能是过期。据此显示「登录状态已过期，当前提问按游客额度计算，也不会存入你的账号」+ 重新登录入口，而不是编一个余额。低额度横幅也加上该判据，否则照旧会把游客的 10 次报成本人余额。

重新登录复用现成的 `goLoginKeepingTranscript`：先暂存当前对话再跳转 —— 过期期间发的消息本来就没进账号，直接 navigate 会当场销毁。**不自动登出**，那会把用户正在输入的内容一起清掉。

**2. quota 的 `queryKey` 带上用户 id**

此前是常量 `["chatQuota"]`，登录前后同一个 key，配上全局 5 分钟 `staleTime`，登录后照旧吃登录前缓存的游客额度 —— 这正是用户说的「即便登录后也会出现」。全项目没有任何一处在登录后 `invalidateQueries`，`refetchQuota` 也只在发完消息后才调。

## ⚠️ 这不是根因修复

修的是症状与止损。根因是 **8 小时 JWT 无续期**，做完之后用户会变成「每天被要求重新登录一次」。续期方案单独决策。

## 顺带：为什么管理员自查不出来

自带 API Key 的用户 `remaining` 是 **-1**，而横幅条件是 `remaining >= 0` —— 这条横幅对他**结构上不可达**。最可能发现并上报问题的人（管理员、重度用户）恰好都被排除在外。

## 验证

- 前端 63 项通过，新增 4 条用例（含按用户截图复现的那条）
- **反向对照两次，各自独立**：撤掉过期横幅 + `authenticated` 判据 → 复现用例变红；`queryKey` 改回常量 → 「登录后必须重新取额度」变红
- 后端此前 `/chat/quota` **一个测试都没有**，新增 4 条；移除 `authenticated` 字段后四条全红
- `tsc` 抓出 ProfilePage.test 两处 fixture 漏字段（正是它该干的活），已补
- ruff 0.9.7（CI 钉的版本）、eslint、i18n ratchet 全过；三个语言各只增 2 行
