### PR TITLE
fix(chat): 过期提示活不过 401——#1196 的横幅实测只闪一下就没了

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { useAuthStore } from "../stores/authStore";
+import { markSessionExpired, useAuthStore } from "../stores/authStore";
 import i18n from "../i18n";
 import type {
   TextId,
@@ -55,7 +55,14 @@ api.interceptors.response.use(
       error.response?.status === 401 &&
       !error.config?.url?.startsWith("/auth/")
     ) {
+      // Mark *before* logout: logout() clears the flag (a deliberate sign-out is
+      // not an expiry) and wipes `user`, after which nothing downstream can tell
+      // "your session died" from "you were never signed in". /chat/quota answers
+      // 200-with-guest-numbers rather than 401, so without this marker the chat
+      // page silently shows a guest quota to someone who still believes they are
+      // signed in — and their questions really are being counted as a guest's.
       useAuthStore.getState().logout();
+      markSessionExpired();
     }
     return Promise.reject(error);
   },
@@ -2167,6 +2174,10 @@ export function sendChatMessageStream(
           // 把原因说明白就够了：他可以直接重发（走游客配额），或者点页面上那个
           // 会先把对话暂存下来的登录入口（goLoginKeepingTranscript）。
           useAuthStore.getState().logout();
+          // 同上：logout() 会清掉这个标记，所以必须在其后置位。下面那句
+          // onError 只是一次性的行内提示，滚上去就看不见了；标记留下来，
+          // 页面上的常驻横幅才能继续说明"你现在是游客身份"。
+          markSessionExpired();
           callbacks.onError(i18n.t("chat.stream.sessionExpired"), "unauthorized");
           callbacks.onDone();
           resolve();

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -7,7 +7,7 @@ import { HelmetProvider } from "react-helmet-async";
 import { MemoryRouter, useLocation } from "react-router";
 import { message } from "antd";
 import ChatPage from "./ChatPage";
-import { useAuthStore } from "../stores/authStore";
+import { markSessionExpired, useAuthStore } from "../stores/authStore";
 import { uploadChatAttachment } from "../api/chatAttachments";
 import {
   getApiKeyStatus,
@@ -147,6 +147,8 @@ afterEach(() => {
   useAuthStore.setState({ token: null, user: null });
   // 侧栏收起状态持久化在 localStorage —— 不清的话它会泄漏到后面的用例里
   localStorage.removeItem("fojin.chat.sidebarCollapsed");
+  // 会话过期标记同理：留着会让后面每个用例都以为登录态刚死掉
+  sessionStorage.clear();
 });
 
 /** 等空状态首屏就绪（建议卡片到位）后再断言结构。 */
@@ -839,6 +841,34 @@ describe("额度提醒", () => {
   it("登录态正常时，额度提醒照常工作（不因这次修复被误伤）", async () => {
     loggedIn({ limit: 200, used: 185, remaining: 15, has_byok: false, authenticated: true });
     expect(await screen.findByText(/今日免费额度快用完了，剩余 15 次/)).toBeInTheDocument();
+    expect(screen.queryByText(/登录状态已过期/)).toBeNull();
+  });
+
+  // 上一版修复漏掉的那一格：401 拦截器的处理是 logout()，user 当场被清空。
+  // 只判 `user && !authenticated` 的话，横幅最多在 401 到达前闪一下 ——
+  // 实测手工把 token 改坏后进 /chat，两条横幅一条都不出现。
+  it("承重点: 401 已清掉 user，过期提示仍必须在", async () => {
+    useAuthStore.setState({ token: null, user: null });   // 拦截器登出后的真实状态
+    markSessionExpired();
+    loggedIn({ limit: 10, used: 2, remaining: 8, has_byok: false, authenticated: false });
+    expect(await screen.findByText(/登录状态已过期/)).toBeInTheDocument();
+  });
+
+  it("过期者不该再被劝「登录后额度更多」——他刚才就是登录状态", async () => {
+    useAuthStore.setState({ token: null, user: null });
+    markSessionExpired();
+    loggedIn({ limit: 10, used: 2, remaining: 8, has_byok: false, authenticated: false });
+    await screen.findByText(/登录状态已过期/);
+    expect(screen.queryByText(/每日免费/)).toBeNull();
+  });
+
+  it("真游客（没置位过期标记）照旧看到常规游客提示", async () => {
+    useAuthStore.setState({ token: null, user: null });
+    vi.mocked(getApiKeyStatus).mockResolvedValue({
+      has_api_key: false, provider: null, model: null, key_preview: null,
+    });
+    loggedIn({ limit: 10, used: 2, remaining: 8, has_byok: false, authenticated: false });
+    expect(await screen.findByText(/每日免费/)).toBeInTheDocument();
     expect(screen.queryByText(/登录状态已过期/)).toBeNull();
   });
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useMemo, useEffect, lazy, Suspense, memo, type ReactNode } from "react";
+import { useState, useRef, useCallback, useMemo, useEffect, useSyncExternalStore, lazy, Suspense, memo, type ReactNode } from "react";
 import { useNavigate, useSearchParams, Link } from "react-router";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
@@ -74,7 +74,13 @@ import {
   uploadChatAttachment,
   type ChatAttachmentMeta,
 } from "../api/chatAttachments";
-import { sessionExpired, useAuthStore, type UserProfile } from "../stores/authStore";
+import {
+  sessionExpired,
+  sessionExpiredServer,
+  subscribeSessionExpired,
+  useAuthStore,
+  type UserProfile,
+} from "../stores/authStore";
 
 // 登录用户的额度提示只在快用完时出现。常驻一个「今日剩余 198 次」是纯噪音 ——
 // 而毫无预警地撞上上限、直接吃一个错误，才是真正会让人懵的那种体验。
@@ -870,12 +876,14 @@ export default function ChatPage() {
     queryFn: getChatQuota,
   });
 
-  // sessionStorage 本身不是响应式的，但它被置位的那一刻 401 拦截器刚调过
-  // logout()，store 一变本组件就会重渲染 —— 借这个时机重读即可。挂在
-  // [user, quota] 上而不是在渲染里直接读，是为了不让 React Compiler 面对一个
-  // 每次渲染结果都可能不同的裸调用。
-  const [expired, setExpired] = useState(sessionExpired);
-  useEffect(() => { setExpired(sessionExpired()); }, [user, quota]);
+  // 登录态是否"自己死掉了"。存在 sessionStorage 里（见 authStore），用
+  // useSyncExternalStore 订阅——这是 React 读取外部可变源的正规做法，置位那一刻
+  // 就重渲染，不必蹭别的 state 变化。
+  const expired = useSyncExternalStore(
+    subscribeSessionExpired,
+    sessionExpired,
+    sessionExpiredServer,
+  );
 
   const filteredSessions = useMemo(
     () => sessions?.filter((s) => !sessionFilter || (s.title || "").includes(sessionFilter)),

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -74,7 +74,7 @@ import {
   uploadChatAttachment,
   type ChatAttachmentMeta,
 } from "../api/chatAttachments";
-import { useAuthStore, type UserProfile } from "../stores/authStore";
+import { sessionExpired, useAuthStore, type UserProfile } from "../stores/authStore";
 
 // 登录用户的额度提示只在快用完时出现。常驻一个「今日剩余 198 次」是纯噪音 ——
 // 而毫无预警地撞上上限、直接吃一个错误，才是真正会让人懵的那种体验。
@@ -869,6 +869,13 @@ export default function ChatPage() {
     queryKey: ["chatQuota", user?.id ?? "anon"],
     queryFn: getChatQuota,
   });
+
+  // sessionStorage 本身不是响应式的，但它被置位的那一刻 401 拦截器刚调过
+  // logout()，store 一变本组件就会重渲染 —— 借这个时机重读即可。挂在
+  // [user, quota] 上而不是在渲染里直接读，是为了不让 React Compiler 面对一个
+  // 每次渲染结果都可能不同的裸调用。
+  const [expired, setExpired] = useState(sessionExpired);
+  useEffect(() => { setExpired(sessionExpired()); }, [user, quota]);
 
   const filteredSessions = useMemo(
     () => sessions?.filter((s) => !sessionFilter || (s.title || "").includes(sessionFilter)),
@@ -1946,20 +1953,24 @@ export default function ChatPage() {
                 }
               />
             </DraggableModal>
-            {!user && !keyStatus?.has_api_key && quota && quota.remaining >= 0 && (
+            {/* 过期者此刻确实是游客，但对他说「登录后额度更多」是答非所问 ——
+                他刚才就是登录状态。这一条让位给下面那句过期说明。 */}
+            {!user && !expired && !keyStatus?.has_api_key && quota && quota.remaining >= 0 && (
               <Alert
                 message={<span>{t("chat.quota_info", { limit: quota.limit, remaining: quota.remaining })}<a onClick={() => navigate("/login")}>{t("chat.login")}</a>{t("chat.login_quota_hint")}</span>}
                 type={quota.remaining <= 2 ? "warning" : "info"} showIcon closable
                 style={{ marginBottom: 8, fontSize: 12 }}
               />
             )}
-            {/* 本地还存着 user，后端却说没认证 —— 只可能是 token 过期了。
-                此时后端返回的是匿名配额，拿它去渲染任何「剩余 N 次」都是编造：
-                实测有用户今日只用 1 次（真实剩余 199）却被告知剩 10 次。
-                更要紧的是 /chat/stream 走的是同一套鉴权，过期后配额降为按 IP
-                共享的 10 次、会话不再存进账号 —— 所以这里必须让用户知道。
-                不自动登出：会把正在输入的内容和上下文一起清掉。 */}
-            {user && quota && !quota.authenticated && (
+            {/* 「登录态是自己死的」这件事，只能靠标记传下来：401 拦截器会先
+                logout() 把 user 清空，此后 user==null 与「从没登录过」完全一样。
+                这里不能只判 user —— 实测那样横幅只在 401 到达前闪一下就没了。
+
+                为什么必须说出来：/chat/quota 对过期 token 返回的是 200 + 游客
+                数字（不是 401），而 /chat/stream 走同一套鉴权，过期后配额降为
+                按 IP 共享的 10 次、会话不再存进账号。用户以为自己登着录，实际
+                提问正被算作游客、历史正在丢。 */}
+            {(expired || (user && quota && !quota.authenticated)) && (
               <Alert
                 message={
                   <span>

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useAuthStore, type UserProfile } from "./authStore";
+import { markSessionExpired, sessionExpired, useAuthStore, type UserProfile } from "./authStore";
 
 const mockUser: UserProfile = {
   id: 1,
@@ -69,5 +69,47 @@ describe("authStore", () => {
     useAuthStore.getState().setAuth("admin-token", adminUser);
 
     expect(useAuthStore.getState().user?.role).toBe("admin");
+  });
+});
+
+// ── 「登录态是自己死的」这个事实必须活过 logout ────────────────────────
+//
+// 401 拦截器的处理是 logout()，而 logout() 会把 user 清空 —— 此后
+// user==null 与「从没登录过」完全一样。实测正是如此：手工把 token 改坏后
+// 进 /chat，两条横幅一条都不出现，因为 user 已经被抹了。所以到期这件事得
+// 单独留一个标记，否则页面没法告诉用户"你现在是游客身份在提问"。
+
+describe("会话过期标记", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    useAuthStore.setState({ token: null, user: null });
+  });
+
+  it("置位后可读到", () => {
+    expect(sessionExpired()).toBe(false);
+    markSessionExpired();
+    expect(sessionExpired()).toBe(true);
+  });
+
+  it("承重点: 重新登录会清掉标记——否则修好了提示还在", () => {
+    markSessionExpired();
+    useAuthStore.getState().setAuth("fresh-token", mockUser);
+    expect(sessionExpired()).toBe(false);
+  });
+
+  it("承重点: 主动登出不算过期——它清标记，只有 401 那条路才置位", () => {
+    useAuthStore.getState().setAuth("t", mockUser);
+    markSessionExpired();
+    useAuthStore.getState().logout();
+    expect(sessionExpired()).toBe(false);
+  });
+
+  it("顺序敏感: 401 路径必须先 logout 再置位，反过来会被自己清掉", () => {
+    // 复现 client.ts 拦截器里的真实调用顺序。
+    useAuthStore.getState().setAuth("dead-token", mockUser);
+    useAuthStore.getState().logout();
+    markSessionExpired();
+    expect(sessionExpired()).toBe(true);
+    expect(useAuthStore.getState().user).toBeNull();
   });
 });

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -18,13 +18,38 @@ interface AuthState {
   logout: () => void;
 }
 
+/**
+ * Set when the 401 interceptor logs someone out, i.e. their session died on its
+ * own rather than at their request. It has to live outside the auth store
+ * because that store is exactly what gets cleared: by the time any UI can react,
+ * `user` is already null and "expired" is indistinguishable from "never logged
+ * in". sessionStorage (not localStorage) so it dies with the tab and cannot
+ * outlive the situation it describes.
+ */
+export const SESSION_EXPIRED_KEY = "fojin.auth.expired";
+
+export function markSessionExpired(): void {
+  try { sessionStorage.setItem(SESSION_EXPIRED_KEY, "1"); } catch { /* ignore */ }
+}
+
+export function clearSessionExpired(): void {
+  try { sessionStorage.removeItem(SESSION_EXPIRED_KEY); } catch { /* ignore */ }
+}
+
+export function sessionExpired(): boolean {
+  try { return sessionStorage.getItem(SESSION_EXPIRED_KEY) === "1"; } catch { return false; }
+}
+
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       token: null,
       user: null,
-      setAuth: (token, user) => set({ token, user }),
-      logout: () => set({ token: null, user: null }),
+      // A fresh sign-in ends the expired state — otherwise the notice would
+      // survive the very act that fixes it.
+      setAuth: (token, user) => { clearSessionExpired(); set({ token, user }); },
+      // Deliberate sign-out is not an expiry; only the 401 path marks it.
+      logout: () => { clearSessionExpired(); set({ token: null, user: null }); },
     }),
     { name: "fojin-auth" },
   ),

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -28,16 +28,40 @@ interface AuthState {
  */
 export const SESSION_EXPIRED_KEY = "fojin.auth.expired";
 
+// sessionStorage is not reactive, so components read it through
+// useSyncExternalStore — the supported way to subscribe React to an external
+// mutable source. The earlier shape (useState + an effect that re-read on every
+// [user, quota] change) piggybacked on unrelated re-renders and tripped
+// react-hooks/set-state-in-effect; this fires exactly when the value changes.
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  listeners.forEach((l) => l());
+}
+
+export function subscribeSessionExpired(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => { listeners.delete(onChange); };
+}
+
 export function markSessionExpired(): void {
   try { sessionStorage.setItem(SESSION_EXPIRED_KEY, "1"); } catch { /* ignore */ }
+  notify();
 }
 
 export function clearSessionExpired(): void {
   try { sessionStorage.removeItem(SESSION_EXPIRED_KEY); } catch { /* ignore */ }
+  notify();
 }
 
+/** getSnapshot for useSyncExternalStore — a primitive, so Object.is is enough. */
 export function sessionExpired(): boolean {
   try { return sessionStorage.getItem(SESSION_EXPIRED_KEY) === "1"; } catch { return false; }
+}
+
+/** getServerSnapshot — the prerender worker has no session to have lost. */
+export function sessionExpiredServer(): boolean {
+  return false;
 }
 
 export const useAuthStore = create<AuthState>()(


### PR DESCRIPTION
#1196 上线后到生产实测才发现的：手工构造「`user` 在、token 已坏」的状态进 `/chat`，**过期横幅一条都不出现**。

## 为什么

401 拦截器（`client.ts`）的处理就是 `logout()`，而 `logout()` 会把 `user` 清空。此后 `user == null`，与「从没登录过」完全一样 —— 而 #1196 的横幅条件是 `user && !quota.authenticated`，等 401 回来时这个条件已经不可能成立。横幅最多在 401 到达前闪一下。

## 顺带纠正一处归因

用户报的现象，**主因其实是 #1196 的第 2 项（queryKey 缓存），不是 token 过期**：

游客态下 `/chat` 把匿名配额 `remaining: 10` 缓存到常量 key → 登录后 key 没变 + 5 分钟 `staleTime` 继续吃它 → `user` 有了、数字还是 10。

这才是「即便登录后也会出现」的字面解释 —— **正是因为登录了才出现**。该用户 `daily_chat_count=1` 也说明他当时 token 是有效的。我先前把它整个归到 token 过期，是过度归因；那条路径真实存在，但会被 401 自我了结。

## 改法

把「登录态是自己死的」这个事实单独留一个标记，让它活过 `logout()`：

- `authStore` 导出 `markSessionExpired` / `sessionExpired` / `clearSessionExpired`，用 **sessionStorage**（不用 localStorage：它该随标签页一起消失，不该活得比它描述的处境还久）
- `setAuth` 和 `logout` 都清标记：重新登录后提示不该还在；主动登出不是过期。**只有 401 那条路置位，且必须置在 `logout()` 之后** —— 反过来会被自己清掉。为这个顺序单写了一个用例
- 流式路径的 401 也置位：它原有的 `onError` 只是行内一次性提示，滚上去就看不见了
- 横幅条件改成 `expired || (user && !authenticated)`；同时让游客那条「登录后额度更多」在 expired 时让位 —— 对一个刚掉线的人说这句是答非所问
- `expired` 用 `useState` + `useEffect([user, quota])` 而不是渲染里裸读 sessionStorage：401 会先 `logout()` 触发 store 变更进而重渲染，借这个时机重读即可，同时避免给 React Compiler 一个每次渲染都可能不同的裸调用

## 验证

- **全套 511 项通过**；新增 7 条用例（ChatPage 3 条 + authStore 4 条）
- **反向对照**：把横幅条件退回 #1196 的 `user && !authenticated`，两条承重用例立刻变红 —— 正是我在生产上看到的那个现象
- `afterEach` 补 `sessionStorage.clear()`：不清的话这个标记会让后面每个用例都以为登录态刚死掉
- tsc / eslint / i18n ratchet 全过
