### PR TITLE
feat(auth): 滑动续期——活跃用户不再每 8 小时被静默降级成游客

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,6 +30,12 @@ class Settings(BaseSettings):
     jwt_secret_key: str = os.environ.get("JWT_SECRET_KEY", _DEFAULT_JWT_SECRET)
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 60 * 8  # 8 hours
+    # Sliding renewal (app/services/token_renewal.py): an authenticated request
+    # past the token's half-life gets a fresh token back, so an active reader is
+    # never logged out mid-use. This caps how long that chain may run — after it,
+    # they sign in again. Not a substitute for revocation: changing a password
+    # bumps password_version and kills every existing token immediately.
+    jwt_absolute_max_days: int = 30
 
     # BYOK API key encryption — independent of jwt_secret_key so rotating
     # one doesn't silently destroy the other (see P0-1 audit).  Must be a

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -20,10 +20,43 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     return bcrypt.checkpw(_truncate(plain_password), hashed_password.encode("ascii"))
 
 
-def create_access_token(user_id: int, password_version: int = 0) -> str:
-    expire = datetime.now(UTC) + timedelta(minutes=settings.jwt_expire_minutes)
-    payload = {"sub": str(user_id), "pwd_v": password_version, "exp": expire}
+def create_access_token(
+    user_id: int,
+    password_version: int = 0,
+    *,
+    original_issued_at: datetime | None = None,
+) -> str:
+    """Mint an access token.
+
+    ``original_issued_at`` carries the *session's* start across sliding renewals
+    (see app/services/token_renewal.py): a renewed token gets a fresh ``exp`` but
+    keeps the original ``oit``, so a chain of renewals still ages against the
+    absolute cap instead of living forever. Omit it for a real sign-in — the
+    session starts now.
+    """
+    now = datetime.now(UTC)
+    expire = now + timedelta(minutes=settings.jwt_expire_minutes)
+    payload = {
+        "sub": str(user_id),
+        "pwd_v": password_version,
+        "exp": expire,
+        "oit": int((original_issued_at or now).timestamp()),
+    }
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+def decode_token_claims(token: str) -> dict | None:
+    """Full verified payload, or None if the token does not verify.
+
+    ``verify_token`` deliberately narrows to (user_id, password_version) — the
+    only things an authorization decision may rest on. Renewal additionally
+    needs ``exp`` and ``oit``, hence this second entry point rather than a wider
+    return type that every caller would have to ignore.
+    """
+    try:
+        return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+    except (PyJWTError, ValueError):
+        return None
 
 
 def verify_token(token: str) -> tuple[int, int] | None:

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,8 +9,22 @@ from app.models.user import User
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
+# Key on request.state where a *successfully authenticated* request leaves what
+# TokenRenewalMiddleware needs to mint a replacement. Only ever set after the
+# password_version check has passed, so renewal can never resurrect a session
+# the user revoked by changing their password. `scope["state"]` is shared
+# between the dependency's Request and the middleware's (verified, not assumed).
+RENEWABLE_STATE_ATTR = "fojin_renewable_token"
+
+
+def _mark_renewable(request: Request | None, token: str, user: User) -> None:
+    if request is None:
+        return
+    setattr(request.state, RENEWABLE_STATE_ATTR, (token, user.id, user.password_version))
+
 
 async def get_current_user(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     db: AsyncSession = Depends(get_db),
 ) -> User:
@@ -28,6 +42,7 @@ async def get_current_user(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="用户不存在或已禁用")
     if user.password_version != token_pwd_v:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="凭证已失效，请重新登录")
+    _mark_renewable(request, credentials.credentials, user)
     return user
 
 
@@ -57,7 +72,12 @@ async def resolve_optional_user(token: str | None, db: AsyncSession) -> User | N
 
 
 async def get_optional_user(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     db: AsyncSession = Depends(get_db),
 ) -> User | None:
-    return await resolve_optional_user(credentials.credentials if credentials else None, db)
+    token = credentials.credentials if credentials else None
+    user = await resolve_optional_user(token, db)
+    if user is not None and token:
+        _mark_renewable(request, token, user)
+    return user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,11 +11,14 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
+from app.core.auth import create_access_token, decode_token_claims
+from app.core.deps import RENEWABLE_STATE_ATTR
 from app.core.elasticsearch import close_es, get_es, init_es
 from app.core.exceptions import FoJinError, fojin_error_to_http
 from app.core.rate_limit import RateLimitMiddleware
 from app.core.version import get_deploy_identity
 from app.database import engine as async_engine
+from app.services.token_renewal import original_issued_at, should_renew
 
 try:
     from app.services.dianjin import get_dianjin_client
@@ -54,7 +57,7 @@ else:
     _app_logger.propagate = False
 
 logger = logging.getLogger(__name__)
-from datetime import UTC
+from datetime import UTC, datetime
 
 from app.api import (
     admin,
@@ -332,6 +335,8 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "Accept", "X-Requested-With"],
+    # 自定义响应头默认对 JS 不可见；不暴露的话跨源部署下续期头会被静默丢弃。
+    expose_headers=["X-Renewed-Token"],
 )
 app.add_middleware(RateLimitMiddleware)
 # GZip handled by nginx — removed from backend to avoid compressing SSE streams
@@ -406,8 +411,59 @@ class LastActiveMiddleware(BaseHTTPMiddleware):
         return response
 
 
+RENEWED_TOKEN_HEADER = "X-Renewed-Token"
+
+
+class TokenRenewalMiddleware(BaseHTTPMiddleware):
+    """Hand back a fresh token when the current one is past its half-life.
+
+    An 8-hour JWT with no refresh means a returning reader is silently demoted
+    to a guest — quota drops from 200/day to an IP-shared 10/day and their
+    conversation stops being saved to their account, with nothing said. Sliding
+    renewal keeps an *active* session alive without a refresh-token store; idle
+    tokens still age out.
+
+    Only acts on requests that actually authenticated: the auth dependency sets
+    ``RENEWABLE_STATE_ATTR`` after its ``password_version`` check, so a token
+    whose session the user revoked (by changing their password) is never
+    renewed. Deciding from the signature alone here would have re-armed exactly
+    the sessions revocation exists to kill.
+
+    Failures are swallowed. A missed renewal costs the reader nothing today —
+    the token is still valid, that is the precondition for renewing at all — so
+    it must never turn a working response into an error.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        renewable = getattr(request.state, RENEWABLE_STATE_ATTR, None)
+        if renewable is None:
+            return response
+        try:
+            token, user_id, pwd_v = renewable
+            claims = decode_token_claims(token)
+            if claims is None:
+                return response
+            now = datetime.now(UTC)
+            if not should_renew(
+                claims,
+                now=now,
+                expire_minutes=settings.jwt_expire_minutes,
+                absolute_max_days=settings.jwt_absolute_max_days,
+            ):
+                return response
+            began = original_issued_at(claims, expire_minutes=settings.jwt_expire_minutes)
+            response.headers[RENEWED_TOKEN_HEADER] = create_access_token(
+                user_id, pwd_v, original_issued_at=began
+            )
+        except Exception:
+            logging.getLogger("app.auth").warning("token renewal skipped", exc_info=True)
+        return response
+
+
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(LastActiveMiddleware)
+app.add_middleware(TokenRenewalMiddleware)
 
 
 @app.exception_handler(FoJinError)

--- a/backend/app/services/token_renewal.py
+++ b/backend/app/services/token_renewal.py
@@ -1,0 +1,98 @@
+"""When a still-valid access token should be swapped for a fresh one.
+
+滑动续期的判定逻辑。
+
+fojin issues an 8-hour JWT and has no refresh token, so a reader who comes back
+the next day is silently demoted to a guest: the quota drops from 200/day to an
+IP-shared 10/day and their conversation stops being saved to their account.
+Nothing tells them — ``get_optional_user`` returns ``None`` for an expired token
+exactly as it does for no token at all. Measured earlier: 52% of chat sessions
+run into the expiry.
+
+Sliding renewal fixes that without a refresh-token store: while someone is
+actively using the site, any authenticated request past the token's half-life
+hands back a fresh one. Idle tokens still age out normally.
+
+This module is pure policy so it can be unit-tested without network, DB or
+clock — the probing/IO lives in ``TokenRenewalMiddleware`` (app/main.py). It
+deliberately does **not** verify signatures or identity: by the time it is
+consulted the request has already authenticated, including the
+``password_version`` check that makes a password change revoke old tokens.
+Renewing on signature validity alone would mint a fresh token for a session the
+user had just revoked.
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+# Renew only in the token's second half. Renewing on every request would mint a
+# token per API call (a chat page fires several) for no added lifetime.
+RENEW_AFTER_FRACTION = 0.5
+
+
+def original_issued_at(claims: dict[str, Any], *, expire_minutes: int) -> datetime | None:
+    """When this *session* began, as opposed to when this token was minted.
+
+    Carried across renewals in ``oit`` so that a chain of renewed tokens still
+    remembers its own start and cannot outrun the absolute cap.
+
+    Tokens minted before ``oit`` existed carry only ``exp`` — but ``exp`` is
+    always issue-time + ``expire_minutes``, so their origin is recoverable
+    exactly. (This holds while ``jwt_expire_minutes`` is unchanged; if it is
+    ever changed, pre-existing tokens are mis-dated by the difference, at worst
+    granting or denying one renewal window near the cap.)
+    """
+    oit = claims.get("oit")
+    if oit is not None:
+        try:
+            return datetime.fromtimestamp(int(oit), UTC)
+        except (TypeError, ValueError, OSError, OverflowError):
+            return None
+    exp = claims.get("exp")
+    if exp is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(exp), UTC) - timedelta(minutes=expire_minutes)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def should_renew(
+    claims: dict[str, Any],
+    *,
+    now: datetime,
+    expire_minutes: int,
+    absolute_max_days: int,
+) -> bool:
+    """True when this token is worth replacing on the current response.
+
+    Four ways to answer no:
+
+    * no ``exp`` — not a token this policy understands;
+    * already expired — renewal is for live sessions. An expired token never
+      authenticated in the first place, so this is unreachable in production,
+      but stating it here keeps the function honest on its own terms;
+    * still in its first half — nothing to gain, and it would mint a token per
+      request;
+    * older than the absolute cap — an active session must not become immortal
+      just because someone keeps clicking. Past the cap they log in again.
+    """
+    exp = claims.get("exp")
+    if exp is None:
+        return False
+    try:
+        expires_at = datetime.fromtimestamp(int(exp), UTC)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return False
+
+    if expires_at <= now:
+        return False
+
+    full_life = timedelta(minutes=expire_minutes)
+    if expires_at - now > full_life * (1 - RENEW_AFTER_FRACTION):
+        return False
+
+    began = original_issued_at(claims, expire_minutes=expire_minutes)
+    if began is None:
+        return False
+    return now - began < timedelta(days=absolute_max_days)

--- a/backend/tests/test_token_renewal_middleware.py
+++ b/backend/tests/test_token_renewal_middleware.py
@@ -1,0 +1,150 @@
+"""端到端：真的会在响应头里发回新 token，且只在该发的时候发。
+
+策略本身在 test_token_renewal_policy.py 里单测。这里管的是接线：中间件能不能
+读到依赖写进 request.state 的东西、头有没有真的发出去、以及最要紧的——**已被
+吊销的会话不能被续期**。
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi import Depends, FastAPI
+
+from app.config import settings
+from app.core.auth import create_access_token, decode_token_claims
+from app.core.deps import get_current_user, get_optional_user
+from app.main import RENEWED_TOKEN_HEADER, TokenRenewalMiddleware
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeUser:
+    def __init__(self, user_id=1, password_version=0):
+        self.id = user_id
+        self.password_version = password_version
+        self.is_active = True
+
+
+def _token(*, expires_in: timedelta, user_id=1, pwd_v=0, oit: datetime | None = None) -> str:
+    """直接签一张任意寿命的 token —— create_access_token 只会签 8 小时的。"""
+    now = datetime.now(UTC)
+    payload = {
+        "sub": str(user_id),
+        "pwd_v": pwd_v,
+        "exp": now + expires_in,
+        "oit": int((oit or now).timestamp()),
+    }
+    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+def _app(*, resolves_to: FakeUser | None):
+    """一个最小应用：真中间件 + 真依赖，只把"查库拿用户"这一步替换掉。"""
+    app = FastAPI()
+    app.add_middleware(TokenRenewalMiddleware)
+
+    @app.get("/protected")
+    async def protected(user=Depends(get_optional_user)):
+        return {"user": getattr(user, "id", None)}
+
+    async def _fake_db():
+        yield None
+
+    from app.core import deps as deps_mod
+    from app.database import get_db
+
+    async def fake_resolve(token, db):
+        # 复刻真实 resolve_optional_user 的规则：签名无效或 pwd_v 不匹配 → None
+        from app.core.auth import verify_token
+
+        if not token:
+            return None
+        payload = verify_token(token)
+        if payload is None or resolves_to is None:
+            return None
+        _uid, token_pwd_v = payload
+        if resolves_to.password_version != token_pwd_v:
+            return None
+        return resolves_to
+
+    app.dependency_overrides[get_db] = _fake_db
+    return app, deps_mod, fake_resolve
+
+
+async def _get(monkeypatch, *, token: str, resolves_to: FakeUser | None):
+    import httpx
+
+    app, deps_mod, fake_resolve = _app(resolves_to=resolves_to)
+    monkeypatch.setattr(deps_mod, "resolve_optional_user", fake_resolve)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        return await c.get("/protected", headers={"Authorization": f"Bearer {token}"})
+
+
+async def test_half_expired_token_comes_back_renewed(monkeypatch):
+    resp = await _get(monkeypatch, token=_token(expires_in=timedelta(hours=1)), resolves_to=FakeUser())
+    assert resp.status_code == 200
+    fresh = resp.headers.get(RENEWED_TOKEN_HEADER)
+    assert fresh, "过半程的请求应当带回一张新 token"
+    claims = decode_token_claims(fresh)
+    assert claims is not None
+    # 新 token 寿命是满的，但会话起点保持不变
+    assert claims["exp"] > (datetime.now(UTC) + timedelta(hours=7)).timestamp()
+    assert claims["sub"] == "1"
+
+
+async def test_fresh_token_is_left_alone(monkeypatch):
+    resp = await _get(monkeypatch, token=_token(expires_in=timedelta(hours=7)), resolves_to=FakeUser())
+    assert resp.status_code == 200
+    assert RENEWED_TOKEN_HEADER not in resp.headers
+
+
+async def test_anonymous_request_gets_no_token(monkeypatch):
+    """没认证成功就没有续期凭据——中间件应当什么都不做。"""
+    resp = await _get(monkeypatch, token=_token(expires_in=timedelta(hours=1)), resolves_to=None)
+    assert resp.status_code == 200
+    assert RENEWED_TOKEN_HEADER not in resp.headers
+
+
+async def test_revoked_session_is_never_renewed(monkeypatch):
+    """⭐ 安全承重点：用户改过密码（password_version 已加一）之后，
+    旧 token 即便签名有效、即便正好过了半程，也绝不能被换发新证。
+
+    如果中间件只凭签名判断——这是最容易写出来的版本——改密码这个吊销手段就被
+    绕过了：旧会话会在每次请求里自动拿到一张全新的 token，永远吊销不掉。
+    """
+    stale = _token(expires_in=timedelta(hours=1), pwd_v=0)
+    resp = await _get(monkeypatch, token=stale, resolves_to=FakeUser(password_version=1))
+    assert resp.status_code == 200
+    assert resp.json()["user"] is None, "pwd_v 不匹配时本就不该认证成功"
+    assert RENEWED_TOKEN_HEADER not in resp.headers, "吊销的会话被续期了——密码吊销形同虚设"
+
+
+async def test_session_past_absolute_cap_stops_renewing(monkeypatch):
+    ancient = datetime.now(UTC) - timedelta(days=settings.jwt_absolute_max_days + 1)
+    resp = await _get(
+        monkeypatch,
+        token=_token(expires_in=timedelta(hours=1), oit=ancient),
+        resolves_to=FakeUser(),
+    )
+    assert resp.status_code == 200
+    assert RENEWED_TOKEN_HEADER not in resp.headers
+
+
+async def test_renewed_token_keeps_the_original_session_start(monkeypatch):
+    """续期链必须一直带着原始 oit，否则上限每次都重新计时 = 没有上限。"""
+    began = datetime.now(UTC) - timedelta(days=10)
+    resp = await _get(
+        monkeypatch,
+        token=_token(expires_in=timedelta(hours=1), oit=began),
+        resolves_to=FakeUser(),
+    )
+    fresh = resp.headers[RENEWED_TOKEN_HEADER]
+    claims = decode_token_claims(fresh)
+    assert claims["oit"] == int(began.timestamp()), "新 token 把会话起点重置了"
+
+
+async def test_login_token_starts_a_new_session_clock():
+    """真正登录签发的 token，oit 就是现在——不该继承任何旧起点。"""
+    claims = decode_token_claims(create_access_token(1, 0))
+    assert abs(claims["oit"] - datetime.now(UTC).timestamp()) < 5

--- a/backend/tests/test_token_renewal_policy.py
+++ b/backend/tests/test_token_renewal_policy.py
@@ -1,0 +1,112 @@
+"""滑动续期的判定策略（纯函数，无网络/无库/无真实时钟）。
+
+背景：JWT 只有 8 小时且无续期，隔夜回访的用户会被静默降级成游客——配额从
+200/天 掉到按 IP 共享的 10 次，会话不再存进账号，而且没有任何提示。之前量过
+52% 的 chat 会话会撞到。滑动续期让"还在用的人"永不掉线，闲置 token 照常老化。
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.token_renewal import RENEW_AFTER_FRACTION, original_issued_at, should_renew
+
+EXPIRE_MINUTES = 60 * 8
+MAX_DAYS = 30
+NOW = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+
+
+def claims(*, expires_in: timedelta, oit: datetime | None = None) -> dict:
+    payload = {"sub": "1", "pwd_v": 0, "exp": int((NOW + expires_in).timestamp())}
+    if oit is not None:
+        payload["oit"] = int(oit.timestamp())
+    return payload
+
+
+def renew(c: dict) -> bool:
+    return should_renew(c, now=NOW, expire_minutes=EXPIRE_MINUTES, absolute_max_days=MAX_DAYS)
+
+
+# ── 半程阈值 ────────────────────────────────────────────────────────────
+
+
+def test_fresh_token_is_not_renewed():
+    """刚签发的 token 不续——否则每个请求都换一张，白白多签。
+
+    承重点：只断言"快过期时会续"是不够的，一个无条件续期的实现照样能过。
+    """
+    assert renew(claims(expires_in=timedelta(hours=8))) is False
+    assert renew(claims(expires_in=timedelta(hours=5))) is False
+
+
+def test_token_past_half_life_is_renewed():
+    assert renew(claims(expires_in=timedelta(hours=3))) is True
+    assert renew(claims(expires_in=timedelta(minutes=1))) is True
+
+
+def test_the_boundary_itself():
+    """约定：剩余 **小于等于** 半程即续。把阈值钉死，改 RENEW_AFTER_FRACTION 会红。
+
+    两边都不能省：只钉"半程续"而不钉"多一秒不续"的话，一个无条件续期的实现
+    照样能过。
+    """
+    half = timedelta(minutes=EXPIRE_MINUTES * (1 - RENEW_AFTER_FRACTION))
+    assert renew(claims(expires_in=half)) is True
+    assert renew(claims(expires_in=half + timedelta(seconds=1))) is False
+
+
+# ── 绝对上限：活跃会话不能靠续期永生 ────────────────────────────────────
+
+
+def test_session_older_than_cap_is_not_renewed():
+    old = NOW - timedelta(days=MAX_DAYS, minutes=1)
+    assert renew(claims(expires_in=timedelta(hours=1), oit=old)) is False
+
+
+def test_session_just_inside_cap_is_still_renewed():
+    almost = NOW - timedelta(days=MAX_DAYS) + timedelta(minutes=1)
+    assert renew(claims(expires_in=timedelta(hours=1), oit=almost)) is True
+
+
+def test_oit_survives_a_chain_of_renewals():
+    """承重点：续期必须沿用原始 oit，否则每续一次上限就重新计时，等于没有上限。
+
+    模拟连续续期——exp 一直是新的，oit 保持不变，第 31 天必须停下。
+    """
+    began = NOW - timedelta(days=MAX_DAYS, hours=1)
+    fresh_looking = claims(expires_in=timedelta(hours=1), oit=began)
+    assert renew(fresh_looking) is False, "oit 被沿用时应当触到上限"
+    # 反面：如果实现把 oit 重置成"现在"，它就会一直续下去
+    reset_oit = claims(expires_in=timedelta(hours=1), oit=NOW)
+    assert renew(reset_oit) is True, "这正是不能重置 oit 的原因"
+
+
+# ── 老 token（还没有 oit 这个字段）────────────────────────────────────
+
+
+def test_legacy_token_without_oit_recovers_its_origin_from_exp():
+    """上线前签发的 token 没有 oit，但 exp = 签发时刻 + 有效期，可精确还原。"""
+    c = claims(expires_in=timedelta(hours=1))  # 无 oit
+    began = original_issued_at(c, expire_minutes=EXPIRE_MINUTES)
+    assert began == NOW + timedelta(hours=1) - timedelta(minutes=EXPIRE_MINUTES)
+    assert renew(c) is True  # 7 小时前签的，远未到 30 天上限
+
+
+# ── 说不的其余理由 ──────────────────────────────────────────────────────
+
+
+def test_expired_token_is_never_renewed():
+    """已过期的 token 不续。生产上不可达（它根本没通过鉴权），但函数自身要自洽。"""
+    assert renew(claims(expires_in=timedelta(seconds=-1))) is False
+
+
+@pytest.mark.parametrize("bad", [{}, {"exp": None}, {"exp": "not-a-number"}, {"exp": object()}])
+def test_unparseable_claims_never_renew(bad):
+    """判不出来就不续——绝不能因为解析失败而误发一张新证。"""
+    assert should_renew(bad, now=NOW, expire_minutes=EXPIRE_MINUTES, absolute_max_days=MAX_DAYS) is False
+
+
+def test_unparseable_oit_falls_back_to_no_renewal():
+    c = claims(expires_in=timedelta(hours=1))
+    c["oit"] = "garbage"
+    assert renew(c) is False

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, it, expect, beforeEach, vi } from "vitest";
 import axios from "axios";
 import type { AxiosError, InternalAxiosRequestConfig, AxiosResponse } from "axios";
-import { useAuthStore } from "../stores/authStore";
+import { useAuthStore, type UserProfile } from "../stores/authStore";
 import { api } from "./client";
 import i18n from "../i18n";
 import enTranslation from "../../public/locales/en/translation.json";
@@ -30,6 +30,20 @@ const responseErrorInterceptor = realInterceptor<(e: AxiosError) => Promise<neve
   api.interceptors.response,
   "rejected",
 );
+
+const responseOkInterceptor = realInterceptor<(r: AxiosResponse) => AxiosResponse>(
+  api.interceptors.response,
+  "fulfilled",
+);
+
+function makeResponse(headers: Record<string, string>): AxiosResponse {
+  return { status: 200, statusText: "OK", data: {}, headers, config: makeConfig() } as AxiosResponse;
+}
+
+const SOMEONE: UserProfile = {
+  id: 7, username: "reader", email: "r@example.com", display_name: null,
+  role: "user", is_active: true, created_at: "2026-01-01T00:00:00Z",
+};
 
 function makeConfig(url: string = "/test"): InternalAxiosRequestConfig {
   return {
@@ -308,5 +322,46 @@ describe("sendChatMessageStream", () => {
     expect(window.location.href).toBe("/chat");
     expect(callbacks.onError).toHaveBeenCalledWith(expect.any(String), "unauthorized");
     expect(callbacks.onDone).toHaveBeenCalledTimes(1);
+  });
+});
+
+
+// ── 滑动续期：后端过半程时用 X-Renewed-Token 发回新证 ──────────────────
+//
+// 没有这条，8 小时 JWT 无续期意味着活跃用户每天被踢下线一次（实测 52% 的
+// chat 会话会撞到登录态失效）。
+
+describe("响应拦截器 - 滑动续期", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthStore.setState({ token: "old-token", user: SOMEONE });
+  });
+
+  it("收到 X-Renewed-Token 时换掉本地 token", () => {
+    responseOkInterceptor(makeResponse({ "x-renewed-token": "brand-new-token" }));
+    expect(useAuthStore.getState().token).toBe("brand-new-token");
+  });
+
+  it("承重点: 只换 token，user 不能被动过", () => {
+    responseOkInterceptor(makeResponse({ "x-renewed-token": "brand-new-token" }));
+    expect(useAuthStore.getState().user).toEqual(SOMEONE);
+  });
+
+  it("没有这个头时保持原样——绝大多数响应都不带它，这是常态不是异常", () => {
+    responseOkInterceptor(makeResponse({}));
+    expect(useAuthStore.getState().token).toBe("old-token");
+  });
+
+  it("承重点: 本地没有 user 时不接受续期——否则会造出一个只有 token 的半截身份", () => {
+    useAuthStore.setState({ token: null, user: null });
+    responseOkInterceptor(makeResponse({ "x-renewed-token": "brand-new-token" }));
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  it("错误响应上带的续期头也照收（比如一次 404）", () => {
+    const err = makeAxiosError(404);
+    (err.response as AxiosResponse).headers = { "x-renewed-token": "from-a-404" };
+    void responseErrorInterceptor(err).catch(() => {});
+    expect(useAuthStore.getState().token).toBe("from-a-404");
   });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -48,9 +48,29 @@ api.interceptors.request.use((config) => {
 // 清掉身份之后交给路由自己判断：ProtectedRoute 见 user 为空会跳登录并顺手写
 // returnTo；而 /texts、/dictionary、/chat 这些公开页原地降级成游客继续看。
 // 令牌失效的意思是「我不再认识你」，不是「你不能待在这个页面」。
+// 滑动续期：后端在 token 过半程时用 X-Renewed-Token 发回一张新的（见
+// app/main.py TokenRenewalMiddleware）。这里换掉本地那张，活跃用户就不会再
+// 每 8 小时被踢下线一次。只换 token 不动 user —— 身份没变，变的只是凭证。
+// 收不到这个头是完全正常的（token 还在前半程 / 这次请求没认证），不是错误。
+const RENEWED_TOKEN_HEADER = "x-renewed-token";
+
+function adoptRenewedToken(headers: unknown): void {
+  const fresh = (headers as Record<string, string> | undefined)?.[RENEWED_TOKEN_HEADER];
+  if (!fresh) return;
+  const { user } = useAuthStore.getState();
+  // 没有 user 就不该有可续的会话；此时写 token 会造出一个半截身份。
+  if (!user) return;
+  useAuthStore.getState().setAuth(fresh, user);
+}
+
 api.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    adoptRenewedToken(response.headers);
+    return response;
+  },
   (error) => {
+    // 4xx/5xx 上也可能带着续期头（比如一次 404）——照收，别浪费。
+    adoptRenewedToken(error.response?.headers);
     if (
       error.response?.status === 401 &&
       !error.config?.url?.startsWith("/auth/")

--- a/frontend/src/pages/CollectionsPage.test.tsx
+++ b/frontend/src/pages/CollectionsPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
@@ -169,20 +169,26 @@ describe("CollectionsPage", () => {
       });
     });
 
+    // 这两条的「另一种字形不存在」用 screen 断言过，即对**整个 document**
+    // 断言——包含上一个用例可能还没拆干净的那棵树。满负载跑全量时实测会红：
+    // 文档里繁简两棵同时在，于是「繁体在」通过、「简体不在」失败。
+    // 限定在自己这次渲染的容器内，断言才是在说这次渲染的事。
     it("folds catalog titles to simplified for 中文简体 readers", async () => {
       await i18n.changeLanguage("zh");
-      renderPage();
+      const { container } = renderPage();
+      const view = within(container);
 
-      expect(await screen.findByText("瑜伽师地论")).toBeInTheDocument();
-      expect(screen.queryByText("瑜伽師地論")).not.toBeInTheDocument();
+      expect(await view.findByText("瑜伽师地论")).toBeInTheDocument();
+      expect(view.queryByText("瑜伽師地論")).not.toBeInTheDocument();
     });
 
     it("keeps catalog titles traditional for 繁體 readers", async () => {
       await i18n.changeLanguage("zh-Hant");
-      renderPage();
+      const { container } = renderPage();
+      const view = within(container);
 
-      expect(await screen.findByText("瑜伽師地論")).toBeInTheDocument();
-      expect(screen.queryByText("瑜伽师地论")).not.toBeInTheDocument();
+      expect(await view.findByText("瑜伽師地論")).toBeInTheDocument();
+      expect(view.queryByText("瑜伽师地论")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
这是 #1196 / #1197 留下的根因。那两个 PR 让「登录态失效」不再撒谎、不再无声，但**失效本身照旧每 8 小时发生一次**：JWT 无续期，隔夜回访的人被当成游客 —— 配额从 200/天 掉到按 IP 共享的 10 次，会话不再存进账号。之前量过 **52% 的 chat 会话**会撞到。

## 做法

任何**已通过鉴权**的请求，若 token 过了半程，就在响应头 `X-Renewed-Token` 里带回一张新的，前端换掉。活跃用户永不掉线，闲置 token 照常老化。不引入 refresh token 那套存储与吊销机制。

## ⭐ 一个必须避开的安全洞

中间件若只凭「签名有效」就续期，会给一个 `pwd_v` 已失效（用户刚改过密码）的 token 换发新证 —— **密码吊销当场被绕过，旧会话反而靠续期永生**。

所以续期凭据由鉴权依赖在**比对过 `password_version` 之后**写入 `request.state`，中间件只认这个。为它单写了用例，并用「只凭签名」的天真实现做反向对照 —— 两条断言同时变红，证明拦得住。

## ⭐ 绝对上限

新增 `oit`（会话起点）声明，跨续期传递，30 天封顶。**若每次续期都把起点重置，上限等于不存在** —— 这一条也单独测了。老 token 没有 `oit`，但 `exp = 签发时刻 + 有效期`，起点可精确还原。

## 其余取舍

- 只在半程后续，否则一个聊天页几个请求就签几张新 token
- 续期失败一律吞掉：token 本来就还有效（这是续期的前提），不能让一次续期失败把正常响应变成错误
- 策略做成纯函数（`app/services/token_renewal.py`），可脱离网络/库/时钟单测，照 `source_health.py` 的先例
- CORS 加 `expose_headers`，否则跨源部署下这个头对 JS 不可见
- 前端只换 token 不动 `user`；本地没有 `user` 时拒绝接受续期，免得造出半截身份

## ⚠️ 承重假设先验证过

「依赖里写的 `request.state` 能否被 `BaseHTTPMiddleware` 读到」（`scope["state"]` 是否共享）—— 写了个最小 ASGI 探针实测确认，没有靠猜。

## 顺带修一个 flaky

`CollectionsPage` 的繁简两条用例用 `screen` 断言「另一种字形不存在」，即对**整个 document** 断言，包含上个用例还没拆干净的树。满负载跑全量时会红（本分支 4 次里红 2 次，master 3 次全绿 —— **是我加的用例把既有 flake 的触发概率抬上来了，不是新引入的**）。限定到各自的 `container` 后，全量连跑 3 次 516/516 全绿。

## 验证

- 后端新增 **20 条**用例（策略 13 + 中间件 7）
- 前端新增 **5 条**；反向对照：拿掉响应拦截器里的接收逻辑即变红
- 门禁按 CI 原命令逐条跑并**检查退出码**：`eslint --max-warnings 0` / `tsc` / i18n ratchet / ruff 0.9.7 全部 exit 0；前端 516 项、后端 1749 项通过
- 后端另有 3 条与本次无关的红：本机 `cryptography 41.0.7` 缺 `not_valid_after_utc`，仓库钉的是 `50.0.0`；已确认在 master 上同样红
