### PR TITLE
fix(profile): 个人中心也会把游客上限（10）当成本人上限报出来

### DIFF
--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 import type { ReactNode } from "react";
@@ -151,6 +151,34 @@ describe("ProfilePage", () => {
     await screen.findByText(/Adding your own AI API key lifts the platform/);
     // 兜底文案里一个具体次数都不该出现
     expect(container.textContent).not.toMatch(/\d+\s*(free questions|次)/);
+  });
+
+  // 与 /chat 上那个 bug 同源（#1196）：后端对**过期 token** 返回的是游客配额
+  // （limit 10），与"没带 token"一模一样。这个页面只有登录用户看得到，把那个
+  // 10 填进「每日 N 次」，等于告诉一个上限 200 的人他只有 10 次——恰好是上面
+  // 那段注释当初要消灭的硬编码 10。
+  it("承重点: token 过期时不得把游客上限（10）当成本人上限报出来", async () => {
+    useAuthStore.setState({
+      token: "expired-but-still-in-localstorage",
+      user: {
+        id: 1, username: "reader", email: "reader@example.com", display_name: null,
+        role: "user", is_active: true, created_at: "2026-01-10T00:00:00Z",
+      },
+    });
+    // 后端此刻返回的就是这个：游客配额 + authenticated=false
+    vi.mocked(getChatQuota).mockResolvedValue({
+      limit: 10, used: 0, remaining: 10, has_byok: false, authenticated: false,
+    });
+    const { container } = renderPage(<ProfilePage />, "/profile?tab=apikey");
+
+    // 必须等 quota 真的落地再断言。只 findByText 兜底文案的话，初始渲染
+    // （quota 还是 undefined）就已经匹配上了——断言在 query 解析前跑完，
+    // 无论有没有修复都绿。实测过：撤掉修复时这条不会红。
+    await waitFor(() => expect(vi.mocked(getChatQuota)).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/Adding your own AI API key lifts the platform/);
+      expect(container.textContent).not.toMatch(/free questions a day/);
+    });
   });
 
   // ── 从 /chat 来的返回入口 ──────────────────────────────────────────

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -115,8 +115,11 @@ export default function ProfilePage() {
   // 额度上限从接口取，不写死在翻译文件里。此前 profile.byok_description 里硬编码
   // 的「每日 10 次」是匿名用户的限额，而这个页面只有登录用户看得到（他们的实际
   // 上限是 200）—— 数字与 FREE_DAILY_LIMIT_USER 各写一处，迟早再次漂移。
+  // 键里带上用户身份：常量键在登录/登出之间不变，会把上一个身份的答案继续
+  // 端给下一个（全局 staleTime 5 分钟）。/chat 上正是这个缺陷让登录用户看到了
+  // 游客的「剩余 10 次」。
   const { data: quota } = useQuery({
-    queryKey: ["chat-quota"],
+    queryKey: ["chat-quota", user?.id ?? "anon"],
     queryFn: getChatQuota,
     enabled: !!token,
   });
@@ -365,7 +368,12 @@ export default function ProfilePage() {
                   <Space direction="vertical" size="middle" style={{ width: "100%" }}>
                     <Alert
                       message="Bring Your Own Key (BYOK)"
-                      description={quota
+                      // 后端对**过期 token** 返回的是游客配额（limit 10），
+                      // 与"没带 token"一模一样。这个页面只有登录用户看得到，
+                      // 把那个 10 填进「每日 N 次」，等于告诉一个上限 200 的人
+                      // 他只有 10 次 —— 恰好是上面那段注释当初要消灭的硬编码。
+                      // 分不清就用不带数字的那句，宁可少说也不要说错。
+                      description={quota?.authenticated
                         ? t("profile.byok_description", { limit: quota.limit })
                         : t("profile.byok_description_generic")}
                       type="info"


### PR DESCRIPTION
复核「用户报的问题是否全修好了」时查出的**同源残留**。#1196 只修了 `/chat`，但 `ProfilePage` 用的是同一个 `/chat/quota`：

```js
queryKey: ["chat-quota"],                              // 常量键，不含用户身份
t("profile.byok_description", { limit: quota.limit })
```

token 过期时后端返回的是游客配额 `limit: 10`，于是这个**只有登录用户看得到**的页面会显示「每日 10 次」—— 而他的真实上限是 200。

讽刺的是这段代码的注释写着当初就是为了消灭硬编码的「每日 10 次」才改成从接口取的：

> 此前 `profile.byok_description` 里硬编码的「每日 10 次」是匿名用户的限额，而这个页面只有登录用户看得到（他们的实际上限是 200）

过期这条路把同一个数字又请了回来。

## 改法

沿用既有的兜底思路（那句注释写得很好：**宁可不带数字，也不要显示错的数字**）：`authenticated` 为假就用 `byok_description_generic`，同时给 `queryKey` 带上用户身份。

## ⚠️ 这条用例我第一版写成了恒真的

它先 `findByText` 兜底文案再断言 —— 而**初始渲染（`quota` 还是 undefined）就已经是兜底文案**，断言在 query 解析之前就跑完，撤掉修复也照样绿。

改成先 `waitFor` 到 `getChatQuota` 被调用、再 `waitFor` 断言最终文本，撤掉修复即变红。

## 验证

- 前端 **517 项**通过
- 反向对照：撤掉 `authenticated` 判据 → 新用例变红（改正后）
- `eslint --max-warnings 0` / `tsc` / i18n ratchet 均 exit 0
