### PR TITLE
feat(mcp): get_parallels 返回 source_chunks，让调用方能把平行段收敛到一段原文

### DIFF
--- a/mcp-server/fojin_mcp/client.py
+++ b/mcp-server/fojin_mcp/client.py
@@ -291,14 +291,25 @@ def shape_parallels(data: Any) -> dict[str, Any]:
 
     ``source="mitra-parallel"`` rows are inline foreign (Skt/Tib) sentences from
     MITRA with text_id 0 — no fojin work to cite, so they stay urn=None but keep
-    their ``original_preview``/``original_lang`` text."""
+    their ``original_preview``/``original_lang`` text.
+
+    We also emit ``source_chunks`` — the Chinese text of each chunk that has
+    parallels, keyed by the same index ``aligns_source_chunk`` refers to.
+    Without it that field is a bare integer with no referent: a caller holding a
+    passage cannot tell which chunk it falls in, so it cannot narrow 600+
+    fascicle-wide parallels down to the ones facing its passage. Only chunks
+    that actually carry parallels are emitted; the rest would be dead weight."""
     d = data if isinstance(data, dict) else {}
     out: list[dict[str, Any]] = []
+    source_chunks: list[dict[str, Any]] = []
     for entry in _as_list(d, "entries"):
         if not isinstance(entry, dict):
             continue
         src_chunk = entry.get("chunk_index")
-        for p in _as_list(entry, "parallels"):
+        entry_parallels = _as_list(entry, "parallels")
+        if entry_parallels:
+            source_chunks.append({"chunk_index": src_chunk, "text": entry.get("chunk_text")})
+        for p in entry_parallels:
             if not isinstance(p, dict):
                 continue
             out.append(
@@ -326,6 +337,7 @@ def shape_parallels(data: Any) -> dict[str, Any]:
             "total_chunks": d.get("total_chunks"),
             "chunks_with_parallels": d.get("chunks_with_parallels"),
         },
+        "source_chunks": source_chunks,
         "parallels": out,
     }
 

--- a/mcp-server/fojin_mcp/server.py
+++ b/mcp-server/fojin_mcp/server.py
@@ -140,8 +140,16 @@ async def get_parallels(text_id: int, juan_num: int) -> dict:
     """Cross-canon parallel passages aligned to a fascicle.
 
     fojin's alignment moat: given a Chinese fascicle, returns the aligned
-    Pali/Tibetan/Sanskrit parallels (each with its own `urn`) so you can compare
-    how a passage is rendered across traditions.
+    Pali/Tibetan/Sanskrit parallels so you can compare how a passage is
+    rendered across traditions.
+
+    A fascicle returns parallels for the *whole* juan — often hundreds. To
+    narrow them to one passage, match the passage against `source_chunks[].text`
+    and keep the parallels whose `aligns_source_chunk` equals that chunk_index.
+
+    `urn` is filled for parallels that are fojin works; rows with
+    `source="mitra-parallel"` are inline Skt/Tib sentences with no fojin work to
+    cite, so they carry `original_preview` instead and stay `urn: null`.
     """
     return await _call("get_parallels", lambda c: c.get_parallels(text_id, juan_num))
 

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -85,6 +85,43 @@ def test_shape_parallels_flattens_real_envelope():
     assert out["parallels"][1]["original_preview"] == "skt sentence"
 
 
+def test_shape_parallels_emits_source_chunks_so_a_passage_can_be_narrowed():
+    """A juan returns parallels for the whole fascicle — T1579.42 returns 685.
+
+    A caller holding one passage needs the few facing that passage, and
+    `aligns_source_chunk` alone cannot get it there: it is a bare index with no
+    referent. `source_chunks` supplies the Chinese text per index, which is what
+    makes narrowing possible at all.
+    """
+    data = {
+        "text_id": 43, "juan_num": 42, "total_chunks": 4, "chunks_with_parallels": 2,
+        "entries": [
+            {"chunk_index": 0, "chunk_text": "云何菩薩善士精進", "parallels": [
+                {"text_id": 0, "juan_num": 0, "chunk_index": 0, "lang": "bo",
+                 "chunk_text": "bo A", "confidence": 1.0, "source": "mitra-parallel"},
+            ]},
+            {"chunk_index": 1, "chunk_text": "無所棄捨精進", "parallels": []},
+            {"chunk_index": 2, "chunk_text": "若於界差別", "parallels": [
+                {"text_id": 0, "juan_num": 0, "chunk_index": 0, "lang": "sa",
+                 "chunk_text": "sa B", "confidence": 0.9, "source": "mitra-parallel"},
+            ]},
+        ],
+    }
+    out = shape_parallels(data)
+
+    # 没有平行段的 chunk 不进来——它对调用方是死重量
+    assert out["source_chunks"] == [
+        {"chunk_index": 0, "text": "云何菩薩善士精進"},
+        {"chunk_index": 2, "text": "若於界差別"},
+    ]
+
+    # 端到端：拿一段原文 → 定位 chunk → 只留面向它的平行段
+    passage = "若於界差別"
+    hit = next(c for c in out["source_chunks"] if passage in (c["text"] or ""))
+    facing = [p for p in out["parallels"] if p["aligns_source_chunk"] == hit["chunk_index"]]
+    assert [p["text"] for p in facing] == ["sa B"]
+
+
 def test_shape_parallels_tolerates_empty():
     assert shape_parallels({})["parallels"] == []
     assert shape_parallels({"entries": []})["parallels"] == []


### PR DESCRIPTION
## Summary

`get_parallels` 返回的是**整卷**的平行段——T1579 第 42 卷实测 **685 条**（藏 345、梵 340），
分布在 21 个 chunk 上。调用方拿着**一段**原文时要的是面向那一段的那几条，但现有字段做不到：

| 字段 | 情况 |
|---|---|
| `aligns_source_chunk` | 有，但是个**光秃秃的整数，没有任何参照物** |
| `read_passage` | 只返回整卷 `content`（9,315 字），**不暴露 chunk 边界** |
| `verify_quote` | 12 个字段里**没有** chunk 索引 |

所以「这条平行段对齐第 7 个 chunk」这句话，调用方无从知道第 7 个 chunk 是哪段汉文。

按字符位置估算不可行：整卷 9,315 字 / 28 chunk ≈ 333 字，某段位于 7,705 位 → 估算落在第 23 chunk，
而 `aligns_source_chunk` 最大只到 20，**估算结果落在无法自证的区间**。切分显然不是等长的，
猜错一个 chunk 会给出**错误的梵藏文，比不给更糟**。

## 做法：后端一行未改

后端本来就返回 `entries[] -> {chunk_index, chunk_text, parallels[]}`，
是 `shape_parallels` 整形时把 `chunk_text` 丢掉了。这里按 `chunk_index` 原样带出来，
**只带有平行段的那些**（无平行段的 chunk 对调用方是死重量）。

调用方现在可以：

```python
hit = next(c for c in out["source_chunks"] if passage in c["text"])
facing = [p for p in out["parallels"] if p["aligns_source_chunk"] == hit["chunk_index"]]
```

## 顺带修正一处文档与实现不符

`get_parallels` 的工具说明原文写着 parallels「each with its own `urn`」，
但 `source="mitra-parallel"` 的行按设计就是 `urn=None`（`client.py` 的 docstring 已说明），
**实测 685 条全部为 null**。说明与实现不符会误导调用方，已改为如实描述。

## Test plan

- [x] `ruff check fojin_mcp/ tests/` —— **All checks passed**（CI 钉的 0.9.7）
- [x] `pytest -q` —— **45 passed**；改动前 stash 掉同样条件跑是 **44 passed**，差值恰为新增那条，**零回归**
- [x] 新增测试做过**变异测试**：去掉 `source_chunks` → 红；把无平行段的 chunk 也塞进来 → 红
- [x] 新增的是**端到端断言**（一段原文 → 定位 chunk → 只留面向它的平行段），不是只断言字段存在

## Notes

**响应体积**：新增约 22 个 chunk × ~333 字 ≈ 7KB，而 parallels 本身已约 68KB，增幅约 10%。
只带有平行段的 chunk 是为了控制这一点。

**本机环境提示**（不影响 CI）：`tests/test_http.py` 在设了 SOCKS 代理变量的机器上会报
`ImportError: Using SOCKS proxy`，与本改动无关；清掉 `*_proxy` 变量后全绿。

**发现来源**：在 Buddhist-AI-Translator 那边试着用 `get_parallels` 做「多本合参自动填充写本」时撞到的——
拿到 685 条平行段却无法收敛到用户粘贴的那一段。
