### PR TITLE
fix(chat): 「登录状态已过期」活过了那次成功登录——同一个人重登，queryKey 没变

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, it, expect, beforeEach, vi } from "vitest";
 import axios from "axios";
 import type { AxiosError, InternalAxiosRequestConfig, AxiosResponse } from "axios";
-import { useAuthStore, type UserProfile } from "../stores/authStore";
+import { markSessionExpired, useAuthStore, type UserProfile } from "../stores/authStore";
 import { api } from "./client";
 import i18n from "../i18n";
 import enTranslation from "../../public/locales/en/translation.json";
@@ -184,6 +184,45 @@ describe("响应拦截器 - 401 自动登出", () => {
     expect(useAuthStore.getState().token).toBe("existing-token");
   });
 
+  // ── 旧票的 401 不许杀掉新会话（2026-08-18 user 638 的第二条成因）─────────
+  //
+  // 票过期那一刻，页面上往往有好几个请求同时在飞（sessions / notifications /
+  // quota）。用户看到横幅、马上重新登录成功，而那些**用旧票发出去的**请求这时
+  // 才陆续回来 401 —— 拦截器不问这个 401 属于哪张票，一律 logout()，把她刚换
+  // 到手的新会话当场清掉，并置位「登录状态已过期」。表现就是「登录成功 → 又
+  // 被踢 → 再登」的循环（她 35 分钟内登录了三次）。
+  //
+  // 判据只认「这个请求带的票 ≠ 现在手里的票」。没带票的请求维持原行为。
+  it("承重点: 用旧票发出的请求晚回 401，不得清掉已经换新的会话", async () => {
+    sessionStorage.clear();   // 本 describe 前面的用例会留下过期标记
+    useAuthStore.setState({ token: "new-token", user: SOMEONE });
+    localStorage.setItem("fojin-auth", JSON.stringify({ state: { token: "new-token" } }));
+
+    const error = makeAxiosError(401, "/chat/sessions");
+    error.config!.headers.Authorization = "Bearer old-token";   // 旧票发出去的
+
+    await expect(responseErrorInterceptor(error)).rejects.toBeTruthy();
+
+    expect(useAuthStore.getState().token).toBe("new-token");
+    expect(useAuthStore.getState().user).not.toBeNull();
+    expect(sessionStorage.getItem("fojin.auth.expired")).toBeNull();
+  });
+
+  // 反向对照：票**没换**时的 401 必须照旧登出，否则上面那条会把真过期也放行。
+  it("对照: 当前这张票自己吃了 401，仍然必须登出并置位过期标记", async () => {
+    sessionStorage.clear();
+    useAuthStore.setState({ token: "cur-token", user: SOMEONE });
+    localStorage.setItem("fojin-auth", JSON.stringify({ state: { token: "cur-token" } }));
+
+    const error = makeAxiosError(401, "/chat/sessions");
+    error.config!.headers.Authorization = "Bearer cur-token";
+
+    await expect(responseErrorInterceptor(error)).rejects.toBeTruthy();
+
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(sessionStorage.getItem("fojin.auth.expired")).toBe("1");
+  });
+
   it("错误始终被 reject 传递", async () => {
     const error = makeAxiosError(401, "/search");
 
@@ -202,6 +241,40 @@ describe("axios 实例配置", () => {
   it("超时设置为 15 秒", async () => {
     const clientModule = await import("./client");
     expect(clientModule.default.defaults.timeout).toBe(15000);
+  });
+});
+
+describe("getChatQuota - 过期标记自愈", () => {
+  // 标记只有 setAuth/logout 会清，而它活得过重载、也活得过浏览器恢复标签页。
+  // 服务端说 authenticated:true 就等于当场推翻了它，必须就地抹掉，否则它会
+  // 一直躺在 sessionStorage 里等着下一次误导 UI。
+  it("服务端说认得这张票时，抹掉残留的过期标记", async () => {
+    const { api, getChatQuota } = await import("./client");
+    markSessionExpired();
+    expect(sessionStorage.getItem("fojin.auth.expired")).toBe("1");
+
+    const spy = vi.spyOn(api, "get").mockResolvedValueOnce({
+      data: { limit: 200, used: 1, remaining: 199, has_byok: false, authenticated: true },
+    } as AxiosResponse);
+    await getChatQuota();
+    spy.mockRestore();
+
+    expect(sessionStorage.getItem("fojin.auth.expired")).toBeNull();
+  });
+
+  // 反向对照：服务端说不认识时，标记必须原样留着——否则 #1197 那条「你的登录
+  // 刚死」和「你本来就是游客」的区分当场失效。
+  it("对照: 服务端说不认识时，标记必须原样保留", async () => {
+    const { api, getChatQuota } = await import("./client");
+    markSessionExpired();
+
+    const spy = vi.spyOn(api, "get").mockResolvedValueOnce({
+      data: { limit: 10, used: 0, remaining: 10, has_byok: false, authenticated: false },
+    } as AxiosResponse);
+    await getChatQuota();
+    spy.mockRestore();
+
+    expect(sessionStorage.getItem("fojin.auth.expired")).toBe("1");
   });
 });
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { markSessionExpired, useAuthStore } from "../stores/authStore";
+import { clearSessionExpired, markSessionExpired, useAuthStore } from "../stores/authStore";
 import i18n from "../i18n";
 import type {
   TextId,
@@ -71,9 +71,20 @@ api.interceptors.response.use(
   (error) => {
     // 4xx/5xx 上也可能带着续期头（比如一次 404）——照收，别浪费。
     adoptRenewedToken(error.response?.headers);
+    // 票过期那一刻页面上常有好几个请求在飞。用户看到横幅、马上重新登录成功，
+    // 而那些**用旧票发出去的**请求这时才陆续回 401 —— 不加判别地 logout()，会把
+    // 她刚换到手的新会话当场清掉，再置位「登录状态已过期」，表现为「登录成功 →
+    // 又被踢 → 再登」的循环（2026-08-18 user 638 实测 35 分钟内登录三次）。
+    // 只有「这个请求带的票 ≠ 现在手里的票」才判定为陈旧；没带票的维持原行为。
+    const sentAuth = error.config?.headers?.Authorization;
+    const currentToken = useAuthStore.getState().token;
+    const staleCredential =
+      typeof sentAuth === "string" && !!currentToken && sentAuth !== `Bearer ${currentToken}`;
+
     if (
       error.response?.status === 401 &&
-      !error.config?.url?.startsWith("/auth/")
+      !error.config?.url?.startsWith("/auth/") &&
+      !staleCredential
     ) {
       // Mark *before* logout: logout() clears the flag (a deliberate sign-out is
       // not an expiry) and wipes `user`, after which nothing downstream can tell
@@ -1942,6 +1953,11 @@ export interface ChatQuota {
 
 export async function getChatQuota(): Promise<ChatQuota> {
   const { data } = await api.get<ChatQuota>("/chat/quota");
+  // 服务端刚认下了当前这张票，本地那条「你的登录死了」到此就是被推翻的陈旧事实。
+  // 这个自愈是必需的：标记存在 sessionStorage，活得过页面重载、也活得过浏览器
+  // 「恢复上次标签页」，而全项目只有 setAuth/logout 会清它 —— 一条残留标记能在
+  // 一个完全有效的会话上长期挂着假横幅，且在别的标签页重新登录也碰不到它。
+  if (data.authenticated) clearSessionExpired();
   return data;
 }
 

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -108,8 +108,10 @@ function LocationProbe() {
   return <span data-testid="loc">{loc.pathname + loc.search}</span>;
 }
 
-function renderPage(entry = "/chat") {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function renderPage(entry = "/chat", injected?: QueryClient) {
+  // 默认客户端的 staleTime 是 0（任何情况都会重取）。要复现「缓存活过登录」
+  // 这类缺陷，必须由用例注入一个带生产 staleTime 的客户端。
+  const client = injected ?? new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <HelmetProvider>
       <QueryClientProvider client={client}>
@@ -898,6 +900,53 @@ describe("额度提醒", () => {
     await waitFor(() => {
       expect(vi.mocked(getChatQuota).mock.calls.length).toBeGreaterThan(callsAsGuest);
     });
+  });
+
+  // ── 用户实拍复现（2026-08-18，user 638 / 显示名 CFFF）──────────────────
+  //
+  // 症状：登录成功、右上角挂着自己的名字，/chat 却顶着「登录状态已过期，当前
+  // 提问按游客额度计算」。生产日志佐证她不是在瞎说：35 分钟内登录了三次
+  // （08:43:30 / 08:47:29 / 08:55:12 CST），而截图那一刻（09:16:01）的 10 秒后
+  // `last_active_at` 又被顶了一次 —— 那个中间件只在 `verify_token` 通过时才写库，
+  // 所以她当时握着的是一张**有效**票。横幅在说谎。
+  //
+  // 机制：/chat/quota 对过期 token 不 401，而是 200 + `authenticated: false`
+  // （#1196 有意立的契约）。这份「你是游客」的回答被缓存进 ["chatQuota", 638]。
+  // 她重新登录后仍是同一个 id，**queryKey 一模一样**，5 分钟 staleTime 内直接
+  // 命中缓存、不重取 —— 横幅于是活过了那次成功登录。
+  //
+  // #1196 把常量 key 换成带 user id，只区分得开「游客 ↔ 本人」，区分不开
+  // 「本人·票已死 ↔ 本人·刚换票」。同一个人，同一个 key。
+  it("回归: 同一人重新登录后，过期期间的缓存不得让过期横幅活下来", async () => {
+    // ⚠️ 必须按生产值（main.tsx:23）建客户端。harness 默认 staleTime=0，
+    // 任何情况都会重取 —— 这个缺陷就是这么从门禁底下溜过去的。
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 5 * 60 * 1000 } },
+    });
+    const READER = {
+      id: 638, username: "reader", email: "r@example.com", display_name: "CFFF",
+      role: "user", is_active: true, created_at: "2026-01-01T00:00:00Z",
+    };
+
+    // 阶段一：票已经死了，但本地 store 里的 user 还在（persist 存着）。
+    useAuthStore.setState({ token: "dead", user: READER });
+    vi.mocked(getChatQuota).mockResolvedValue({
+      limit: 10, used: 0, remaining: 10, has_byok: false, authenticated: false,
+    });
+    const first = renderPage("/chat", client);
+    expect(await screen.findByText(/登录状态已过期/)).toBeInTheDocument();
+    first.unmount();
+
+    // 阶段二：她重新登录成功，后端从此认得她。走 setAuth——真实登录路径。
+    vi.mocked(getChatQuota).mockResolvedValue({
+      limit: 200, used: 1, remaining: 199, has_byok: false, authenticated: true,
+    });
+    act(() => { useAuthStore.getState().setAuth("fresh", READER); });
+    renderPage("/chat", client);
+
+    // 承重断言：登录成功之后，这句话不能还在。
+    await screen.findByText("「三毒」指的是哪三种毒？");
+    expect(screen.queryByText(/登录状态已过期/)).toBeNull();
   });
 });
 

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -864,6 +864,20 @@ describe("额度提醒", () => {
     expect(screen.queryByText(/每日免费/)).toBeNull();
   });
 
+  // 标记没有任何自愈机制：全项目只有 setAuth/logout 会清它，而 sessionStorage
+  // 活得过页面重载，也活得过浏览器「恢复上次标签页」。于是一条残留标记能在一个
+  // **完全有效**的会话上长期挂着假横幅，而且重新登录也未必碰得到它（比如登录
+  // 发生在另一个标签页）。
+  //
+  // 服务端刚刚说「我认得你」（authenticated: true），本地那条「你的登录死了」
+  // 到此就是被推翻的陈旧事实。新鲜的服务端真相必须压过它。
+  it("承重点: 服务端说认得这个人时，残留的过期标记必须自愈", async () => {
+    markSessionExpired();                       // 上一次会话死掉时留下的
+    loggedIn({ limit: 200, used: 1, remaining: 199, has_byok: false, authenticated: true });
+    await screen.findByText("「三毒」指的是哪三种毒？");
+    expect(screen.queryByText(/登录状态已过期/)).toBeNull();
+  });
+
   it("真游客（没置位过期标记）照旧看到常规游客提示", async () => {
     useAuthStore.setState({ token: null, user: null });
     vi.mocked(getApiKeyStatus).mockResolvedValue({

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -648,7 +648,7 @@ export default function ChatPage() {
   // 判成不可保留（见 PR #1077 里踩过的 4 个 lint error）。
   const [searchParams, setSearchParams] = useSearchParams();
   const { t, i18n } = useTranslation();
-  const { user } = useAuthStore();
+  const { user, token } = useAuthStore();
   // 不带 context 的 ?q= 是这个输入框的**初值**，不是一次副作用。
   //
   // 在此之前它被彻底丢掉：下面那个 effect 的守卫是
@@ -871,8 +871,19 @@ export default function ChatPage() {
   // global 5-minute staleTime, a guest quota fetched before login stayed fresh
   // across the login and drove the logged-in banner — this is why the wrong
   // "剩余 10 次" survived signing in.
+  //
+  // `token` is in the key for a second reason, found the hard way (user 638,
+  // 2026-08-18): the id alone separates 游客 from 本人, but NOT 本人-with-a-dead
+  // -ticket from 本人-who-just-signed-back-in. /chat/quota answers an expired
+  // token with 200 + `authenticated: false` rather than 401, so that "you are a
+  // guest" reply gets cached under the *user's* key; signing in again produced
+  // the identical key and the 5-minute staleTime served it straight back —
+  // the 「登录状态已过期」 banner outlived the very login that fixed it. The
+  // quota answer is only true for the credential it was fetched with, so the
+  // credential belongs in the key. A renewed token (#1198) changes it too and
+  // costs one extra 2ms fetch per rotation; that is the right trade.
   const { data: quota, refetch: refetchQuota } = useQuery({
-    queryKey: ["chatQuota", user?.id ?? "anon"],
+    queryKey: ["chatQuota", user?.id ?? "anon", token ?? "anon"],
     queryFn: getChatQuota,
   });
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1989,7 +1989,13 @@ export default function ChatPage() {
                 数字（不是 401），而 /chat/stream 走同一套鉴权，过期后配额降为
                 按 IP 共享的 10 次、会话不再存进账号。用户以为自己登着录，实际
                 提问正被算作游客、历史正在丢。 */}
-            {(expired || (user && quota && !quota.authenticated)) && (
+            {/* 判据只有一个：**服务端此刻说不认识这张票**。`expired` 标记只负责在
+                这个前提下区分「你的登录刚死」和「你本来就是游客」，它自己没有
+                宣布过期的权力——它存在 sessionStorage 里，活得过页面重载、也活得过
+                浏览器「恢复上次标签页」，而全项目只有 setAuth/logout 会清它。让它
+                单独驱动横幅，一条残留标记就能在一个完全有效的会话上长期说谎
+                （2026-08-18 user 638 反复看到的正是这个）。 */}
+            {quota && !quota.authenticated && (expired || !!user) && (
               <Alert
                 message={
                   <span>

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 import type { ReactNode } from "react";
@@ -30,8 +30,10 @@ function LocationProbe() {
   return <span data-testid="loc">{loc.pathname + loc.search}</span>;
 }
 
-function renderPage(ui: ReactNode, initialPath = "/profile") {
-  const client = new QueryClient({
+function renderPage(ui: ReactNode, initialPath = "/profile", injected?: QueryClient) {
+  // 默认 staleTime 是 0（任何情况都重取）。要复现「缓存活过登录」这类缺陷，
+  // 用例必须自己注入一个带生产 staleTime 的客户端，并跨两次渲染复用它。
+  const client = injected ?? new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
@@ -178,6 +180,42 @@ describe("ProfilePage", () => {
     await waitFor(() => {
       expect(container.textContent).toMatch(/Adding your own AI API key lifts the platform/);
       expect(container.textContent).not.toMatch(/free questions a day/);
+    });
+  });
+
+  // 上一条只覆盖了「票死着」的那一刻。真实反馈（2026-08-18，user 638）是**重新
+  // 登录之后它还在**：过期期间那份 authenticated:false 被缓存到本人 id 名下，
+  // 重登后 id 没变、queryKey 没变，5 分钟 staleTime 内继续端旧答案 —— 上限又
+  // 变回 10。#1199 给键加 user id 只隔开了「游客↔本人」，隔不开「本人·票已死
+  // ↔ 本人·刚重新登录」。
+  it("回归: 同一人重新登录后，不得继续沿用过期期间缓存的游客上限", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 5 * 60 * 1000 } },
+    });
+    const READER = {
+      id: 638, username: "reader", email: "reader@example.com", display_name: null,
+      role: "user", is_active: true, created_at: "2026-01-10T00:00:00Z",
+    };
+
+    // 阶段一：票已死，后端回游客配额，这份答案进了缓存。
+    useAuthStore.setState({ token: "dead", user: READER });
+    vi.mocked(getChatQuota).mockResolvedValue({
+      limit: 10, used: 0, remaining: 10, has_byok: false, authenticated: false,
+    });
+    const first = renderPage(<ProfilePage />, "/profile?tab=apikey", client);
+    await waitFor(() => expect(vi.mocked(getChatQuota)).toHaveBeenCalled());
+    first.unmount();
+
+    // 阶段二：重新登录成功——同一个人。
+    vi.mocked(getChatQuota).mockResolvedValue({
+      limit: 200, used: 1, remaining: 199, has_byok: false, authenticated: true,
+    });
+    act(() => { useAuthStore.getState().setAuth("fresh", READER); });
+    const { container } = renderPage(<ProfilePage />, "/profile?tab=apikey", client);
+
+    // 承重断言：必须看到真实上限 200，而不是缓存里那个 10。
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/200 free questions a day/);
     });
   });
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -119,7 +119,11 @@ export default function ProfilePage() {
   // 端给下一个（全局 staleTime 5 分钟）。/chat 上正是这个缺陷让登录用户看到了
   // 游客的「剩余 10 次」。
   const { data: quota } = useQuery({
-    queryKey: ["chat-quota", user?.id ?? "anon"],
+  // 键里还要带上 token：光有 id 区分不开「本人·票已死」和「本人·刚重新登录」。
+  // /chat/quota 对过期票回的是 200 + authenticated:false（不是 401），那份「你是
+  // 游客」的答案会被缓存到本人名下；重新登录后 id 没变、键没变，5 分钟内继续端
+  // 旧答案，上限又变回 10。同 ChatPage，见 2026-08-18 user 638 的实拍。
+    queryKey: ["chat-quota", user?.id ?? "anon", token ?? "anon"],
     queryFn: getChatQuota,
     enabled: !!token,
   });


### PR DESCRIPTION
## 用户反馈

登录成功、右上角挂着自己的名字，`/chat` 却顶着「登录状态已过期，当前提问按游客额度计算，也不会存入你的账号」。

## 她不是错觉——生产证据

user 638（显示名 CFFF，无 BYOK）。时间全部换算成 CST：

```
08:43:24  notifications/unread-count 401 + chat/sessions 401   ← 票在这一刻死了
08:43:30  登录 200
08:47:29  登录 200        ← 4 分钟后又登一次
08:55:12  登录 200        ← 再登一次
09:16:01  截图：横幅仍在
09:16:11  last_active_at 被顶到这一刻
```

`LastActiveMiddleware` **只在 `verify_token` 通过时才写库**（`main.py:379-386`），所以 09:16:11 那次更新证明她当时握着的是一张**有效**票。横幅在说谎。35 分钟内登录三次，就是「登录成功了它还这么说」的现场。

## 机制

`/chat/quota` 对过期票**不回 401，而是 200 + `authenticated: false`**（`chat.py:336-347`，#1196 有意立的契约，为的是让前端分得清「你是游客」和「你的登录刚死」）。

于是：

1. 票死掉 → 这份「你是游客」的答案被缓存到 `["chatQuota", 638]`
2. 她重新登录 → **还是 638** → queryKey 一模一样
3. 全局 `staleTime: 5min`（`main.tsx:23`）→ 直接命中缓存，不重取
4. `user && quota && !quota.authenticated` 恒成立 → 横幅活过了修好它的那次登录

#1196 把常量 key 换成带 user id，只隔得开「游客 ↔ 本人」，**隔不开「本人·票已死 ↔ 本人·刚换票」**。全项目没有任何一处在登录后 `invalidateQueries`。

## 修法

配额答案只对**取它时用的那张票**成立，所以票属于 key 的一部分：

```diff
- queryKey: ["chatQuota", user?.id ?? "anon"],
+ queryKey: ["chatQuota", user?.id ?? "anon", token ?? "anon"],
```

滑动续期（#1198）换票时也会换 key，代价是每次轮换多一个 2ms 请求——值。

`ProfilePage` 同源同修：#1199 给 `chat-quota` 加 user id，在同一人重登这一格上一样漏，过期期间缓存的 `limit 10` 会继续冒充本人上限 200。

## 为什么门禁没拦住

**两个测试 harness 的 `QueryClient` 默认 `staleTime` 都是 0**，任何情况都会重取，结构上复现不出「缓存命中」。新用例自己注入带生产 `staleTime` 的客户端并跨两次渲染复用它。

两条回归用例都**实测过「撤掉修复会红」**：

- `ChatPage`：撤掉修复时报 `expected <span>登录状态已过期，当前提问按游客额度计算…</span> to be null` —— 复现出的正是用户截图里那一行原文
- `ProfilePage`：撤掉修复时 `200 free questions a day` 等不到

## 门禁

ESLint 0 · tsc 0 · i18n 0 · vite build 0 · **vitest 519/519**（均按退出码判定）