### PR TITLE
fix(eval): --no-llm 报告把「没测」印成了「零分」

### DIFF
--- a/backend/eval/run_eval.py
+++ b/backend/eval/run_eval.py
@@ -388,6 +388,14 @@ def generate_report(results: list[dict], tag: str = "") -> str:
     )
     overall_pct = round(overall / 12 * 100, 1)
 
+    # A --no-llm run judges nothing, so every score list is empty and `avg`
+    # returns 0 — which rendered as "综合得分: 0.0%" over a table of zeros. The
+    # nightly gate runs --no-llm, so that is what every recent report says, and
+    # it reads as "the system scored zero" rather than "this run measured no
+    # answers". Same principle the faithfulness section already applies: a note
+    # instead of misleading zeros.
+    judged = any(all_scores[dim] for dim in all_scores)
+
     # Deterministic retrieval metrics (no LLM judge involved).
     retr_agg = aggregate([r["retrieval_metrics"] for r in results if r.get("retrieval_metrics")])
     graded = sum(
@@ -408,13 +416,21 @@ def generate_report(results: list[dict], tag: str = "") -> str:
         f"# AI Chat 评测报告{' — ' + tag if tag else ''}",
         "", f"**日期**: {now}", f"**题目数**: {total}",
         f"**模型**: {results[0].get('model', 'unknown') if results else 'N/A'}",
-        f"**综合得分**: {overall_pct}%",
+        f"**综合得分**: {overall_pct}%" if judged
+        else "**综合得分**: —（本次为 --no-llm 检索评测，未生成回答）",
         "", "## 总体评分", "",
+    ]
+    lines += [
         "| 维度 | 平均分 | 满分 |", "|------|--------|------|",
         f"| 检索相关性 | {avg(all_scores['retrieval_relevance'])} | 3 |",
         f"| 引用准确性 | {avg(all_scores['citation_accuracy'])} | 3 |",
         f"| 回答完整性 | {avg(all_scores['answer_completeness'])} | 3 |",
         f"| 无编造 | {avg(all_scores['no_hallucination'])} | 1 |",
+    ] if judged else [
+        "*本次为 --no-llm 检索评测，未生成回答，故无评分数据。"
+        "下面的检索指标是确定性的，不依赖 LLM 评审。*",
+    ]
+    lines += [
         "", "## 检索指标（确定性，对照黄金来源）", "",
         f"*基于 {graded}/{total} 道有黄金来源标注的题目*",
         "",
@@ -440,20 +456,27 @@ def generate_report(results: list[dict], tag: str = "") -> str:
 
     lines += _faithfulness_section(faith_agg)
 
-    lines += [
-        "## 分类得分", "",
-        "| 分类 | 题数 | 检索 | 引用 | 完整 | 无编造 |",
-        "|------|------|------|------|------|--------|",
-    ]
-
-    for cat in ["term_explanation", "source_lookup", "historical", "comparative", "practice", "out_of_scope"]:
-        if cat in categories:
-            c = categories[cat]
-            lines.append(
-                f"| {cat_names.get(cat, cat)} | {c['count']} "
-                f"| {avg(c['retrieval_relevance'])} | {avg(c['citation_accuracy'])} "
-                f"| {avg(c['answer_completeness'])} | {avg(c['no_hallucination'])} |"
-            )
+    lines += ["## 分类得分", ""]
+    if judged:
+        lines += [
+            "| 分类 | 题数 | 检索 | 引用 | 完整 | 无编造 |",
+            "|------|------|------|------|------|--------|",
+        ]
+        for cat in ["term_explanation", "source_lookup", "historical", "comparative", "practice", "out_of_scope"]:
+            if cat in categories:
+                c = categories[cat]
+                lines.append(
+                    f"| {cat_names.get(cat, cat)} | {c['count']} "
+                    f"| {avg(c['retrieval_relevance'])} | {avg(c['citation_accuracy'])} "
+                    f"| {avg(c['answer_completeness'])} | {avg(c['no_hallucination'])} |"
+                )
+    else:
+        #题数 still carries information without an LLM judge; the four score
+        # columns do not.
+        lines += ["| 分类 | 题数 |", "|------|------|"]
+        for cat in ["term_explanation", "source_lookup", "historical", "comparative", "practice", "out_of_scope"]:
+            if cat in categories:
+                lines.append(f"| {cat_names.get(cat, cat)} | {categories[cat]['count']} |")
 
     total_time = sum(r.get("timing", {}).get("total_s", 0) for r in results)
     avg_time = round(total_time / total, 1) if total else 0

--- a/backend/tests/test_eval_report_no_llm.py
+++ b/backend/tests/test_eval_report_no_llm.py
@@ -1,0 +1,86 @@
+"""`--no-llm` 报告不得把「没测」印成「零分」。
+
+夜间门禁跑的就是 `--no-llm`，所以生产 `eval/reports/` 里最近每一份报告的抬头
+都写着 **综合得分: 0.0%**，底下跟着一张四维全 0 的表 —— 2026-08-21 翻最新报告
+时就是这么读到的。它的真实含义是「这一轮没有生成回答，因此无从评分」，但纸面上
+读起来是「这个系统得零分」。
+
+这不是新问题的新形状：`test_eval_llm_call_config.py` 记的那次事故里，一份
+「90 道题全是空答案」的报告同样把各项印成 0，而我们差点拿它去比较推理档位。
+零和「未测量」在报告里必须长得不一样。
+
+`_faithfulness_section` 早就守着这条规矩（空数据时印一行说明而不是零），
+本测试把同一条规矩钉在 LLM 评审那两张表上。
+"""
+
+from eval.run_eval import generate_report
+
+_RETRIEVAL = {"recall@5": 0.26, "hit@5": 0.342, "mrr": 0.214, "num_gold": 2}
+
+
+def _row(scores: dict) -> dict:
+    return {
+        "id": "q1",
+        "category": "term_explanation",
+        "question": "五蕴是什么？",
+        "scores": scores,
+        "retrieval_metrics": _RETRIEVAL,
+        "timing": {"total_s": 1.5},
+    }
+
+
+_SKIPPED = {
+    "retrieval_relevance": -1,
+    "citation_accuracy": -1,
+    "answer_completeness": -1,
+    "no_hallucination": -1,
+    "reason": "LLM skipped",
+}
+_JUDGED = {
+    "retrieval_relevance": 3,
+    "citation_accuracy": 3,
+    "answer_completeness": 2,
+    "no_hallucination": 1,
+}
+
+
+class TestNoLlmRun:
+    def test_does_not_claim_a_zero_overall_score(self):
+        report = generate_report([_row(_SKIPPED)])
+        assert "**综合得分**: 0.0%" not in report
+        assert "未生成回答" in report
+
+    def test_says_why_the_scores_are_absent(self):
+        report = generate_report([_row(_SKIPPED)])
+        # The four judged dimensions must not appear as a table of zeros.
+        assert "| 检索相关性 | 0 | 3 |" not in report
+        assert "| 检索相关性 | 0.0 | 3 |" not in report
+        assert "无评分数据" in report
+
+    def test_still_reports_deterministic_retrieval_metrics(self):
+        # The whole point of a --no-llm run: these are measured and must survive.
+        report = generate_report([_row(_SKIPPED)])
+        assert "0.342" in report
+        assert "检索指标" in report
+
+    def test_category_table_keeps_question_counts(self):
+        # Whole line, not a prefix: "| 名相解释 | 2 |" is also a prefix of the
+        # old zero-padded row, so a substring check would pass either way and
+        # discriminate nothing.
+        report = generate_report([_row(_SKIPPED), _row(_SKIPPED)])
+        assert "\n| 名相解释 | 2 |\n" in report
+
+
+class TestJudgedRun:
+    def test_reports_the_percentage(self):
+        report = generate_report([_row(_JUDGED)])
+        # 3 + 3 + 2 + 1*3 = 11 out of 12. ("未生成回答" still appears further
+        # down, in the faithfulness section — these rows carry no faithfulness
+        # data, and that section has always said so.)
+        assert "**综合得分**: 91.7%" in report
+        assert "综合得分**: —" not in report
+
+    def test_keeps_the_score_tables(self):
+        report = generate_report([_row(_JUDGED)])
+        assert "| 检索相关性 | 3.0 | 3 |" in report
+        assert "| 名相解释 | 1 | 3.0 | 3.0 | 2.0 | 1.0 |" in report


### PR DESCRIPTION
夜间门禁跑的就是 `--no-llm`，所以生产 `eval/reports/` 里**最近每一份报告**的抬头都写着「综合得分: **0.0%**」，底下跟着一张四维全 0 的表。它的真实含义是「这一轮没有生成回答，因此无从评分」，但纸面上读起来是「这个系统得零分」。

2026-08-21 翻最新报告（`eval-20260820-204730.md`）时就是这么读到的：

```
**综合得分**: 0.0%

| 维度 | 平均分 | 满分 |
| 检索相关性 | 0 | 3 |
| 引用准确性 | 0 | 3 |
...
```

## 成因

`--no-llm` 时每题 `scores` 全是 `-1`，四个列表全空，`avg()` 对空列表返回 `0`，`overall_pct` 于是算成 `0.0`。

## 改法

`_faithfulness_section` 早就守着这条规矩——空数据时印一行说明而不是零，它的 docstring 原话就是 *"returns an explanatory note instead of misleading zeros"*。只是 LLM 评审那两张表一直没沾上这条。现在抬头、总体评分表、分类得分表按同一条规矩走：

```
**综合得分**: —（本次为 --no-llm 检索评测，未生成回答）

## 总体评分

*本次为 --no-llm 检索评测，未生成回答，故无评分数据。下面的检索指标是确定性的，不依赖 LLM 评审。*
```

分类得分表保留**题数**（没有评审也仍然成立），只去掉那四个评分列。检索指标一个字没动——那正是 `--no-llm` 要量的东西。

判据用 `any(all_scores)`（这一轮到底有没有评审过），不用 `skip_llm` 形参：半数题目评审失败的那种局部情况同样该走这条路。

## 为什么值得单独修

零和「未测量」在报告里必须长得不一样。`test_eval_llm_call_config.py` 记的那次事故里，一份「90 道题全是空答案」的报告同样把各项印成 0，而我们差点拿它去比较推理档位——那次的教训写在它的 docstring 里，这次是同一条规矩的另一面。

## 门禁

`ruff check eval/ tests/` 通过 · 新增 6 个用例，eval 相关 **63 passed**

**已实测红/绿**：还原 `run_eval.py` 到 master 后三条断言全红（假零分抬头、零分表、分类表）。分类表那条特意断言**整行** `\n| 名相解释 | 2 |\n` —— `"| 名相解释 | 2 |"` 也是旧补零行的前缀，子串匹配两边都过、什么都不区分。