### PR TITLE
feat(rag): 正藏优先先验——注疏不再把本经挤出上下文（默认关闭）

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -94,6 +94,29 @@ class Settings(BaseSettings):
     mitra_min_score: float = 0.30
     enable_mitra_score_gate: bool = True
 
+    # Canonical-tier prior on RAG results: demote 卍續藏 (cbeta_id "X…", which
+    # is almost entirely commentary) below the root canons before the top-5 cut.
+    # X is 200K of the 425K Chinese chunks, and commentary is terser texts'
+    # natural competitor — it repeats the root's vocabulary at higher term
+    # density, so both vector search and the cross-encoder reward it. 「五蕴是
+    # 什么」 came back with four 心經注疏 and no root sutra.
+    #
+    # Measured on production (2026-08-21, 90-question eval, retrieval only):
+    #   Hit@5 0.342 → 0.384 · lenient Hit@5 0.466 → 0.534 · MRR 0.214 → 0.230
+    #   passage-type Hit@5 0.270 → 0.317 · attribution unchanged at 0.800
+    # The curve saturates at 0.55 and is flat from there to dropping X outright,
+    # so the value below buys the whole effect; anything lower only distorts
+    # scores further. Average X chunks in the served five: 2.24 → 0.79.
+    #
+    # ⚠️ Default OFF. It reorders 71 of 90 served contexts, and the ruler that
+    # measured it has only 2 卍續藏 titles among 89 gold sources — so it cannot
+    # see the case this prior would hurt (a reader asking what a commentator
+    # said). Turn it on together with an LLM-arm faithfulness run, not before.
+    # Never applies in master-persona mode: a Chan master's scoped corpus IS
+    # 語錄 (古尊宿語錄 is an X text), and demoting it there is simply wrong.
+    enable_canonical_prior: bool = False
+    canonical_prior_penalty: float = 0.55
+
     # Sentence-level 逐句对读 read path (Phase 4 Package C). Gates
     # GET /alignment/sentences/{text_id}/{juan_num}, which serves the future
     # reader's sentence-by-sentence parallel view out of ``sentence_alignments``.

--- a/backend/app/services/rag_retrieval.py
+++ b/backend/app/services/rag_retrieval.py
@@ -740,6 +740,48 @@ async def _api_rerank(query: str, results: list[dict]) -> list[dict]:
         return _keyword_rerank(query, results)
 
 
+def _is_continued_canon(result: dict) -> bool:
+    """卍續藏 (X…) — the canon that is almost entirely commentary.
+
+    Keyed on ``cbeta_id``, never on ``buddhist_texts.category``: that column has
+    6,318 NULLs and is not trustworthy for tiering.
+    """
+    return (result.get("cbeta_id") or "").startswith("X")
+
+
+def apply_canonical_prior(results: list[dict], *, scoped: bool = False) -> list[dict]:
+    """Rank root-canon chunks above 卍續藏 commentary, config permitting.
+
+    ``scoped=True`` (master-persona mode, i.e. a caller-supplied
+    ``scope_text_ids``) returns the input untouched: that corpus was chosen
+    deliberately and is frequently 語錄 — 古尊宿語錄 is itself an X text — so
+    demoting it would fight the very selection the persona depends on. The rule
+    lives here rather than at the call site so it is covered by a unit test
+    instead of by reading.
+
+    Commentary out-competes the text it comments on: it restates the root's
+    vocabulary at higher term density, so both the vector search and the
+    cross-encoder score it higher. Left alone, 「五蕴是什么」 comes back with four
+    心經注疏 and no 心經. See ``settings.enable_canonical_prior`` for the measured
+    effect and for why it ships off.
+
+    Sorts on a derived key rather than rewriting ``score``: the score travels to
+    the client on every ChatSource, and a penalised value there would misreport
+    similarity to the reader. Ordering is identical either way — scaling one
+    group by a constant and re-sorting is the same permutation. Python's sort is
+    stable, so chunks that tie keep the reranker's ordering, and nothing is
+    dropped: this only re-ranks, so a query whose only good evidence is a
+    commentary still gets that commentary.
+    """
+    if scoped or not settings.enable_canonical_prior:
+        return results
+    penalty = settings.canonical_prior_penalty
+    return sorted(
+        results,
+        key=lambda r: -(r["score"] * penalty if _is_continued_canon(r) else r["score"]),
+    )
+
+
 async def _rerank(query: str, results: list[dict]) -> list[dict]:
     """Rerank results using API cross-encoder if configured, else keyword-based."""
     if not results:
@@ -987,6 +1029,11 @@ async def retrieve_rag_context(
 
         # Rerank filtered results
         reranked = await _rerank(query, filtered)
+
+        # Canonical-tier prior — must run BEFORE the cut, since its whole job is
+        # to let a root sutra sitting at rank 6-15 take a served slot from the
+        # commentary above it.
+        reranked = apply_canonical_prior(reranked, scoped=bool(scope_text_ids))
 
         # Cap at MAX_CONTEXT_CHUNKS (fewer but more relevant after reranking)
         search_results = reranked[:MAX_CONTEXT_CHUNKS]

--- a/backend/tests/test_canonical_prior.py
+++ b/backend/tests/test_canonical_prior.py
@@ -1,0 +1,141 @@
+"""正藏优先：把 X 藏（卍續藏，几乎全是注疏）排到本经之后。
+
+注疏天生赢过它所注的那部经——它把本经的词汇以更高的术语密度重述一遍，所以向量
+检索和交叉编码器都更爱它。生产实测「五蕴是什么」召回四部心經注疏，本经缺席；
+服务给 LLM 的五条上下文里平均 **2.24 条**是卍續藏。
+
+2026-08-21 在生产管线上按档位扫过一遍（90 题，仅检索，基线臂精确重现了当天
+夜间报告的 0.342 / 0.214，确认复现忠实）：
+
+    档位      top5注疏   Hit@5    宽松Hit@5   MRR      段落题Hit@5
+    基线       2.24      0.342     0.466      0.214     0.270
+    ×0.70      1.08      0.384     0.534      0.221     0.317
+    ×0.55      0.79      0.384     0.534      0.230     0.317
+    ×0.25      0.54      0.384     0.534      0.230     0.317
+    完全剔除    0.11      0.384     0.534      0.234     0.317
+
+曲线在 ×0.55 饱和，此后到「完全剔除 X」都不再变化——真正起作用的只是「把 X 整体
+排到非 X 之后」，档位数值本身不重要。归属题在每个档位都是 0.800，纹丝不动。
+
+⚠️ 这些数字来自一把**几乎不问注疏**的尺子：89 个 gold 标题里只有 2 个是 X 藏
+（古尊宿語錄、淨土聖賢錄）。所以它量得出「找不到本经」这种伤，量不出「读者想看
+某家注疏却被降级」那种伤。默认关闭就是因为这个。
+"""
+
+import pytest
+
+from app.services.rag_retrieval import _is_continued_canon, apply_canonical_prior
+
+
+def _c(cbeta_id: str, score: float) -> dict:
+    return {"cbeta_id": cbeta_id, "score": score, "text_id": 1, "juan_num": 1}
+
+
+@pytest.fixture
+def prior_on(monkeypatch):
+    monkeypatch.setattr("app.services.rag_retrieval.settings.enable_canonical_prior", True)
+    monkeypatch.setattr("app.services.rag_retrieval.settings.canonical_prior_penalty", 0.55)
+
+
+class TestTierDetection:
+    def test_recognises_the_continued_canon(self):
+        assert _is_continued_canon(_c("X0123", 0.5)) is True
+
+    @pytest.mark.parametrize("cid", ["T0251", "J0001", "B0001", "", "GA001"])
+    def test_leaves_every_other_canon_alone(self, cid):
+        assert _is_continued_canon(_c(cid, 0.5)) is False
+
+    def test_survives_a_missing_cbeta_id(self):
+        # LEFT JOIN, so cbeta_id can be None — must not raise.
+        assert _is_continued_canon({"cbeta_id": None, "score": 0.5}) is False
+        assert _is_continued_canon({"score": 0.5}) is False
+
+
+class TestOrdering:
+    def test_root_sutra_overtakes_a_higher_scoring_commentary(self, prior_on):
+        # The production shape: commentary wins the rerank, root sutra sits below.
+        results = [_c("X0523", 0.60), _c("T0251", 0.40)]
+        assert [r["cbeta_id"] for r in apply_canonical_prior(results)] == ["T0251", "X0523"]
+
+    def test_a_commanding_commentary_still_wins(self, prior_on):
+        # 0.90 * 0.55 = 0.495 > 0.40 — the prior demotes, it does not exile.
+        results = [_c("X0523", 0.90), _c("T0251", 0.40)]
+        assert [r["cbeta_id"] for r in apply_canonical_prior(results)] == ["X0523", "T0251"]
+
+    def test_nothing_is_dropped(self, prior_on):
+        results = [_c("X1", 0.9), _c("X2", 0.8), _c("T1", 0.1)]
+        assert len(apply_canonical_prior(results)) == 3
+
+    def test_commentary_only_results_survive_in_rank_order(self, prior_on):
+        # A question whose only real evidence is commentary must still get it.
+        results = [_c("X1", 0.9), _c("X2", 0.5)]
+        assert [r["cbeta_id"] for r in apply_canonical_prior(results)] == ["X1", "X2"]
+
+    def test_ties_keep_the_reranker_order(self, prior_on):
+        results = [_c("T0002", 0.5), _c("T0001", 0.5)]
+        assert [r["cbeta_id"] for r in apply_canonical_prior(results)] == ["T0002", "T0001"]
+
+    def test_does_not_rewrite_the_score_shown_to_the_reader(self, prior_on):
+        # score rides out to the client on every ChatSource; a penalised value
+        # there would misreport similarity.
+        results = [_c("X0523", 0.60), _c("T0251", 0.40)]
+        by_id = {r["cbeta_id"]: r["score"] for r in apply_canonical_prior(results)}
+        assert by_id == {"X0523": 0.60, "T0251": 0.40}
+
+
+class TestDisabledByDefault:
+    def test_off_is_a_no_op(self, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.rag_retrieval.settings.enable_canonical_prior", False
+        )
+        results = [_c("X0523", 0.60), _c("T0251", 0.40)]
+        assert apply_canonical_prior(results) is results
+
+    def test_ships_off(self):
+        from app.config import Settings
+
+        assert Settings.model_fields["enable_canonical_prior"].default is False
+
+
+class TestMasterPersonaCarveOut:
+    """人格模式下不许应用先验——那份语料是特意选的，而且常常本身就是 X 藏。"""
+
+    def test_scoped_retrieval_is_left_alone(self, prior_on):
+        # 古尊宿語錄 is an X text and is exactly what a Chan master's corpus is.
+        results = [_c("X1315", 0.60), _c("T0251", 0.40)]
+        assert apply_canonical_prior(results, scoped=True) is results
+
+    def test_unscoped_is_still_reordered(self, prior_on):
+        results = [_c("X1315", 0.60), _c("T0251", 0.40)]
+        got = apply_canonical_prior(results, scoped=False)
+        assert [r["cbeta_id"] for r in got] == ["T0251", "X1315"]
+
+
+class TestTheShapeItExistsFor:
+    """生产形状：15 条候选里注疏霸榜，本经在第 6 位——它必须挤进前 5。
+
+    这条用例才是先验的价值主张。上面多数断言是**不变量**（不丢行、不改分、
+    平手保序），先验不生效时它们照样成立；把实现改成空操作，只有这里和
+    TestOrdering 里那两条会红。
+    """
+
+    def _pool(self):
+        # Commentary sweeps the rerank; 心經 loses the cosine race to its own
+        # 注疏 and lands 6th — exactly the 「五蕴是什么」 failure.
+        pool = [_c(f"X{i:04d}", 0.90 - i * 0.01) for i in range(5)]
+        pool.append(_c("T0251", 0.80))
+        pool += [_c(f"X{i:04d}", 0.70 - i * 0.01) for i in range(5, 14)]
+        return pool
+
+    def test_root_sutra_misses_the_cut_without_the_prior(self, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.rag_retrieval.settings.enable_canonical_prior", False
+        )
+        served = apply_canonical_prior(self._pool())[:5]
+        assert "T0251" not in [r["cbeta_id"] for r in served]
+
+    def test_root_sutra_takes_a_served_slot_with_it(self, prior_on):
+        served = apply_canonical_prior(self._pool())[:5]
+        assert served[0]["cbeta_id"] == "T0251"
+        # And commentary is not exiled — it still fills the rest.
+        assert sum(1 for r in served if r["cbeta_id"].startswith("X")) == 4


### PR DESCRIPTION
注疏天生赢过它所注的那部经：它把本经的词汇以更高的术语密度重述一遍，所以向量检索和交叉编码器**都**更爱它。卍續藏（`cbeta_id` 前缀 `X`）占汉文语料 200K/425K 块，而实测服务给 LLM 的五条上下文里**平均 2.24 条是注疏**——「五蕴是什么」召回四部心經注疏，本经缺席。

`rag_retrieval.py` 里那两段注释（`MIN_RELEVANCE_SCORE`、`PARALLEL_LZH_K`）早就写明了这个失败模式；本 PR 是在**截断到 5 条之前**给它一个对策。位置是必须的：先验的全部作用就是让排在第 6~15 位的本经拿到一个服务位。

## 生产实测（2026-08-21）

在**真实生产管线**上按档位扫了一遍（90 题，仅检索，通过给 `_rerank` 打运行时补丁完成，未改动生产代码）。**基线臂精确重现了当天夜间报告**（0.342 / 0.214，题型拆分 0.800 / 0.270）——复现忠实，对照才可信。

| 档位 | top5 注疏数 | Hit@5 | 宽松 Hit@5 | MRR | 段落题 Hit@5 | 归属题 |
|---|---|---|---|---|---|---|
| 基线 | 2.24 | 0.342 | 0.466 | 0.214 | 0.270 | 0.800 |
| ×0.70 | 1.08 | 0.384 | 0.534 | 0.221 | 0.317 | 0.800 |
| **×0.55** | 0.79 | **0.384** | **0.534** | **0.230** | **0.317** | 0.800 |
| ×0.40 / ×0.25 | 0.59 / 0.54 | 0.384 | 0.534 | 0.230 | 0.317 | 0.800 |
| 完全剔除 X | 0.11 | 0.384 | 0.534 | 0.234 | 0.317 | 0.800 |

**曲线在 ×0.55 饱和**，此后直到「完全剔除 X」都不再变化——真正起作用的只是「把 X 整体排到非 X 之后」，档位数值本身不重要。所以取 0.55：拿满收益且失真最小。归属题在**每个档位**都纹丝不动，是很好的安全性质。

> 顺带更正一条旧记录：早先记的 **+8.1pp** 是在剥掉 reranker 和三张白名单表的裸向量池上测的（0.113→0.194）。在今天的生产管线上并没有转移过来，真实增益是 **+4.2pp**（严格）/ **+6.8pp**（宽松）。两次基线跑之间 recall@5 有 0.007 的抖动（疑似 reranker API），效应量约是它的 5 倍。

## ⚠️ 为什么默认关闭

1. 它**重排了 90 题里 71 题**的服务上下文——这是对核心产品的大面积行为改动。
2. 量它的那把尺子，89 个 gold 标题里**只有 2 个是 X 藏**（古尊宿語錄、淨土聖賢錄）。所以尺子**结构上看不见**这个先验会误伤的那类人：想看某家注疏怎么讲的读者。
3. 忠实度 eval 目前没有自动化消费者（夜间只跑 `--no-llm`），答案层的影响没人守。

**建议：和一次 LLM 臂忠实度实测一起开**，不要单独开。开法是 `ENABLE_CANONICAL_PRIOR=true`，不需要重新部署镜像。

## 两处设计选择

**人格模式永不应用**：禅师的语料本身就是語錄，`古尊宿語錄` 正是 X 藏——在那里降级等于跟人格的语料选择对着干。这条规则放进纯函数（`scoped=` 形参）而不是调用点，是为了让它**被测试覆盖**而不是只被阅读。

**排序用派生键，不改写 `score`**：score 会随每个 `ChatSource` 送到前端，改了就是向读者误报相似度。两种写法次序完全相同（同一组乘常数再排序是同一个置换），所以上面的测量原样成立。

分层一律用 `cbeta_id` 前缀，不用 `category`——那个字段有 6,318 个 NULL，不可信。

## 门禁

`ruff` 通过 · **19 个用例** · 全量 `pytest` **1768 passed**

做过**变异检验**：把先验改成空操作，三条会红（本经挤进前 5 的生产形状用例 + 两条次序用例）。其余是**不变量**断言——不丢行、不改分、平手保序、注疏独有时仍然给出——先验不生效时它们本就该成立，我不把它们算作覆盖。

`test_health_check_probe` 的 3 个失败是本机 `cryptography` 版本问题，master 上同样失败，与本 PR 无关。