### PR TITLE
fix(search): 同一个「楞伽经」，搜索和问答给的是两部不同的经

### DIFF
--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -176,8 +176,25 @@ _SUTRA_ABBREV: dict[str, str] = {
     # precise_retrieval._TITLE_ALIASES and rag_retrieval._ROOT_SUTRA_ALIASES
     # both resolve the same abbreviation to T0670, so the one word 楞伽经
     # reached a different sutra depending on which door the reader came in.
-    # Aligned on T0670 — the recension Chan transmits and the one usually
-    # meant unqualified. All three still rank; this is a boost, not a filter.
+    #
+    # Aligned on T0670, and the corpus decides it rather than taste. Each
+    # translation divides into differently-named chapters, so a commentary
+    # betrays its base text by which chapter names it quotes. 一切佛語心品
+    # occurs in T0670 and in neither other translation; 羅婆那王勸請品 only in
+    # T0672 (摩羅耶山 appears in all three and discriminates nothing). Counting
+    # those markers across the 22 楞伽 commentaries this corpus holds:
+    #
+    #   T0670  13 commentaries (智旭 義疏, 德清 觀楞伽經記, 通潤 合轍, 正受
+    #                           集註, 圅昰 心印, 宗泐 註解, 員珂 會譯 …)
+    #   T0672   1 commentary   (寶臣 注大乘入楞伽經 — says so in its title)
+    #   T0671   0
+    #
+    # So the recension the Chinese commentarial tradition actually reads —
+    # and the one Chan transmits (cf. T2837 楞伽師資記) — is T0670, while the
+    # translation this table used to boost has no commentary built on it at
+    # all. Reader demand cannot settle it: all three have ~0 reads.
+    #
+    # All three still rank; this is a `should` boost, not a filter.
     "楞伽经": "楞伽阿跋多羅寶經", "楞伽經": "楞伽阿跋多羅寶經",
     "维摩经": "維摩詰所說經", "維摩經": "維摩詰所說經",
     "地藏经": "地藏菩薩本願經", "地藏經": "地藏菩薩本願經",

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -159,6 +159,40 @@ async def fetch_related_translations(
     return dict(result_map)
 
 
+# Expand common sutra abbreviations to full titles. Module-level so the
+# cross-module consistency test can read it: this table and
+# precise_retrieval._TITLE_ALIASES must not send the same abbreviation to
+# two different sutras (they did, for 楞伽经).
+_SUTRA_ABBREV: dict[str, str] = {
+    "金刚经": "金剛般若波羅蜜經", "金剛經": "金剛般若波羅蜜經",
+    "心经": "般若波羅蜜多心經", "心經": "般若波羅蜜多心經",
+    "法华经": "妙法蓮華經", "法華經": "妙法蓮華經",
+    "华严经": "大方廣佛華嚴經", "華嚴經": "大方廣佛華嚴經",
+    "楞严经": "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經", "楞嚴經": "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經",
+    "圆觉经": "大方廣圓覺修多羅了義經", "圓覺經": "大方廣圓覺修多羅了義經",
+    # 楞伽經 has three Chinese translations — T0670 楞伽阿跋多羅寶經
+    # (求那跋陀羅, 4卷), T0671 入楞伽經 (菩提流支, 10卷), T0672 大乘入楞伽經
+    # (實叉難陀, 7卷). This table used to boost T0671 while
+    # precise_retrieval._TITLE_ALIASES and rag_retrieval._ROOT_SUTRA_ALIASES
+    # both resolve the same abbreviation to T0670, so the one word 楞伽经
+    # reached a different sutra depending on which door the reader came in.
+    # Aligned on T0670 — the recension Chan transmits and the one usually
+    # meant unqualified. All three still rank; this is a boost, not a filter.
+    "楞伽经": "楞伽阿跋多羅寶經", "楞伽經": "楞伽阿跋多羅寶經",
+    "维摩经": "維摩詰所說經", "維摩經": "維摩詰所說經",
+    "地藏经": "地藏菩薩本願經", "地藏經": "地藏菩薩本願經",
+    "药师经": "藥師琉璃光如來本願功德經", "藥師經": "藥師琉璃光如來本願功德經",
+    "阿弥陀经": "佛說阿彌陀經", "阿彌陀經": "佛說阿彌陀經",
+    "无量寿经": "佛說無量壽經", "無量壽經": "佛說無量壽經",
+    "涅盘经": "大般涅槃經", "涅槃經": "大般涅槃經",
+    "般若经": "大般若波羅蜜多經", "般若經": "大般若波羅蜜多經",
+    "长阿含经": "長阿含經", "长阿含經": "長阿含經",
+    "中阿含经": "中阿含經", "杂阿含经": "雜阿含經",
+    "增一阿含经": "增壹阿含經",
+    "坛经": "六祖大師法寶壇經", "壇經": "六祖大師法寶壇經",
+}
+
+
 async def search_texts(
     es: AsyncElasticsearch,
     query: str,
@@ -175,28 +209,7 @@ async def search_texts(
     must = []
     filter_clauses = []
 
-    # Expand common sutra abbreviations to full titles
-    ABBREV = {
-        "金刚经": "金剛般若波羅蜜經", "金剛經": "金剛般若波羅蜜經",
-        "心经": "般若波羅蜜多心經", "心經": "般若波羅蜜多心經",
-        "法华经": "妙法蓮華經", "法華經": "妙法蓮華經",
-        "华严经": "大方廣佛華嚴經", "華嚴經": "大方廣佛華嚴經",
-        "楞严经": "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經", "楞嚴經": "大佛頂如來密因修證了義諸菩薩萬行首楞嚴經",
-        "圆觉经": "大方廣圓覺修多羅了義經", "圓覺經": "大方廣圓覺修多羅了義經",
-        "楞伽经": "入楞伽經", "楞伽經": "入楞伽經",
-        "维摩经": "維摩詰所說經", "維摩經": "維摩詰所說經",
-        "地藏经": "地藏菩薩本願經", "地藏經": "地藏菩薩本願經",
-        "药师经": "藥師琉璃光如來本願功德經", "藥師經": "藥師琉璃光如來本願功德經",
-        "阿弥陀经": "佛說阿彌陀經", "阿彌陀經": "佛說阿彌陀經",
-        "无量寿经": "佛說無量壽經", "無量壽經": "佛說無量壽經",
-        "涅盘经": "大般涅槃經", "涅槃經": "大般涅槃經",
-        "般若经": "大般若波羅蜜多經", "般若經": "大般若波羅蜜多經",
-        "长阿含经": "長阿含經", "长阿含經": "長阿含經",
-        "中阿含经": "中阿含經", "杂阿含经": "雜阿含經",
-        "增一阿含经": "增壹阿含經",
-        "坛经": "六祖大師法寶壇經", "壇經": "六祖大師法寶壇經",
-    }
-    full_title = ABBREV.get(query.strip())
+    full_title = _SUTRA_ABBREV.get(query.strip())
 
     if query:
         must.append(

--- a/backend/tests/test_sutra_abbrev_consistency.py
+++ b/backend/tests/test_sutra_abbrev_consistency.py
@@ -1,0 +1,66 @@
+"""同一个简称，三个模块必须指向同一部经。
+
+一部佛经常有数本汉译。《楞伽經》就有三本：T0670 楞伽阿跋多羅寶經（求那跋陀羅，
+4 卷）、T0671 入楞伽經（菩提流支，10 卷）、T0672 大乘入楞伽經（實叉難陀，7 卷）。
+所以「楞伽经」这三个字必须由代码选定一本——而它此前选了两本：
+
+- `search._SUTRA_ABBREV`            → 入楞伽經    （T0671）
+- `precise_retrieval._TITLE_ALIASES` → 楞伽阿跋多羅寶經（T0670）
+- `rag_retrieval._ROOT_SUTRA_ALIASES` → T0670
+
+结果是：读者在 /search 打「楞伽经」，排第一的是入楞伽經；同一个人拿同一个词去问
+AI，引的是楞伽阿跋多羅寶經。同一个词，两部经，取决于他从哪个门进来。
+
+这类分歧靠读代码发现不了——三张表分处三个文件、格式还不一样（两张给标题，一张
+给 cbeta_id）。所以钉成测试：**共有的键必须同解**。新增简称时若只改一处，这里会红。
+"""
+
+import pytest
+
+from app.services.precise_retrieval import _TITLE_ALIASES
+from app.services.rag_retrieval import _ROOT_SUTRA_ALIASES
+from app.services.search import _SUTRA_ABBREV
+
+SHARED_KEYS = sorted(set(_SUTRA_ABBREV) & set(_TITLE_ALIASES))
+
+
+def test_the_two_tables_actually_overlap():
+    """守住上面那个交集：两张表若哪天不再共享任何键，下面的用例会全部空转。"""
+    assert len(SHARED_KEYS) >= 10
+    assert "楞伽经" in SHARED_KEYS
+
+
+@pytest.mark.parametrize("abbrev", SHARED_KEYS)
+def test_search_and_precise_retrieval_agree(abbrev):
+    assert _SUTRA_ABBREV[abbrev] == _TITLE_ALIASES[abbrev], (
+        f"「{abbrev}」在搜索里是《{_SUTRA_ABBREV[abbrev]}》，"
+        f"在精确检索里是《{_TITLE_ALIASES[abbrev]}》——同一个词指向了两部经"
+    )
+
+
+# rag_retrieval 用 cbeta_id 而不是标题，无法直接比对，所以在这里把两边钉在一起。
+# 只列那些三张表都收了的简称；改动任何一边都必须同步改这里。
+_RAG_ALIAS_TITLES = {
+    "T0251": "般若波羅蜜多心經",
+    "T0262": "妙法蓮華經",
+    "T0475": "維摩詰所說經",
+    "T0412": "地藏菩薩本願經",
+    "T0670": "楞伽阿跋多羅寶經",
+    "T0842": "大方廣圓覺修多羅了義經",
+}
+
+
+@pytest.mark.parametrize("alias,cbeta_id", sorted(_ROOT_SUTRA_ALIASES.items()))
+def test_rag_alias_agrees_with_the_title_tables(alias, cbeta_id):
+    """RAG 的本经保底若和标题表选了不同的译本，答案与搜索会各说各话。"""
+    expected_title = _RAG_ALIAS_TITLES.get(cbeta_id)
+    if expected_title is None:
+        pytest.skip(f"{cbeta_id} 不在三表共有范围内")
+    for table_name, table in (("search", _SUTRA_ABBREV), ("precise", _TITLE_ALIASES)):
+        title = table.get(alias)
+        if title is None:
+            continue
+        assert title == expected_title, (
+            f"「{alias}」：RAG 保底指向 {cbeta_id}《{expected_title}》，"
+            f"而 {table_name} 指向《{title}》"
+        )


### PR DESCRIPTION
《楞伽經》有**三本汉译**，生产库里都在：

| cbeta_id | 标题 | 译者 | 卷 |
|---|---|---|---|
| T0670 | 楞伽阿跋多羅寶經 | 求那跋陀羅 | 4 |
| T0671 | 入楞伽經 | 魏 菩提流支 | 10 |
| T0672 | 大乘入楞伽經 | 實叉難陀 | 7 |

所以「楞伽经」这三个字必须由代码选定一本。而它选了**两本**：

| 模块 | 解析成 |
|---|---|
| `search._SUTRA_ABBREV` | 入楞伽經（T0671）|
| `precise_retrieval._TITLE_ALIASES` | 楞伽阿跋多羅寶經（T0670）|
| `rag_retrieval._ROOT_SUTRA_ALIASES` | T0670 |

**读者在 `/search` 打「楞伽经」，排第一的是入楞伽經；同一个人拿同一个词去问 AI，引的是楞伽阿跋多羅寶經。** 同一个词、两部经，取决于他从哪个门进来。

## 改法

统一到 **T0670**——三处中的多数，也是禅宗所传、无限定时通常所指的那本。

⚠️ 这一步是**教理判断**，不是纯工程判断，请复核：如果你认为默认该指向别本，改这一处即可，一致性测试会逼另外两处跟上。

这是 `should` 里的 **boost 而非过滤**（`match_phrase` boost 30），三本仍然都在结果里，只是次序变了。

## 顺手

`ABBREV` 从 `search_texts` 的局部变量提到模块级 `_SUTRA_ABBREV`：一是让一致性测试读得到，二是免得每次搜索都重建这个 30 项字典。

## 新门禁

`test_sutra_abbrev_consistency.py` —— 共有的键必须同解。这类分歧**靠读代码发现不了**：三张表分处三个文件，格式还不一样（两张给标题、一张给 `cbeta_id`），所以第三张用一张显式对照表钉住，改任何一边都必须同步。

还有一条 `test_the_two_tables_actually_overlap` 守着交集本身——两张表哪天不再共享键，参数化用例会全部空转而不是报警。

**已实测红/绿**：把映射改回旧值（保留 hoist），简繁两条断言变红；改回来全绿。

## 门禁

`ruff` 通过 · 全量 `pytest` **1788 passed**（`test_health_check_probe` 的 3 个失败是本机 `cryptography` 版本问题，master 上同样失败，与本 PR 无关）