### PR TITLE
fix(chat): 响应耗时对登录用户从来没显示过——id 在流中途被换掉了

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -283,6 +283,31 @@ describe("ChatPage 首屏结构", () => {
     });
   });
 
+  // 响应耗时必须在**登录用户**身上也成立。这是它上线当天就挂掉的地方：
+  // 后端在 done 之前先发 message_id（chat.py:1356 → :1361），onMessageId 把消息 id
+  // 从 Date.now() 占位符换成真实的 chat_messages.id；而 onDone 里仍按占位符去找那条
+  // 消息，于是再也匹配不上，耗时一个字都没写进去。
+  //
+  // 游客不落库、收不到 message_id，id 一直是占位符 —— 所以以游客身份怎么试都是好的。
+  // 这条用例的关键就是**先发 message_id 再发 done**，复刻登录用户的真实顺序。
+  it("响应耗时: message_id 换过 id 之后，onDone 仍要把耗时记到那条消息上", async () => {
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks) => { cb = callbacks; },
+    );
+    const { container } = await renderEmpty();
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+
+    cb!.onToken("《药师经》以东方净琉璃世界为依报。");
+    cb!.onMessageId?.(31337);   // ← 登录用户才有的这一步
+    cb!.onDone();
+
+    await waitFor(() => {
+      expect(screen.getByText(/共 \d/)).toBeInTheDocument();
+    });
+  });
+
   // 推理进度：把此前被丢弃的 reasoning 增量用作「仍在推进」的实证。
   // 与 retrieved 同一条承重约束 —— 只写独立字段，绝不碰 content（哨兵一旦被顶掉，
   // onDone 的空回复兜底就失效）。

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1323,13 +1323,22 @@ export default function ChatPage() {
     const startedAt = Date.now();
     let firstTokenMs: number | null = null;
 
+    // 这条回答在 messages 里的 id 会**在流中途变**：后端在 done 之前先发
+    // message_id（services/chat.py:1356 → :1361），onMessageId 用真实的
+    // chat_messages.id 换掉 Date.now() 占位符。所以任何在 message_id 之后还要
+    // 找到这条消息的回调，都必须认这个活变量，不能再认 assistantId ——
+    // 2026-08-21 响应耗时上线当天就栽在这里：onDone 按占位符去找，匹配不上，
+    // 耗时一个字都没写进去。而游客不落库、收不到 message_id，id 一直是占位符，
+    // 所以以游客身份怎么试都是好的，只有登录用户看不到。
+    let liveAssistantId = assistantId;
+
     await sendChatMessageStream(msg, sessionId, masterId, {
       onToken: (content: string) => {
         tokenCount += 1;
         if (firstTokenMs === null) firstTokenMs = Date.now() - startedAt;
         setMessages((prev) =>
           prev.map((m) => {
-            if (m.id !== assistantId) return m;
+            if (m.id !== liveAssistantId) return m;
             const current = m.content === THINKING_SENTINEL ? "" : m.content;
             // reasoningText 随首个 token 销毁：被模型自己推翻的中间结论
             // 不能留在屏幕上（渲染层另有一道保险，两道各自独立）。
@@ -1345,14 +1354,14 @@ export default function ChatPage() {
         // re-introduce the hallucination we just stripped.
         setMessages((prev) =>
           prev.map((m) =>
-            m.id === assistantId ? { ...m, content: correctedAnswer } : m,
+            m.id === liveAssistantId ? { ...m, content: correctedAnswer } : m,
           ),
         );
       },
       onSources: (sources: ChatSource[]) => {
         setMessages((prev) =>
           prev.map((m) =>
-            m.id === assistantId ? { ...m, sources } : m,
+            m.id === liveAssistantId ? { ...m, sources } : m,
           ),
         );
         // Prefetch each citation's chunk context so the drawer opens instantly.
@@ -1369,7 +1378,7 @@ export default function ChatPage() {
       onTrustStatus: (trustStatus: ChatTrustStatus) => {
         setMessages((prev) =>
           prev.map((m) =>
-            m.id === assistantId ? { ...m, trust_status: trustStatus } : m,
+            m.id === liveAssistantId ? { ...m, trust_status: trustStatus } : m,
           ),
         );
       },
@@ -1383,7 +1392,7 @@ export default function ChatPage() {
         // 与 onRetrieved 同一条承重约束：只写独立字段，绝不碰 content。
         setMessages((prev) =>
           prev.map((m) => {
-            if (m.id !== assistantId) return m;
+            if (m.id !== liveAssistantId) return m;
             const next = { ...m };
             if (next.reasoningSince == null) next.reasoningSince = Date.now();
             if (r.text) {
@@ -1406,7 +1415,7 @@ export default function ChatPage() {
         // 哨兵，onDone 里「流结束但从未收到 token → 转失败哨兵」的兜底靠它；
         // 一旦 content 被顶掉，用户会永远卡在假的「正在检索…」上且没有重试按钮。
         setMessages((prev) =>
-          prev.map((m) => (m.id === assistantId ? { ...m, retrieval } : m)),
+          prev.map((m) => (m.id === liveAssistantId ? { ...m, retrieval } : m)),
         );
       },
       onMessageId: (realId: number) => {
@@ -1415,8 +1424,12 @@ export default function ChatPage() {
         // correct row. Without this, every freshly-streamed message
         // would PUT feedback to a nonexistent id, which is why
         // production feedback rate is currently zero.
+        // 旧 id 先捕获进 updater 的闭包再改活变量：updater 是延后执行的，
+        // 若先改了活变量，它会去找一个还不存在的 id。
+        const placeholderId = liveAssistantId;
+        liveAssistantId = realId;
         setMessages((prev) =>
-          prev.map((m) => (m.id === assistantId ? { ...m, id: realId } : m)),
+          prev.map((m) => (m.id === placeholderId ? { ...m, id: realId } : m)),
         );
       },
       onSessionId: (newSessionId: number) => {
@@ -1448,7 +1461,7 @@ export default function ChatPage() {
         message.error(errMsg);
         setMessages((prev) =>
           prev.map((m) =>
-            m.id === assistantId && m.content === THINKING_SENTINEL
+            m.id === liveAssistantId && m.content === THINKING_SENTINEL
               ? { ...m, content: REQUEST_FAILED_SENTINEL }
               : m,
           ),
@@ -1478,7 +1491,7 @@ export default function ChatPage() {
         const totalMs = Date.now() - startedAt;
         setMessages((prev) =>
           prev.map((m) => {
-            if (m.id !== assistantId) return m;
+            if (m.id !== liveAssistantId) return m;
             const settled = m.content === THINKING_SENTINEL
               ? { ...m, content: REQUEST_FAILED_SENTINEL }
               : m;


### PR DESCRIPTION
#1210 上线后用户实测看不到耗时。**这个功能只对游客生效过。**

## 根因

这条回答在 `messages` 里的 id **会在流中途变**：

```
后端 SSE 顺序（services/chat.py:1356 → :1361）
  … token* → trust_status → sources → message_id → done
                                       ↑ 就是这里
```

`onMessageId` 用真实的 `chat_messages.id` 换掉发送时那个 `Date.now()` 占位符；而 `onDone` 里仍按**占位符**去找那条消息：

```js
prev.map((m) => { if (m.id !== assistantId) return m; ... })   // ← 再也匹配不上
```

于是 `totalMs` 一个字都没写进去，渲染条件 `m.totalMs != null` 永远不成立。

## 为什么我自己验的时候是好的

游客**不落库** —— `chat.py:1359` 走 `_record_anonymous_message` 分支，`assistant_msg_id` 为 `None`，`message_id` 帧根本不发。id 一直是占位符，所以以游客身份怎么试都正常。

**只有登录用户看不到，而那正是用户的使用方式。** 这是「验证了相邻场景」的又一例：我验的那条路和用户走的那条路不是同一条。

## 修法

把「当前这条回答的 id」做成随 `message_id` 更新的活变量：

```js
let liveAssistantId = assistantId;
…
onMessageId: (realId) => {
  const placeholderId = liveAssistantId;   // 先捕获进 updater 的闭包
  liveAssistantId = realId;                // 再改活变量
  setMessages((prev) => prev.map((m) => (m.id === placeholderId ? { ...m, id: realId } : m)));
},
```

顺序不能反：updater 是延后执行的，若先改了活变量，它会去找一个还不存在的 id。

**八处 id 匹配全部改掉，不只 onDone 那一处。** 其余七处目前都在 `message_id` 之前触发、本来没坏，但同一个陷阱对它们同样成立——SSE 一旦重排顺序，它们会以完全相同的方式静默失效。把整类 bug 一次断掉。

## 回归测试

按**生产真实顺序**驱动：`onToken` → `onMessageId(31337)` → `onDone`，断言耗时出现。**已实测无修复时红**（`Unable to find /共 \d/`）。

以前那 9 条用例抓不到这个：它们直接给 `MessageBubble` 传 `totalMs`，验的是**渲染**，而坏掉的是**接线**。

## 门禁

`i18n:check` OK · `eslint --max-warnings 0` 通过 · `tsc -b --noEmit` 通过 · `vitest` **76 文件 / 545 用例全绿**（ChatPage 自身 69 条全过，覆盖 token/sources/trust/retrieved/error/done 全部走占位符 id 的游客路径，确认这次改动没碰坏它）