### PR TITLE
fix(commentary): 读者划一句，给的是上一段的注——窗口只认了划选的起点

### DIFF
--- a/backend/app/api/commentary.py
+++ b/backend/app/api/commentary.py
@@ -136,13 +136,15 @@ async def passage(
     """
     pkgs = svc.packages()
     for pkg in pkgs:
-        line = pkg.find(q)
-        if not line:
+        loc = pkg.locate(q)
+        if not loc:
             continue
-        span, hits, total = pkg.passage(line, limit)
+        core, i0, i1 = loc
+        span, hits, total = pkg.passage(core, i0, i1, limit)
         base_work = pkg.meta["base_work"]
-        # 经文侧锚到这一段的第一行——读者点过去，落在他问的那句上。
-        base_key = (base_work, span[0] if span else None)
+        # 经文侧锚到**读者划的第一行**，不是窗口的第一行——窗口向前多放了几行
+        # 上文，锚在那里会把点进来的人送到他划的那句之前。
+        base_key = (base_work, pkg.ids[i0] if i0 is not None else None)
         located = await _locate(
             db, [(h["work"], h["anchor"]) for h in hits] + [base_key]
         )
@@ -165,6 +167,8 @@ async def passage(
                     note=h["text"],
                     anchor=h["anchor"],
                     base_line=h["base_line"],
+                    base_text=pkg.text.get(h["base_line"]),
+                    on_selection=h["base_line"] in core,
                     score=h["score"],
                     same_as=(pkg.comms.get(h["work"], {}) or {}).get("same_as"),
                     urn=located.get((h["work"], h["anchor"]), (None, None))[0],

--- a/backend/app/schemas/commentary.py
+++ b/backend/app/schemas/commentary.py
@@ -19,6 +19,11 @@ class CommentaryHit(BaseModel):
     note: str
     anchor: str
     base_line: str
+    # 这家注的是哪一句经 —— 一段里各家牒的句子不同，不给出来读者无从判断
+    # 眼前这条是不是在回答他划的那句。
+    base_text: str | None = None
+    # 该注锚定的行是否落在读者划选范围内。False = 窗口边缘的兜底结果。
+    on_selection: bool = True
     score: float
     # 同一部书的另一版本（牒句分布几乎重合），例如玄宗御注收在两部藏经里。
     # 只标不合并——藏掉一部 CBETA 书对要按版本查证的人更糟。

--- a/backend/app/services/commentary.py
+++ b/backend/app/services/commentary.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections import Counter
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -32,6 +33,11 @@ PACKAGE_DIR = Path("/data/commentary")
 # 读得完；超出时如实标 truncated，绝不假装这就是全部。
 DEFAULT_LIMIT = 8
 MAX_LIMIT = 50
+
+# 读者划选的首尾常常只沾到一行的几个字（几乎没人正好停在 CBETA 行末）。
+# 这样的边界行不算「他在问这一行」——否则下一句的注家会挤满名额，把他真正
+# 划的那句的注家顶出去。实测：不设这道门槛时 44 例里有 1 例被下一句占满。
+_CORE_MIN_CHARS = 6
 
 # CBETA 书号 → fojin 的 cbeta_id：T08n0235 → T0235、X24n0461 → X0461。
 _WORK_ID = re.compile(r"^([A-Z]+)\d*n(\w+)$")
@@ -70,6 +76,7 @@ class Package:
     text: dict = field(default_factory=dict)
     _flat: str = ""
     _owner: list[str] = field(default_factory=list)
+    _len: dict = field(default_factory=dict)
 
     @classmethod
     def load(cls, path: Path) -> Package:
@@ -89,6 +96,7 @@ class Package:
             t = normalise_for_match(ln["text"])
             parts.append(t)
             pkg._owner.extend([ln["id"]] * len(t))
+            pkg._len[ln["id"]] = len(t)
         pkg._flat = "".join(parts)
         return pkg
 
@@ -100,26 +108,65 @@ class Package:
         p = self._flat.find(needle)
         return self._owner[p] if p >= 0 else None
 
-    def passage(self, center: str, limit: int) -> tuple[list[str], list[dict], int]:
+    def locate(self, quote: str) -> tuple[set[str], int, int] | None:
+        """读者划选实质覆盖了哪几行 —— (行号集合, 起始下标, 结束下标)。
+
+        ``find`` 只给起点，丢掉了划选的长度。读者划一整段（常有七八行）时，
+        只按起点行前后取窗口，会把他没划到的上文也算进来，而上文的注家按
+        置信度排序往往排在前面，于是他划 A 段、看到的却是 B 段的注。
+        """
+        needle = normalise_for_match(quote)
+        if not needle:
+            return None
+        p = self._flat.find(needle)
+        if p < 0:
+            return None
+        covered = Counter(self._owner[p:p + len(needle)])
+        core = {
+            ln for ln, n in covered.items()
+            if n >= min(_CORE_MIN_CHARS, max(1, self._len.get(ln, 1)) // 2)
+        }
+        if not core:  # 划选比一行还短时，门槛会把唯一那行也筛掉
+            core = {self._owner[p]}
+        idx = [self.pos[x] for x in core if x in self.pos]
+        if not idx:
+            return None
+        return core, min(idx), max(idx)
+
+    def passage(
+        self, core: set[str], i0: int, i1: int, limit: int
+    ) -> tuple[list[str], list[dict], int]:
         """(段内各行, 去重后的各家注, 本段总家数)。
 
         同一部注疏常在段内多行都有锚点（牒文分几处引），按行列会让它重复出现，
-        把「有几家注」答成「有几条对齐」。按注疏去重，保留置信度最高的锚点。
+        把「有几家注」答成「有几条对齐」。按注疏去重，保留最贴题的那个锚点。
+
+        ``core`` 是读者实际划到的行；窗口仍向两侧各放 ``passage_radius`` 行，
+        因为对齐锚点本身有偏移，只认 core 会让一些段一家都取不到。但 core 内的
+        注**永远排在**窗口边缘的注之前 —— 边缘只是兜底，不该顶替正题。
         """
-        i = self.pos.get(center)
-        if i is None:
+        if i0 is None:
             return [], [], 0
         r = self.meta.get("passage_radius", 3)
-        span = self.ids[max(0, i - r): i + r + 1]
+        span = self.ids[max(0, i0 - r): i1 + r + 1]
+
+        def pick(n: dict) -> tuple[int, float]:
+            """同一部书取哪个锚点：先看是不是落在读者划的行上，再看置信度。"""
+            return (0 if n["base_line"] in core else 1, -n["score"])
+
         best: dict[str, dict] = {}
         for bl in span:
             for n in self.by_line.get(bl, ()):
-                if n["work"] not in best or n["score"] > best[n["work"]]["score"]:
+                if n["work"] not in best or pick(n) < pick(best[n["work"]]):
                     best[n["work"]] = n
         order = {"A": 0, "B": 1, "C": 2}
         ranked = sorted(
             best.values(),
-            key=lambda n: (order.get(self.comms.get(n["work"], {}).get("tier"), 9), -n["score"]),
+            key=lambda n: (
+                0 if n["base_line"] in core else 1,
+                order.get(self.comms.get(n["work"], {}).get("tier"), 9),
+                -n["score"],
+            ),
         )
         return span, ranked[:limit], len(ranked)
 

--- a/backend/tests/test_commentary.py
+++ b/backend/tests/test_commentary.py
@@ -49,6 +49,14 @@ def _pkg(tmp_path, notes):
     return d
 
 
+def _passage(pkg, quote, limit):
+    """读者划一段 → 各家注。locate 决定他划到了哪几行，passage 据此排序。"""
+    loc = pkg.locate(quote)
+    assert loc is not None, f"划选未命中: {quote}"
+    core, i0, i1 = loc
+    return pkg.passage(core, i0, i1, limit)
+
+
 def _note(work, base_line, anchor, score, text):
     return {"work": work, "base_line": base_line, "anchor": anchor,
             "score": score, "text": text}
@@ -105,7 +113,7 @@ def test_simplified_query_matches_traditional_source(loaded):
 def test_passage_merges_neighbouring_lines(loaded):
     """注家把牒文锚在同一段的不同行上；只看锚点那一行会把一段的注切碎。"""
     pkg = svc.packages()[0]
-    span, hits, total = pkg.passage("T08n0235_p0749c22", 10)
+    span, hits, total = _passage(pkg, "不應住色生心，不應住聲、香、味、觸、法生心，應無所住而生其心。", 10)
     assert len(span) >= 4
     # c21 上的两家 + c22 上的一家，跨行合并后都在
     assert {h["work"] for h in hits} == {"F03n0100", "ZW10n0081", "X24n0461"}
@@ -115,7 +123,7 @@ def test_passage_merges_neighbouring_lines(loaded):
 def test_one_entry_per_commentary_keeping_best_anchor(loaded):
     """同一部书段内多处锚点只算一家，否则「有几家注」会被答成「有几条对齐」。"""
     pkg = svc.packages()[0]
-    _, hits, _ = pkg.passage("T08n0235_p0749c22", 10)
+    _, hits, _ = _passage(pkg, "不應住色生心，不應住聲、香、味、觸、法生心，應無所住而生其心。", 10)
     f = [h for h in hits if h["work"] == "F03n0100"]
     assert len(f) == 1
     assert f[0]["score"] == 1.0            # 留置信度高的那个锚点
@@ -125,15 +133,19 @@ def test_one_entry_per_commentary_keeping_best_anchor(loaded):
 def test_limit_reports_the_true_total(loaded):
     """截断时必须能看出被截断了——列出三家不能让人以为只有三家。"""
     pkg = svc.packages()[0]
-    _, hits, total = pkg.passage("T08n0235_p0749c22", 2)
+    _, hits, total = _passage(pkg, "不應住色生心，不應住聲、香、味、觸、法生心，應無所住而生其心。", 2)
     assert len(hits) == 2
     assert total == 3
 
 
 def test_tier_orders_before_score(loaded):
-    """A 档在前：质检档次比单条置信度更能说明这部书可不可信。"""
+    """A 档在前：质检档次比单条置信度更能说明这部书可不可信。
+
+    档次只在「读者划到的那几行」内部比 —— 所以这里划的是 c21+c22 两行，
+    三家注都落在划选内。跨越划选边界时另有更强的次序，见下面那条测试。
+    """
     pkg = svc.packages()[0]
-    _, hits, _ = pkg.passage("T08n0235_p0749c22", 10)
+    _, hits, _ = _passage(pkg, "不應住色生心，不應住聲、香、味、觸、法生心，應無所住而生其心。", 10)
     assert hits[-1]["work"] == "X24n0461"   # 唯一的 C 档排最后
 
 
@@ -298,3 +310,70 @@ async def test_juan_lookup_against_a_real_corpus():
             _JUAN_OF_LINE, {"tids": [12400], "refs": ["9999z99"]}
         )).all()
     assert rows == []
+
+
+def test_locate_covers_the_whole_selection_not_just_its_start(loaded):
+    """划选跨几行就该收几行 —— 只认起点会把读者没划的上文也当成正题。"""
+    pkg = svc.packages()[0]
+    core, i0, i1 = pkg.locate(
+        "不應住色生心，不應住聲、香、味、觸、法生心，應無所住而生其心。"
+    )
+    assert core == {"T08n0235_p0749c21", "T08n0235_p0749c22"}
+    assert pkg.ids[i0] == "T08n0235_p0749c21"
+    assert pkg.ids[i1] == "T08n0235_p0749c22"
+
+
+def test_boundary_line_grazed_by_a_few_chars_is_not_core(loaded):
+    """读者几乎不会正好停在 CBETA 行末；末尾沾到的那一两个字不算他在问它。
+
+    不设这道门槛的话，下一句的注家会挤满名额 —— 生产 44 例抽样里实测撞到 1 例。
+    """
+    pkg = svc.packages()[0]
+    core, _, _ = pkg.locate("觸、法生心，應無所住而生其心。「須")
+    assert "T08n0235_p0749c23" not in core
+    assert core == {"T08n0235_p0749c22"}
+
+
+@pytest.fixture()
+def upstream_is_better_graded(tmp_path, monkeypatch):
+    """上文两家是 A 档，读者划的那一行只有一家 C 档 —— 次序该听谁的。"""
+    notes = [
+        _note("F03n0100", "T08n0235_p0749c20", "F03n0100_p0334b01", 1.0, "註上文一"),
+        _note("ZW10n0081", "T08n0235_p0749c21", "ZW10n0081_p0073a01", 1.0, "註上文二"),
+        _note("X24n0461", "T08n0235_p0749c22", "X24n0461_p0546b12", 1.0, "註本句"),
+    ]
+    d = _pkg(tmp_path, notes)
+    monkeypatch.setattr(svc, "PACKAGE_DIR", d)
+    svc.packages.cache_clear()
+    yield
+    svc.packages.cache_clear()
+
+
+def test_notes_on_the_selected_line_outrank_upstream_ones(upstream_is_better_graded):
+    """读者划哪句，就先给注那句的 —— 哪怕它档次更低。
+
+    这是这个功能此前最大的毛病：窗口向前多放三行，而上文的注按档次/置信度
+    排在前面，于是读者划 A 段、看到的是 B 段的注。生产 44 例抽样里，注文与
+    划选对得上的只有 27%，其中 15 例八家全部答非所问。
+    """
+    pkg = svc.packages()[0]
+    _, hits, _ = _passage(pkg, "應無所住而生其心", 10)
+    # X24n0461 是 C 档，另外两家是 A 档；但只有它注的是读者划的这一行。
+    assert hits[0]["work"] == "X24n0461"
+    assert hits[0]["base_line"] == "T08n0235_p0749c22"
+    # 上文那两家仍然给，但退到后面当兜底 —— 对齐锚点有偏移，全砍掉会有段取不到注。
+    assert {h["work"] for h in hits[1:]} == {"F03n0100", "ZW10n0081"}
+
+
+def test_a_books_anchor_on_the_selected_line_beats_its_own_higher_scored_one(loaded):
+    """一部书在段内多处有锚点时，给读者看它注**这一句**的那条。
+
+    F03n0100 在 c21 的锚点置信度更高（1.0 vs 0.8），但读者划的是 c22；
+    注 c21 的那条再准，也不是他问的问题。
+    """
+    pkg = svc.packages()[0]
+    _, hits, _ = _passage(pkg, "應無所住而生其心", 10)
+    f = [h for h in hits if h["work"] == "F03n0100"]
+    assert len(f) == 1
+    assert f[0]["base_line"] == "T08n0235_p0749c22"
+    assert f[0]["score"] == 0.8


### PR DESCRIPTION
## 起因

在给「经注对读」开前端入口之前，先对生产 API 做了一次只读评测（金刚经全经分层抽样 44 条真实划选，全部经过「必须是原文连续子串」自检）。

覆盖率、速度、数据本身三关都过了：

- 命中率 **44/44 = 100%**，响应 480–710ms，带 CBETA 换行的划选完全不受影响
- 数据 tier 全 A、score 全 1.0、注文中位 84 字且无硬截断

**但注文和读者划的句子对不上。** 判据取「注文与划选重叠 ≥6 字」：

- 对得上 **96/352 = 27%**
- **43% 的划选（19/44），八家全部答非所问**
- 77% 的划选，八家里最多对上 2 家

实例：读者划「如來昔在然燈佛所，於法有所得不？」，返回的四家全在注**上一段**的「以須菩提實無所行，而名須菩提是樂阿蘭那行」。

先排除了「注疏按段科判、牒文引段首所以读者认不出」这个解释——注文开头 60 字重叠率 26%、全文重叠率 27%，差值只有 4 条。是真的给错了段。

## 根因

1. `find()` 只返回划选的**起点行**，长度信息被丢掉；`passage()` 再按「起点行 ±3」取窗口，向前多吃三行读者没划到的上文。
2. 排序只看 tier/score，不看这条注锚在窗口哪一行。实测八家锚定的不同行数**中位是 1**——给的是「窗口里注家最密那一行」的注，那一行是不是读者划的纯看运气。所以结果是两极的：八家全对（7 次）或八家全错（19 次）。

## 改动

- 新增 `locate()`：用划选首尾各定位一次，得出实质覆盖的行（core）。边界行只沾几个字的不算——读者几乎不会正好停在 CBETA 行末，不设这道门槛时实测有 1 例被下一句的注家占满。
- `passage()` 的排序、以及「同一部书取哪个锚点」，都以 core 内优先。窗口仍向两侧各放 `passage_radius` 行兜底（对齐锚点有偏移，只认 core 会有段一家都取不到），但兜底永远排在正题之后。
- `base_reader_url` 从窗口首行改锚到划选首行。原注释写「读者点过去落在他问的那句上」，**实测 44/44 例都落在他划选之前**——这条从来没成立过。
- `CommentaryHit` 增 `base_text`（这家注的是哪一句）和 `on_selection`（是不是兜底结果）。即使排序修好，读者也需要能自己判断眼前这条在不在回答他。

`same_as` 没动——schema 里写明「只标不合并，藏掉一部 CBETA 书对要按版本查证的人更糟」，是有意设计，归组该在前端做。

## 验证

把**本 PR 的代码**（不是运行时补丁）送进生产容器，对同一批样本、同一判据复测：

| | 对得上 | 8 家全错 | ≥5 家对 |
|---|---|---|---|
| 旧（线上） | 96/352 = 27% | 15/44 | 10/44 |
| 新（本 PR） | **337/352 = 95%** | **0/44** | 42/44 |

逐条：变好 36、变差 1、持平 7。唯一变差那条（2/8 → 1/8）根因是该行没有任何注家锚定，属数据覆盖缺口而非算法问题，旧算法在那条也只有 2/8。

单测：`test_commentary.py` 29 passed。两个新增的核心用例已实测「退回旧排序时会红、恢复后绿」，不是恒真断言。

## 不在本 PR 内

- **前端入口仍然是零**——`TextReaderPage` 里 commentary 只出现在一句注释里。划词浮层现在是「≤20 字查辞典、>20 字只有问小津」，长句分支空着，正好是这个功能该待的位置。建议本 PR 合并后单独做，届时需要处理：`truncated` 每次都触发（每段中位 47 家只给 8 家）、23% 的注文无 `reader_url`（4 部书不在本站语料库，其中「金剛般若波羅蜜經講義」是出现频率第 2 高的注疏）、`same_as` 两条并列时的视觉归组。
- 数据覆盖缺口（部分行无任何注家锚定）属于对齐数据本身，不在代码层。
