### PR TITLE
fix(chat): 收尾帧与 message_id 同一 tick 到达时，引文/信任行/参考经文被静默丢弃

### DIFF
--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -22,7 +22,7 @@ import {
   deleteChatSession,
   type ChatSessionItem,
 } from "../api/client";
-import type { ChatSessionId } from "../types/branded";
+import type { ChatSessionId, TextId } from "../types/branded";
 
 // 只替换 message，其余 antd 组件保持真实。
 // 为什么不能靠"页面上有没有出现错误文案"来断言：antd v5 的静态 message 在
@@ -306,6 +306,47 @@ describe("ChatPage 首屏结构", () => {
     await waitFor(() => {
       expect(screen.getByText(/共 \d/)).toBeInTheDocument();
     });
+  });
+
+  // 可点引文 / 「引用已校验」/ 「参考经文」必须在**登录用户**流结束时就在，而不是刷新后。
+  // 生产实锤（2026-08-25，会话 2987 + 直读 SSE 复核）：trust_status → sources →
+  // message_id → done 四帧落在同一个 XHR chunk、同一个同步 tick 里到达。onSources /
+  // onTrustStatus 的 setMessages updater 是延后执行的，执行时才读 liveAssistantId，
+  // 而 onMessageId 已在同一 tick 把它改成真 id —— updater 去找一个此刻还不存在的
+  // id，sources 与 trust_status 静默丢弃；刷新后从库里读回来才有。
+  //
+  // 游客不落库、不发 message_id，活变量永不改名 —— 以游客身份怎么试都是好的。
+  // 这条用例的关键是四帧**同步连发**（中间不 await），复刻真实到达顺序与时序。
+  it("引文/信任行/参考经文: 与 message_id 同一 tick 到达时不得丢失", async () => {
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks) => { cb = callbacks; },
+    );
+    const { container } = await renderEmpty();
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+
+    // 最后一批 token 与收尾四帧同一个 chunk —— 先来一个 token，让 fiber 带着
+    // 未渲染的更新，后面的 updater 才会像生产那样被真正延后。
+    cb!.onToken("「應無所住而生其心」出自【《金剛般若波羅蜜經》第1卷】。");
+    cb!.onTrustStatus?.({
+      state: "verified", citation_count: 1, source_count: 1,
+      citation_mutation_count: 0, quote_mutation_count: 0, quote_checked_count: 1,
+    });
+    cb!.onSources([{
+      text_id: 235 as TextId, juan_num: 1, chunk_index: 3,
+      chunk_text: "應無所住而生其心", score: 0.9, title_zh: "金剛般若波羅蜜經",
+    }]);
+    cb!.onMessageId?.(31338);   // ← 登录用户才有的这一步，改名发生在这里
+    cb!.onDone();
+
+    await waitFor(() => {
+      expect(screen.getByText("参考经文")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/引用已校验/)).toBeInTheDocument();
+    // 内联引文（精确文案）与「参考经文」chip 各一个按钮，两者都要在。
+    expect(screen.getByRole("button", { name: "【《金刚般若波罗蜜经》第1卷】" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /金刚般若波罗蜜经/ })).toHaveLength(2);
   });
 
   // 推理进度：把此前被丢弃的 reasoning 增量用作「仍在推进」的实证。

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1331,20 +1331,27 @@ export default function ChatPage() {
     // 耗时一个字都没写进去。而游客不落库、收不到 message_id，id 一直是占位符，
     // 所以以游客身份怎么试都是好的，只有登录用户看不到。
     let liveAssistantId = assistantId;
+    // 所有「改这条回答」的 setMessages 都必须走这里：id 在**回调时**捕获，而不是在
+    // updater 里读活变量。updater 是延后执行的 —— trust_status / sources / message_id
+    // / done 常落在同一个 XHR chunk、同一个同步 tick 里到达，等 updater 跑起来时
+    // onMessageId 已经把 liveAssistantId 改成真 id，而消息本身还挂着占位符；在
+    // updater 里比较活变量就会去找一个此刻不存在的 id，把 sources 与 trust_status
+    // 静默丢掉（生产实锤：登录用户流结束时引文不可点、无信任行，刷新后才有）。
+    const patchLive = (patch: (m: ChatMessageItem) => ChatMessageItem) => {
+      const id = liveAssistantId;
+      setMessages((prev) => prev.map((m) => (m.id === id ? patch(m) : m)));
+    };
 
     await sendChatMessageStream(msg, sessionId, masterId, {
       onToken: (content: string) => {
         tokenCount += 1;
         if (firstTokenMs === null) firstTokenMs = Date.now() - startedAt;
-        setMessages((prev) =>
-          prev.map((m) => {
-            if (m.id !== liveAssistantId) return m;
-            const current = m.content === THINKING_SENTINEL ? "" : m.content;
-            // reasoningText 随首个 token 销毁：被模型自己推翻的中间结论
-            // 不能留在屏幕上（渲染层另有一道保险，两道各自独立）。
-            return { ...m, content: current + content, reasoningText: null };
-          }),
-        );
+        patchLive((m) => {
+          const current = m.content === THINKING_SENTINEL ? "" : m.content;
+          // reasoningText 随首个 token 销毁：被模型自己推翻的中间结论
+          // 不能留在屏幕上（渲染层另有一道保险，两道各自独立）。
+          return { ...m, content: current + content, reasoningText: null };
+        });
         scrollToBottom();
       },
       onCitationCorrection: (correctedAnswer: string) => {
@@ -1352,18 +1359,10 @@ export default function ChatPage() {
         // arrive after `citation_correction`. If that contract is ever
         // broken, a late chunk would append to the corrected answer and
         // re-introduce the hallucination we just stripped.
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === liveAssistantId ? { ...m, content: correctedAnswer } : m,
-          ),
-        );
+        patchLive((m) => ({ ...m, content: correctedAnswer }));
       },
       onSources: (sources: ChatSource[]) => {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === liveAssistantId ? { ...m, sources } : m,
-          ),
-        );
+        patchLive((m) => ({ ...m, sources }));
         // Prefetch each citation's chunk context so the drawer opens instantly.
         for (const s of sources) {
           if (s.text_id == null || s.juan_num == null || s.chunk_index == null) continue;
@@ -1376,11 +1375,7 @@ export default function ChatPage() {
         }
       },
       onTrustStatus: (trustStatus: ChatTrustStatus) => {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === liveAssistantId ? { ...m, trust_status: trustStatus } : m,
-          ),
-        );
+        patchLive((m) => ({ ...m, trust_status: trustStatus }));
       },
       onSearching: (_searchMsg: string) => {
         // 搜索状态由初始占位符 "正在检索经文并生成回答..." 显示，不覆盖 content
@@ -1390,20 +1385,17 @@ export default function ChatPage() {
         // （削档已被 90 题 eval 证否），能改的只有等待的感受 —— 推理文本是
         // 现成的可读中文，此前整条丢掉。
         // 与 onRetrieved 同一条承重约束：只写独立字段，绝不碰 content。
-        setMessages((prev) =>
-          prev.map((m) => {
-            if (m.id !== liveAssistantId) return m;
-            const next = { ...m };
-            if (next.reasoningSince == null) next.reasoningSince = Date.now();
-            if (r.text) {
-              // 全量累加、不截尾：打字机组件按前缀吐字，截尾会让前缀失配、
-              // 整窗重排跳动。上限由推理预算天然封顶（≤ 数万字，流结束即清），
-              // 显示端的活窗高度由 CSS clip 管。
-              next.reasoningText = (next.reasoningText ?? "") + r.text;
-            }
-            return next;
-          }),
-        );
+        patchLive((m) => {
+          const next = { ...m };
+          if (next.reasoningSince == null) next.reasoningSince = Date.now();
+          if (r.text) {
+            // 全量累加、不截尾：打字机组件按前缀吐字，截尾会让前缀失配、
+            // 整窗重排跳动。上限由推理预算天然封顶（≤ 数万字，流结束即清），
+            // 显示端的活窗高度由 CSS clip 管。
+            next.reasoningText = (next.reasoningText ?? "") + r.text;
+          }
+          return next;
+        });
         // 活窗把气泡向下撑高 ~100px，而钉底发生在发送时 —— 不跟滚的话，已可
         // 滚动的对话里活窗整段等待期落在折叠线以下，token 一到又被销毁，用户
         // 从头到尾看不见它（对抗审查实锤的失效场景）。scrollToBottom 非 force
@@ -1414,9 +1406,7 @@ export default function ChatPage() {
         // 只写独立字段。绝不能写进 content —— THINKING_SENTINEL 是按身份比较的
         // 哨兵，onDone 里「流结束但从未收到 token → 转失败哨兵」的兜底靠它；
         // 一旦 content 被顶掉，用户会永远卡在假的「正在检索…」上且没有重试按钮。
-        setMessages((prev) =>
-          prev.map((m) => (m.id === liveAssistantId ? { ...m, retrieval } : m)),
-        );
+        patchLive((m) => ({ ...m, retrieval }));
       },
       onMessageId: (realId: number) => {
         // Replace the in-flight Date.now() placeholder with the real
@@ -1459,12 +1449,8 @@ export default function ChatPage() {
           });
         }
         message.error(errMsg);
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === liveAssistantId && m.content === THINKING_SENTINEL
-              ? { ...m, content: REQUEST_FAILED_SENTINEL }
-              : m,
-          ),
+        patchLive((m) =>
+          m.content === THINKING_SENTINEL ? { ...m, content: REQUEST_FAILED_SENTINEL } : m,
         );
       },
       onDone: () => {
@@ -1489,15 +1475,12 @@ export default function ChatPage() {
         // 历史消息读回来时为空，于是不会显示一个没人计过的时间。失败与空回复
         // 也照记 —— 渲染层负责不给失败哨兵显示耗时，判据留在一处就够了。
         const totalMs = Date.now() - startedAt;
-        setMessages((prev) =>
-          prev.map((m) => {
-            if (m.id !== liveAssistantId) return m;
-            const settled = m.content === THINKING_SENTINEL
-              ? { ...m, content: REQUEST_FAILED_SENTINEL }
-              : m;
-            return { ...settled, firstTokenMs, totalMs };
-          }),
-        );
+        patchLive((m) => {
+          const settled = m.content === THINKING_SENTINEL
+            ? { ...m, content: REQUEST_FAILED_SENTINEL }
+            : m;
+          return { ...settled, firstTokenMs, totalMs };
+        });
         // Clear attachment chips only after successful stream completion.
         // On error the chips stay so the user can retry without re-uploading.
         if (attachmentIdsForSend.length > 0) {


### PR DESCRIPTION
## 现象（生产实锤，2026-08-25）

登录用户在 /chat 发问，流结束后：内联引文 `【《金剛般若波羅蜜經》第1卷】` 是纯文本（DOM 里就是 `<p>` 文字，没有 button）、没有「引用已校验」行、没有「参考经文」chips。**刷新页面后**同一条消息三样全有。游客身份看不到这个问题。

## 根因

直读 SSE 复核，后端帧齐全：`trust_status → sources → message_id → done` 四帧在同一个 XHR chunk、同一个同步 tick 里到达。

`ChatPage.tsx` 里 `onSources / onTrustStatus / onCitationCorrection / onRetrieved / onReasoning` 的 `setMessages((prev) => prev.map((m) => m.id === liveAssistantId ? … : m))` 在 **updater 延后执行时**才读 `liveAssistantId`；而 `onMessageId` 已在同一 tick 把活变量改成真 id，消息本身却还挂着占位符 → 不匹配 → `sources` / `trust_status` 静默丢弃。`onMessageId` 自己写的就是「先捕获旧 id 再改活变量」，其余 handler 没跟上。

游客不落库、不发 `message_id`，活变量永不改名 —— 以游客身份怎么试都是好的。

## 修法

所有「改这条回答」的更新统一走 `patchLive()`：id 在**回调时**捕获，再交给 updater。`citation_correction` 走同一条路 —— 之前同样场景下修正后的答案也会丢（用户看到的是修正前的文本）。

## 测试

新用例「引文/信任行/参考经文: 与 message_id 同一 tick 到达时不得丢失」按生产顺序在同一 tick 连发 `token → trust_status → sources → message_id → done`：修复前红（`Unable to find … 参考经文`），修复后绿。ChatPage 70/70、全套 546/546、eslint / tsc / i18n ratchet 全过。

## 上线后验证（必须用登录账号）

发一问，流结束**不刷新**：答案里引文是可点按钮、有「引用已校验」行、有「参考经文」chips。游客验证不出这个问题。
