### PR TITLE
fix(reader): 手机上默认看不到经文——AI 面板改为窄屏底部抽屉、默认收起

### DIFF
--- a/frontend/src/hooks/useNarrowViewport.test.tsx
+++ b/frontend/src/hooks/useNarrowViewport.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { NARROW_VIEWPORT_QUERY, isNarrowViewport, useNarrowViewport } from "./useNarrowViewport";
+
+type ChangeListener = (e: { matches: boolean }) => void;
+
+/** 装一个可手动触发 change 的 matchMedia；只对 NARROW_VIEWPORT_QUERY 回答 matches。 */
+function installMatchMedia(matches: boolean) {
+  const listeners = new Set<ChangeListener>();
+  const mql = {
+    matches,
+    media: NARROW_VIEWPORT_QUERY,
+    onchange: null,
+    addEventListener: (_: string, cb: ChangeListener) => { listeners.add(cb); },
+    removeEventListener: (_: string, cb: ChangeListener) => { listeners.delete(cb); },
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  };
+  window.matchMedia = vi.fn((q: string) =>
+    q === NARROW_VIEWPORT_QUERY ? mql : { ...mql, matches: false, media: q },
+  ) as unknown as typeof window.matchMedia;
+  return {
+    fire(next: boolean) {
+      mql.matches = next;
+      listeners.forEach((cb) => cb({ matches: next }));
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+const originalMatchMedia = window.matchMedia;
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+describe("useNarrowViewport", () => {
+  it("matchMedia 缺失（jsdom / SSR）时按宽屏处理，不抛错", () => {
+    // @ts-expect-error 故意拆掉，模拟没有 matchMedia 的环境
+    delete window.matchMedia;
+    expect(isNarrowViewport()).toBe(false);
+    const { result } = renderHook(() => useNarrowViewport());
+    expect(result.current).toBe(false);
+  });
+
+  it("窄屏首帧即为 true，断点变化时跟随，卸载后不再监听", () => {
+    const mm = installMatchMedia(true);
+    expect(isNarrowViewport()).toBe(true);
+    const { result, unmount } = renderHook(() => useNarrowViewport());
+    expect(result.current).toBe(true);
+
+    act(() => mm.fire(false));
+    expect(result.current).toBe(false);
+
+    act(() => mm.fire(true));
+    expect(result.current).toBe(true);
+
+    unmount();
+    expect(mm.listenerCount()).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useNarrowViewport.ts
+++ b/frontend/src/hooks/useNarrowViewport.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 阅读器「侧栏不再并排」的断点。与 reader.css 的 Tablet 块（max-width: 1024px）
+ * 保持同一个数，改一处必须改另一处。
+ */
+export const NARROW_VIEWPORT_QUERY = "(max-width: 1024px)";
+
+/**
+ * 一次性判断，供 useState 惰性初值用。matchMedia 缺失（jsdom / SSR）时按宽屏处理 ——
+ * 宽屏是原有行为，缺环境时保持原样比猜成窄屏安全。
+ */
+export function isNarrowViewport(query: string = NARROW_VIEWPORT_QUERY): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(query).matches;
+}
+
+/** 响应式的 isNarrowViewport：断点跨越时跟着变（与 useEffectiveTheme 同一手法）。 */
+export function useNarrowViewport(query: string = NARROW_VIEWPORT_QUERY): boolean {
+  const [narrow, setNarrow] = useState(() => isNarrowViewport(query));
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const mql = window.matchMedia(query);
+    const onChange = (e: MediaQueryListEvent) => setNarrow(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+  return narrow;
+}

--- a/frontend/src/pages/TextReaderPage.mobile.test.tsx
+++ b/frontend/src/pages/TextReaderPage.mobile.test.tsx
@@ -1,0 +1,148 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter, Route, Routes } from "react-router";
+import TextReaderPage from "./TextReaderPage";
+import {
+  checkBookmark,
+  getJuanAudio,
+  getJuanContent,
+  getJuanLanguages,
+  getJuanLineAnchors,
+  getJuanList,
+  getTextDetail,
+} from "../api/client";
+import type { TextId } from "../types/branded";
+
+// 阅读页首屏要打的接口全部换成桩；没换的（书签写入、辞典、校勘、流式问答）在
+// 本文件的用例里不会被触发。
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    getTextDetail: vi.fn(),
+    getJuanList: vi.fn(),
+    getJuanContent: vi.fn(),
+    getJuanLanguages: vi.fn(),
+    getJuanLineAnchors: vi.fn(),
+    getJuanAudio: vi.fn(),
+    getJuanApparatus: vi.fn(),
+    checkBookmark: vi.fn(),
+    searchDictionaryGrouped: vi.fn(),
+    sendChatMessageStream: vi.fn(),
+  };
+});
+
+vi.mock("../api/chatModels", () => ({
+  fetchChatModels: vi.fn().mockResolvedValue([]),
+}));
+
+const NARROW_QUERY = "(max-width: 1024px)";
+
+/** 只对阅读器自己的断点查询回答 narrow；antd 的 useBreakpoint 查询一律 false。 */
+function installMatchMedia(narrow: boolean) {
+  window.matchMedia = ((query: string) => ({
+    matches: narrow && query === NARROW_QUERY,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+  if (!window.requestAnimationFrame) {
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+      setTimeout(() => cb(0), 0) as unknown as number) as typeof window.requestAnimationFrame;
+  }
+});
+
+const TEXT_ID = 69 as TextId;
+
+beforeEach(() => {
+  vi.mocked(getTextDetail).mockResolvedValue({
+    id: TEXT_ID, taisho_id: "T0676", cbeta_id: "T0676", title_zh: "解深密經",
+    title_sa: null, title_bo: null, title_pi: null, translator: "玄奘", dynasty: "唐",
+    fascicle_count: 5, category: null, subcategory: null, cbeta_url: null,
+    has_content: true, content_char_count: 7574, lang: "lzh", created_at: "2026-01-01T00:00:00Z",
+  });
+  vi.mocked(getJuanList).mockResolvedValue({
+    text_id: TEXT_ID, title_zh: "解深密經", total_juans: 5,
+    juans: [{ juan_num: 1, char_count: 7574 }, { juan_num: 2, char_count: 7000 }],
+  });
+  vi.mocked(getJuanContent).mockResolvedValue({
+    text_id: TEXT_ID, cbeta_id: "T0676", title_zh: "解深密經", juan_num: 1, total_juans: 5,
+    content: "如是我聞：一時，薄伽梵住最勝光曜七寶莊嚴。", char_count: 20,
+    prev_juan: null, next_juan: 2, canon: "taisho", canon_label: "大正藏",
+  });
+  vi.mocked(getJuanLanguages).mockResolvedValue({
+    text_id: TEXT_ID, juan_num: 1, languages: ["lzh"], default_lang: "lzh",
+  });
+  vi.mocked(getJuanLineAnchors).mockResolvedValue({ text_id: TEXT_ID, juan_num: 1, anchors: [] });
+  // 只有心經有音频，其余卷后端 404 —— 调用方必须容忍。
+  vi.mocked(getJuanAudio).mockRejectedValue(new Error("404"));
+  vi.mocked(checkBookmark).mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function renderReader() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const r = render(
+    <HelmetProvider>
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/texts/69/read"]}>
+          <Routes>
+            <Route path="/texts/:id/read" element={<TextReaderPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+  await screen.findByText(/如是我聞/);
+  return r;
+}
+
+describe("阅读器 AI 面板在窄屏上的形态", () => {
+  // 2026-08-25 Playwright 390px 实测：aiPanelOpen 初值 true，≤1024px 时
+  // .reader-with-sidebar.reader-ai-active 锁高 calc(100vh - 64px) + overflow hidden，
+  // 列布局里侧栏吃掉 60vh，.reader-container 只剩 178px 且全被标题/导航占掉 ——
+  // 经文一行都不露，用户必须先发现并关掉 AI 面板才能读。
+  it("窄屏首屏：不内联侧栏、不锁高，经文可见，AI 只留一个浮动按钮", async () => {
+    installMatchMedia(true);
+    const { container } = await renderReader();
+
+    expect(container.querySelector(".reader-ai-sidebar")).toBeNull();
+    expect(container.querySelector(".reader-with-sidebar")!.classList.contains("reader-ai-active")).toBe(false);
+    expect(container.querySelector(".reader-ai-fab")).not.toBeNull();
+  });
+
+  it("窄屏点浮动按钮：AI 面板以底部抽屉打开，仍不内联", async () => {
+    installMatchMedia(true);
+    const { container } = await renderReader();
+
+    fireEvent.click(container.querySelector(".reader-ai-fab")!);
+
+    await waitFor(() => {
+      expect(document.querySelector(".ant-drawer-open")).not.toBeNull();
+    });
+    expect(document.querySelector(".ant-drawer-open")!.textContent).toContain("AI 解读");
+    expect(container.querySelector(".reader-ai-sidebar")).toBeNull();
+  });
+
+  it("宽屏不受影响：AI 面板默认内联打开", async () => {
+    installMatchMedia(false);
+    const { container } = await renderReader();
+
+    expect(container.querySelector(".reader-ai-sidebar")).not.toBeNull();
+    expect(container.querySelector(".reader-with-sidebar")!.classList.contains("reader-ai-active")).toBe(true);
+    expect(document.querySelector(".ant-drawer-open")).toBeNull();
+  });
+});

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Typography, Spin, Button, Select, Breadcrumb, Row, Col, message, Tooltip, Tag, Popover, Dropdown } from "antd";
+import { Typography, Spin, Button, Select, Breadcrumb, Row, Col, message, Tooltip, Tag, Popover, Dropdown, Drawer } from "antd";
 import { getLastPosition, recordReading } from "../utils/readingHistory";
 import {
   HomeOutlined,
@@ -24,6 +24,7 @@ import {
 import { trackAudio } from "../audio/telemetry";
 import { useAudioPlayer } from "../audio/useAudioPlayback";
 import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, getJuanLineAnchors, getJuanAudio, type ApparatusEntryItem } from "../api/client";
+import { isNarrowViewport, useNarrowViewport } from "../hooks/useNarrowViewport";
 import { useAuthStore } from "../stores/authStore";
 import CitationGenerator from "../components/CitationGenerator";
 import SourceAttribution from "../components/SourceAttribution";
@@ -246,7 +247,12 @@ export default function TextReaderPage() {
   const readerContentRef = useRef<HTMLDivElement>(null);
 
   // AI panel state
-  const [aiPanelOpen, setAiPanelOpen] = useState(true);
+  // 窄屏（≤1024px，与 reader.css 的 Tablet 断点同值）默认收起：内联侧栏在列布局里
+  // 会把经文挤进一个 178px 的滚动盒、一行都不露（2026-08-25 Playwright 390px 实测），
+  // 用户得先发现并关掉 AI 面板才能读经。惰性初值而不是 effect 里 setState ——
+  // react-hooks/set-state-in-effect 会红。
+  const narrow = useNarrowViewport();
+  const [aiPanelOpen, setAiPanelOpen] = useState(() => !isNarrowViewport());
   const [aiPanelWidth, setAiPanelWidth] = useState(420);
   const [aiSelectedText, setAiSelectedText] = useState<string | undefined>();
   const isDraggingRef = useRef(false);
@@ -801,8 +807,23 @@ export default function TextReaderPage() {
     });
   };
 
+  // 关闭态的入口：两种形态（内联 / 抽屉）共用同一颗浮动按钮。
+  const aiFab = (
+    <Tooltip title={t("reader.ai.title")} placement="left">
+      <Button
+        className="reader-ai-fab"
+        type="primary"
+        shape="circle"
+        size="large"
+        icon={<RobotOutlined />}
+        onClick={() => setAiPanelOpen(true)}
+        aria-label={t("reader.ai.title")}
+      />
+    </Tooltip>
+  );
+
   return (
-    <div className={`reader-with-sidebar${aiPanelOpen || parallelPanelOpen ? " reader-ai-active" : ""}`}>
+    <div className={`reader-with-sidebar${!narrow && (aiPanelOpen || parallelPanelOpen) ? " reader-ai-active" : ""}`}>
     <div className={`reader-container${compareLang ? " reader-bilingual" : ""}`}>
       <Helmet>
         <title>
@@ -1186,8 +1207,31 @@ export default function TextReaderPage() {
       </>
     )}
 
-    {/* AI 解读：最右侧内联面板 + 拖拽分割条 */}
-    {aiPanelOpen ? (
+    {/* AI 解读：宽屏是最右侧内联面板 + 拖拽分割条；窄屏改底部抽屉 —— 内联侧栏在
+        列布局里会把经文挤到看不见（.reader-ai-active 锁高 + 侧栏 60vh），抽屉盖在
+        经文之上、随手可关，经文始终留在正常文档流里。 */}
+    {narrow ? (
+      <>
+        <Drawer
+          placement="bottom"
+          height="62vh"
+          open={aiPanelOpen}
+          onClose={() => setAiPanelOpen(false)}
+          title={<span className="reader-ai-sidebar-title"><RobotOutlined /> {t("reader.ai.title")}</span>}
+          rootClassName="reader-ai-drawer"
+        >
+          <ReaderAIPanel
+            textId={textId}
+            juanNum={juanNum}
+            textTitle={content?.title_zh || textDetail?.title_zh || ""}
+            juanContent={content?.content}
+            selectedText={aiSelectedText}
+            onSelectedTextConsumed={handleSelectedTextConsumed}
+          />
+        </Drawer>
+        {!aiPanelOpen && aiFab}
+      </>
+    ) : aiPanelOpen ? (
       <>
         <div className="reader-ai-divider" onMouseDown={handleDragStart} />
         <div className="reader-ai-sidebar" style={{ width: aiPanelWidth }}>
@@ -1206,17 +1250,7 @@ export default function TextReaderPage() {
         </div>
       </>
     ) : (
-      <Tooltip title={t("reader.ai.title")} placement="left">
-        <Button
-          className="reader-ai-fab"
-          type="primary"
-          shape="circle"
-          size="large"
-          icon={<RobotOutlined />}
-          onClick={() => setAiPanelOpen(true)}
-          aria-label={t("reader.ai.title")}
-        />
-      </Tooltip>
+      aiFab
     )}
 
     {/* 回到顶部：落点由 backTopStyle 动态计算（让开 AI 面板与 AI FAB） */}

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -879,3 +879,10 @@
 @media (max-width: 640px) {
   .reader-audio-progress, .reader-audio-meta, .reader-audio-time { display: none; }
 }
+
+/* ── 窄屏 AI 抽屉：≤1024px 时 AI 面板不再内联（见 TextReaderPage 的 narrow 分支） ── */
+.reader-ai-drawer .ant-drawer-body {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}


### PR DESCRIPTION
## 现象（Playwright 390×664 实测，生产）

`aiPanelOpen` 初值 `true`；≤1024px 时 `.reader-with-sidebar.reader-ai-active` 锁高 `calc(100vh - 64px)` + `overflow:hidden`，列布局里侧栏占 60vh，`.reader-container` 只剩 **178px** 且全被标题/导航占掉 —— **经文一行都不露**。用户必须先发现并点掉 AI 面板的 ✕ 才能读（关掉后容器 16,711px）。texts+read 30 天 628 会话，全站 36.5% 移动端。

## 改法

- 新增 `hooks/useNarrowViewport.ts`（`isNarrowViewport` 供惰性初值，`useNarrowViewport` 响应断点变化；断点 1024px 与 `reader.css` Tablet 块同值）。
- `aiPanelOpen` 初值 `!isNarrowViewport()`（惰性初值，不在 effect 里 setState）。
- 窄屏下 AI 面板改 antd `Drawer placement="bottom" height="62vh"`，盖在经文之上、随手可关；经文始终在正常文档流里。关闭态复用同一颗浮动按钮（`aiFab`）。划词「问小津」照常打开抽屉。
- 窄屏不再给外层加 `reader-ai-active`。宽屏行为不变。

## 测试

- `useNarrowViewport.test.tsx`：无 matchMedia 时按宽屏；窄屏首帧 true、断点变化跟随、卸载解绑。
- `TextReaderPage.mobile.test.tsx`（先红后绿）：窄屏首屏无 `.reader-ai-sidebar`、无 `reader-ai-active`、有 `.reader-ai-fab`；点按钮出 `.ant-drawer-open`（含「AI 解读」）且仍不内联；宽屏仍内联。
- 全套 550/550，eslint / tsc / i18n ratchet 通过。

## 真机验证（本地 dist + `/api` 代理生产，Playwright iPhone 14）

默认：`.reader-container` 16,711px、无侧栏、有浮动按钮、`scrollWidth == clientWidth`；点按钮：底部抽屉 h=412 打开；关掉复原。1440px 桌面：内联 420px 面板不变。
