### PR TITLE
fix(layout): /chat 顶栏被裁 30px——铬高度改为共享 token，外壳按 token 计算

### DIFF
--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -104,3 +104,16 @@ test("chat page renders its input box", async ({ page }) => {
     page.locator("textarea, [contenteditable='true']").first()
   ).toBeVisible({ timeout: 20_000 });
 });
+
+test("chat page chrome fits the viewport — the header must not scroll away", async ({ page }) => {
+  // 2026-08-25: .chat-shell was sized with a hard-coded calc(100vh - 120px) while the
+  // real chrome (header 52 + content padding 48 + footer 50) is 150px, so the document
+  // was 30px taller than the viewport and the auto scroll-to-bottom after sending
+  // pushed the navigation bar half out of view on every conversation.
+  await page.goto("/chat");
+  await expect(page.locator(".chat-shell")).toBeVisible({ timeout: 20_000 });
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollHeight - window.innerHeight
+  );
+  expect(overflow, "document taller than viewport by (px)").toBeLessThanOrEqual(0);
+});

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -67,3 +67,16 @@ describe("页脚的「唤回小津」", () => {
     expect(screen.queryByText("唤回小津")).not.toBeInTheDocument();
   });
 });
+
+describe("布局铬高度走 token", () => {
+  // 顶栏 52 / 页脚 50 / 内容区内边距 24×2 曾各自写死在内联样式与 ChatPage 的 calc()
+  // 里，合起来 150，而 ChatPage 以为是 120 —— 于是 /chat 文档比视口高 30px，发送后
+  // 贴底把导航栏滚出视口。高度只能来自 global.css 的 token，内联样式只许引用它。
+  it("顶栏与页脚的高度引用 --fj-header-h / --fj-footer-h，而不是裸数字", () => {
+    const { container } = renderLayout();
+    const header = container.querySelector(".ant-layout-header") as HTMLElement;
+    const footer = container.querySelector(".ant-layout-footer") as HTMLElement;
+    expect(header.style.height).toBe("var(--fj-header-h)");
+    expect(footer.style.height).toBe("var(--fj-footer-h)");
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -204,8 +204,8 @@ export default function Layout() {
           background: headerBg,
           backdropFilter: isHome ? "blur(12px)" : undefined,
           padding: "0 32px",
-          height: 52,
-          lineHeight: "52px",
+          height: "var(--fj-header-h)",
+          lineHeight: "var(--fj-header-h)",
           borderBottom: `1px solid rgba(217,208,193,0.5)`,
           position: isHome ? "sticky" : undefined,
           top: 0,
@@ -404,6 +404,9 @@ export default function Layout() {
           background: pageBg,
           borderTop: "1px solid rgba(217,208,193,0.5)",
           padding: "16px 32px",
+          // 16 + 18 + 16 = 50，与 --fj-footer-h 同值；写死行高是为了让 token 可信。
+          height: "var(--fj-footer-h)",
+          lineHeight: "18px",
         }}
       >
         {t("footer.copyright")}

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -176,6 +176,23 @@ describe("ChatPage 首屏结构", () => {
     expect(shell.style.height).toBe("");
   });
 
+  // 手机空态：外壳锁高 + 建议卡片/横幅/输入框把消息区挤到 52px，标题在里面被裁掉
+  // 下半截、副标题整个不见（2026-08-25 Playwright 390px 生产实测）。空态时给外壳打
+  // 上 chat-shell--empty，≤768px 的 CSS 据此放开高度；有对话后去掉，恢复锁高钉底。
+  it("空态外壳带 chat-shell--empty，发出第一条消息后去掉", async () => {
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks) => { cb = callbacks; },
+    );
+    const { container } = await renderEmpty();
+    const shell = container.querySelector(".chat-shell") as HTMLElement;
+    expect(shell.classList.contains("chat-shell--empty")).toBe(true);
+
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+    expect(shell.classList.contains("chat-shell--empty")).toBe(false);
+  });
+
   it("空状态渲染出标题与建议卡片（脚手架自检）", async () => {
     const { container } = await renderEmpty();
     expect(screen.getByText("小津 佛典问答")).toBeInTheDocument();

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -166,6 +166,16 @@ const FOLLOWING = 4; // Node.DOCUMENT_POSITION_FOLLOWING
 const CONTAINED_BY = 16; // Node.DOCUMENT_POSITION_CONTAINED_BY
 
 describe("ChatPage 首屏结构", () => {
+  // 外壳高度曾写死 calc(100vh - 120px)，而布局铬实际 150px：文档比视口高 30px，
+  // 发送后自动贴底把导航栏滚出视口。高度必须由 global.css 的 .chat-shell 按 token
+  // 计算，内联样式不许再给一个数字。
+  it("对话外壳不再内联写死高度（交给 .chat-shell 的 token 计算）", async () => {
+    const { container } = await renderEmpty();
+    const shell = container.querySelector(".chat-shell") as HTMLElement;
+    expect(shell).not.toBeNull();
+    expect(shell.style.height).toBe("");
+  });
+
   it("空状态渲染出标题与建议卡片（脚手架自检）", async () => {
     const { container } = await renderEmpty();
     expect(screen.getByText("小津 佛典问答")).toBeInTheDocument();

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1696,7 +1696,9 @@ export default function ChatPage() {
           「移动端把引用面板铺满宽度」的规则结构上不可能生效为「堆叠」，面板
           只会在同一行里把对话列挤成 0 宽。给它一个类名，断点才改得动
           flex-direction。 */}
-      <div className="chat-shell">
+      {/* 空态打上 chat-shell--empty：手机上（≤768px）据此放开锁高，让标题/横幅/输入框/
+          建议卡片按内容铺开、整页滚动；有对话后去掉，恢复锁高 + 输入框钉底。 */}
+      <div className={`chat-shell${messages.length === 0 ? " chat-shell--empty" : ""}`}>
 
         {/* Mobile sidebar drawer (logged in only) */}
         {user && sidebarOpen && (

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1696,11 +1696,7 @@ export default function ChatPage() {
           「移动端把引用面板铺满宽度」的规则结构上不可能生效为「堆叠」，面板
           只会在同一行里把对话列挤成 0 宽。给它一个类名，断点才改得动
           flex-direction。 */}
-      <div className="chat-shell" style={{
-        display: "flex",
-        height: "calc(100vh - 120px)",
-        gap: 16,
-      }}>
+      <div className="chat-shell">
 
         {/* Mobile sidebar drawer (logged in only) */}
         {user && sidebarOpen && (

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -977,6 +977,13 @@ em {
   .chat-shell {
     flex-direction: column;
   }
+  /* 空态：外壳锁高时，建议卡片 + 配额横幅 + 输入框把消息区挤到 52px，标题在里面
+     被裁掉下半截、副标题整个不见（2026-08-25 Playwright 390px 生产实测）。空态没有
+     消息可滚，放开高度让整页滚动即可；有对话后 ChatPage 去掉这个类，恢复锁高钉底。 */
+  .chat-shell.chat-shell--empty {
+    height: auto;
+    min-height: calc(100dvh - var(--fj-header-h) - var(--fj-footer-h) - 2 * var(--fj-content-pad-y));
+  }
   /* 行内样式只给了 minWidth:0；换成纵向后要限制的是高度，否则对话列会按内容
      撑开，把面板顶出视口。 */
   .chat-main-column {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,6 +1,14 @@
 @import './fonts.css';
 
 :root {
+  /* 布局铬高度：顶栏 / 页脚 / 内容区上下内边距。任何页面要「铺满视口减去铬」都
+     从这三枚 token 算，Layout 的内联样式也只许引用它们 —— 2026-08-25 之前 /chat
+     自己写死 calc(100vh - 120px)，而实际 52 + 24×2 + 50 = 150，文档比视口高 30px，
+     发送后贴底把导航栏滚出视口。数字分居两处就一定会漂。 */
+  --fj-header-h:      52px;
+  --fj-footer-h:      50px;
+  --fj-content-pad-y: 24px;
+  --fj-content-pad-x: 32px;
   --fj-bg:        #f8f5ef;
   --fj-bg-alt:    #f0ebe2;
   --fj-ink:       #2b2318;
@@ -992,12 +1000,22 @@ em {
 
 /* ========== Layout Content ========== */
 .layout-content-inner {
-  padding: 24px 32px;
+  padding: var(--fj-content-pad-y) var(--fj-content-pad-x);
+}
+
+/* /chat 的外壳：铺满视口减去铬。100dvh 那份给手机 —— 地址栏收放时 100vh 是固定的
+   大值，会多出一截溢出；不支持 dvh 的浏览器落到上一行的 100vh。 */
+.chat-shell {
+  display: flex;
+  gap: 16px;
+  height: calc(100vh - var(--fj-header-h) - var(--fj-footer-h) - 2 * var(--fj-content-pad-y));
+  height: calc(100dvh - var(--fj-header-h) - var(--fj-footer-h) - 2 * var(--fj-content-pad-y));
 }
 
 @media (max-width: 768px) {
-  .layout-content-inner {
-    padding: 12px 10px;
+  :root {
+    --fj-content-pad-y: 12px;
+    --fj-content-pad-x: 10px;
   }
 }
 

--- a/frontend/src/styles/layoutChrome.test.ts
+++ b/frontend/src/styles/layoutChrome.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * 页面「铬」（顶栏 / 页脚 / 内容区上下内边距）的高度必须是共享 token，而不是散落在
+ * Layout 内联样式与各页 calc() 里的裸数字。
+ *
+ * 2026-08-25 生产实锤：/chat 的外壳写死 `calc(100vh - 120px)`，而实际是
+ * 顶栏 52 + 内容区上下 24×2 + 页脚 50 = 150 —— 文档比视口高 30px，发送后自动贴底
+ * 把导航栏整个滚出视口，每次对话都能看到半截图标。数字分居两处就一定会漂。
+ */
+
+const CSS = readFileSync(resolve(__dirname, "global.css"), "utf-8");
+
+function rootBlock(): string {
+  const m = CSS.match(/:root\s*\{([\s\S]*?)\n\}/);
+  if (!m) throw new Error(":root block not found");
+  return m[1];
+}
+
+function rule(selector: string): string {
+  // 取该选择器在文件里的**第一条**声明块（基础值；媒体查询里的覆盖另测）。
+  const idx = CSS.indexOf(`\n${selector} {`);
+  if (idx < 0) throw new Error(`rule ${selector} not found in global.css`);
+  const end = CSS.indexOf("}", idx);
+  return CSS.slice(idx, end);
+}
+
+describe("布局铬高度 token", () => {
+  it(":root 定义顶栏/页脚/内容区内边距三个 token", () => {
+    const root = rootBlock();
+    expect(root).toMatch(/--fj-header-h:\s*52px/);
+    expect(root).toMatch(/--fj-footer-h:\s*50px/);
+    expect(root).toMatch(/--fj-content-pad-y:\s*24px/);
+  });
+
+  it("内容区内边距吃 token，而不是再写一遍 24px", () => {
+    expect(rule(".layout-content-inner")).toMatch(/padding:\s*var\(--fj-content-pad-y\)/);
+  });
+
+  it("移动端把内容区内边距 token 改成 12px（与原来的 12px 10px 一致）", () => {
+    const mobile = CSS.match(/@media \(max-width: 768px\)\s*\{[\s\S]*?--fj-content-pad-y:\s*(\d+)px/);
+    expect(mobile?.[1]).toBe("12");
+  });
+
+  it("对话外壳高度用三个 token 算，且给 100dvh 一份（手机地址栏收放不再溢出）", () => {
+    const shell = rule(".chat-shell");
+    expect(shell).toMatch(
+      /height:\s*calc\(100vh - var\(--fj-header-h\) - var\(--fj-footer-h\) - 2 \* var\(--fj-content-pad-y\)\)/,
+    );
+    expect(shell).toMatch(
+      /height:\s*calc\(100dvh - var\(--fj-header-h\) - var\(--fj-footer-h\) - 2 \* var\(--fj-content-pad-y\)\)/,
+    );
+    expect(shell).not.toMatch(/120px/);
+  });
+});

--- a/frontend/src/styles/layoutChrome.test.ts
+++ b/frontend/src/styles/layoutChrome.test.ts
@@ -54,4 +54,11 @@ describe("布局铬高度 token", () => {
     );
     expect(shell).not.toMatch(/120px/);
   });
+
+  it("手机空态放开外壳高度（height:auto），有对话后才锁高钉底", () => {
+    const m = CSS.match(/@media \(max-width: 768px\)\s*\{[\s\S]*?\.chat-shell\.chat-shell--empty\s*\{([^}]*)\}/);
+    expect(m, ".chat-shell.chat-shell--empty rule missing from the ≤768px block").not.toBeNull();
+    expect(m![1]).toMatch(/height:\s*auto/);
+    expect(m![1]).toMatch(/min-height:\s*calc\(100dvh - var\(--fj-header-h\)/);
+  });
 });


### PR DESCRIPTION
## 现象

/chat 发送后导航栏只剩半截：`.chat-shell` 写死 `calc(100vh - 120px)`，而布局铬实际 = 顶栏 52 + 内容区上下内边距 24×2 + 页脚 50 = **150px**。文档比视口高 30px（生产实测 `scrollY=30`、`docH 941 > innerH 911`），自动贴底把顶栏滚出视口。

## 改法

- `global.css :root` 新增 `--fj-header-h / --fj-footer-h / --fj-content-pad-y / --fj-content-pad-x`；`.layout-content-inner` 及 ≤768px 覆盖改吃 token。
- `Layout.tsx` 顶栏/页脚内联高度改为引用 token（页脚写死行高 18px：16+18+16=50，让 token 可信）。
- `.chat-shell` 的 display/gap/height 从内联样式搬进 CSS，按三枚 token 计算，并给 `100dvh` 一份（手机地址栏收放时 100vh 会多出一截）。

## 测试（先红后绿）

- `layoutChrome.test.ts`：token 定义、`.layout-content-inner` 吃 token、移动端 12px 覆盖、`.chat-shell` 的 vh/dvh 双规则。
- `Layout.test.tsx`：顶栏/页脚内联高度只许引用 token。`ChatPage.test.tsx`：外壳不再内联写死高度。修复前 6 条全红。
- 全套 551/551，eslint / tsc / i18n ratchet 通过。

## 验收

- 新增生产冒烟 `chat page chrome fits the viewport`：对**当前生产红**（+27px @1280×720），对本地 dist 绿。
- 本地 dist + `/api` 代理生产，Playwright 实测：1920×911 / 1440×900 / 1280×720 / iPhone 14 溢出均为 **0**，`headerTop=0`，顶栏 52 / 页脚 50，外壳高 = 视口 − 150（手机 − 126）。
