### PR TITLE
fix(mobile): /sources 卡片撑宽视口、/kg 搜索框只剩 1px

### DIFF
--- a/frontend/src/styles/kg.css
+++ b/frontend/src/styles/kg.css
@@ -732,7 +732,9 @@
 
   .kg-toolbar-main .ant-input-search {
     max-width: none;
-    flex: 1;
+    /* 独占一行。写 flex: 1（basis 0%）会和「全部类型」110px、「深度」120px 同排
+       挤在一行，只剩 86px，减去搜索按钮后输入框 1px 宽（2026-08-25 生产实测）。 */
+    flex: 1 1 100%;
     min-width: 0;
   }
 

--- a/frontend/src/styles/mobileLayout.test.ts
+++ b/frontend/src/styles/mobileLayout.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * 两处手机布局坏点（2026-08-25 Playwright 390px 生产实测）：
+ *
+ * /sources：`.sources-grid` 在 ≤768px 只写了 `1fr`，而 `1fr` = `minmax(auto, 1fr)`，
+ *   轨道的最小值是卡片的 min-content —— `.source-card-top` 是 nowrap 的 flex 行，
+ *   英文名一整行不折，min-content 算到 504px，于是单列轨道被撑到 504.6px、卡片 505px、
+ *   布局视口撑到 608px，描述文字在屏幕右缘被裁。要 `minmax(0, 1fr)`。
+ *
+ * /kg：≤768px 里 `.kg-toolbar-main .ant-input-search { flex: 1; min-width: 0 }`
+ *   让搜索框跟「全部类型」(110px) 与「深度」(120px) 同排挤在一行，只剩 86px，
+ *   减去搜索按钮后输入框 1px 宽。要占满整行（flex-basis 100%），让另外两个换行。
+ */
+
+const SOURCES = readFileSync(resolve(__dirname, "sources.css"), "utf-8");
+const KG = readFileSync(resolve(__dirname, "kg.css"), "utf-8");
+
+/** 取某个 max-width 媒体块里某选择器的声明体（第一处）。 */
+function ruleInMedia(css: string, maxWidth: number, selector: string): string {
+  const re = new RegExp(`@media \\(max-width: ${maxWidth}px\\)\\s*\\{([\\s\\S]*?)\\n\\}`, "g");
+  for (const m of css.matchAll(re)) {
+    const block = m[1];
+    const i = block.indexOf(`${selector} {`);
+    if (i >= 0) return block.slice(i, block.indexOf("}", i));
+  }
+  throw new Error(`${selector} not found in any @media (max-width: ${maxWidth}px) block`);
+}
+
+function baseRule(css: string, selector: string): string {
+  const i = css.indexOf(`\n${selector} {`);
+  if (i < 0) throw new Error(`${selector} not found`);
+  return css.slice(i, css.indexOf("}", i));
+}
+
+describe("手机布局：/sources 网格与 /kg 工具栏", () => {
+  it("/sources 单列轨道最小值必须是 0，不能让卡片的 min-content 撑宽视口", () => {
+    expect(ruleInMedia(SOURCES, 768, ".sources-grid")).toMatch(/grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+  });
+
+  it("/sources 桌面网格的列宽下限不得超过容器（min(320px, 100%)）", () => {
+    expect(baseRule(SOURCES, ".sources-grid")).toMatch(/minmax\(min\(320px,\s*100%\),\s*1fr\)/);
+  });
+
+  it("/kg 手机上搜索框独占一行（flex-basis 100%），不与类型/深度同排挤压", () => {
+    const rule = ruleInMedia(KG, 768, ".kg-toolbar-main .ant-input-search");
+    expect(rule).toMatch(/flex:\s*1 1 100%/);
+    expect(rule).toMatch(/min-width:\s*0/);
+  });
+});

--- a/frontend/src/styles/sources.css
+++ b/frontend/src/styles/sources.css
@@ -281,11 +281,15 @@
 /* ---------- 卡片网格 ---------- */
 .sources-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  /* min(320px, 100%)：列宽下限不得超过容器，否则窄容器里轨道比容器还宽。 */
+  grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
   gap: 12px;
 }
 
 .source-card {
+  /* 网格项的自动最小尺寸是 min-content；卡片顶行是 nowrap 的英文名，会把轨道撑到
+     500px+。归零后由 .source-card-name-en 自己 ellipsis。 */
+  min-width: 0;
   background: var(--fj-surface);
   border: 1px solid var(--fj-border);
   border-radius: 8px;
@@ -626,7 +630,10 @@
   }
 
   .sources-grid {
-    grid-template-columns: 1fr;
+    /* 不能写 1fr：它等于 minmax(auto, 1fr)，最小值取卡片 min-content（504px），
+       单列轨道反而比 390px 视口宽，布局视口被撑到 608px、描述文字在右缘被裁
+       （2026-08-25 Playwright 生产实测）。 */
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .sources-title {


### PR DESCRIPTION
## 现象（Playwright iPhone 14 / 390px，生产实测）

- **/sources**：`.source-card` 505px 宽，布局视口被撑到 608px（`scrollWidth 608`），描述文字在屏幕右缘被裁。
- **/kg**：搜索输入框宽 **1px**，只剩放大镜按钮，手机上图谱无法搜索。

## 根因与改法

- `/sources`：≤768px 的 `.sources-grid { grid-template-columns: 1fr }` —— `1fr` 等于 `minmax(auto, 1fr)`，轨道最小值取卡片 min-content；`.source-card-top` 是 nowrap 的 flex 行，英文名整行不折，min-content 算到 504px → 轨道 504.6px。改 `minmax(0, 1fr)`；桌面 `auto-fill` 的下限改 `min(320px, 100%)`；`.source-card { min-width: 0 }`。
- `/kg`：≤768px 的 `.kg-toolbar-main .ant-input-search { flex: 1 }`（basis 0%）与「全部类型」110px、「深度」120px 同排挤在一行只剩 86px。改 `flex: 1 1 100%` 独占一行，另外两个自然换行。

## 测试

`frontend/src/styles/mobileLayout.test.ts` 钉住三条规则，修复前全红；全套 548/548，eslint / tsc / i18n ratchet 通过。

## 验收（本地 dist + `/api` 代理生产，iPhone 14）

| | 修复前（生产） | 修复后 |
|---|---|---|
| /sources scrollWidth / clientWidth | 608 / 390 | **390 / 390** |
| /sources 卡片宽 | 505 | **338** |
| /kg 输入框宽 | 1 | **247** |
