### PR TITLE
fix(dict): 命名 HTML 实体未解码——「般若」条显示 praj&ntilde;ā

### DIFF
--- a/backend/scripts/archive/imports/import_mdict.py
+++ b/backend/scripts/archive/imports/import_mdict.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import sys
+from html import unescape
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -35,9 +36,10 @@ def strip_html(html_str: str) -> str:
     s = re.sub(r"</(p|div|li|tr|h[1-6])>", "\n", s, flags=re.IGNORECASE)
     # Remove all remaining tags
     s = re.sub(r"<[^>]+>", "", s)
-    # Decode common HTML entities
-    s = s.replace("&nbsp;", " ").replace("&lt;", "<").replace("&gt;", ">")
-    s = s.replace("&amp;", "&").replace("&quot;", '"').replace("&#39;", "'")
+    # Decode ALL HTML entities. The old hand-rolled six replacements left every
+    # other named entity verbatim — 佛光大辞典 shipped ``praj&ntilde;ā`` to prod
+    # (see scripts/fix_dict_html_entities.py). &nbsp; keeps mapping to a plain space.
+    s = unescape(s).replace("\xa0", " ")
     # Normalize whitespace: collapse multiple spaces on same line, strip trailing
     lines = [line.strip() for line in s.split("\n")]
     s = "\n".join(line for line in lines if line)

--- a/backend/scripts/fix_dict_html_entities.py
+++ b/backend/scripts/fix_dict_html_entities.py
@@ -15,6 +15,13 @@ already in the database.
 Why it matters beyond cosmetics: each junk headword is a /dict/ page crawlers index,
 and every crawl costs a reverse-index lookup against a 276MB TOASTed column.
 
+2026-08-25 second pass — named entities. 佛光大辞典「般若」 shows ``praj&ntilde;ā`` in
+prod: those rows came through import_mdict.py, whose hand-rolled decoder only knew
+amp/quot/#39/nbsp/lt/gt, so every other named entity was stored verbatim.
+decode_entities() is the backfill's single entry point: numeric → named → numeric
+again (a double-escaped ``&amp;#X4E98;`` needs two rounds). Only ``;``-terminated
+names that HTML5 defines are touched; a bare ``&`` or an unknown ``&foo;`` stays.
+
 Usage:
     python -m scripts.fix_dict_html_entities              # dry run (default)
     python -m scripts.fix_dict_html_entities --write      # apply
@@ -27,6 +34,7 @@ import argparse
 import asyncio
 import re
 import sys
+from html.entities import html5
 
 # app.database is imported inside main() on purpose: importing it builds the
 # async engine, and decode_numeric_entities() is a pure function that its tests
@@ -79,10 +87,53 @@ def decode_numeric_entities(s: str) -> str:
     return _NUMERIC_REF.sub(_repl, s)
 
 
-SELECT_SQL = """
+# Named references: ``&ntilde;`` — a ``;``-terminated name. Names without the
+# semicolon are deliberately NOT matched (``&ntilde`` is legal HTML too, but here
+# we only repair the shape we know is broken).
+_NAMED_REF = re.compile(r"&([A-Za-z][A-Za-z0-9]{1,31});")
+
+
+def decode_named_entities(s: str) -> str:
+    """Replace ``;``-terminated named references HTML5 defines; leave the rest."""
+    if not s:
+        return s
+
+    def _repl(m: re.Match[str]) -> str:
+        decoded = html5.get(m.group(1) + ";", m.group(0))
+        # &nbsp; → plain space, same as the importers do; a U+00A0 inside a
+        # definition body only confuses search and copy-paste.
+        return " " if decoded == "\xa0" else decoded
+
+    return _NAMED_REF.sub(_repl, s)
+
+
+def decode_entities(s: str) -> str:
+    """Numeric → named → numeric, repeated until stable (max 3 rounds).
+
+    Two rounds are needed for buddhaspace's double-escaped ``&amp;#X4E98;``:
+    the named pass turns it into ``&#X4E98;`` and the numeric pass finishes it.
+    Unsafe numeric references are still refused by decode_numeric_entities().
+    """
+    out = s
+    for _ in range(3):
+        nxt = decode_numeric_entities(decode_named_entities(decode_numeric_entities(out)))
+        if nxt == out:
+            break
+        out = nxt
+    return out
+
+
+# Postgres regex (``~``) mirrors _NAMED_REF; the LIKE keeps the numeric shape.
+_BROKEN_ROWS_WHERE = """
+    WHERE headword LIKE '%&#%' OR definition LIKE '%&#%'
+       OR headword ~ '&[A-Za-z][A-Za-z0-9]{1,31};'
+       OR definition ~ '&[A-Za-z][A-Za-z0-9]{1,31};'
+"""
+
+SELECT_SQL = f"""
     SELECT id, headword, definition
     FROM dictionary_entries
-    WHERE headword LIKE '%&#%' OR definition LIKE '%&#%'
+    {_BROKEN_ROWS_WHERE}
     ORDER BY id
 """
 
@@ -116,8 +167,8 @@ async def main() -> int:
         planned = []
         skipped = []
         for row_id, headword, definition in rows:
-            new_head = decode_numeric_entities(headword or "")
-            new_def = decode_numeric_entities(definition or "")
+            new_head = decode_entities(headword or "")
+            new_def = decode_entities(definition or "")
             if new_head == (headword or "") and new_def == (definition or ""):
                 # Nothing decodable — a leftover unsafe reference, or a stray '&#'
                 # that is not a character reference at all.
@@ -166,13 +217,10 @@ async def main() -> int:
 
         left = (
             await session.execute(
-                text(
-                    "SELECT count(*) FROM dictionary_entries "
-                    "WHERE headword LIKE '%&#%' OR definition LIKE '%&#%'"
-                )
+                text(f"SELECT count(*) FROM dictionary_entries {_BROKEN_ROWS_WHERE}")
             )
         ).scalar()
-        print(f"[verify] 仍含 '&#' 的行: {left}")
+        print(f"[verify] 仍含实体（数字或命名）的行: {left}")
     return 0
 
 

--- a/backend/tests/test_fix_dict_html_entities.py
+++ b/backend/tests/test_fix_dict_html_entities.py
@@ -16,8 +16,7 @@ so the backfill can never rewrite a legitimate ``&`` in a definition body.
 """
 
 import pytest
-
-from scripts.fix_dict_html_entities import decode_numeric_entities
+from scripts.fix_dict_html_entities import SELECT_SQL, decode_entities, decode_numeric_entities
 
 
 def test_decodes_uppercase_hex_reference():
@@ -96,3 +95,57 @@ def test_importer_strip_html_no_longer_manufactures_the_bad_string():
     assert _strip_html("<p>&#X4E98;以</p>") == "亘以"
     # Ordinary named entities still decode.
     assert _strip_html("<p>A &amp; B</p>") == "A & B"
+
+
+# ---------------------------------------------------------------------------
+# 命名实体（2026-08-25）：佛光大辞典「般若」条释义显示 ``praj&ntilde;ā``。这批词条
+# 来自 mdict 导入器，它只手工替换了 amp/quot/#39/nbsp/lt/gt 六个，其余命名实体原样
+# 落库。decode_entities() 是给回填脚本用的总入口：数字 → 命名 → 再数字（双重转义
+# ``&amp;#X4E98;`` 要两轮），只认带分号的、HTML5 认识的名字。
+# ---------------------------------------------------------------------------
+
+
+def test_decodes_named_entity_seen_in_prod():
+    assert decode_entities("praj&ntilde;ā") == "prajñā"
+    assert decode_entities("Prajñāpāramitā &mdash; 般若") == "Prajñāpāramitā — 般若"
+
+
+def test_named_pass_also_handles_markup_entities():
+    # 释义正文里存的 ``&lt;`` 在页面上就显示成 ``&lt;``（前端按纯文本渲染），一样是错的。
+    # 生产实数（2026-08-25）：10,596 行受影响，&amp; 12,109 处、&rarr; 1,749、&ntilde; 1,068。
+    assert decode_entities("A &amp; B") == "A & B"
+    assert decode_entities("&lt;tag&gt; &quot;q&quot;") == '<tag> "q"'
+    assert decode_entities("参见 &rarr; 般若") == "参见 → 般若"
+
+
+def test_nbsp_becomes_a_plain_space_like_the_importers_do():
+    assert decode_entities("a&nbsp;b") == "a b"
+    assert "\xa0" not in decode_entities("a&nbsp;b")
+
+
+def test_double_escaped_numeric_reference_needs_two_rounds():
+    # buddhaspace 的老病：``&amp;#X4E98;`` —— 先解成 ``&#X4E98;`` 再解成字。
+    assert decode_entities("&amp;#X4E98;以") == "亘以"
+
+
+def test_bare_ampersand_and_unknown_names_are_left_alone():
+    assert decode_entities("A & B") == "A & B"
+    assert decode_entities("&foo;") == "&foo;"
+    # 没有分号的不碰：``&ntilde`` 在 HTML 里也合法，但这里只修确定坏了的形态。
+    assert decode_entities("&ntilde") == "&ntilde"
+    assert decode_entities("") == ""
+
+
+def test_named_pass_keeps_unsafe_numeric_refusal():
+    assert decode_entities("&#XD800;x") == "&#XD800;x"
+
+
+def test_decode_entities_is_idempotent():
+    once = decode_entities("praj&ntilde;ā &amp;#X4E98;")
+    assert decode_entities(once) == once == "prajñā 亘"
+
+
+def test_select_sql_finds_named_entities_too():
+    """回填 SELECT 只查 '&#' 会漏掉 ``&ntilde;`` 这类行 —— 修脚本却查不出行等于没修。"""
+    assert "&[A-Za-z][A-Za-z0-9]{1,31};" in SELECT_SQL
+    assert "LIKE '%&#%'" in SELECT_SQL


### PR DESCRIPTION
## 现象

辞典查「般若」，佛光大辞典第一条释义显示 `praj&ntilde;ā`（`/api/dictionary/search?q=般若` 原样返回 `&ntilde;`）。第一大词头的第一屏。

## 根因

这批词条经 `scripts/archive/imports/import_mdict.py` 入库，它手工只替换 `amp/quot/#39/nbsp/lt/gt` 六个实体，其余命名实体原样落库；回填脚本 `fix_dict_html_entities.py` 只解数字实体、`SELECT` 只查 `'&#'`，这类行既没修也查不出。

## 改法

- 回填脚本新增 `decode_named_entities`（只认带分号、HTML5 定义的名字；裸 `&`、未知 `&foo;`、无分号的 `&ntilde` 不碰）与总入口 `decode_entities`（数字 → 命名 → 再数字直到稳定；双重转义 `&amp;#X4E98;` 需要两轮）。数字实体的不安全码点拒绝逻辑原样保留。`SELECT` / 写后 verify 的 `WHERE` 同时匹配 `~ '&[A-Za-z][A-Za-z0-9]{1,31};'`。
- `import_mdict.py` 改用 `html.unescape`（`&nbsp;` 仍映射为普通空格），从源头堵住。

## 测试

新增 7 条（先红后绿）：生产原样 `praj&ntilde;ā`、标记类实体、双重转义两轮、裸 `&` / 未知名 / 无分号不碰、不安全码点仍拒绝、幂等、`SELECT_SQL` 覆盖命名实体。原有 12 条不变，19/19。全套 backend 1827 通过（3 条 `test_health_check_probe` 失败为 master 既有，不在 CI 范围）。ruff 0.9.7 对改动文件无新增告警（`SIM103` 为既有）。

## 上线后的一步手工操作

```bash
# 生产（/home/admin/fojin），先看行数与样本，再写
docker compose run --rm --no-deps backend python -m scripts.fix_dict_html_entities
docker compose run --rm --no-deps backend python -m scripts.fix_dict_html_entities --write
```
