### PR TITLE
fix(pages): 五个页面 <title> 为空/沿用首页标题；阅读器无音频的卷不再请求 /audio

### DIFF
--- a/backend/app/api/texts.py
+++ b/backend/app/api/texts.py
@@ -14,7 +14,7 @@ from app.models.source import DataSource
 from app.models.text import BuddhistText
 from app.models.user import ReadingHistory, User
 from app.schemas.text import JuanContentResponse, JuanLanguagesResponse, JuanListResponse, TextResponseBase
-from app.services.audio import get_juan_audio
+from app.services.audio import get_juan_audio, has_juan_audio
 from app.services.content import (
     get_juan_apparatus,
     get_juan_content,
@@ -215,6 +215,8 @@ async def read_juan(
     result = await get_juan_content(db, text_id, juan_num, lang=lang)
     if result is None:
         raise TextNotFoundError(text_id=text_id)
+    # 只有心經有音频；此前阅读器每换一卷都无条件打一次 /audio，其余卷全是 404。
+    result.has_audio = await has_juan_audio(db, text_id, juan_num)
 
     # Record reading history for logged-in users
     if user is not None:

--- a/backend/app/schemas/text.py
+++ b/backend/app/schemas/text.py
@@ -82,6 +82,8 @@ class JuanContentResponse(BaseModel):
     lang: str = "lzh"
     prev_juan: int | None = None
     next_juan: int | None = None
+    # 本卷是否有读诵音频。前端据此决定要不要请求 /audio —— 没有就不问，省一个 404。
+    has_audio: bool = False
     # Reader-side base-edition (底本) declaration. Same provenance as
     # TextResponseBase.canon — derived from cbeta_id prefix.
     canon: str | None = None

--- a/backend/app/services/audio.py
+++ b/backend/app/services/audio.py
@@ -54,6 +54,20 @@ async def get_juan_audio(
     return build_audio_payload(audio) if audio else None
 
 
+async def has_juan_audio(session: AsyncSession, text_id: int, juan_num: int, lang: str = "zh") -> bool:
+    """本卷有没有音频 —— 读经接口把它带给前端，没有就别再请求 /audio 吃 404。"""
+    stmt = (
+        select(TextAudio.id)
+        .where(
+            TextAudio.text_id == text_id,
+            TextAudio.juan_num == juan_num,
+            TextAudio.lang == lang,
+        )
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+
 def group_audio_by_text(rows: list[tuple]) -> list[dict]:
     """``[(TextAudio, BuddhistText), …]`` → 按经聚合的目录项。
 

--- a/backend/tests/test_audio_api.py
+++ b/backend/tests/test_audio_api.py
@@ -141,3 +141,31 @@ async def test_endpoint_returns_payload_when_audio_exists(client) -> None:
         assert body["cues"][0]["kind"] == "head"
     finally:
         texts_api.get_juan_audio = original
+
+
+async def test_juan_content_reports_has_audio(client) -> None:
+    """读经接口带 has_audio —— 前端据此决定要不要再请求 /audio。
+
+    此前阅读器每换一卷都无条件打一次 /audio，而只有心經有音频：其余 10,531 部
+    每卷一个 404（2026-08-25 走查实测）。
+    """
+    from app.api import texts as texts_api
+    from app.schemas.text import JuanContentResponse
+
+    content = JuanContentResponse(
+        text_id=9, cbeta_id="T0251", title_zh="般若波羅蜜多心經", juan_num=1,
+        total_juans=1, content="觀自在菩薩", char_count=5,
+    )
+    orig_content, orig_has = texts_api.get_juan_content, texts_api.has_juan_audio
+    texts_api.get_juan_content = AsyncMock(return_value=content)
+    try:
+        texts_api.has_juan_audio = AsyncMock(return_value=True)
+        resp = await client.get("/api/texts/9/juans/1")
+        assert resp.status_code == 200
+        assert resp.json()["has_audio"] is True
+
+        texts_api.has_juan_audio = AsyncMock(return_value=False)
+        resp = await client.get("/api/texts/9/juans/1")
+        assert resp.json()["has_audio"] is False
+    finally:
+        texts_api.get_juan_content, texts_api.has_juan_audio = orig_content, orig_has

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -205,6 +205,8 @@ export interface JuanContentResponse {
   char_count: number;
   prev_juan: number | null;
   next_juan: number | null;
+  /** 本卷有读诵音频才为 true；旧后端副本不带这个字段（滚动部署期间）→ 当 false。 */
+  has_audio?: boolean;
   // Base-edition (底本) — derived from cbeta_id prefix by the backend.
   // canon is the machine code (taisho / xuzang / pali / kangyur / gretil);
   // canon_label is the Chinese display string (大正藏 / 卍续藏 / …).

--- a/frontend/src/pages/DictionaryPage.tsx
+++ b/frontend/src/pages/DictionaryPage.tsx
@@ -236,7 +236,7 @@ export default function DictionaryPage() {
   return (
     <div className="dict-page">
       <Helmet>
-        <title>{t("nav.dictionary")} - {t("app.name")}</title>
+        <title>{`${t("nav.dictionary")} - ${t("app.name")}`}</title>
       </Helmet>
 
       {/* Header */}

--- a/frontend/src/pages/KGMapPage.tsx
+++ b/frontend/src/pages/KGMapPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Checkbox, Spin, Empty, Tooltip, Switch, AutoComplete } from "antd";
 import { GlobalOutlined, BarChartOutlined, SearchOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
+import { Helmet } from "react-helmet-async";
 import * as OpenCC from "opencc-js";
 import DeckGLMap from "../components/kg-map/DeckGLMap";
 import { typeColorCss } from "../components/kg-map/typeColors";
@@ -136,6 +137,9 @@ export default function KGMapPage() {
 
   return (
     <div className="kg-map-page">
+      <Helmet>
+        <title>{`${t("geo.title")} - ${t("app.name")}`}</title>
+      </Helmet>
       {/* Header */}
       <div className="kg-map-header">
         <GlobalOutlined />

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { HelmetProvider } from "react-helmet-async";
 import { MemoryRouter } from "react-router";
 import i18n from "../i18n";
 import enTranslation from "../../public/locales/en/translation.json";
@@ -20,6 +21,10 @@ beforeAll(() => {
       }) as unknown as MediaQueryList;
   }
   i18n.addResourceBundle("en", "translation", enTranslation, true, true);
+  // react-helmet-async 默认 defer: true，把 <title> 写入排到 requestAnimationFrame；
+  // jsdom 下这个 rAF 不会自己跑，document.title 永远是空串。这里让它走宏任务。
+  window.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+    setTimeout(() => cb(0), 0) as unknown as number) as typeof window.requestAnimationFrame;
 });
 
 describe("LoginPage", () => {
@@ -33,13 +38,29 @@ describe("LoginPage", () => {
 
   it("renders social login copy in the active UI language", () => {
     render(
-      <MemoryRouter initialEntries={["/login"]}>
-        <LoginPage />
-      </MemoryRouter>,
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/login"]}>
+          <LoginPage />
+        </MemoryRouter>
+      </HelmetProvider>,
     );
 
     expect(screen.getByText("or continue with a third-party account")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Log in with GitHub/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Log in with Google/ })).toBeInTheDocument();
+  });
+
+  // /login 此前没有 <title>，浏览器标签、历史记录、分享卡片都显示首页标题
+  //（2026-08-25 Playwright 走查实测）。
+  it("sets a page-specific document title", async () => {
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={["/login"]}>
+          <LoginPage />
+        </MemoryRouter>
+      </HelmetProvider>,
+    );
+    await waitFor(() => expect(document.title).toMatch(/Log in|登录/));
+    expect(document.title).toMatch(/FoJin|佛津/);
   });
 });

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { Card, Form, Input, Button, Typography, Tabs, Divider, message, Space } from "antd";
 import { UserOutlined, LockOutlined, MailOutlined, GithubOutlined, GoogleOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
+import { Helmet } from "react-helmet-async";
 import axios from "axios";
 import { useAuthStore } from "../stores/authStore";
 import api from "../api/client";
@@ -127,6 +128,9 @@ export default function LoginPage() {
         padding: 24,
       }}
     >
+      <Helmet>
+        <title>{`${t("auth.login")} - ${t("app.name")}`}</title>
+      </Helmet>
       <Card style={{ width: 420 }}>
         <Title level={3} style={{ textAlign: "center", marginBottom: 24 }}>
           {t("app.name")}

--- a/frontend/src/pages/ResearchPage.tsx
+++ b/frontend/src/pages/ResearchPage.tsx
@@ -66,7 +66,7 @@ export default function ResearchPage() {
         {/* 品牌后缀用 app.name（短名）而非 app.title：后者是首页专用的完整主张句，
             拼进来会变成「研究助手 — 佛津 FoJin — 佛经 AI 问答，每句引用可点开核对原文」。
             DictionaryPage 等页面用的就是 app.name，这里跟齐。 */}
-        <title>{t("research.title")} — {t("app.name")}</title>
+        <title>{`${t("research.title")} — ${t("app.name")}`}</title>
       </Helmet>
 
       <header className="rp-header">

--- a/frontend/src/pages/TextReaderPage.audio.test.tsx
+++ b/frontend/src/pages/TextReaderPage.audio.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter, Route, Routes } from "react-router";
+import TextReaderPage from "./TextReaderPage";
+import {
+  checkBookmark,
+  getJuanAudio,
+  getJuanContent,
+  getJuanLanguages,
+  getJuanLineAnchors,
+  getJuanList,
+  getTextDetail,
+  type JuanContentResponse,
+} from "../api/client";
+import type { TextId } from "../types/branded";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    getTextDetail: vi.fn(),
+    getJuanList: vi.fn(),
+    getJuanContent: vi.fn(),
+    getJuanLanguages: vi.fn(),
+    getJuanLineAnchors: vi.fn(),
+    getJuanAudio: vi.fn(),
+    getJuanApparatus: vi.fn(),
+    checkBookmark: vi.fn(),
+    searchDictionaryGrouped: vi.fn(),
+    sendChatMessageStream: vi.fn(),
+  };
+});
+
+vi.mock("../api/chatModels", () => ({
+  fetchChatModels: vi.fn().mockResolvedValue([]),
+}));
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false, media: query, onchange: null,
+      addListener: () => {}, removeListener: () => {},
+      addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+  if (!window.requestAnimationFrame) {
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+      setTimeout(() => cb(0), 0) as unknown as number) as typeof window.requestAnimationFrame;
+  }
+});
+
+const TEXT_ID = 69 as TextId;
+
+function content(extra: Partial<JuanContentResponse>): JuanContentResponse {
+  return {
+    text_id: TEXT_ID, cbeta_id: "T0676", title_zh: "解深密經", juan_num: 1, total_juans: 5,
+    content: "如是我聞：一時，薄伽梵住最勝光曜七寶莊嚴。", char_count: 20,
+    prev_juan: null, next_juan: 2, canon: "taisho", canon_label: "大正藏",
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(getTextDetail).mockResolvedValue({
+    id: TEXT_ID, taisho_id: "T0676", cbeta_id: "T0676", title_zh: "解深密經",
+    title_sa: null, title_bo: null, title_pi: null, translator: "玄奘", dynasty: "唐",
+    fascicle_count: 5, category: null, subcategory: null, cbeta_url: null,
+    has_content: true, content_char_count: 7574, lang: "lzh", created_at: "2026-01-01T00:00:00Z",
+  });
+  vi.mocked(getJuanList).mockResolvedValue({
+    text_id: TEXT_ID, title_zh: "解深密經", total_juans: 5,
+    juans: [{ juan_num: 1, char_count: 7574 }, { juan_num: 2, char_count: 7000 }],
+  });
+  vi.mocked(getJuanLanguages).mockResolvedValue({
+    text_id: TEXT_ID, juan_num: 1, languages: ["lzh"], default_lang: "lzh",
+  });
+  vi.mocked(getJuanLineAnchors).mockResolvedValue({ text_id: TEXT_ID, juan_num: 1, anchors: [] });
+  vi.mocked(getJuanAudio).mockRejectedValue(new Error("404"));
+  vi.mocked(checkBookmark).mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function renderReader() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const r = render(
+    <HelmetProvider>
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/texts/69/read"]}>
+          <Routes>
+            <Route path="/texts/:id/read" element={<TextReaderPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+  await screen.findByText(/如是我聞/);
+  return r;
+}
+
+// 只有心經有音频，其余 10,531 部每换一卷都无条件打一次 /audio 吃 404
+//（2026-08-25 走查实测）。读经接口现在带 has_audio，没有就别问。
+describe("阅读器只在本卷真有音频时才请求 /audio", () => {
+  it("has_audio 缺省/false：不请求", async () => {
+    vi.mocked(getJuanContent).mockResolvedValue(content({}));
+    await renderReader();
+    // 给 react-query 一个 tick 去调度可能的请求，再断言它没发生
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getJuanAudio).not.toHaveBeenCalled();
+  });
+
+  it("has_audio 为 true：请求本卷音频", async () => {
+    vi.mocked(getJuanContent).mockResolvedValue(content({ has_audio: true }));
+    await renderReader();
+    await waitFor(() => expect(getJuanAudio).toHaveBeenCalledWith(69, 1));
+  });
+});

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -656,7 +656,8 @@ export default function TextReaderPage() {
   const { data: audioData } = useQuery({
     queryKey: ["juanAudio", textId, juanNum],
     queryFn: () => getJuanAudio(Number(textId), juanNum),
-    enabled: !!textId,
+    // 只有本卷真有音频才问：此前每换一卷都无条件请求，只有心經有音频，其余全是 404。
+    enabled: !!textId && content?.has_audio === true,
     staleTime: 3600000,
     retry: false,
   });

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -37,7 +37,7 @@ export default function TimelinePage() {
   return (
     <>
       <Helmet>
-        <title>{t("timeline.title", "时间线")} - FoJin</title>
+        <title>{`${t("timeline.title", "时间线")} - FoJin`}</title>
       </Helmet>
       <div className="timeline-container">
         <div className="timeline-header">

--- a/frontend/src/pages/pageTitles.test.ts
+++ b/frontend/src/pages/pageTitles.test.ts
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * react-helmet-async 3.x 只接受 <title> 的**单个**子节点：写成
+ * `<title>{t("x")} - {t("app.name")}</title>`（三个子节点）时它整个丢掉，页面
+ * 的 <title> 变成空串 —— 生产 /dictionary 的标签页标题就是这么空的
+ * （2026-08-25 Playwright 走查实测；jsdom 里同样复现）。
+ *
+ * 规则：每个 <title>…</title> 里最多一个 `{…}` 表达式，且表达式外不得再有文字。
+ * 要拼接就用模板字符串：`<title>{`${a} - ${b}`}</title>`。
+ */
+const PAGES_DIR = resolve(__dirname);
+
+function titleBodies(src: string): string[] {
+  return [...src.matchAll(/<title>([\s\S]*?)<\/title>/g)].map((m) => m[1].trim());
+}
+
+/** 顶层 `{…}` 表达式个数（忽略模板字符串/嵌套花括号内部）。 */
+function topLevelExpressions(body: string): { count: number; loose: string } {
+  let depth = 0;
+  let count = 0;
+  let loose = "";
+  for (const ch of body) {
+    if (ch === "{") {
+      if (depth === 0) count += 1;
+      depth += 1;
+    } else if (ch === "}") {
+      depth -= 1;
+    } else if (depth === 0) {
+      loose += ch;
+    }
+  }
+  return { count, loose: loose.trim() };
+}
+
+describe("<title> 只能有一个子节点（react-helmet-async 3 会丢掉数组子节点）", () => {
+  const files = readdirSync(PAGES_DIR).filter((f) => f.endsWith(".tsx") && !f.includes(".test."));
+
+  it.each(files)("%s", (file) => {
+    const src = readFileSync(resolve(PAGES_DIR, file), "utf-8");
+    for (const body of titleBodies(src)) {
+      const { count, loose } = topLevelExpressions(body);
+      const single = count <= 1 && (count === 0 || loose === "");
+      expect(single, `${file}: <title>${body}</title> 有 ${count} 个表达式、松散文本 "${loose}"`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## 两件走查里的小病

### 1. 标签页标题
- `/dictionary` 的 `<title>` 是**空串**，`/login`、`/map` 沿用首页那句长标题（Playwright 生产实测）。
- 根因：react-helmet-async 3 只接受 `<title>` 的**单个**子节点。`<title>{t("x")} - {t("app.name")}</title>` 是三个子节点，它整个丢掉（jsdom 可复现）。
- 改法：五处改为模板字符串（Dictionary / Research / Timeline 既有写法，Login / Map 新补 Helmet）。新增 `pageTitles.test.ts` 扫描 `src/pages/*.tsx`，`<title>` 里只许一个表达式 —— 修前五个文件全红，防止再写回去。

### 2. 阅读器的 /audio 404
- 每换一卷都无条件请求 `/texts/:id/juans/:n/audio`，而只有心經有音频：其余 10,531 部每卷一个 404。
- 改法：读经接口 `JuanContentResponse` 新增 `has_audio`（`services/audio.py::has_juan_audio`，一条 EXISTS），前端只在为 `true` 时才请求。旧后端副本不带该字段（滚动部署期间）视为 `false`。

## 测试（先红后绿）
- 后端 `test_audio_api.py` 新增 `has_audio` 端点用例；ruff 0.9.7 无告警。
- 前端 `TextReaderPage.audio.test.tsx`（缺省不请求 / 为 true 才请求）、`LoginPage.test.tsx` 标题、`pageTitles.test.ts` 守卫。全套 585/585，eslint / tsc / i18n ratchet 通过。

## 验收（本地 dist + `/api` 代理生产 vs 当前生产）

| | 生产 | 修复后 |
|---|---|---|
| `/login` title | 首页长标题 | **登录 - 佛津** |
| `/map` title | 首页长标题 | **佛教地理 - 佛津** |
| `/dictionary?q=般若` title | 空串 | **佛学辞典 - 佛津** |
| `/texts/69/read` 请求 `/audio` | 1 次（404） | **0 次** |

心經（text 9）的「为 true 才请求」分支要等后端一起上线后在生产复验（本地代理的是旧后端，不带 `has_audio`）。
