### PR TITLE
feat(chat): 等待期先给原文——retrieved 帧带轻量 refs，检索到的经文立刻可点

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -954,6 +954,28 @@ async def send_message_stream(
         for _s in sources:
             if _s.title_zh and _s.title_zh not in _seen_titles:
                 _seen_titles.append(_s.title_zh)
+        # refs：等待期就能点开原文的定位字段（首字前常等 30–180 秒，而检索 2–3 秒
+        # 就完成了）。只带 text_id / juan_num / chunk_index / title_zh，**不带 chunk_text**
+        # —— 它不是 sources：前端把它存在 retrieval 字段里、不喂 injectCitationLinks，
+        # 上面那两条「不提前发 sources」的理由都不受影响。按 (text_id, juan_num) 去重、
+        # 保持召回顺序、至多 8 条。
+        _refs: list[dict] = []
+        _seen_ref_keys: set[tuple[int, int]] = set()
+        for _s in sources:
+            _key = (_s.text_id, _s.juan_num)
+            if _key in _seen_ref_keys:
+                continue
+            _seen_ref_keys.add(_key)
+            _refs.append(
+                {
+                    "text_id": _s.text_id,
+                    "juan_num": _s.juan_num,
+                    "chunk_index": _s.chunk_index,
+                    "title_zh": _s.title_zh,
+                }
+            )
+            if len(_refs) >= 8:
+                break
         yield (
             "data: "
             + json.dumps(
@@ -963,6 +985,7 @@ async def send_message_stream(
                     # 只取前 3 部：召回通常 5-8 部，全列会把等待提示撑得比答案还长。
                     # count 仍是全量数字，所以「已检索 8 部经典：《A》《B》《C》」诚实。
                     "titles": _seen_titles[:3],
+                    "refs": _refs,
                 },
                 ensure_ascii=False,
             )

--- a/backend/tests/test_chat_stream_retrieved_event.py
+++ b/backend/tests/test_chat_stream_retrieved_event.py
@@ -154,3 +154,35 @@ async def test_no_retrieved_event_when_nothing_retrieved():
     events = await _run_stream([])
     types = [e.get("type") for e in events]
     assert "retrieved" not in types, f"零召回不该发 retrieved；实际: {types}"
+
+
+@pytest.mark.anyio
+async def test_retrieved_carries_light_refs_for_early_source_chips():
+    """等待期（首字前常 30–180 秒）就能点开原文：``retrieved`` 带轻量 ``refs``。
+
+    ``refs`` 只有定位字段（text_id / juan_num / chunk_index / title_zh），**没有**
+    chunk_text —— 完整 ``sources`` 仍是最后一个数据事件（见上一条用例），前端也不会
+    把 refs 喂给 injectCitationLinks。按 (text_id, juan_num) 去重、保持召回顺序、
+    至多 8 条。
+    """
+    events = await _run_stream(_sources())
+    retrieved = next(e for e in events if e.get("type") == "retrieved")
+
+    refs = retrieved["refs"]
+    assert [(r["text_id"], r["juan_num"]) for r in refs] == [(1, 1), (2, 403), (3, 1), (4, 1)]
+    assert [r["title_zh"] for r in refs] == ["心经", "大般若经", "华严经", "法华经"]
+    for r in refs:
+        assert set(r) == {"text_id", "juan_num", "chunk_index", "title_zh"}, r
+    assert "chunk_text" not in json.dumps(retrieved, ensure_ascii=False)
+
+
+@pytest.mark.anyio
+async def test_retrieved_refs_capped_at_eight():
+    many = [
+        ChatSource(text_id=i, juan_num=1, chunk_text="x", score=0.5, title_zh=f"经{i}")
+        for i in range(1, 13)
+    ]
+    events = await _run_stream(many)
+    retrieved = next(e for e in events if e.get("type") == "retrieved")
+    assert len(retrieved["refs"]) == 8
+    assert retrieved["count"] == 12

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -373,6 +373,32 @@ describe("sendChatMessageStream", () => {
     expect(onReasoning).toHaveBeenCalledWith({ chars: 12, text: "先看《心經》這一段" });
   });
 
+  it("retrieved 帧的 refs 要透传给 onRetrieved —— 等待期可点原文 chip 的原料", async () => {
+    // 同 reasoning.text：页面级测试全部 mock 掉 sendChatMessageStream，只有这里
+    // 走真实 processChunk。旧后端不带 refs 时要落成 undefined 而不是抛错。
+    const { sendChatMessageStream } = await import("./client");
+    const onRetrieved = vi.fn();
+    const callbacks = {
+      onToken: vi.fn(), onSources: vi.fn(), onSessionId: vi.fn(),
+      onError: vi.fn(), onDone: vi.fn(), onRetrieved,
+    };
+
+    const promise = sendChatMessageStream("hello", undefined, null, callbacks);
+    const xhr = MockStreamXHR.instances[0];
+    xhr.responseText =
+      'data: {"type": "retrieved", "count": 2, "titles": ["心經"], "refs": [{"text_id": 9, "juan_num": 1, "chunk_index": 3, "title_zh": "心經"}]}\n\n' +
+      'data: {"type": "retrieved", "count": 1, "titles": ["法華經"]}\n\n' +
+      'data: {"type": "done"}\n\n';
+    xhr.onprogress?.();
+    await promise;
+
+    expect(onRetrieved).toHaveBeenNthCalledWith(1, {
+      count: 2, titles: ["心經"],
+      refs: [{ text_id: 9, juan_num: 1, chunk_index: 3, title_zh: "心經" }],
+    });
+    expect(onRetrieved).toHaveBeenNthCalledWith(2, { count: 1, titles: ["法華經"], refs: undefined });
+  });
+
   it("流上收到 401：清身份 + 报出原因，但不硬跳登录页丢掉整段对话", async () => {
     // 承重条。这里曾经是 window.location.href = "/login" 且 return（连 onDone
     // 都不调，Promise 永不 settle —— 因为反正整页要重载）。代价是用户刚打完的

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1856,9 +1856,19 @@ export async function runResearch(question: string, maxSteps = 3): Promise<Resea
 
 /** 检索完成、生成尚未开始时的轻量进度信息。只用于等待期提示，与答案下方的
  *  完整 `sources` 列表是两回事（后者仍在答案之后才发）。 */
+/** retrieved.refs 的一条：等待期可点开原文的定位字段。没有 chunk_text —— 它不是 ChatSource。 */
+export interface ChatRetrievalRef {
+  text_id: number;
+  juan_num: number;
+  chunk_index?: number | null;
+  title_zh?: string | null;
+}
+
 export interface ChatRetrieval {
   count: number;
   titles: string[];
+  /** 旧后端副本（滚动部署期间）不带；缺席时前端退回纯文本经名。 */
+  refs?: ChatRetrievalRef[];
 }
 
 /** 推理模型思考阶段的进度帧（后端按约 4 帧/秒节流聚合，见
@@ -2166,6 +2176,7 @@ export function sendChatMessageStream(
               callbacks?.onRetrieved?.({
                 count: event.count,
                 titles: Array.isArray(event.titles) ? event.titles : [],
+                refs: Array.isArray(event.refs) ? event.refs : undefined,
               });
               break;
             case "trust_status":

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -262,6 +262,59 @@ describe("ChatPage 首屏结构", () => {
     expect(container.querySelector(".chat-thinking")).not.toBeNull();
   });
 
+  // 等待期先给原文：首字前常等 30–180 秒，而检索 2–3 秒就完成了。retrieved.refs
+  // 渲染成可点 chip，点开即引文抽屉 —— 用户等答案的同时先读经。承重约束不变：
+  // refs 只进 retrieval 字段，content 仍是哨兵；m.sources 仍为 null（不喂
+  // injectCitationLinks，否则会在残缺的流式文本上改写经名）。
+  it("等待期: retrieved.refs 渲染成可点 chip，点开引文抽屉，content 仍是哨兵", async () => {
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks) => { cb = callbacks; },
+    );
+    const { container } = await renderEmpty();
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+
+    cb!.onRetrieved?.({
+      count: 5,
+      titles: ["般若波羅蜜多心經", "大智度論"],
+      refs: [
+        { text_id: 9, juan_num: 1, chunk_index: 3, title_zh: "般若波羅蜜多心經" },
+        { text_id: 1509, juan_num: 43, chunk_index: 12, title_zh: "大智度論" },
+      ],
+    });
+
+    const chip = await screen.findByRole("button", { name: /般若波罗蜜多心经/ });
+    expect(container.querySelector(".chat-thinking")).not.toBeNull();
+    expect(container.querySelector(".chat-thinking")!.contains(chip)).toBe(true);
+
+    fireEvent.click(chip);
+    await waitFor(() => {
+      expect(container.querySelector(".chat-citation-panel")).not.toBeNull();
+    });
+    // 哨兵未被顶掉；参考经文行（依赖 m.sources）此时不该出现
+    expect(container.querySelector(".chat-thinking")).not.toBeNull();
+    expect(screen.queryByText("参考经文")).toBeNull();
+  });
+
+  // 旧后端副本（滚动部署期间）不带 refs：退回纯文本经名，不能因为 refs 缺席而不显示。
+  it("等待期: 没有 refs 时仍显示纯文本经名", async () => {
+    let cb: Parameters<typeof sendChatMessageStream>[3] | undefined;
+    vi.mocked(sendChatMessageStream).mockImplementation(
+      async (_m, _s, _mid, callbacks) => { cb = callbacks; },
+    );
+    const { container } = await renderEmpty();
+    fireEvent.click(container.querySelector(".chat-hero-card")!);
+    await waitFor(() => expect(cb).toBeDefined());
+
+    cb!.onRetrieved?.({ count: 2, titles: ["般若波羅蜜多心經"] });
+    await waitFor(() => {
+      expect(screen.getByText(/已检索 2 部经典/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/般若波羅蜜多心經/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /般若波羅蜜多心經/ })).toBeNull();
+  });
+
   // 上一条验的是症状（哨兵没被顶掉），这一条验真正的后果：哨兵一旦被改写，
   // onDone 里「流结束却从未收到 token → 转失败哨兵」的兜底就失效，用户会永远
   // 卡在假的「正在检索…」上、且没有重试按钮。这条不依赖 .chat-thinking 这个

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -83,6 +83,7 @@ import {
   useAuthStore,
   type UserProfile,
 } from "../stores/authStore";
+import type { TextId } from "../types/branded";
 
 // 登录用户的额度提示只在快用完时出现。常驻一个「今日剩余 198 次」是纯噪音 ——
 // 而毫无预警地撞上上限、直接吃一个错误，才是真正会让人懵的那种体验。
@@ -345,7 +346,7 @@ interface MessageBubbleProps {
   onShare: (m: ChatMessageItem) => void;
   onRetry: (m: ChatMessageItem) => void;
   onFeedback: (m: ChatMessageItem, dir: "up" | "down") => void;
-  onSourceClick: (source: ChatSource) => void;
+  onSourceClick: (source: ChatSource, phase?: "retrieved") => void;
 }
 
 /** One chat message row, memoised on (m, isStreaming, sending, user). A streaming
@@ -456,11 +457,25 @@ function MessageBubbleInner({
                     {m.retrieval && (
                       <>
                         {t("chat.retrieved_hint", { n: m.retrieval.count })}
-                        {m.retrieval.titles.map((tt) => (
-                          <span key={tt} className="chat-retrieved-title">
-                            {t("chat.retrieved_title", { title: tt })}
-                          </span>
-                        ))}
+                        {/* 有 refs（新后端）就给可点 chip：等答案的同时先读原文。
+                            点开走 onSourceClick 的 retrieved 相位 —— 与流末的「参考经文」
+                            同一条抽屉。旧后端没有 refs 时退回纯文本经名。 */}
+                        {m.retrieval.refs && m.retrieval.refs.length > 0
+                          ? m.retrieval.refs.map((r) => (
+                              <SourceChipButton
+                                key={`${r.text_id}:${r.juan_num}`}
+                                label={t("reader.citation.title_with_juan", { title: localizeHan(r.title_zh ?? "", lang), n: r.juan_num })}
+                                onClick={() => onSourceClick(
+                                  { text_id: r.text_id as TextId, juan_num: r.juan_num, chunk_index: r.chunk_index ?? undefined, chunk_text: "", score: 0, title_zh: r.title_zh ?? undefined },
+                                  "retrieved",
+                                )}
+                              />
+                            ))
+                          : m.retrieval.titles.map((tt) => (
+                              <span key={tt} className="chat-retrieved-title">
+                                {t("chat.retrieved_title", { title: tt })}
+                              </span>
+                            ))}
                         <span className="chat-retrieved-sep">·</span>
                       </>
                     )}
@@ -513,21 +528,11 @@ function MessageBubbleInner({
                   <div style={{ marginTop: 8, display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center" }}>
                     <span style={{ fontSize: 12, color: "var(--fj-ink-muted)" }}>{t("chat.reference_sources")}</span>
                     {sourceChips.map((s) => (
-                      <button
+                      <SourceChipButton
                         key={`${s.text_id}:${s.juan_num}`}
-                        type="button"
+                        label={t("reader.citation.title_with_juan", { title: localizeHan(s.title_zh ?? "", lang), n: s.juan_num })}
                         onClick={() => onSourceClick(s)}
-                        style={{
-                          display: "inline-flex", alignItems: "center", gap: 4,
-                          padding: "3px 10px", borderRadius: 12,
-                          border: "1px solid rgba(176,141,87,0.5)", background: "rgba(176,141,87,0.06)",
-                          color: "var(--fj-ink-muted)", fontSize: 12, lineHeight: 1.6, cursor: "pointer", transition: "all 0.2s",
-                        }}
-                        onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.16)"; e.currentTarget.style.color = "var(--fj-accent)"; }}
-                        onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.06)"; e.currentTarget.style.color = "var(--fj-ink-muted)"; }}
-                      >
-                        {t("reader.citation.title_with_juan", { title: localizeHan(s.title_zh ?? "", lang), n: s.juan_num })}
-                      </button>
+                      />
                     ))}
                   </div>
                 )}
@@ -653,6 +658,26 @@ function MessageBubbleInner({
         )}
       </div>
     </div>
+  );
+}
+
+/** 经文 chip：流末「参考经文」行与等待期 retrieved.refs 共用一个样子、一条抽屉。 */
+function SourceChipButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        display: "inline-flex", alignItems: "center", gap: 4,
+        padding: "3px 10px", borderRadius: 12,
+        border: "1px solid rgba(176,141,87,0.5)", background: "rgba(176,141,87,0.06)",
+        color: "var(--fj-ink-muted)", fontSize: 12, lineHeight: 1.6, cursor: "pointer", transition: "all 0.2s",
+      }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.16)"; e.currentTarget.style.color = "var(--fj-accent)"; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.06)"; e.currentTarget.style.color = "var(--fj-ink-muted)"; }}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -1555,11 +1580,12 @@ export default function ChatPage() {
     }
   }, [messages, handleSendMessage]);
 
-  const handleSourceClick = useCallback((s: ChatSource) => {
+  const handleSourceClick = useCallback((s: ChatSource, phase?: "retrieved") => {
     // Behavioural signal, mirroring inline citation clicks: opening a source
     // from the persistent list is engagement with / trust in the retrieved text.
+    // phase=retrieved：答案还没来、用户先点开了原文 —— 单独可分，别混进流末的点击。
     if (typeof umami !== "undefined") {
-      umami.track("source_click", { text_id: s.text_id });
+      umami.track("source_click", phase ? { text_id: s.text_id, phase } : { text_id: s.text_id });
     }
     const chunkIndex = s.chunk_index ?? -1;
     if (chunkIndex < 0) {


### PR DESCRIPTION
## 为什么

首字前常等 30–180 秒（2026-08-25 生产实测 109 秒），而检索 2–3 秒就完成了。此前等待区只有「已检索 5 部经典《A》《B》《C》」几个纯文本经名，用户只能干等。对标 Perplexity 的「sources first」：等答案的同时先读原文。

## 改法

- **后端** `retrieved` 帧新增 `refs`：只带 `text_id / juan_num / chunk_index / title_zh`，**不带 chunk_text**。它不是 `sources` —— 完整 `sources` 仍是最后一个数据事件（「先论点后论据」、不让 `injectCitationLinks` 在残缺流式文本上改写经名，两条理由原样保留，既有用例 `test_full_sources_still_last` 继续钉着）。按 `(text_id, juan_num)` 去重、召回顺序、至多 8 条。
- **前端** `ChatRetrieval.refs` 透传；等待区把纯文本经名换成可点 chip，点开走同一条引文抽屉（`onSourceClick(s, "retrieved")`，埋点 `source_click` 带 `phase` 可与流末点击分开）。`refs` 只进 `retrieval` 字段，`content` 仍是哨兵，`m.sources` 仍为 `null`。旧后端副本（滚动部署期间）不带 `refs` 时退回纯文本经名。
- 「参考经文」行与等待区共用 `SourceChipButton`，样式只此一份。

## 测试（先红后绿）

- 后端 `test_chat_stream_retrieved_event.py`：refs 形状（四个键、无 chunk_text）、按经卷去重保序、封顶 8。9/9。
- `client.test.ts`：真实 `processChunk` 透传 refs，缺席为 `undefined`。
- `ChatPage.test.tsx`：等待期 chip 可点 → 出现 `.chat-citation-panel`；哨兵未被顶掉、「参考经文」行未提前出现；无 refs 退回纯文本。
- 全套前端 548/548，eslint / tsc / i18n ratchet；ruff 0.9.7。

## 上线后复验（游客即可）

/chat 发一问，2–3 秒内「已检索 N 部经典」后面应出现可点的经名 chip，点开右侧抽屉能看到原文；答案到达后「参考经文」行照常出现。
