### PR TITLE
feat(reader): 阅读列限宽 42em 居中、AI 面板记住开合、「高丽藏」标成外链

### DIFF
--- a/frontend/src/pages/TextReaderPage.desktop.test.tsx
+++ b/frontend/src/pages/TextReaderPage.desktop.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter, Route, Routes } from "react-router";
+import TextReaderPage from "./TextReaderPage";
+import {
+  checkBookmark,
+  getJuanAudio,
+  getJuanContent,
+  getJuanLanguages,
+  getJuanLineAnchors,
+  getJuanList,
+  getTextDetail,
+  type TextDetail,
+} from "../api/client";
+import type { TextId } from "../types/branded";
+
+vi.mock("../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../api/client")>("../api/client");
+  return {
+    ...actual,
+    getTextDetail: vi.fn(),
+    getJuanList: vi.fn(),
+    getJuanContent: vi.fn(),
+    getJuanLanguages: vi.fn(),
+    getJuanLineAnchors: vi.fn(),
+    getJuanAudio: vi.fn(),
+    getJuanApparatus: vi.fn(),
+    checkBookmark: vi.fn(),
+    searchDictionaryGrouped: vi.fn(),
+    sendChatMessageStream: vi.fn(),
+  };
+});
+
+vi.mock("../api/chatModels", () => ({
+  fetchChatModels: vi.fn().mockResolvedValue([]),
+}));
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+  // 宽屏：所有媒体查询都不命中
+  window.matchMedia = ((query: string) => ({
+    matches: false, media: query, onchange: null,
+    addListener: () => {}, removeListener: () => {},
+    addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  if (!window.requestAnimationFrame) {
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+      setTimeout(() => cb(0), 0) as unknown as number) as typeof window.requestAnimationFrame;
+  }
+});
+
+const TEXT_ID = 69 as TextId;
+
+function detail(extra: Partial<TextDetail> = {}): TextDetail {
+  return {
+    id: TEXT_ID, taisho_id: "T0676", cbeta_id: "T0676", title_zh: "解深密經",
+    title_sa: null, title_bo: null, title_pi: null, translator: "玄奘", dynasty: "唐",
+    fascicle_count: 5, category: null, subcategory: null, cbeta_url: null,
+    has_content: true, content_char_count: 7574, lang: "lzh", created_at: "2026-01-01T00:00:00Z",
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(getTextDetail).mockResolvedValue(detail());
+  vi.mocked(getJuanList).mockResolvedValue({
+    text_id: TEXT_ID, title_zh: "解深密經", total_juans: 5,
+    juans: [{ juan_num: 1, char_count: 7574 }, { juan_num: 2, char_count: 7000 }],
+  });
+  vi.mocked(getJuanContent).mockResolvedValue({
+    text_id: TEXT_ID, cbeta_id: "T0676", title_zh: "解深密經", juan_num: 1, total_juans: 5,
+    content: "如是我聞：一時，薄伽梵住最勝光曜七寶莊嚴。", char_count: 20,
+    prev_juan: null, next_juan: 2, canon: "taisho", canon_label: "大正藏",
+  });
+  vi.mocked(getJuanLanguages).mockResolvedValue({
+    text_id: TEXT_ID, juan_num: 1, languages: ["lzh"], default_lang: "lzh",
+  });
+  vi.mocked(getJuanLineAnchors).mockResolvedValue({ text_id: TEXT_ID, juan_num: 1, anchors: [] });
+  vi.mocked(getJuanAudio).mockRejectedValue(new Error("404"));
+  vi.mocked(checkBookmark).mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.removeItem("fojin.reader.aiPanel");
+});
+
+async function renderReader() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const r = render(
+    <HelmetProvider>
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/texts/69/read"]}>
+          <Routes>
+            <Route path="/texts/:id/read" element={<TextReaderPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+  await screen.findByText(/如是我聞/);
+  return r;
+}
+
+describe("阅读器桌面端：AI 面板记忆与外链标识", () => {
+  // 桌面默认开着 420px 的 AI 面板，每次进阅读页都要重新关一次。关过一次就记住。
+  it("上次关掉了 AI 面板：这次进来仍是关的，只留浮动按钮；点开后记为 open", async () => {
+    localStorage.setItem("fojin.reader.aiPanel", "closed");
+    const { container } = await renderReader();
+    expect(container.querySelector(".reader-ai-sidebar")).toBeNull();
+    expect(container.querySelector(".reader-ai-fab")).not.toBeNull();
+
+    fireEvent.click(container.querySelector(".reader-ai-fab")!);
+    await waitFor(() => expect(container.querySelector(".reader-ai-sidebar")).not.toBeNull());
+    expect(localStorage.getItem("fojin.reader.aiPanel")).toBe("open");
+  });
+
+  it("没有记忆时桌面默认开着（原有行为不变）", async () => {
+    const { container } = await renderReader();
+    expect(container.querySelector(".reader-ai-sidebar")).not.toBeNull();
+  });
+
+  // 「高丽藏」是 window.open 去东国大学 KABC 的外链，却长得和「跨藏对照」这种面板开关
+  // 一模一样。给它外链图标。
+  it("高丽藏按钮带外链图标", async () => {
+    vi.mocked(getTextDetail).mockResolvedValue(detail({ goryeo_k: "K0154", kabc_url: "https://kabc.dongguk.edu/content/view?dataId=ABC_IT_K0154" }));
+    const { container } = await renderReader();
+    const btn = await screen.findByRole("button", { name: /高丽藏/ });
+    expect(btn.querySelector(".anticon-export")).not.toBeNull();
+    expect(container.querySelector(".reader-ai-sidebar")).not.toBeNull();
+  });
+});

--- a/frontend/src/pages/TextReaderPage.tsx
+++ b/frontend/src/pages/TextReaderPage.tsx
@@ -20,11 +20,22 @@ import {
   VerticalAlignTopOutlined,
   DownloadOutlined,
   SoundOutlined,
+  ExportOutlined,
 } from "@ant-design/icons";
 import { trackAudio } from "../audio/telemetry";
 import { useAudioPlayer } from "../audio/useAudioPlayback";
 import { getJuanList, getJuanContent, getJuanLanguages, getTextDetail, checkBookmark, addBookmark, removeBookmark, searchDictionaryGrouped, getJuanApparatus, getJuanLineAnchors, getJuanAudio, type ApparatusEntryItem } from "../api/client";
 import { isNarrowViewport, useNarrowViewport } from "../hooks/useNarrowViewport";
+
+const AI_PANEL_PREF_KEY = "fojin.reader.aiPanel";
+function readAiPanelPref(): "open" | "closed" | null {
+  try {
+    const v = localStorage.getItem(AI_PANEL_PREF_KEY);
+    return v === "open" || v === "closed" ? v : null;
+  } catch {
+    return null;
+  }
+}
 import { useAuthStore } from "../stores/authStore";
 import CitationGenerator from "../components/CitationGenerator";
 import SourceAttribution from "../components/SourceAttribution";
@@ -252,7 +263,17 @@ export default function TextReaderPage() {
   // 用户得先发现并关掉 AI 面板才能读经。惰性初值而不是 effect 里 setState ——
   // react-hooks/set-state-in-effect 会红。
   const narrow = useNarrowViewport();
-  const [aiPanelOpen, setAiPanelOpen] = useState(() => !isNarrowViewport());
+  // 桌面记住上次的开合：默认开着 420px 的面板，每次进阅读页都要重新关一次，是噪音。
+  // 只在宽屏读写 —— 窄屏的「默认关」是布局所迫，不是用户的选择，不该写进偏好。
+  const [aiPanelOpen, setAiPanelOpen] = useState(() => !isNarrowViewport() && readAiPanelPref() !== "closed");
+  useEffect(() => {
+    if (narrow) return;
+    try {
+      localStorage.setItem(AI_PANEL_PREF_KEY, aiPanelOpen ? "open" : "closed");
+    } catch {
+      /* 隐私模式等：记不住就算了 */
+    }
+  }, [aiPanelOpen, narrow]);
   const [aiPanelWidth, setAiPanelWidth] = useState(420);
   const [aiSelectedText, setAiSelectedText] = useState<string | undefined>();
   const isDraggingRef = useRef(false);
@@ -1029,6 +1050,8 @@ export default function TextReaderPage() {
                 }
               >
                 {t("reader.kabc.button")}
+                {/* 外链标识：它去的是东国大学 KABC，不是站内面板 —— 别让它长得像「跨藏对照」 */}
+                <ExportOutlined style={{ fontSize: 11, marginLeft: 2, opacity: 0.7 }} />
               </Button>
             </Tooltip>
           )}

--- a/frontend/src/styles/reader.css
+++ b/frontend/src/styles/reader.css
@@ -111,6 +111,12 @@
   line-break: strict; /* CJK 标点禁则：句号逗号不出现在行首，左引号不出现在行尾 */
   color: var(--fj-ink);
   padding: 20px 0;
+  /* 行宽（measure）：2026-08-25 实测 18px 字号下一行 76 个字（AI 面板开着时），
+     Sefaria / SuttaCentral / 84000 都压在 38–45 字。42em 以正文字号为基，
+     字号增减、面板开合都跟着变；居中，两侧留白。双语对照的半宽列本就窄于此值。 */
+  max-width: 42em;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* ── CBETA-style typography ── */

--- a/frontend/src/styles/readerTypography.test.ts
+++ b/frontend/src/styles/readerTypography.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * 阅读列的行宽（measure）。2026-08-25 实测：18px 字号下正文列宽 1,374px，一行 76 个字
+ * （AI 面板开着时；关掉更宽）。Sefaria / SuttaCentral / 84000 都把阅读列压在 38–45 字。
+ * 42em 以正文字号为基（--reader-font-size 17–18px → 714–756px ≈ 40–42 字），居中，
+ * 面板开合、字号增减时跟着变。
+ */
+const CSS = readFileSync(resolve(__dirname, "reader.css"), "utf-8");
+
+function baseRule(selector: string): string {
+  const i = CSS.indexOf(`\n${selector} {`);
+  if (i < 0) throw new Error(`${selector} not found in reader.css`);
+  return CSS.slice(i, CSS.indexOf("}", i));
+}
+
+describe("阅读列行宽", () => {
+  it(".reader-body 以 em 限宽并居中（随字号缩放，不再铺满 1400px）", () => {
+    const rule = baseRule(".reader-body");
+    expect(rule).toMatch(/max-width:\s*42em/);
+    expect(rule).toMatch(/margin(-left|-right)?:\s*(0\s+)?auto/);
+  });
+});


### PR DESCRIPTION
> 基于 #1214（包含其提交，用了它的 `useNarrowViewport`）。**请在 #1214 之后合并**；合并 #1214 后本 PR 的 diff 会自动缩到只剩这一个提交。

## 现象（2026-08-25 实测）

- 18px 字号下阅读列宽 1,374px，一行 **76 个字**（AI 面板开着时；关掉更宽）。Sefaria / SuttaCentral / 84000 都把阅读列压在 38–45 字。
- 桌面每次进阅读页都默认开着 420px 的 AI 面板，关过还得再关。
- 「高丽藏」是 `window.open` 去东国大学 KABC 的外链，却和「跨藏对照」这种面板开关长得一样。

## 改法

- `.reader-body { max-width: 42em; margin: 0 auto }`：以正文字号为基，字号增减、面板开合都跟着变。双语对照的半宽列本就窄于此值。
- AI 面板开合记在 `localStorage["fojin.reader.aiPanel"]`；只在宽屏读写（窄屏的「默认关」是布局所迫，不是用户选择）。无记忆时桌面默认开，行为不变。
- 「高丽藏」按钮加外链图标。

## 测试（先红后绿）

`readerTypography.test.ts`（CSS 规则）、`TextReaderPage.desktop.test.tsx`（记住关闭并点开后记为 open / 无记忆默认开 / 外链图标）。全套 554/554，eslint / tsc / i18n ratchet 通过。

## 验收（本地 dist + `/api` 代理生产，1920×911）

| | 结果 |
|---|---|
| 阅读列宽 / 每行字数 | **756px / 42 字**，居中（修前 1,374px / 76 字） |
| 关掉面板后刷新 | 仍关，`pref=closed`，浮动按钮在 |
| 「高丽藏」 | 带 ↗ 外链图标 |

工具栏分组（显示 / 工具 / 对照）另起 PR。
