### PR TITLE
docs(observability): 更正截断上限——推理模型是 26000 不是 2000

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -1319,8 +1319,12 @@ async def send_message_stream(
         yield f"data: {json.dumps({'type': 'done'})}\n\n"
         return
 
-    # 被 max_tokens 截断：告诉前端「没写完」，让它渲染「继续写完」。上限本身不动 ——
-    # 先量一周截断率（这行是分子，phase-2 那行是分母）再定该不该调、调到多少。
+    # 被 max_tokens 截断：告诉前端「没写完」，让它渲染「继续写完」。
+    # ⚠️ 别把上面的 2000 当成真实上限：_with_reasoning_headroom 给推理模型再加 24000，
+    # 所以 deepseek-v4-* 的实际额度是 26000（推理与正文共用）。2026-08-27 实测生产
+    # 答案长度无截断悬崖、最长 12,883 字 —— 这条分支在默认模型下几乎不会走到，真正
+    # 会撞上限的是 BYOK 选了非推理模型（额度就是 2000）或推理吃光预算的情况。
+    # 详见 docs/OBSERVABILITY.md「上限的真实数字」。
     if finish_reason in TRUNCATED_FINISH_REASONS:
         logger.info(
             "chat/stream answer truncated (finish_reason=%s, chars=%d, session_id=%s, "

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -115,7 +115,7 @@ Prometheus 量的是系统；下面这四个数量的是产品。定位（2026-0
 | **核对率** | 打过 `citation_click` 或 `source_click` 的访客 ÷ 打过 `chat` 的访客（也可按事件数：核对事件 ÷ 回答数） | 点过引文的人问得深 2.6×，这是产品核心承诺被用上的比例 |
 | **隔天回访率** | 同一 `session_id` 在 ≥2 个不同日期打过 `chat` 的访客 ÷ 打过 `chat` 的访客 | `session_id` 按月重置，只能算月内；基线 12.5%（2026-08） |
 | **重发率** | 同一访客 30 分钟内原样重发同一 `question`（中间没有 `chat_retry`/`chat_regenerate`）÷ `chat` | 基线 9%（222/2,4xx，2026-08）；有了「重新生成」后应降 |
-| **截断率** | 客户端：`answer_truncated` ÷ (`chat` + `answer_continue` + `chat_regenerate`)。**服务端更准**：`docker logs fojin-backend` 里 `answer truncated` 行数 ÷ `phase-2 LLM done` 行数（后者每条回答都写 `finish_reason=`） | 2026-08-27 起才有数；一周后据此定 max_tokens 该不该从 2000 上调（R2b） |
+| **截断率** | 客户端：`answer_truncated` ÷ (`chat` + `answer_continue` + `chat_regenerate`)。**服务端更准**：`docker logs fojin-backend` 里 `answer truncated` 行数 ÷ `phase-2 LLM done` 行数（后者每条回答都写 `finish_reason=`） | 2026-08-27 起才有数。⚠️ 见下方「上限的真实数字」——默认模型下预期接近 0 |
 
 服务端截断率一行命令（生产）：
 
@@ -124,3 +124,23 @@ docker logs fojin-backend --since 168h 2>&1 | grep -c "answer truncated"
 docker logs fojin-backend --since 168h 2>&1 | grep -c "phase-2 LLM done"
 # 按 reader 模式分开看：grep "answer truncated" | grep -c "reader=True"
 ```
+
+## ⚠️ 上限的真实数字（别拿 2000 当上限）
+
+`chat.py` 里写的是 `max_tokens = 2000`（reader 模式 8000），但 `_with_reasoning_headroom`
+会给**推理模型**（模型名含 `deepseek-v4` / `reasoner` / `thinking` / `o1` / `o3`）再加
+`_REASONING_HEADROOM_TOKENS = 24000`。所以：
+
+| 谁 | 真实上限（推理 + 正文共用） |
+|---|---|
+| 平台默认 & DeepSeek BYOK（v4-pro / v4-flash） | **26000 tokens** |
+| reader 模式（带 page_content）+ 推理模型 | 32000 tokens |
+| BYOK 选了非推理模型（qwen / kimi / glm / doubao / gpt / claude / gemini） | **2000 tokens** |
+
+2026-08-27 生产实测：60 天 3,605 条回答的长度分布平滑衰减、**没有截断悬崖**，最长
+12,883 字；一条 4,517 字的长答案 `finish_reason=stop`。所以「长答案被 2000 截断」对
+默认模型**不成立**，真正会撞上限的是非推理 BYOK 模型，以及推理吃光预算的情况
+（2026-08-01 flash 事故：11,826 字符推理把当时 6000 的总额度顶穿，正文 0 字）。
+
+改上限前先看 `finish_reason=length` 的实际行数，别看「答案不以句末标点结尾」这类代理指标
+（它量的是引文括号 / 列表项收尾，不是截断）。


### PR DESCRIPTION
## 更正 #1222 里的一个错误前提

#1222 的截断功能是基于「普通问答 `max_tokens=2000`，长答案会被截断」写的。**这个前提对生产的默认模型不成立**：`_with_reasoning_headroom` 会给推理模型（模型名含 `deepseek-v4` / `reasoner` / `thinking` / `o1` / `o3`）再加 `_REASONING_HEADROOM_TOKENS = 24000`。

| 谁 | 真实上限（推理 + 正文共用） |
|---|---|
| 平台默认 & DeepSeek BYOK（v4-pro / v4-flash） | **26000 tokens** |
| reader 模式 + 推理模型 | 32000 tokens |
| BYOK 选了非推理模型（qwen / kimi / glm / doubao / gpt / claude / gemini） | **2000 tokens** |

## 证据（2026-08-27 生产实测）

- 生产库 60 天 3,605 条回答的长度分布**平滑衰减、没有截断悬崖**，最长 12,883 字
- 真机一条 4,517 字的长答案：`finish_reason=stop`，未截断
- 之前推动这项工作的「13.7% 答案不以句末标点结尾」是个**坏代理指标**——它量的是以 `【《X》第N卷】` 引文括号或列表项收尾，不是截断

## 影响

- 截断检测与 `finish_reason=` 日志**照旧有用**：它把代理指标换成了真值，这正是发现上面这个错误的手段
- 「继续写完」在默认模型下几乎不会出现；真正会撞上限的是非推理 BYOK 模型，以及推理吃光预算的情况（2026-08-01 flash 事故：11,826 字符推理把当时 6000 的额度顶穿，正文 0 字）
- **R2b「把 2000 上调」大概率是伪需求**，一周后按 `finish_reason=length` 的实际行数定，不再按那个代理指标

改动只有两处注释/文档，无行为变更；`tests/test_chat_stream_truncated_event.py` + `tests/test_chat_regenerate.py` 11 passed，ruff clean。
