### PR TITLE
fix(auth): 吊销自身凭证的接口不得带回续期票——那张票签发即作废

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.core.client_ip import get_real_client_ip
 from app.core.crypto import decrypt_api_key, encrypt_api_key
-from app.core.deps import get_current_user
+from app.core.deps import clear_renewable, get_current_user
 from app.core.url_security import normalize_public_https_url
 from app.database import get_db
 from app.models.user import User
@@ -194,6 +194,10 @@ async def change_password(
     前端应立刻用返回的新 token 替换本地存储的旧 token。
     同一用户在其他设备上的所有旧 JWT 都会在下一次请求时变成 401。
     """
+    # The version bump below kills the token this request carried; the renewal
+    # middleware would otherwise hand back a replacement signed at the old
+    # version — dead on arrival. The fresh token is in the response body.
+    clear_renewable(request)
     client_ip = get_real_client_ip(request, default=None)
     user_agent = request.headers.get("user-agent")
     return await change_user_password(
@@ -223,6 +227,7 @@ async def logout_all_devices(
 
     The current device is not logged out: it swaps in the returned token.
     """
+    clear_renewable(request)  # same reason as change-password above
     client_ip = get_real_client_ip(request, default=None)
     user_agent = request.headers.get("user-agent")
     return await revoke_all_sessions(db, user, client_ip=client_ip, user_agent=user_agent)

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -23,6 +23,25 @@ def _mark_renewable(request: Request | None, token: str, user: User) -> None:
     setattr(request.state, RENEWABLE_STATE_ATTR, (token, user.id, user.password_version))
 
 
+def clear_renewable(request: Request) -> None:
+    """Cancel this request's renewal credential.
+
+    For endpoints that revoke the very token they were called with — anything
+    that bumps ``password_version``. The auth dependency stamps the credential
+    (including the *old* version) before the endpoint body runs, so without
+    this the middleware happily mints a replacement at a version that no longer
+    exists: a token that is dead the moment it is signed, handed back in
+    ``X-Renewed-Token`` for the client to adopt.
+
+    The frontend survives it by overwriting with the token in the response body
+    a beat later, but "correct only because something else corrects it" is not
+    a property to rely on — and any other client that honours the header would
+    simply be logged out.
+    """
+    if hasattr(request.state, RENEWABLE_STATE_ATTR):
+        delattr(request.state, RENEWABLE_STATE_ATTR)
+
+
 async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),

--- a/backend/tests/test_session_lifetime.py
+++ b/backend/tests/test_session_lifetime.py
@@ -122,3 +122,4 @@ async def test_revoke_all_sessions_is_audited_in_the_same_transaction():
     assert len(rows[0].outcome) <= 40  # column width
     # One commit: the audit row rides the same transaction as the bump.
     assert session.commit.await_count == 1
+

--- a/backend/tests/test_token_renewal_middleware.py
+++ b/backend/tests/test_token_renewal_middleware.py
@@ -9,11 +9,12 @@ from datetime import UTC, datetime, timedelta
 
 import jwt
 import pytest
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 
 from app.config import settings
 from app.core.auth import create_access_token, decode_token_claims
-from app.core.deps import get_current_user, get_optional_user
+from app.core.deps import clear_renewable, get_current_user, get_optional_user
+from app.database import get_db
 from app.main import RENEWED_TOKEN_HEADER, TokenRenewalMiddleware
 
 pytestmark = pytest.mark.anyio
@@ -155,3 +156,70 @@ async def test_login_token_starts_a_new_session_clock():
     """真正登录签发的 token，oit 就是现在——不该继承任何旧起点。"""
     claims = decode_token_claims(create_access_token(1, 0))
     assert abs(claims["oit"] - datetime.now(UTC).timestamp()) < 5
+
+
+# ── 吊销自身凭证的接口不得带回续期票 ─────────────────────────────────
+#
+# 鉴权依赖在**接口体跑之前**就把续期凭据（含**旧的** password_version）盖进
+# request.state；接口随后 bump 了版本。中间件照单签发 = 一张签发即作废的票，
+# 塞进 X-Renewed-Token 让客户端换上。前端因为随后会用响应体里的票覆盖而侥幸
+# 无恙，但「靠别处纠正才对」不是能依赖的性质：别的客户端照收就是当场登出。
+
+
+def _revoking_app(*, clear: bool):
+    """最小的「吊销自身凭证」接口，可选择调不调 clear_renewable。"""
+    user = FakeUser(password_version=3)
+    app = FastAPI()
+    app.add_middleware(TokenRenewalMiddleware)
+
+    @app.post("/revoke")
+    async def revoke(request: Request, _=Depends(get_current_user)):
+        if clear:
+            clear_renewable(request)
+        user.password_version += 1  # change_user_password / revoke_all_sessions 做的事
+        return {"version": user.password_version}
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return user
+
+    class _Session:
+        async def execute(self, *a, **k):
+            return _Result()
+
+    async def _fake_db():
+        yield _Session()
+
+    app.dependency_overrides[get_db] = _fake_db
+    return app, user
+
+
+async def _post_revoke(*, clear: bool):
+    import httpx
+
+    app, user = _revoking_app(clear=clear)
+    token = _token(expires_in=PAST_HALFWAY, pwd_v=3)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.post("/revoke", headers={"Authorization": f"Bearer {token}"})
+    return resp, user
+
+
+async def test_revoking_endpoint_emits_no_renewed_token():
+    resp, user = await _post_revoke(clear=True)
+    assert resp.status_code == 200
+    assert user.password_version == 4
+    assert RENEWED_TOKEN_HEADER not in resp.headers
+
+
+async def test_without_clearing_the_renewed_token_would_be_born_dead():
+    """反向对照：不清凭据时，发出去的票签在**旧**版本上。
+
+    不是在测产品行为，是在证明上一条真的挡住了什么 —— 少了它，
+    「没有这个头」可能只是因为压根没走到续期分支。
+    """
+    resp, user = await _post_revoke(clear=False)
+    stale = resp.headers.get(RENEWED_TOKEN_HEADER)
+    assert stale, "这张票本该被签出来，否则上一条用例是恒真的"
+    assert decode_token_claims(stale)["pwd_v"] == 3
+    assert user.password_version == 4  # 签发的版本已经不存在了


### PR DESCRIPTION
#1226 的收尾。上线后顺着 `/auth/logout-all` 的响应路径复查时撞出来的，`/auth/change-password` 上是既有缺陷。

## 缺陷

鉴权依赖 `get_current_user` 在**接口体跑之前**就把续期凭据盖进 `request.state`，其中带的是**旧的** `password_version`。接口体随后 bump 了版本。`TokenRenewalMiddleware` 照单签发 —— 于是 `/auth/change-password` 和 `/auth/logout-all` 的响应会带一个 `X-Renewed-Token`，里面的 `pwd_v` 正是刚刚被作废的那个。

**一张签发即死的票，还明着让客户端换上。**

实测复现（最小 ASGI 应用，不是推理）：

```
状态: 200 {'new_version': 4}
⚠️ 响应带回 X-Renewed-Token，其中 pwd_v = 3，而用户现在的 password_version = 4
```

## 为什么现在没人报

前端侥幸无恙：拦截器先把死票写进 localStorage，随后 `handleChangePassword` / `handleLogoutAll` 用响应体里的正确票覆盖。但「**只有靠别处纠正才对**」不是能依赖的性质 —— 覆盖之间那一瞬有别的在途请求会读到死票，而任何别的客户端（fojin-cli / MCP）照收这个头就是当场登出。

`change-password` 上这条是既有缺陷，而且**8 小时寿命下命中面比现在大得多**：那时任何超过 4 小时的票都过了半程，现在要超过 15 天。

## 改法

`clear_renewable(request)`：由这两个接口在 bump 之前主动撤掉凭据。改在源头，不指望客户端兜底。

## 测试

一条正向 + **一条反向对照** —— 不清凭据时死票确实会被签出来（`pwd_v == 3` 而用户已是 4）。没有这条反向对照，"响应里没有这个头" 可能只是因为压根没走到续期分支，正向用例就是恒真的。

ruff 0.9.7 ✅ · pytest 1855 passed ✅（`test_health_check_probe` 3 条失败在 master 上同样存在）