### PR TITLE
fix(i18n): 「退出所有设备」取消键显示成原始键名；补缺失键门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Lint (ESLint)
         run: npx eslint src/ --max-warnings 0
 
-      - name: i18n ratchet (no new hardcoded Chinese)
+      - name: i18n ratchet (no new hardcoded Chinese + no undefined keys)
         run: npm run i18n:check
 
       - name: Type check

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "i18n:scan": "node scripts/scan-hardcoded-zh.mjs",
-    "i18n:check": "node scripts/scan-hardcoded-zh.mjs --check"
+    "i18n:check": "node scripts/scan-hardcoded-zh.mjs --check && node scripts/check-i18n-keys.mjs",
+    "i18n:keys": "node scripts/check-i18n-keys.mjs"
   },
   "dependencies": {
     "@ant-design/charts": "^2.6.7",

--- a/frontend/scripts/check-i18n-keys.mjs
+++ b/frontend/scripts/check-i18n-keys.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Fail on `t("some.key")` where the key does not exist in the zh locale.
+ *
+ * The ratchet next door (scan-hardcoded-zh.mjs) catches Chinese text that never
+ * went through i18n. This catches the opposite mistake: a key that went through
+ * i18n and has nowhere to land. i18next renders a missing key as the key
+ * itself, so the page shows a literal `common.cancel` — visible to every user,
+ * invisible to typecheck, lint, and any test that does not assert on that exact
+ * string. One shipped to production on 2026-08-29 (the Popconfirm cancel button
+ * in ProfilePage) and was only caught by looking at the rendered page.
+ *
+ * zh is the reference locale: it is bundled synchronously in i18n.ts and is the
+ * fallbackLng, so a key missing there is missing everywhere. Keys present in zh
+ * but absent from another locale fall back to zh — degraded, not broken, and
+ * out of scope here.
+ *
+ * Only string-literal keys are checked. `t(\`a.${b}\`)` and `t(someVar)` are
+ * invisible to any static check and are left alone. A second argument makes the
+ * call safe regardless — i18next treats it as the default value — so those are
+ * skipped too.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = "src";
+const LOCALE = "public/locales/zh/translation.json";
+
+const known = new Set(Object.keys(JSON.parse(readFileSync(LOCALE, "utf8"))));
+
+// t("key")            → checked
+// t("key", "default") → skipped, the default renders
+// t("key", { n: 1 })  → checked; interpolation options are not a default value
+const CALL = /\bt\(\s*"([A-Za-z][\w.-]*)"\s*(,\s*(.))?/g;
+
+function* walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) yield* walk(p);
+    else if (/\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name)) yield p;
+  }
+}
+
+const bad = [];
+for (const file of walk(SRC)) {
+  const lines = readFileSync(file, "utf8").split("\n");
+  lines.forEach((line, i) => {
+    for (const m of line.matchAll(CALL)) {
+      const [, key, secondArg, firstChar] = m;
+      if (secondArg && firstChar === '"') continue; // has a default value
+      if (!known.has(key)) bad.push({ file, line: i + 1, key });
+    }
+  });
+}
+
+if (bad.length) {
+  console.error(`✗ ${bad.length} translation key(s) used but not defined in ${LOCALE}:\n`);
+  for (const b of bad) console.error(`  ${b.file}:${b.line}  t("${b.key}")`);
+  console.error("\ni18next renders a missing key as the key itself — users would see the raw string.");
+  console.error("Add the key to all three locales, or use an existing one.");
+  process.exit(1);
+}
+console.log(`✓ i18n keys OK: every t("...") literal in ${SRC}/ exists in ${LOCALE}.`);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -34,7 +34,7 @@ export default function DashboardPage() {
   if (!data) {
     return (
       <div className="dashboard-container" style={{ textAlign: "center", paddingTop: 80 }}>
-        <Empty description={t("common.noData")} />
+        <Empty description={t("activity.noData")} />
       </div>
     );
   }

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -288,6 +288,20 @@ describe("ProfilePage", () => {
     });
   }
 
+  it("确认弹层的两个按钮都是译文，不是原始键名", async () => {
+    // 上线时这里写的是 t("common.cancel")，而这个键不存在 —— i18next 把
+    // 缺失键原样渲染，线上真的显示了一个写着「common.cancel」的按钮。
+    // typecheck / lint / 其余用例全绿，只有真去看渲染结果才看得见。
+    signedIn();
+    renderPage(<ProfilePage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /Account security/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Sign out everywhere" }));
+
+    expect(await screen.findByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.queryByText(/^[a-z_]+\.[a-zA-Z_]+$/)).not.toBeInTheDocument();
+  });
+
   it("退出所有设备：调用接口并换上返回的新 token（否则当前设备被自己踢掉）", async () => {
     signedIn();
     vi.mocked(logoutAllDevices).mockResolvedValue({

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -573,7 +573,11 @@ export default function ProfilePage() {
                         title={t("profile.logout_all_title")}
                         description={t("profile.logout_all_confirm")}
                         okText={t("profile.logout_all_ok")}
-                        cancelText={t("common.cancel")}
+                        cancelText={t("auth.cancel")}
+                        // 请求在飞时禁掉确认键：连点两次会连着 bump 两次
+                        // password_version，两个响应乱序到达就可能把先回来的
+                        // （已被第二次作废的）票留在本地。
+                        okButtonProps={{ loading: loggingOutAll }}
                         onConfirm={handleLogoutAll}
                       >
                         <Button danger loading={loggingOutAll}>


### PR DESCRIPTION
真机点开确认弹层才看见的。

## 缺陷

「退出所有设备」的确认弹层里，取消键上写着 **`common.cancel`**。

#1226 里我写了 `t("common.cancel")`，而这个键**根本不存在**（仓库里只有 `auth.cancel` / `chat.cancel` / `admin_crud.common.cancel`）。i18next 把缺失键原样渲染 —— 于是线上真的有一个写着键名的按钮。

**全套门禁一个都没拦住**：typecheck 绿、eslint 绿、i18n ratchet 绿（它只查"新增的硬编码中文"，缺失键是反方向的错）、633 条前端用例绿（没有一条断言这个按钮的字）。**没有任何一层在看渲染出来的字。**

## 改了什么

- `ProfilePage`：`common.cancel` → `auth.cancel`（zh / zh-Hant / en 都有）
- `DashboardPage`：`common.noData` → `activity.noData` —— **同类既有缺陷**，是全站扫描扫出来的，`<Empty description>` 一直显示着 `common.noData`
- 新增 `scripts/check-i18n-keys.mjs`，接进 `npm run i18n:check`（CI 已经在跑这条，无需改 workflow 的 run）：对 `src/` 下所有 `t("字面量")` 校验键在 zh locale 存在
  - 带默认值的 `t("k", "默认")` 跳过 —— i18next 会渲染默认值，`theme.toggle` 就是这种，不是缺陷
  - 模板串 `` t(`a.${b}`) `` 与变量键静态查不了，不管
  - zh 是基准：它在 `i18n.ts` 里同步内联且是 `fallbackLng`，zh 缺了就是哪儿都缺；其他 locale 缺则回退到 zh，是降级不是坏掉
- 补一条用例断言弹层两个按钮都是译文而非键名

顺带修一个实测时自己撞出来的：确认键加 `okButtonProps={{ loading }}`。连点两次会连着 bump 两次 `password_version`，两个响应乱序到达就可能把先回来的（已被第二次作废的）票留在本地。

## 全站扫描结果

只有 3 处，`theme.toggle` 有默认值不算：

```
src/pages/DashboardPage.tsx:37  t("common.noData")     ← 既有缺陷
src/pages/ProfilePage.tsx:576   t("common.cancel")     ← #1226 引入
```

## 测试

反向对照跑过：把键改回 `common.cancel`，**新用例与门禁脚本双双变红**。

eslint --max-warnings 0 ✅ · tsc ✅ · i18n:check（两条）✅ · vitest 634 ✅ · vite build ✅