### PR TITLE
feat(eval): 生产答案忠实度回放——零 LLM，且不再把洗过的衣服当脏衣服量

### DIFF
--- a/backend/eval/README.md
+++ b/backend/eval/README.md
@@ -9,6 +9,7 @@
 |----|--------|----------|--------|
 | **确定性检索指标** | Recall@K / Hit@K / MRR / Precision@K，对照每题黄金来源，繁简折叠匹配经名（+可选卷号） | 只需语料库 DB（不需 LLM） | prod / cron，可做回归门 |
 | **确定性引用忠实度** | 「每一句都能点回原典」的可度量版：重放线上引用守卫 + 引文核验 + 可信状态管线，算 `citation_grounding_rate` / `verified_rate_of_cited` + 可信状态分布 | DB + LLM key（需生成回答） | prod / cron，可做回归门 |
+| **生产答案回放** | 线上已服务答案的真实忠实度：serve 时诊断（原始答案真值）+ 回放补测卷号准确率与覆盖缺口 | 只需业务 DB（**不需 LLM**） | prod，按月或改动前后 |
 | **LLM-as-judge** | 检索相关性 / 引用准确性 / 回答完整性 / 无编造（语义打分） | DB + LLM key | prod / 人工 |
 | **指标逻辑单测** | `retrieval_metrics.py` / `faithfulness.py` 的纯函数单测 | 无（纯逻辑） | **CI 自动跑**（`tests/test_retrieval_metrics.py` / `tests/test_faithfulness.py`） |
 
@@ -155,3 +156,53 @@ python -m eval.from_feedback --window-days 90 --limit 200
 - `test_set.json` — 黄金评测集
 - `ALIGNMENT_EVAL.md` + `alignment_metrics.py` / `build_alignment_gold.py` / `run_alignment_eval.py` /
   `run_alignment_regression.sh` / `alignment_gold.sample.jsonl` — 跨藏对齐质量评测（独立黄金集与回归门）
+
+## 生产答案回放（`replay_production.py`）——不烧 token 的那把尺子
+
+题库量的是 90 道精选题；这个量的是**用户真正拿到的答案**。零 LLM 调用，因为答案早已生成并
+连同当时的 `sources` 存在 `chat_messages` 里。
+
+```bash
+# 最近 30 天线上真实忠实度（1,427 条约 106 秒）
+python -m eval.replay_production --window-days 30 --tag monthly
+
+# 改护栏前后的受控对照：同一批答案跑两遍
+python -m eval.replay_production --window-days 30 --tag before
+#   ...改 citation_guard / quote_verifier...
+python -m eval.replay_production --ids-from eval/reports/replay-<ts>-before.json \
+    --baseline eval/reports/replay-<ts>-before.json --tag after
+```
+
+### ⚠️ 为什么忠实度**不能**靠回放算
+
+`chat_messages.content` 存的是护栏**处理后**的答案。`verify_quoted_content` 把不逐字的引文
+降级成散文（去掉引号），它自己的 docstring 写明这是幂等的——「a downgraded passage carries
+no quote marks, so a second pass is a no-op」。所以回放存文必然报 100% 干净，无论模型当时多糟。
+
+**2026-09-01 实测 300 条：回放报 0 次引文降级、0 次引用纠正；serve 时诊断表记录的是 203 次和 43 次。**
+
+原始答案的质量只能读 `chat_answer_diagnostics`（护栏在改写**之前**把要改什么写下来了）。
+本工具因此分成两节：A 节读诊断表，B/C 节才是回放——回放只负责护栏从没碰过的东西。
+
+### ⛔ 它不是每日门
+
+生产日均约 47.5 条答案，`verbatim_quote_rate` 的分母更窄（约 25 条/天）。p≈0.8 时日粒度标准误
+约 8 个百分点，周粒度约 3，月粒度约 1.5。**日序列全是噪声，设阈值会天天误报。**
+按月跑，或在改动前后成对跑。每日的确定性检索门（`run_regression.sh`）照旧，两者不合并。
+
+### 基线（2026-09-01，最近 30 天，1,427 条）
+
+| 指标 | 值 | 分母 | 来源 |
+|------|-----|------|------|
+| `citation_grounding_rate` | 98.9% | 2,810 条引用 | serve 诊断 |
+| `verified_rate_of_cited` | 61.7% | 962 条有引用回答 | serve 诊断 |
+| `verbatim_quote_rate` | **79.9%** | 757 条含可核验引文回答 | serve 诊断 |
+| `fascicle_accuracy_rate` | **96.0%** | 1,695 条可解析卷号引文 | **回放**（护栏盲区） |
+| 核验覆盖率 | **67.8%** | 967 / 1,427 | 回放 |
+
+> 对照 2026-07-09 题库基线的 `verbatim_quote_rate` 56.6% —— **口径不同，不可直接比**：
+> 那是 90 题题库、这是生产全量，且中间护栏行为从「加警告」改成了「降级引文」。
+
+> **覆盖率 67.8% 是所有 A 节比率的真实分母上限。** 另外 460 条（32.2%）答案不含 `【《` 标记，
+> `verify_quoted_content` 首行早退、整条不核验——它们不是「核验通过」，是「从没被看过」。
+> 这批答案的存文因此是**原始**的，是唯一能靠回放查清的一批。

--- a/backend/eval/replay_production.py
+++ b/backend/eval/replay_production.py
@@ -1,0 +1,552 @@
+"""Read what production actually served, and re-score only what the guards missed.
+
+``run_eval`` measures citation faithfulness by *generating* 90 answers with the
+LLM. That is the right instrument for a controlled before/after — the question
+set is fixed, so a delta is attributable — but it costs a model call per
+question and it measures a hand-curated test set rather than what users get.
+
+This module measures production, for free. It has two halves, and keeping them
+apart is the whole point:
+
+**A. The guard-visible numbers come from ``chat_answer_diagnostics``, not from
+replay.** ``chat_messages.content`` stores the answer *after* the guards ran.
+``verify_quoted_content`` downgrades a non-verbatim quote by stripping its quote
+marks, and its docstring is explicit that this is idempotent — "a downgraded
+passage carries no quote marks, so a second pass is a no-op (and returns no
+mutations — the served answer is already clean)". So replaying stored content
+through the guards reports 100% grounding on every run, by construction, no
+matter how bad the model was. Measured 2026-09-01 on 300 stored answers: replay
+said 0 quote downgrades and 0 citation corrections; the serve-time table said
+203 and 43 over the same window. The number was real; reading it as quality
+would have been fiction.
+
+The serve-time record is the raw-answer truth, because the guards wrote down
+what they had to change *before* changing it. That is where faithfulness comes
+from here.
+
+**B. Replay measures the two things the guards never did.**
+
+  - **卷号 accuracy.** ``quote_verifier._find_sources`` falls back to any
+    fascicle of the cited text, so a quote that is verbatim in 卷16 passes while
+    the answer says 第13卷. No guard can see this, so nothing was baked into the
+    stored answer and replay against ``text_contents`` reads true.
+  - **The answers the verifier declined to open.** ``verify_quoted_content``
+    early-exits when the answer carries no ``【《`` marker. Those answers were
+    never touched, so their stored content is raw with respect to quote
+    verification — replay is the *only* way to find out what is in them. Sizing
+    that cohort is what this tool exists for next.
+
+**What this is NOT: a daily gate.** Production serves ~47.5 answers/day and
+``verbatim_quote_rate``'s denominator is narrower still — roughly 25/day. At
+p≈0.8 that is a standard error of ~8 points daily, ~3 weekly, ~1.5 monthly. A
+daily series is noise and any threshold on it would page every day. Run it
+monthly, or side-by-side around a change. The deterministic *retrieval* gate
+stays daily; this does not join it.
+
+Usage::
+
+    # What did we actually serve over the last 30 days?
+    python -m eval.replay_production --window-days 30 --tag monthly
+
+    # Adjudicate a guard change over the same answers, before and after.
+    python -m eval.replay_production --window-days 30 --tag before
+    #   ...edit the guard...
+    python -m eval.replay_production --ids-from eval/reports/replay-<ts>-before.json \\
+        --baseline eval/reports/replay-<ts>-before.json --tag after
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from functools import partial
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.schemas.chat import ChatSource
+from eval.faithfulness import (
+    TRUST_STATES,
+    aggregate_faithfulness,
+    compute_faithfulness,
+    compute_fascicle_accuracy,
+)
+
+EVAL_DIR = Path(__file__).parent
+REPORTS_DIR = EVAL_DIR / "reports"
+
+# The literal early-exit condition in ``quote_verifier.verify_quoted_content``:
+# no marker → the answer is returned untouched and nothing is ever checked.
+# Measured directly rather than inferred from ``citation_count`` (a slightly
+# looser regex) so the coverage number means exactly "answers the verifier
+# declined to look at".
+CITATION_MARKER = "【《"
+
+# ``juan_text(message_id, title, juan) -> fascicle body | None``. The message id
+# is part of the key because one 经名 legitimately resolves to different texts in
+# different answers — 「楞伽经」 meant two different 经 in search and in chat until
+# PR #1209 — and adjudicating one answer's citation against another's fascicle
+# would be worse than not adjudicating it.
+JuanTextResolver = Callable[[int, str, int], "str | None"]
+
+
+@dataclass(frozen=True)
+class StoredAnswer:
+    """One persisted assistant turn, ready to re-score."""
+
+    message_id: int
+    created_at: str
+    answer: str
+    sources: list[ChatSource]
+
+
+@dataclass(frozen=True)
+class ServeRecord:
+    """What the guards recorded about an answer at serve time, pre-correction.
+
+    This is the raw-model-quality signal. It cannot be recovered by replaying
+    the stored answer, because the stored answer is the corrected one — see the
+    module docstring.
+    """
+
+    message_id: int
+    trust_state: str
+    citation_count: int
+    citation_mutations: int
+    quote_mutations: int
+    quote_checked: int | None
+
+
+def parse_stored_sources(raw: object) -> list[ChatSource]:
+    """Deserialise ``chat_messages.sources`` into ``ChatSource`` objects.
+
+    Production writes ``[s.model_dump() for s in sources]`` (a JSON array), but
+    the column is nullable and older rows predate the trilingual fields, so this
+    tolerates: SQL NULL, JSON ``null``, ``[]``, and entries missing the optional
+    keys. A single unparseable entry is dropped rather than raised — one bad row
+    out of 1,400 must not end the run, and a row that cannot be read is a row
+    whose faithfulness is genuinely unknown, not zero.
+    """
+    if not isinstance(raw, list):
+        return []
+    out: list[ChatSource] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            out.append(ChatSource(**entry))
+        except Exception:
+            continue
+    return out
+
+
+def aggregate_serve_records(records: Sequence[ServeRecord]) -> dict:
+    """Fold serve-time diagnostics into the faithfulness rates.
+
+    Mirrors ``aggregate_faithfulness``'s definitions so the two are readable
+    side by side, but sourced from what the guards recorded rather than from a
+    re-run. ``verbatim_quote_rate``'s denominator is answers that actually
+    quoted; an answer that cites without quoting scores 0 in
+    ``verified_rate_of_cited`` (it verified nothing) rather than passing
+    vacuously.
+    """
+    if not records:
+        return {}
+    cited = [r for r in records if r.citation_count > 0]
+    quoted = [r for r in records if (r.quote_checked or 0) > 0]
+    verbatim = [r for r in quoted if r.quote_mutations == 0]
+    verified = [
+        r for r in cited if (r.quote_checked or 0) > 0 and not r.quote_mutations and not r.citation_mutations
+    ]
+    total_citations = sum(r.citation_count for r in records)
+    grounded = sum(max(0, r.citation_count - r.citation_mutations) for r in records)
+
+    distribution = dict.fromkeys(TRUST_STATES, 0)
+    for r in records:
+        distribution[r.trust_state] = distribution.get(r.trust_state, 0) + 1
+
+    return {
+        "num_answers": len(records),
+        "citation_grounding_rate": (grounded / total_citations) if total_citations else None,
+        "verified_rate_of_cited": (len(verified) / len(cited)) if cited else None,
+        "verbatim_quote_rate": (len(verbatim) / len(quoted)) if quoted else None,
+        "total_citations": total_citations,
+        "answers_with_citations": len(cited),
+        "answers_with_quotes": len(quoted),
+        "answers_with_downgraded_quote": sum(1 for r in records if r.quote_mutations),
+        "state_distribution": distribution,
+    }
+
+
+def replay_answers(
+    answers: Iterable[StoredAnswer],
+    juan_text: JuanTextResolver | None = None,
+) -> tuple[list[dict], dict]:
+    """Score stored answers with the production guards; return rows + aggregate.
+
+    ⚠️ The grounding/verbatim rates in the returned aggregate are **tautological
+    for answers the guards already corrected** — the stored text is the
+    corrected text. They are meaningful only for the cohort the verifier never
+    opened (``has_citation_marker == 0``) and for adjudicating a guard change
+    over a fixed id set. Production faithfulness comes from
+    :func:`aggregate_serve_records`. See the module docstring.
+
+    ``fascicle_checked``/``fascicle_correct`` are exempt: no guard writes to the
+    答案 based on 卷号, so replay reads true there.
+    """
+    rows: list[dict] = []
+    for a in answers:
+        row = compute_faithfulness(a.answer, a.sources)
+        row["message_id"] = a.message_id
+        row["created_at"] = a.created_at
+        row["has_citation_marker"] = 1 if CITATION_MARKER in (a.answer or "") else 0
+        row["source_count"] = len(a.sources)
+        if juan_text is not None:
+            row.update(compute_fascicle_accuracy(a.answer, partial(juan_text, a.message_id)))
+        rows.append(row)
+    return rows, aggregate_faithfulness(rows)
+
+
+def coverage(rows: Sequence[dict]) -> dict:
+    """How much of the run the quote verifier ever looked at."""
+    marked = sum(r["has_citation_marker"] for r in rows)
+    return {
+        "answers": len(rows),
+        "with_citation_marker": marked,
+        "without_citation_marker": len(rows) - marked,
+        "marker_rate": (marked / len(rows)) if rows else None,
+    }
+
+
+# ── DB layer (needs the prod corpus; not exercised in CI) ────────────────────
+
+
+async def fetch_stored_answers(
+    session,
+    *,
+    window_days: int = 30,
+    limit: int | None = None,
+    message_ids: Sequence[int] | None = None,
+) -> list[StoredAnswer]:
+    """Load served assistant turns, newest first.
+
+    ``message_ids`` pins the exact set for a controlled second run and ignores
+    the window entirely; without it the window selects. Rows whose sources did
+    not persist are kept — an answer served with no sources is a real outcome
+    (``no_sources``), and dropping it would flatter every rate.
+    """
+    from sqlalchemy import text as sql_text
+
+    if message_ids is not None:
+        if not message_ids:
+            return []
+        stmt = sql_text(
+            "SELECT id, created_at, content, sources FROM chat_messages "
+            "WHERE role = 'assistant' AND id = ANY(:ids) ORDER BY id"
+        )
+        params: dict = {"ids": list(message_ids)}
+    else:
+        stmt = sql_text(
+            "SELECT id, created_at, content, sources FROM chat_messages "
+            "WHERE role = 'assistant' AND created_at > now() - make_interval(days => :d) "
+            "ORDER BY id DESC" + (" LIMIT :lim" if limit else "")
+        )
+        params = {"d": window_days}
+        if limit:
+            params["lim"] = limit
+
+    rows = (await session.execute(stmt, params)).fetchall()
+    return [
+        StoredAnswer(
+            message_id=r[0],
+            created_at=r[1].isoformat() if r[1] else "",
+            answer=r[2] or "",
+            sources=parse_stored_sources(r[3]),
+        )
+        for r in rows
+    ]
+
+
+async def fetch_serve_records(session, message_ids: Sequence[int]) -> list[ServeRecord]:
+    """Load the serve-time guard diagnostics for these answers.
+
+    Answers with no diagnostics row are omitted rather than defaulted to zero —
+    a missing row means the guards' verdict was never recorded, which is not the
+    same as "nothing to correct".
+    """
+    from sqlalchemy import text as sql_text
+
+    if not message_ids:
+        return []
+    rows = (
+        await session.execute(
+            sql_text(
+                "SELECT message_id, trust_state, citation_count, citation_mutation_count, "
+                "quote_mutation_count, quote_checked_count FROM chat_answer_diagnostics "
+                "WHERE message_id = ANY(:ids)"
+            ),
+            {"ids": list(message_ids)},
+        )
+    ).fetchall()
+    return [
+        ServeRecord(
+            message_id=r[0],
+            trust_state=r[1],
+            citation_count=r[2] or 0,
+            citation_mutations=r[3] or 0,
+            quote_mutations=r[4] or 0,
+            quote_checked=r[5],
+        )
+        for r in rows
+    ]
+
+
+async def build_juan_resolver(session, answers: Sequence[StoredAnswer]) -> JuanTextResolver:
+    """Prefetch every cited fascicle once, return a sync (message, title, juan) lookup.
+
+    Synchronous by design: ``compute_fascicle_accuracy`` is unit-tested in CI
+    where there is no database, so the metric must not learn to await. Titles
+    resolve to a text_id through that answer's own retrieved sources, using the
+    guard's fold rules — same source of truth the runtime used.
+    """
+    from sqlalchemy import text as sql_text
+
+    from app.services.citation_guard import _norm_title
+    from app.services.quote_verifier import iter_quote_citations
+
+    body_cache: dict[tuple[int, int], str | None] = {}
+    loaded: dict[tuple[int, str, int], str | None] = {}
+
+    for a in answers:
+        by_title: dict[str, int] = {}
+        for s in a.sources:
+            if s.title_zh and s.text_id > 0:
+                by_title.setdefault(_norm_title(s.title_zh), s.text_id)
+        for cite in iter_quote_citations(a.answer):
+            if cite.juan is None or (a.message_id, cite.title, cite.juan) in loaded:
+                continue
+            text_id = by_title.get(_norm_title(cite.title))
+            if text_id is None:
+                # Title outside this answer's retrieved set — the guard already
+                # strips those, and a fascicle cannot be adjudicated without
+                # knowing its text. Unresolved → left out of the denominator.
+                continue
+            key = (text_id, cite.juan)
+            if key not in body_cache:
+                row = (
+                    await session.execute(
+                        sql_text(
+                            "SELECT content FROM text_contents "
+                            "WHERE text_id = :t AND juan_num = :j AND lang = 'lzh' LIMIT 1"
+                        ),
+                        {"t": text_id, "j": cite.juan},
+                    )
+                ).fetchone()
+                body_cache[key] = row[0] if row else None
+            loaded[(a.message_id, cite.title, cite.juan)] = body_cache[key]
+
+    return lambda message_id, title, juan: loaded.get((message_id, title, juan))
+
+
+# ── Reporting ────────────────────────────────────────────────────────────────
+
+
+def _fmt_rate(value: object) -> str:
+    return f"{round(value * 100, 1)}%" if isinstance(value, int | float) else "N/A"
+
+
+def generate_report(
+    rows: list[dict],
+    replay_agg: dict,
+    serve_agg: dict,
+    cov: dict,
+    *,
+    selection: str,
+    tag: str,
+) -> str:
+    lines = [
+        "# 生产答案 · 引用忠实度",
+        "",
+        f"**日期**: {datetime.now().strftime('%Y-%m-%d %H:%M')}",
+        f"**选样**: {selection}",
+        f"**答案数**: {cov['answers']}" + (f"  ·  **标签**: {tag}" if tag else ""),
+        "",
+        "> 零 LLM 调用：答案是线上已服务过的，不重新生成。",
+        "",
+        "## A. 忠实度（serve 时记录，原始答案上量到的）",
+        "",
+    ]
+    if not serve_agg:
+        lines += ["*该批答案没有 serve 时诊断记录。*", ""]
+    else:
+        lines += [
+            "| 指标 | 值 | 分母 |",
+            "|------|-----|------|",
+            f"| `citation_grounding_rate` | {_fmt_rate(serve_agg['citation_grounding_rate'])} "
+            f"| {serve_agg['total_citations']} 条引用 |",
+            f"| `verified_rate_of_cited` | {_fmt_rate(serve_agg['verified_rate_of_cited'])} "
+            f"| {serve_agg['answers_with_citations']} 条有引用的回答 |",
+            f"| `verbatim_quote_rate` | **{_fmt_rate(serve_agg['verbatim_quote_rate'])}** "
+            f"| {serve_agg['answers_with_quotes']} 条含可核验引文的回答 |",
+            f"| 引文被降级的回答 | {serve_agg['answers_with_downgraded_quote']} 条 "
+            f"| 共 {serve_agg['num_answers']} 条 |",
+            "",
+            "> **为什么这一节不从回放算。** `chat_messages.content` 存的是护栏**处理后**的答案，"
+            "而 `verify_quoted_content` 把不逐字的引文降级成散文（去掉引号）后是幂等的——"
+            "再跑一遍必然零改写。2026-09-01 实测 300 条：回放报 0 次降级，serve 记录是 203 次。"
+            "所以原始答案的质量只能读 `chat_answer_diagnostics`，不能靠重放。",
+            "",
+            "### 可信状态分布（serve 时）",
+            "",
+            "| 状态 | 条数 |",
+            "|------|------|",
+        ]
+        for state in TRUST_STATES:
+            lines.append(f"| {state} | {serve_agg['state_distribution'].get(state, 0)} |")
+        lines.append("")
+
+    lines += [
+        "## B. 回放新测：护栏看不见的部分",
+        "",
+        "| 指标 | 值 | 分母 |",
+        "|------|-----|------|",
+        f"| `fascicle_accuracy_rate`（卷号对不对） | **{_fmt_rate(replay_agg.get('fascicle_accuracy_rate'))}** "
+        f"| {replay_agg.get('fascicle_checked', 0)} 条可解析卷号的引文 |",
+        "",
+        "> 这是唯一不查召回 chunk、直接问 `text_contents` 的指标。"
+        "`quote_verifier._find_sources` 在所标卷找不到时会回退到该经**任意**卷，"
+        "所以「引文逐字正确但卷号指向别处」对所有运行时护栏都是盲区——"
+        "正因为没有护栏改写过它，回放在这里读到的是真值。",
+        "",
+        "## C. 覆盖：核验器根本没打开过的那些答案",
+        "",
+        f"| 全部答案 | 带 `{CITATION_MARKER}` 标记（被核验） | 无标记（**整条跳过**） |",
+        "|---|---|---|",
+        f"| {cov['answers']} | {cov['with_citation_marker']} "
+        f"（{_fmt_rate(cov['marker_rate'])}） | {cov['without_citation_marker']} |",
+        "",
+        "> `verify_quoted_content` 首行即 `if \"【《\" not in answer: return answer, []`。"
+        "A 节所有比率的分母**只是带标记的那部分**——无标记的那些不是「核验通过」，是「从没被看过」，"
+        "而且正因为没被改写，它们的存文是**原始**的，是唯一能靠回放查清的一批。",
+    ]
+    return "\n".join(lines)
+
+
+def compare_baseline(baseline_path: str, serve_agg: dict, replay_agg: dict, ids: Sequence[int]) -> list[str]:
+    """Deltas against a prior replay report — meaningful only on the same ids."""
+    try:
+        prior = json.loads(Path(baseline_path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        return ["", f"⚠️ 基线读取失败（{exc}）——本次不做对照。"]
+
+    prior_ids = {r["message_id"] for r in prior.get("rows", [])}
+    now_ids = set(ids)
+    out = ["", "## 对照基线", "", f"基线：`{baseline_path}`"]
+    if prior_ids and now_ids and prior_ids != now_ids:
+        out += [
+            "",
+            f"⚠️ **两次跑的不是同一批答案**（基线 {len(prior_ids)} 条，本次 {len(now_ids)} 条，"
+            f"交集 {len(prior_ids & now_ids)} 条）。差值里混着人群变化，**不可归因于代码改动**。"
+            f"用 `--ids-from {baseline_path}` 重跑才能得到受控对照。",
+        ]
+    out += ["", "| 指标 | 基线 | 本次 | 差 |", "|---|---|---|---|"]
+    pairs = [
+        ("serve", "citation_grounding_rate", prior.get("serve_aggregate") or {}, serve_agg),
+        ("serve", "verified_rate_of_cited", prior.get("serve_aggregate") or {}, serve_agg),
+        ("serve", "verbatim_quote_rate", prior.get("serve_aggregate") or {}, serve_agg),
+        ("replay", "fascicle_accuracy_rate", prior.get("replay_aggregate") or {}, replay_agg),
+    ]
+    for kind, key, old_agg, new_agg in pairs:
+        old, new = old_agg.get(key), new_agg.get(key)
+        delta = (
+            f"{(new - old) * 100:+.1f}pp"
+            if isinstance(old, int | float) and isinstance(new, int | float)
+            else "—"
+        )
+        out.append(f"| `{key}` ({kind}) | {_fmt_rate(old)} | {_fmt_rate(new)} | {delta} |")
+    return out
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Read production faithfulness; replay what the guards missed")
+    parser.add_argument("--window-days", type=int, default=30, help="How far back to select answers (default 30)")
+    parser.add_argument("--limit", type=int, help="Cap the number of answers")
+    parser.add_argument("--ids-from", type=str,
+                        help="Replay exactly the message ids in a prior report — the controlled A/B")
+    parser.add_argument("--baseline", type=str, help="Prior report to diff against")
+    parser.add_argument("--no-fascicle", action="store_true",
+                        help="Skip the text_contents 卷号 check (saves a handful of reads per answer)")
+    parser.add_argument("--tag", type=str, default="", help="Tag for the report filename")
+    args = parser.parse_args()
+
+    from app.database import async_session
+
+    ids_filter = None
+    selection = f"最近 {args.window_days} 天" + (f"（上限 {args.limit} 条）" if args.limit else "")
+    if args.ids_from:
+        prior = json.loads(Path(args.ids_from).read_text(encoding="utf-8"))
+        ids_filter = [r["message_id"] for r in prior.get("rows", [])]
+        selection = f"复现 `{args.ids_from}` 的 {len(ids_filter)} 条（受控对照）"
+
+    async with async_session() as session:
+        answers = await fetch_stored_answers(
+            session, window_days=args.window_days, limit=args.limit, message_ids=ids_filter
+        )
+        if not answers:
+            print("没有可回放的答案。")
+            return 0
+        ids = [a.message_id for a in answers]
+        serve_records = await fetch_serve_records(session, ids)
+        resolver = None if args.no_fascicle else await build_juan_resolver(session, answers)
+
+    rows, replay_agg = replay_answers(answers, juan_text=resolver)
+    serve_agg = aggregate_serve_records(serve_records)
+    cov = coverage(rows)
+
+    report = generate_report(rows, replay_agg, serve_agg, cov, selection=selection, tag=args.tag)
+    if args.baseline:
+        report += "\n" + "\n".join(compare_baseline(args.baseline, serve_agg, replay_agg, ids))
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    tag_suffix = f"-{args.tag}" if args.tag else ""
+    payload = {
+        "generated_at": timestamp,
+        "selection": selection,
+        "coverage": cov,
+        "serve_aggregate": serve_agg,
+        "replay_aggregate": replay_agg,
+        "rows": rows,
+    }
+    try:
+        REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+        base = REPORTS_DIR / f"replay-{timestamp}{tag_suffix}"
+        base.with_suffix(".md").write_text(report, encoding="utf-8")
+        base.with_suffix(".json").write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        saved = f"\nReport: {base}.md\nRaw: {base}.json"
+    except OSError as exc:
+        # Same trap run_eval documents: in prod eval/reports is a bind mount owned
+        # by admin(1000) while the container runs as app(999). A silent fallback
+        # to /tmp dies with the container, taking the ids a controlled second run
+        # would need with it — so say it loudly.
+        base = Path("/tmp") / f"replay-{timestamp}{tag_suffix}"
+        base.with_suffix(".md").write_text(report, encoding="utf-8")
+        base.with_suffix(".json").write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        saved = (
+            f"\n⚠️  {REPORTS_DIR} 不可写（{exc}）——报告写到了 EPHEMERAL 的 /tmp，容器重启即丢，"
+            f"届时 --ids-from 无从复现。\n    修复：chgrp 999 backend/eval/reports && chmod g+w backend/eval/reports"
+            f"\nReport: {base}.md\nRaw: {base}.json"
+        )
+
+    print(f"\n{'=' * 60}")
+    print(report)
+    print(saved)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_replay_production.py
+++ b/backend/tests/test_replay_production.py
@@ -1,0 +1,328 @@
+"""Tests for replaying stored production answers through the faithfulness pipeline.
+
+``eval/replay_production.py`` reads answers that prod already generated
+(``chat_messages.content`` + ``.sources``) and runs the same deterministic
+guards ``eval/faithfulness.py`` runs — no LLM, because the answers already
+exist. These tests cover the parts that are pure logic: deserialising what prod
+actually stored, and folding a run's answers into rows + an aggregate.
+
+The DB layer (which rows to fetch) is not covered here for the same reason
+``run_eval`` isn't: it needs the prod corpus. What CI *can* protect is that a
+malformed stored row can't take down a 1,400-answer run, and that answers which
+skip verification stay visible in the output instead of vanishing.
+
+Pure logic: no DB, no LLM, no network — same tier as test_faithfulness.
+"""
+
+import pytest
+
+from eval.replay_production import (
+    ServeRecord,
+    StoredAnswer,
+    aggregate_serve_records,
+    coverage,
+    parse_stored_sources,
+    replay_answers,
+)
+
+from app.schemas.chat import ChatSource
+
+
+_LONG_CHUNK = "舍利子，色不异空，空不异色，色即是空，空即是色。"
+
+# The exact shape ``chat.py:_save_messages`` writes: ``[s.model_dump() for s in
+# sources]``. Kept verbatim rather than trimmed to the fields under test —
+# a fixture that only carries what the assertion reads is how a real defect
+# hides (a stored key the parser chokes on would never appear here).
+_STORED_SOURCE = {
+    "text_id": 7,
+    "juan_num": 1,
+    "chunk_index": 0,
+    "chunk_text": _LONG_CHUNK,
+    "score": 0.87,
+    "title_zh": "心经",
+    "lang": "lzh",
+    "source_id": 3,
+    "parallel_chunks": [],
+    "urn": "fojin:cbeta/T0251.1",
+}
+
+
+def _answer(msg_id: int, text: str, sources: list | None = None) -> StoredAnswer:
+    return StoredAnswer(
+        message_id=msg_id,
+        created_at="2026-09-01T04:00:00+00:00",
+        answer=text,
+        sources=parse_stored_sources(sources if sources is not None else [_STORED_SOURCE]),
+    )
+
+
+class TestParseStoredSources:
+    def test_parses_the_shape_production_actually_stores(self):
+        parsed = parse_stored_sources([_STORED_SOURCE])
+        assert len(parsed) == 1
+        assert isinstance(parsed[0], ChatSource)
+        assert parsed[0].title_zh == "心经"
+        assert parsed[0].chunk_text == _LONG_CHUNK
+        assert parsed[0].urn == "fojin:cbeta/T0251.1"
+
+    def test_fills_defaults_for_rows_written_before_the_trilingual_fields(self):
+        """History predating the lang/urn/parallel_chunks columns must still load.
+
+        ``ChatSource`` gives those fields defaults precisely so stored chat
+        history keeps deserialising; a replay that only handled today's shape
+        would silently drop every older answer from the denominator.
+        """
+        legacy = {
+            "text_id": 7,
+            "juan_num": 1,
+            "chunk_index": 0,
+            "chunk_text": _LONG_CHUNK,
+            "score": 0.5,
+            "title_zh": "心经",
+        }
+        parsed = parse_stored_sources([legacy])
+        assert len(parsed) == 1
+        assert parsed[0].lang == "lzh"
+        assert parsed[0].urn is None
+        assert parsed[0].parallel_chunks == []
+
+    @pytest.mark.parametrize("raw", [None, [], "null"])
+    def test_absent_sources_become_an_empty_list(self, raw):
+        assert parse_stored_sources(raw) == []
+
+    def test_a_malformed_entry_is_dropped_without_losing_its_siblings(self):
+        """One bad row must not abort the run.
+
+        1,410 of 1,426 stored answers are arrays and 16 are JSON null; a single
+        unparseable neighbour taking down the whole replay would make the tool
+        useless exactly when history is messiest.
+        """
+        parsed = parse_stored_sources([_STORED_SOURCE, {"text_id": "not-an-int"}, "garbage"])
+        assert len(parsed) == 1
+        assert parsed[0].title_zh == "心经"
+
+
+class TestReplayAnswers:
+    def test_returns_one_row_per_answer_carrying_its_message_id(self):
+        rows, agg = replay_answers([
+            _answer(101, f"经云：「{_LONG_CHUNK}」【《心经》第1卷】"),
+            _answer(102, "见【《心经》第1卷】。"),
+        ])
+        assert [r["message_id"] for r in rows] == [101, 102]
+        assert agg["num_answers"] == 2
+
+    def test_a_verbatim_quote_scores_as_grounded(self):
+        rows, agg = replay_answers([
+            _answer(1, f"经云：「{_LONG_CHUNK}」【《心经》第1卷】"),
+        ])
+        assert rows[0]["fully_grounded"] == 1
+        assert agg["verbatim_quote_rate"] == 1.0
+
+    def test_a_paraphrase_in_quote_marks_is_counted_against_verbatim_rate(self):
+        """The failure mode the brand claim actually rests on.
+
+        The quote is 14 chars (above MIN_QUOTE_CHARS) and cites a retrieved
+        source, so the verifier really examines it — it just isn't in the chunk.
+        """
+        rows, agg = replay_answers([
+            _answer(1, "经云：「五蕴皆空，一切苦厄悉皆远离度尽」【《心经》第1卷】"),
+        ])
+        assert rows[0]["quotes_downgraded"] >= 1
+        assert agg["verbatim_quote_rate"] == 0.0
+
+    def test_answers_that_skip_verification_stay_in_the_output(self):
+        """The 32.2% coverage hole must be visible, not silently dropped.
+
+        ``verify_quoted_content`` early-exits when the answer carries no
+        ``【《`` marker, so these answers are never checked. They still have to
+        appear in num_answers and the state distribution — otherwise the
+        reported rates look like they cover everything, which is the exact
+        misreading this whole exercise exists to stop.
+        """
+        rows, agg = replay_answers([
+            _answer(1, f"经云：「{_LONG_CHUNK}」【《心经》第1卷】"),
+            _answer(2, "五蕴是色受想行识五种聚合，出自心经。"),
+        ])
+        assert agg["num_answers"] == 2
+        assert sum(agg["state_distribution"].values()) == 2
+        assert rows[1]["has_citation_marker"] == 0
+        assert rows[0]["has_citation_marker"] == 1
+
+    def test_an_unmarked_answer_carries_its_quote_past_every_guard(self):
+        """The coverage hole, stated as the defect it is rather than a caveat.
+
+        ``verify_quoted_content`` early-exits on ``"【《" not in answer``, so an
+        answer that puts canon in 「」 without a bracket citation is never
+        examined. It reports zero quote mutations — not because the quote held
+        up, but because nobody looked. 459 of 1,426 production answers over 30
+        days (32.2%) take this path, and every faithfulness rate silently
+        excludes them.
+
+        This is the number step 2 of this work has to move, so it needs a test
+        that fails the moment the early-exit stops applying.
+        """
+        unmarked = "经中说「五蕴皆空一切苦厄悉皆远离度尽无余」，此为要义。"
+        rows, agg = replay_answers([_answer(1, unmarked)])
+        assert rows[0]["has_citation_marker"] == 0
+        # Zero mutations here means "unexamined", not "verified".
+        assert rows[0]["quote_mutations"] == 0
+        assert agg["verbatim_quote_rate"] is None
+
+    def test_a_stripped_citation_still_counts_as_marked(self):
+        """"Cited a text we never retrieved" is a different defect from "never cited".
+
+        The guard strips the citation, but ``citation_count`` is read off the
+        RAW answer (chat_trust.py:38), so this answer reports a citation *and* a
+        mutation. It is inside the measured 68%, unlike the case above — which
+        is why the marker flag, not ``answers_with_citations``, is what delimits
+        the coverage hole.
+        """
+        rows, _ = replay_answers([
+            _answer(1, "经云：「凡所有相皆是虚妄不实之法」【《金刚经》第1卷】"),
+        ])
+        assert rows[0]["has_citation_marker"] == 1
+        assert rows[0]["citation_count"] == 1
+        assert rows[0]["citation_mutations"] == 1
+
+    def test_fascicle_resolver_is_threaded_through_to_the_juan_check(self):
+        """The wrong-卷号 class of error is invisible to the runtime guards.
+
+        ``quote_verifier._find_sources`` falls back to any fascicle of the cited
+        text, so a quote that is verbatim in 卷2 passes while the answer says
+        第1卷. Only compute_fascicle_accuracy consults text_contents and catches
+        it — replay must pass the resolver down or that column reads N/A forever.
+        """
+        def juan_text(message_id: int, title: str, juan: int) -> str | None:
+            return _LONG_CHUNK if juan == 2 else "别的卷的内容，完全不含所引之句。"
+
+        _, agg = replay_answers(
+            [_answer(1, f"经云：「{_LONG_CHUNK}」【《心经》第1卷】")],
+            juan_text=juan_text,
+        )
+        assert agg["fascicle_checked"] == 1
+        assert agg["fascicle_accuracy_rate"] == 0.0
+
+    def test_the_resolver_is_scoped_per_answer_so_one_title_can_mean_two_texts(self):
+        """The same 经名 legitimately resolves to different texts in different answers.
+
+        PR #1209 landed on exactly this: 「楞伽经」 in search and in chat were two
+        different 经. A resolver keyed only on (title, juan) would blur them and
+        silently adjudicate one answer's citation against the other's fascicle,
+        so the message id has to be part of the key.
+        """
+        seen: list[int] = []
+
+        def juan_text(message_id: int, title: str, juan: int) -> str | None:
+            seen.append(message_id)
+            # 卷1 holds the quote only for message 2; message 1 cites the other 楞伽经.
+            return _LONG_CHUNK if message_id == 2 else "另一部同名经的卷一，不含此句。"
+
+        _, agg = replay_answers(
+            [
+                _answer(1, f"经云：「{_LONG_CHUNK}」【《楞伽经》第1卷】"),
+                _answer(2, f"经云：「{_LONG_CHUNK}」【《楞伽经》第1卷】"),
+            ],
+            juan_text=juan_text,
+        )
+        assert seen == [1, 2]
+        assert agg["fascicle_checked"] == 2
+        assert agg["fascicle_accuracy_rate"] == 0.5
+
+    def test_no_resolver_leaves_the_fascicle_column_unmeasured_rather_than_zero(self):
+        _, agg = replay_answers([_answer(1, f"经云：「{_LONG_CHUNK}」【《心经》第1卷】")])
+        assert agg["fascicle_checked"] == 0
+        assert agg["fascicle_accuracy_rate"] is None
+
+    def test_empty_run_aggregates_to_nothing_measurable(self):
+        rows, agg = replay_answers([])
+        assert rows == []
+        assert agg == {}
+
+
+class TestServeRecords:
+    """The raw-answer truth, read from what the guards recorded at serve time."""
+
+    def _rec(self, mid, *, state="verified", cites=1, cite_mut=0, quote_mut=0, checked=1):
+        return ServeRecord(
+            message_id=mid, trust_state=state, citation_count=cites,
+            citation_mutations=cite_mut, quote_mutations=quote_mut, quote_checked=checked,
+        )
+
+    def test_verbatim_rate_is_denominated_in_answers_that_quoted(self):
+        agg = aggregate_serve_records([
+            self._rec(1),                              # quoted, clean
+            self._rec(2, state="quote_relaxed", quote_mut=1),  # quoted, downgraded
+            self._rec(3, checked=0),                   # cited but never quoted
+        ])
+        assert agg["answers_with_quotes"] == 2
+        assert agg["verbatim_quote_rate"] == 0.5
+
+    def test_citing_without_quoting_does_not_pass_vacuously(self):
+        """An answer that cites a source and quotes none of it verified nothing.
+
+        Scoring it 1 would let the model improve the metric by quoting less —
+        the exact reward hack aggregate_faithfulness documents guarding against.
+        """
+        agg = aggregate_serve_records([self._rec(1, checked=0)])
+        assert agg["answers_with_citations"] == 1
+        assert agg["verified_rate_of_cited"] == 0.0
+        assert agg["verbatim_quote_rate"] is None
+
+    def test_grounding_rate_weights_by_citation_not_by_answer(self):
+        agg = aggregate_serve_records([
+            self._rec(1, cites=10, cite_mut=1, state="citation_corrected"),
+            self._rec(2, cites=1),
+        ])
+        assert agg["total_citations"] == 11
+        assert agg["citation_grounding_rate"] == 10 / 11
+
+    def test_empty_run_is_unmeasurable_not_zero(self):
+        assert aggregate_serve_records([]) == {}
+
+
+class TestReplayCannotSubstituteForServeRecords:
+    """Pins the 2026-09-01 defect so it cannot be "simplified" back in.
+
+    The first version of this tool computed production faithfulness by replaying
+    stored answers. It reported 100% on every rate. The stored answer is the
+    *corrected* one: verify_quoted_content strips the quote marks off a
+    non-verbatim quote, and says in its own docstring that a second pass is
+    therefore a no-op. Replay measured a washed shirt and reported no dirt.
+    """
+
+    def test_an_already_downgraded_answer_replays_as_spotless(self):
+        # What production stored after downgrading a paraphrase: the quote marks
+        # are gone, the citation stayed. Nothing left for the verifier to catch.
+        served = "经中说五蕴皆空一切苦厄悉皆远离度尽，见【《心经》第1卷】。"
+        rows, replay_agg = replay_answers([_answer(1, served)])
+        assert rows[0]["quote_mutations"] == 0
+        assert rows[0]["quotes_downgraded"] == 0
+
+        # The serve-time record of the SAME answer remembers the downgrade.
+        serve_agg = aggregate_serve_records([
+            ServeRecord(message_id=1, trust_state="quote_relaxed", citation_count=1,
+                        citation_mutations=0, quote_mutations=1, quote_checked=1)
+        ])
+        assert serve_agg["verbatim_quote_rate"] == 0.0
+        assert serve_agg["answers_with_downgraded_quote"] == 1
+
+        # The two disagree by construction. Whenever they do, the serve record is
+        # the one telling the truth about the model.
+        assert replay_agg.get("verbatim_quote_rate") != serve_agg["verbatim_quote_rate"]
+
+
+class TestCoverage:
+    def test_counts_the_answers_the_verifier_declined_to_open(self):
+        rows, _ = replay_answers([
+            _answer(1, f"经云：「{_LONG_CHUNK}」【《心经》第1卷】"),
+            _answer(2, "五蕴是色受想行识五种聚合。"),
+            _answer(3, "另一条也没有标记。"),
+        ])
+        cov = coverage(rows)
+        assert cov == {
+            "answers": 3,
+            "with_citation_marker": 1,
+            "without_citation_marker": 2,
+            "marker_rate": 1 / 3,
+        }


### PR DESCRIPTION
## 为什么

线上引用忠实度**自 2026-07-09 起没有任何自动化消费者**：生产 61 份 eval 报告里只有第一份带忠实度数据，其余 60 份全是 `--no-llm`。`compute_faithfulness` 的消费方只有 `run_eval` 和单测，所以每次想知道线上真实数字都得重新手写一次性脚本——这本身就是它漂了 54 天没人量的原因之一。

这是「修量尺」三步里的第 1 步，后面两步（补核验覆盖洞、跑 LLM 臂建基线 + 正藏先验 A/B）都要用它当验证台。

## 做了什么

工具分成两节，**这个分节是本次实现里最要紧的一件事**：

- **A 节**读 `chat_answer_diagnostics` —— serve 时护栏在**改写之前**记下的真值。
- **B/C 节**才是回放，只负责护栏从没碰过的东西。

### ⚠️ 为什么不能整个靠回放（第一版的真实错误）

`chat_messages.content` 存的是护栏**处理后**的答案。`verify_quoted_content` 把不逐字的引文降级成散文（去掉引号），它自己的 docstring 写明这是幂等的——*"a downgraded passage carries no quote marks, so a second pass is a no-op"*。

第一版就是整个靠回放的，跑出来所有指标 100%。决定性对照：

| 同一窗口 | 回放 | serve 诊断表 |
|---|---|---|
| 引文被降级 | **0** | **203** |
| 引用被纠正 | **0** | **43** |

数字是真的，把它读成质量则是虚构。

### 回放真正能测的两样（护栏对它们全盲，故存文未被改写）

1. **卷号准确率** —— `quote_verifier._find_sources` 在所标卷无匹配时回退到该经**任意**卷，所以「引文逐字正确但卷号指向别处」对所有运行时护栏都是盲区。实测 **96.0%**（1,695 条可解析引文）。
2. **核验覆盖缺口** —— `verify_quoted_content` 首行 `if "【《" not in answer: return answer, []`，**32.2%（460/1,427）**的答案整条跳过核验。它们不是「核验通过」，是「从没被看过」，也因此是唯一能靠回放查清的一批。

## 实测（2026-09-01，最近 30 天，1,427 条，106 秒，零 LLM 调用）

| 指标 | 值 | 分母 | 来源 |
|------|-----|------|------|
| `citation_grounding_rate` | 98.9% | 2,810 条引用 | serve 诊断 |
| `verified_rate_of_cited` | 61.7% | 962 条有引用回答 | serve 诊断 |
| `verbatim_quote_rate` | **79.9%** | 757 条含可核验引文回答 | serve 诊断 |
| `fascicle_accuracy_rate` | **96.0%** | 1,695 条可解析卷号引文 | **回放**（护栏盲区） |
| 核验覆盖率 | **67.8%** | 967 / 1,427 | 回放 |

> ⚠️ 与 2026-07-09 题库基线的 `verbatim_quote_rate` 56.6% **口径不同、不可直接比**：那是 90 题题库、这是生产全量，且中间护栏行为从「加警告」改成了「降级引文」。

## ⛔ 明确不做每日门

日均 47.5 条答案，`verbatim_quote_rate` 分母约 25 条/天。p≈0.8 时日粒度标准误约 **8 个百分点**，周约 3，月约 1.5。日序列是噪声，设任何阈值都会天天误报。**按月跑，或在改动前后成对跑。** 每日的确定性检索门（`run_regression.sh`）照旧，两者不合并。

## 受控对照

`--ids-from` 复现上一次报告的完整 message id 集合：同一批答案跑两遍，输入不漂移，差值才归得到改动头上。两次 id 集合不一致时报告会显式警告「差值里混着人群变化，不可归因」。

## 测试

22 条新单测，纯逻辑（无 DB / LLM / 网络），与 `test_faithfulness.py` 同层。全部做过变异检验——逐条改坏实现确认测试会红，其中包括：覆盖洞探测器失灵、解析器丢掉 message_id 作用域（一个经名在不同答案里可能是两部经，见 #1209）、畸形 sources 毒死整轮、不引原文却记为已核验。

另有一条 `TestReplayCannotSubstituteForServeRecords` 专门把上面那个第一版错误钉住，防止有人"简化"回来。

`ruff==0.9.7`（CI 钉的版本）+ `pytest` 全绿；已在生产全量数据上跑通。