### PR TITLE
chore(deps): pypdf 6.15.0 → 6.16.1 —— 三条新披露 CVE，其中两条正打在我们用的那条路上

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,6 @@ tiktoken==0.13.0
 opencc-python-reimplemented==0.1.7
 Pillow==12.3.0
 python-multipart==0.0.32
-pypdf==6.15.0
+pypdf==6.16.1
 python-docx==1.2.0
 beautifulsoup4==4.15.0


### PR DESCRIPTION
`Python dependency audit` 从今天起在 master 和所有在途 PR 上变红（#1232 撞上），原因是 pypdf 新披露了三条 advisory，不是谁引入的。

| CVE | 影响 | 我们受不受影响 |
|---|---|---|
| CVE-2026-84310 | 读取条目众多/深度嵌套的 outline → 长时间运行 + 大量内存 | **是** |
| CVE-2026-84311 | 提取含大量 XForm 的页面正文 → 长时间运行 + 大量内存 | **是** |
| CVE-2026-84309 | `TreeObject.insert_child`（写路径）→ 无限循环 | 否，我们不写 PDF |

后两条正打在 `app/services/attachment_parser.py:_parse_pdf` 实际走的路径上（`reader.pages` → `page.extract_text()`），而这条路径是**用户上传附件就能触达**的，不是理论风险。

## 验证

用法面很窄（`PdfReader` / `.pages` / `.extract_text`），6.15 → 6.16.1 无 API 变动。本地装 6.16.1 后跑 `test_attachment_parser.py` + `test_chat_attachments.py`，**17 条全绿**。